### PR TITLE
feat(gax-internal): return `gax::response::Response`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,7 @@ dependencies = [
  "google-cloud-wkt",
  "grpc-server",
  "http",
+ "http-body-util",
  "mockall",
  "prost",
  "reqwest",

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -84,8 +84,11 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{^PathInfo.Codec.HasBody}}None::<gaxi::http::NoBody>{{/PathInfo.Codec.HasBody}},
             options,
         ).await
+        {{^ReturnsEmpty}}
+        .map(|r: gax::response::Response<{{OutputType.Codec.QualifiedName}}>| r.into_body())
+        {{/ReturnsEmpty}}
         {{#ReturnsEmpty}}
-        .map(|_: {{OutputType.Codec.QualifiedName}}| ())
+        .map(|_: gax::response::Response<{{OutputType.Codec.QualifiedName}}>| ())
         {{/ReturnsEmpty}}
     }
 

--- a/generator/testdata/rust/openapi/golden/src/transport.rs
+++ b/generator/testdata/rust/openapi/golden/src/transport.rs
@@ -65,6 +65,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -90,6 +91,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Location>| r.into_body())
     }
 
     async fn list_secrets(
@@ -117,6 +119,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListSecretsResponse>| r.into_body())
     }
 
     async fn create_secret(
@@ -142,6 +145,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn list_secrets_by_project_and_location(
@@ -170,6 +174,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListSecretsResponse>| r.into_body())
     }
 
     async fn create_secret_by_project_and_location(
@@ -196,6 +201,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn add_secret_version(
@@ -221,6 +227,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn add_secret_version_by_project_and_location_and_secret(
@@ -247,6 +254,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn get_secret(
@@ -272,6 +280,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn delete_secret(
@@ -298,6 +307,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Empty>| r.into_body())
     }
 
     async fn update_secret(
@@ -324,6 +334,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn get_secret_by_project_and_location_and_secret(
@@ -350,6 +361,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn delete_secret_by_project_and_location_and_secret(
@@ -377,6 +389,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Empty>| r.into_body())
     }
 
     async fn update_secret_by_project_and_location_and_secret(
@@ -404,6 +417,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn list_secret_versions(
@@ -432,6 +446,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListSecretVersionsResponse>| r.into_body())
     }
 
     async fn list_secret_versions_by_project_and_location_and_secret(
@@ -461,6 +476,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListSecretVersionsResponse>| r.into_body())
     }
 
     async fn get_secret_version(
@@ -487,6 +503,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn get_secret_version_by_project_and_location_and_secret_and_version(
@@ -514,6 +531,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn access_secret_version(
@@ -540,6 +558,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::AccessSecretVersionResponse>| r.into_body())
     }
 
     async fn access_secret_version_by_project_and_location_and_secret_and_version(
@@ -567,6 +586,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::AccessSecretVersionResponse>| r.into_body())
     }
 
     async fn disable_secret_version(
@@ -593,6 +613,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn disable_secret_version_by_project_and_location_and_secret_and_version(
@@ -620,6 +641,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn enable_secret_version(
@@ -646,6 +668,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn enable_secret_version_by_project_and_location_and_secret_and_version(
@@ -673,6 +696,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn destroy_secret_version(
@@ -699,6 +723,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn destroy_secret_version_by_project_and_location_and_secret_and_version(
@@ -726,6 +751,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -751,6 +777,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy_by_project_and_location_and_secret(
@@ -777,6 +804,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -803,6 +831,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy_by_project_and_location_and_secret(
@@ -830,6 +859,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -855,6 +885,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::TestIamPermissionsResponse>| r.into_body())
     }
 
     async fn test_iam_permissions_by_project_and_location_and_secret(
@@ -881,6 +912,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::TestIamPermissionsResponse>| r.into_body())
     }
 
 }

--- a/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/iam/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -86,6 +87,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -110,6 +112,7 @@ impl super::stub::IAMPolicy for IAMPolicy {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::TestIamPermissionsResponse>| r.into_body())
     }
 
 }

--- a/generator/testdata/rust/protobuf/golden/location/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/location/src/transport.rs
@@ -65,6 +65,7 @@ impl super::stub::Locations for Locations {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -89,6 +90,7 @@ impl super::stub::Locations for Locations {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Location>| r.into_body())
     }
 
 }

--- a/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
+++ b/generator/testdata/rust/protobuf/golden/secretmanager/src/transport.rs
@@ -65,6 +65,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListSecretsResponse>| r.into_body())
     }
 
     async fn create_secret(
@@ -90,6 +91,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn add_secret_version(
@@ -114,6 +116,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn get_secret(
@@ -138,6 +141,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn update_secret(
@@ -163,6 +167,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn delete_secret(
@@ -188,7 +193,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
-        .map(|_: wkt::Empty| ())
+        .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_secret_versions(
@@ -216,6 +221,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ListSecretVersionsResponse>| r.into_body())
     }
 
     async fn get_secret_version(
@@ -240,6 +246,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn access_secret_version(
@@ -264,6 +271,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::AccessSecretVersionResponse>| r.into_body())
     }
 
     async fn disable_secret_version(
@@ -288,6 +296,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn enable_secret_version(
@@ -312,6 +321,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn destroy_secret_version(
@@ -336,6 +346,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -360,6 +371,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<iam::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -385,6 +397,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<iam::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -409,6 +422,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<iam::model::TestIamPermissionsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -436,6 +450,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -460,6 +475,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
 }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -41,6 +41,7 @@ _internal_common = ["dep:auth", "dep:gax", "dep:thiserror"]
 
 [dependencies]
 http = "1"
+http-body-util = "0.1"
 prost = "0.13"
 reqwest = { version = "0.12", optional = true }
 serde = { version = "1", optional = true }

--- a/src/gax-internal/tests/auth.rs
+++ b/src/gax-internal/tests/auth.rs
@@ -66,7 +66,8 @@ mod test {
         let body = json!({});
         let response: serde_json::Value = client
             .execute(builder, Some(body), RequestOptions::default())
-            .await?;
+            .await?
+            .into_body();
         assert_eq!(
             get_header_value(&response, "auth-key-1"),
             Some("auth-value-1".to_string())
@@ -97,8 +98,9 @@ mod test {
         let builder = client.builder(reqwest::Method::GET, "/echo".into());
         let body = json!({});
         let options = RequestOptions::default();
-        let result: std::result::Result<serde_json::Value, gax::error::Error> =
-            client.execute(builder, Some(body), options).await;
+        let result = client
+            .execute::<serde_json::Value, serde_json::Value>(builder, Some(body), options)
+            .await;
 
         assert!(result.is_err());
 
@@ -135,8 +137,12 @@ mod test {
         let builder = client.builder(reqwest::Method::GET, "/echo".into());
         let body = serde_json::json!({});
 
-        let result: std::result::Result<serde_json::Value, gax::error::Error> = client
-            .execute(builder, Some(body), RequestOptions::default())
+        let result = client
+            .execute::<serde_json::Value, serde_json::Value>(
+                builder,
+                Some(body),
+                RequestOptions::default(),
+            )
             .await;
 
         assert!(result.is_err());

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -36,7 +36,7 @@ mod test {
             .await;
 
         match response {
-            Ok(v) => assert!(false, "expected an error got={v}"),
+            Ok(v) => assert!(false, "expected an error got={v:?}"),
             Err(e) => {
                 let inner = e.as_inner::<gax::error::ServiceError>().unwrap();
                 assert_eq!(

--- a/src/gax-internal/tests/http_metadata.rs
+++ b/src/gax-internal/tests/http_metadata.rs
@@ -1,0 +1,77 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "_internal_http_client"))]
+mod test {
+    use axum::http::{HeaderName, HeaderValue, StatusCode};
+    use gax::options::RequestOptions;
+    use google_cloud_gax_internal::http::ReqwestClient;
+    use google_cloud_gax_internal::options::ClientConfig;
+    use serde_json::json;
+    use tokio::task::JoinHandle;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn capture_headers() -> anyhow::Result<()> {
+        let (endpoint, _server) = start().await?;
+
+        let client = ReqwestClient::new(test_config(), &endpoint).await?;
+        let builder = client.builder(reqwest::Method::GET, "/hello".into());
+        let body = json!({});
+
+        let response = client
+            .execute::<serde_json::Value, serde_json::Value>(
+                builder,
+                Some(body),
+                RequestOptions::default(),
+            )
+            .await;
+        let response = response?;
+        let (parts, body) = response.into_parts();
+        assert_eq!(body, json!({"greeting": "Hello World!"}));
+        assert_eq!(
+            parts.headers.get("x-test-header"),
+            Some(&HeaderValue::from_static("test-only"))
+        );
+        Ok(())
+    }
+
+    pub async fn start() -> anyhow::Result<(String, JoinHandle<()>)> {
+        let app = axum::Router::new().route("/hello", axum::routing::get(hello));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let server = tokio::spawn(async {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        Ok((format!("http://{}:{}", addr.ip(), addr.port()), server))
+    }
+
+    async fn hello() -> impl axum::response::IntoResponse {
+        use axum::response::Json;
+        (
+            StatusCode::OK,
+            [(
+                HeaderName::from_static("x-test-header"),
+                HeaderValue::from_static("test-only"),
+            )],
+            Json(json!({"greeting": "Hello World!"})),
+        )
+    }
+
+    fn test_config() -> ClientConfig {
+        let mut config = ClientConfig::default();
+        config.cred = auth::credentials::testing::test_credentials().into();
+        config
+    }
+}

--- a/src/gax-internal/tests/retry_loop.rs
+++ b/src/gax-internal/tests/retry_loop.rs
@@ -56,7 +56,7 @@ mod test {
                 RequestOptions::default(),
             )
             .await;
-        let response = response?;
+        let response = response?.into_body();
         assert_eq!(response, json!({"status": "done"}));
         Ok(())
     }
@@ -108,7 +108,7 @@ mod test {
         let response = client
             .execute::<serde_json::Value, serde_json::Value>(builder, Some(body), options)
             .await;
-        let response = response?;
+        let response = response?.into_body();
         assert_eq!(response, json!({"status": "done"}));
         Ok(())
     }
@@ -255,7 +255,7 @@ mod test {
         let response = client
             .execute::<serde_json::Value, serde_json::Value>(builder, Some(body), options)
             .await;
-        let response = response?;
+        let response = response?.into_body();
         assert_eq!(response, json!({"status": "done"}));
         Ok(())
     }
@@ -298,7 +298,7 @@ mod test {
         let response = client
             .execute::<serde_json::Value, serde_json::Value>(builder, Some(body), options)
             .await;
-        let response = response?;
+        let response = response?.into_body();
         assert_eq!(response, json!({"status": "done"}));
         Ok(())
     }
@@ -529,7 +529,7 @@ mod test {
         let response = client
             .execute::<serde_json::Value, serde_json::Value>(builder, Some(body), options)
             .await;
-        let response = response?;
+        let response = response?.into_body();
         assert_eq!(response, json!({"status": "done"}));
         Ok(())
     }
@@ -614,7 +614,8 @@ mod test {
                     let _ = tx.send("--marker--");
                     let _ = tx.send("success");
                     assert!(r.is_ok(), "{r:?}");
-                    assert_eq!(r.ok(), Some(json!({"status": "done"})));
+                    let response = r.unwrap().into_body();
+                    assert_eq!(response, json!({"status": "done"}));
                     break;
                 },
                 _ = interval.tick() => {
@@ -785,7 +786,8 @@ mod test {
                     let _ = tx.send("--marker--");
                     let _ = tx.send("success");
                     assert!(r.is_ok(), "{r:?}");
-                    assert_eq!(r.ok(), Some(json!({"status": "done"})));
+                    let response = r.unwrap().into_body();
+                    assert_eq!(response, json!({"status": "done"}));
                     break;
                 },
                 _ = interval.tick() => {

--- a/src/gax-internal/tests/timeout.rs
+++ b/src/gax-internal/tests/timeout.rs
@@ -48,7 +48,7 @@ mod test {
             tokio::select! {
                 _ = &mut server => { },
                 r = &mut response => {
-                    let response = r?;
+                    let response = r?.into_body();
                     assert_eq!(
                         get_query_value(&response, "delay_ms"),
                         Some("200".to_string())
@@ -86,7 +86,7 @@ mod test {
             tokio::select! {
                 _ = &mut server => {  },
                 r = &mut response => {
-                    let response = r?;
+                    let response = r?.into_body();
                     assert_eq!(
                         get_query_value(&response, "delay_ms"),
                         Some("200".to_string())

--- a/src/gax-internal/tests/user_agent.rs
+++ b/src/gax-internal/tests/user_agent.rs
@@ -31,7 +31,8 @@ mod test {
         let body = json!({});
         let response: serde_json::Value = client
             .execute(builder, Some(body), RequestOptions::default())
-            .await?;
+            .await?
+            .into_body();
         let got = get_header_value(&response, "user-agent");
         assert_eq!(got, None);
         Ok(())
@@ -53,7 +54,10 @@ mod test {
             o.set_user_agent(prefix);
             o
         };
-        let response: serde_json::Value = client.execute(builder, Some(body), options).await?;
+        let response: serde_json::Value = client
+            .execute(builder, Some(body), options)
+            .await?
+            .into_body();
         let got = get_header_value(&response, "user-agent");
         assert_eq!(got.as_deref(), Some(prefix));
         Ok(())

--- a/src/generated/api/apikeys/v2/src/transport.rs
+++ b/src/generated/api/apikeys/v2/src/transport.rs
@@ -55,7 +55,10 @@ impl super::stub::ApiKeys for ApiKeys {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("keyId", &req.key_id)]);
-        self.inner.execute(builder, Some(req.key), options).await
+        self.inner
+            .execute(builder, Some(req.key), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_keys(
@@ -78,6 +81,7 @@ impl super::stub::ApiKeys for ApiKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListKeysResponse>| r.into_body())
     }
 
     async fn get_key(
@@ -97,6 +101,7 @@ impl super::stub::ApiKeys for ApiKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Key>| r.into_body())
     }
 
     async fn get_key_string(
@@ -116,6 +121,7 @@ impl super::stub::ApiKeys for ApiKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GetKeyStringResponse>| r.into_body())
     }
 
     async fn update_key(
@@ -151,7 +157,10 @@ impl super::stub::ApiKeys for ApiKeys {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.key), options).await
+        self.inner
+            .execute(builder, Some(req.key), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_key(
@@ -172,6 +181,7 @@ impl super::stub::ApiKeys for ApiKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_key(
@@ -188,7 +198,10 @@ impl super::stub::ApiKeys for ApiKeys {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn lookup_key(
@@ -209,6 +222,7 @@ impl super::stub::ApiKeys for ApiKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LookupKeyResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -228,6 +242,7 @@ impl super::stub::ApiKeys for ApiKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/api/servicecontrol/v1/src/transport.rs
+++ b/src/generated/api/servicecontrol/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::QuotaController for QuotaController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AllocateQuotaResponse>| r.into_body())
     }
 }
 
@@ -100,7 +103,10 @@ impl super::stub::ServiceController for ServiceController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CheckResponse>| r.into_body())
     }
 
     async fn report(
@@ -120,6 +126,9 @@ impl super::stub::ServiceController for ServiceController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ReportResponse>| r.into_body())
     }
 }

--- a/src/generated/api/servicecontrol/v2/src/transport.rs
+++ b/src/generated/api/servicecontrol/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::ServiceController for ServiceController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CheckResponse>| r.into_body())
     }
 
     async fn report(
@@ -77,6 +80,9 @@ impl super::stub::ServiceController for ServiceController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ReportResponse>| r.into_body())
     }
 }

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn get_service(
@@ -83,6 +84,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ManagedService>| r.into_body())
     }
 
     async fn create_service(
@@ -102,6 +104,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service(
@@ -124,6 +127,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_service(
@@ -146,6 +150,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_service_configs(
@@ -170,6 +175,11 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_config(
@@ -196,6 +206,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<api::model::Service>| r.into_body())
     }
 
     async fn create_service_config(
@@ -218,6 +229,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, Some(req.service_config), options)
             .await
+            .map(|r: gax::response::Response<api::model::Service>| r.into_body())
     }
 
     async fn submit_config_source(
@@ -237,7 +249,10 @@ impl super::stub::ServiceManager for ServiceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_service_rollouts(
@@ -263,6 +278,11 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceRolloutsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_rollout(
@@ -288,6 +308,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Rollout>| r.into_body())
     }
 
     async fn create_service_rollout(
@@ -310,6 +331,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, Some(req.rollout), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_config_report(
@@ -329,7 +351,9 @@ impl super::stub::ServiceManager for ServiceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateConfigReportResponse>| r.into_body(),
+        )
     }
 
     async fn set_iam_policy(
@@ -349,7 +373,10 @@ impl super::stub::ServiceManager for ServiceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -369,7 +396,10 @@ impl super::stub::ServiceManager for ServiceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -389,7 +419,9 @@ impl super::stub::ServiceManager for ServiceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -413,6 +445,11 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -432,6 +469,7 @@ impl super::stub::ServiceManager for ServiceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/api/serviceusage/v1/src/transport.rs
+++ b/src/generated/api/serviceusage/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::ServiceUsage for ServiceUsage {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn disable_service(
@@ -71,7 +74,10 @@ impl super::stub::ServiceUsage for ServiceUsage {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_service(
@@ -91,6 +97,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn list_services(
@@ -113,6 +120,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn batch_enable_services(
@@ -132,7 +140,10 @@ impl super::stub::ServiceUsage for ServiceUsage {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_get_services(
@@ -159,6 +170,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BatchGetServicesResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -182,6 +194,11 @@ impl super::stub::ServiceUsage for ServiceUsage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -201,6 +218,7 @@ impl super::stub::ServiceUsage for ServiceUsage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/appengine/v1/src/transport.rs
+++ b/src/generated/appengine/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Applications for Applications {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Application>| r.into_body())
     }
 
     async fn create_application(
@@ -76,6 +77,7 @@ impl super::stub::Applications for Applications {
         self.inner
             .execute(builder, Some(req.application), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_application(
@@ -105,6 +107,7 @@ impl super::stub::Applications for Applications {
         self.inner
             .execute(builder, Some(req.application), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn repair_application(
@@ -121,7 +124,10 @@ impl super::stub::Applications for Applications {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -144,6 +150,11 @@ impl super::stub::Applications for Applications {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -163,6 +174,7 @@ impl super::stub::Applications for Applications {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -221,6 +233,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn get_service(
@@ -240,6 +253,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn update_service(
@@ -270,6 +284,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service(
@@ -289,6 +304,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -311,6 +327,11 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -330,6 +351,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -389,6 +411,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVersionsResponse>| r.into_body())
     }
 
     async fn get_version(
@@ -409,6 +432,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn create_version(
@@ -431,6 +455,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_version(
@@ -460,6 +485,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_version(
@@ -479,6 +505,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -501,6 +528,11 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -520,6 +552,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -581,6 +614,7 @@ impl super::stub::Instances for Instances {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -600,6 +634,7 @@ impl super::stub::Instances for Instances {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn delete_instance(
@@ -619,6 +654,7 @@ impl super::stub::Instances for Instances {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn debug_instance(
@@ -635,7 +671,10 @@ impl super::stub::Instances for Instances {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -658,6 +697,11 @@ impl super::stub::Instances for Instances {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -677,6 +721,7 @@ impl super::stub::Instances for Instances {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -739,6 +784,7 @@ impl super::stub::Firewall for Firewall {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIngressRulesResponse>| r.into_body())
     }
 
     async fn batch_update_ingress_rules(
@@ -758,7 +804,11 @@ impl super::stub::Firewall for Firewall {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchUpdateIngressRulesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn create_ingress_rule(
@@ -778,7 +828,10 @@ impl super::stub::Firewall for Firewall {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.rule), options).await
+        self.inner
+            .execute(builder, Some(req.rule), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FirewallRule>| r.into_body())
     }
 
     async fn get_ingress_rule(
@@ -798,6 +851,7 @@ impl super::stub::Firewall for Firewall {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FirewallRule>| r.into_body())
     }
 
     async fn update_ingress_rule(
@@ -824,7 +878,10 @@ impl super::stub::Firewall for Firewall {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.rule), options).await
+        self.inner
+            .execute(builder, Some(req.rule), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FirewallRule>| r.into_body())
     }
 
     async fn delete_ingress_rule(
@@ -844,7 +901,7 @@ impl super::stub::Firewall for Firewall {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -867,6 +924,11 @@ impl super::stub::Firewall for Firewall {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -886,6 +948,7 @@ impl super::stub::Firewall for Firewall {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -933,6 +996,11 @@ impl super::stub::AuthorizedDomains for AuthorizedDomains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAuthorizedDomainsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -955,6 +1023,11 @@ impl super::stub::AuthorizedDomains for AuthorizedDomains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -974,6 +1047,7 @@ impl super::stub::AuthorizedDomains for AuthorizedDomains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -1022,6 +1096,11 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAuthorizedCertificatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_authorized_certificate(
@@ -1042,6 +1121,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AuthorizedCertificate>| r.into_body())
     }
 
     async fn create_authorized_certificate(
@@ -1064,6 +1144,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, Some(req.certificate), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AuthorizedCertificate>| r.into_body())
     }
 
     async fn update_authorized_certificate(
@@ -1093,6 +1174,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, Some(req.certificate), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AuthorizedCertificate>| r.into_body())
     }
 
     async fn delete_authorized_certificate(
@@ -1112,7 +1194,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -1135,6 +1217,11 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1154,6 +1241,7 @@ impl super::stub::AuthorizedCertificates for AuthorizedCertificates {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -1201,6 +1289,11 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDomainMappingsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_domain_mapping(
@@ -1220,6 +1313,7 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DomainMapping>| r.into_body())
     }
 
     async fn create_domain_mapping(
@@ -1243,6 +1337,7 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, Some(req.domain_mapping), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_domain_mapping(
@@ -1272,6 +1367,7 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, Some(req.domain_mapping), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_domain_mapping(
@@ -1291,6 +1387,7 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -1313,6 +1410,11 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1332,6 +1434,7 @@ impl super::stub::DomainMappings for DomainMappings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_instance(
@@ -77,6 +80,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn list_instances(
@@ -100,6 +104,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn update_instance(
@@ -116,7 +121,10 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn partial_update_instance(
@@ -155,6 +163,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -174,7 +183,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_cluster(
@@ -198,6 +207,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_cluster(
@@ -217,6 +227,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn list_clusters(
@@ -237,6 +248,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn update_cluster(
@@ -253,7 +265,10 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn partial_update_cluster(
@@ -292,6 +307,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -311,7 +327,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_app_profile(
@@ -336,6 +352,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.app_profile), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AppProfile>| r.into_body())
     }
 
     async fn get_app_profile(
@@ -355,6 +372,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AppProfile>| r.into_body())
     }
 
     async fn list_app_profiles(
@@ -379,6 +397,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAppProfilesResponse>| r.into_body())
     }
 
     async fn update_app_profile(
@@ -418,6 +437,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.app_profile), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_app_profile(
@@ -438,7 +458,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_iam_policy(
@@ -458,7 +478,10 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -478,7 +501,10 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -498,7 +524,9 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_hot_tablets(
@@ -543,6 +571,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListHotTabletsResponse>| r.into_body())
     }
 
     async fn create_logical_view(
@@ -566,6 +595,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.logical_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_logical_view(
@@ -585,6 +615,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogicalView>| r.into_body())
     }
 
     async fn list_logical_views(
@@ -609,6 +640,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLogicalViewsResponse>| r.into_body())
     }
 
     async fn update_logical_view(
@@ -647,6 +679,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.logical_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_logical_view(
@@ -667,7 +700,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_materialized_view(
@@ -691,6 +724,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.materialized_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_materialized_view(
@@ -710,6 +744,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MaterializedView>| r.into_body())
     }
 
     async fn list_materialized_views(
@@ -734,6 +769,11 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMaterializedViewsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_materialized_view(
@@ -772,6 +812,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, Some(req.materialized_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_materialized_view(
@@ -792,7 +833,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -815,6 +856,11 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -834,6 +880,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -853,7 +900,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -873,7 +920,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -927,7 +974,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn create_table_from_snapshot(
@@ -947,7 +997,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_tables(
@@ -970,6 +1023,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTablesResponse>| r.into_body())
     }
 
     async fn get_table(
@@ -990,6 +1044,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn update_table(
@@ -1026,7 +1081,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("ignoreWarnings", &req.ignore_warnings)]);
-        self.inner.execute(builder, Some(req.table), options).await
+        self.inner
+            .execute(builder, Some(req.table), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_table(
@@ -1046,7 +1104,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn undelete_table(
@@ -1063,7 +1121,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_authorized_view(
@@ -1087,6 +1148,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, Some(req.authorized_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_authorized_views(
@@ -1112,6 +1174,11 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAuthorizedViewsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_authorized_view(
@@ -1132,6 +1199,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AuthorizedView>| r.into_body())
     }
 
     async fn update_authorized_view(
@@ -1171,6 +1239,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, Some(req.authorized_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_authorized_view(
@@ -1191,7 +1260,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn modify_column_families(
@@ -1211,7 +1280,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn drop_row_range(
@@ -1234,7 +1306,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn generate_consistency_token(
@@ -1254,7 +1326,11 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateConsistencyTokenResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn check_consistency(
@@ -1274,7 +1350,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CheckConsistencyResponse>| r.into_body())
     }
 
     async fn snapshot_table(
@@ -1291,7 +1370,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_snapshot(
@@ -1311,6 +1393,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Snapshot>| r.into_body())
     }
 
     async fn list_snapshots(
@@ -1335,6 +1418,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSnapshotsResponse>| r.into_body())
     }
 
     async fn delete_snapshot(
@@ -1354,7 +1438,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_backup(
@@ -1372,7 +1456,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("backupId", &req.backup_id)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup(
@@ -1392,6 +1479,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn update_backup(
@@ -1427,7 +1515,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn delete_backup(
@@ -1447,7 +1538,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_backups(
@@ -1471,6 +1562,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn restore_table(
@@ -1490,7 +1582,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn copy_backup(
@@ -1510,7 +1605,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1530,7 +1628,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1550,7 +1651,10 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1570,7 +1674,9 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1593,6 +1699,11 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1612,6 +1723,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1631,7 +1743,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1651,7 +1763,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/accessapproval/v1/src/transport.rs
+++ b/src/generated/cloud/accessapproval/v1/src/transport.rs
@@ -63,6 +63,11 @@ impl super::stub::AccessApproval for AccessApproval {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListApprovalRequestsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_approval_request(
@@ -82,6 +87,7 @@ impl super::stub::AccessApproval for AccessApproval {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ApprovalRequest>| r.into_body())
     }
 
     async fn approve_approval_request(
@@ -98,7 +104,10 @@ impl super::stub::AccessApproval for AccessApproval {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ApprovalRequest>| r.into_body())
     }
 
     async fn dismiss_approval_request(
@@ -115,7 +124,10 @@ impl super::stub::AccessApproval for AccessApproval {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ApprovalRequest>| r.into_body())
     }
 
     async fn invalidate_approval_request(
@@ -135,7 +147,10 @@ impl super::stub::AccessApproval for AccessApproval {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ApprovalRequest>| r.into_body())
     }
 
     async fn get_access_approval_settings(
@@ -155,6 +170,7 @@ impl super::stub::AccessApproval for AccessApproval {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AccessApprovalSettings>| r.into_body())
     }
 
     async fn update_access_approval_settings(
@@ -193,6 +209,7 @@ impl super::stub::AccessApproval for AccessApproval {
         self.inner
             .execute(builder, Some(req.settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AccessApprovalSettings>| r.into_body())
     }
 
     async fn delete_access_approval_settings(
@@ -212,7 +229,7 @@ impl super::stub::AccessApproval for AccessApproval {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_access_approval_service_account(
@@ -232,5 +249,10 @@ impl super::stub::AccessApproval for AccessApproval {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::AccessApprovalServiceAccount>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/transport.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/transport.rs
@@ -64,6 +64,9 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNotificationsResponse>| r.into_body(),
+            )
     }
 
     async fn get_notification(
@@ -84,6 +87,7 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Notification>| r.into_body())
     }
 
     async fn get_settings(
@@ -103,6 +107,7 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn update_settings(
@@ -131,5 +136,6 @@ impl super::stub::AdvisoryNotificationsService for AdvisoryNotificationsService 
         self.inner
             .execute(builder, Some(req.settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_dataset(
@@ -89,6 +90,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn update_dataset(
@@ -127,6 +129,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn list_datasets(
@@ -160,6 +163,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDatasetsResponse>| r.into_body())
     }
 
     async fn delete_dataset(
@@ -179,6 +183,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_data(
@@ -195,7 +200,10 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_data(
@@ -212,7 +220,10 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_dataset_version(
@@ -235,6 +246,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset_version), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_dataset_version(
@@ -273,6 +285,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset_version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DatasetVersion>| r.into_body())
     }
 
     async fn delete_dataset_version(
@@ -292,6 +305,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_dataset_version(
@@ -321,6 +335,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DatasetVersion>| r.into_body())
     }
 
     async fn list_dataset_versions(
@@ -357,6 +372,11 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDatasetVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn restore_dataset_version(
@@ -376,6 +396,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_data_items(
@@ -412,6 +433,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDataItemsResponse>| r.into_body())
     }
 
     async fn search_data_items(
@@ -470,6 +492,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchDataItemsResponse>| r.into_body())
     }
 
     async fn list_saved_queries(
@@ -506,6 +529,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSavedQueriesResponse>| r.into_body())
     }
 
     async fn delete_saved_query(
@@ -525,6 +549,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_annotation_spec(
@@ -554,6 +579,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnnotationSpec>| r.into_body())
     }
 
     async fn list_annotations(
@@ -590,6 +616,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAnnotationsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -612,6 +639,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -631,6 +659,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -650,7 +679,10 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -683,6 +715,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -709,6 +742,11 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -731,6 +769,11 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -750,6 +793,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -769,7 +813,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -789,7 +833,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -819,6 +863,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -875,7 +920,10 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_deployment_resource_pool(
@@ -895,6 +943,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DeploymentResourcePool>| r.into_body())
     }
 
     async fn list_deployment_resource_pools(
@@ -919,6 +968,11 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDeploymentResourcePoolsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_deployment_resource_pool(
@@ -957,6 +1011,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, Some(req.deployment_resource_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_deployment_resource_pool(
@@ -976,6 +1031,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn query_deployed_models(
@@ -1000,6 +1056,11 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::QueryDeployedModelsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -1022,6 +1083,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1041,6 +1103,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1060,7 +1123,10 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1093,6 +1159,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1119,6 +1186,11 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -1141,6 +1213,11 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1160,6 +1237,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1179,7 +1257,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1199,7 +1277,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -1229,6 +1307,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1289,6 +1368,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, Some(req.endpoint), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_endpoint(
@@ -1308,6 +1388,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Endpoint>| r.into_body())
     }
 
     async fn list_endpoints(
@@ -1344,6 +1425,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEndpointsResponse>| r.into_body())
     }
 
     async fn update_endpoint(
@@ -1382,6 +1464,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, Some(req.endpoint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Endpoint>| r.into_body())
     }
 
     async fn update_endpoint_long_running(
@@ -1407,7 +1490,10 @@ impl super::stub::EndpointService for EndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_endpoint(
@@ -1427,6 +1513,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn deploy_model(
@@ -1446,7 +1533,10 @@ impl super::stub::EndpointService for EndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undeploy_model(
@@ -1466,7 +1556,10 @@ impl super::stub::EndpointService for EndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn mutate_deployed_model(
@@ -1486,7 +1579,10 @@ impl super::stub::EndpointService for EndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1509,6 +1605,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1528,6 +1625,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1547,7 +1645,10 @@ impl super::stub::EndpointService for EndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1580,6 +1681,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1606,6 +1708,11 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -1628,6 +1735,11 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1647,6 +1759,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1666,7 +1779,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1686,7 +1799,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -1716,6 +1829,7 @@ impl super::stub::EndpointService for EndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1772,7 +1886,9 @@ impl super::stub::EvaluationService for EvaluationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::EvaluateInstancesResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -1795,6 +1911,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1814,6 +1931,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1833,7 +1951,10 @@ impl super::stub::EvaluationService for EvaluationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1866,6 +1987,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1892,6 +2014,11 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -1914,6 +2041,11 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1933,6 +2065,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1952,7 +2085,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1972,7 +2105,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -2002,6 +2135,7 @@ impl super::stub::EvaluationService for EvaluationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -2048,6 +2182,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, Some(req.feature_online_store), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_feature_online_store(
@@ -2067,6 +2202,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeatureOnlineStore>| r.into_body())
     }
 
     async fn list_feature_online_stores(
@@ -2093,6 +2229,11 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFeatureOnlineStoresResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_feature_online_store(
@@ -2131,6 +2272,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, Some(req.feature_online_store), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_feature_online_store(
@@ -2151,6 +2293,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_feature_view(
@@ -2175,6 +2318,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, Some(req.feature_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_feature_view(
@@ -2194,6 +2338,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeatureView>| r.into_body())
     }
 
     async fn list_feature_views(
@@ -2220,6 +2365,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFeatureViewsResponse>| r.into_body())
     }
 
     async fn update_feature_view(
@@ -2258,6 +2404,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, Some(req.feature_view), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_feature_view(
@@ -2277,6 +2424,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn sync_feature_view(
@@ -2296,7 +2444,10 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SyncFeatureViewResponse>| r.into_body())
     }
 
     async fn get_feature_view_sync(
@@ -2316,6 +2467,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeatureViewSync>| r.into_body())
     }
 
     async fn list_feature_view_syncs(
@@ -2342,6 +2494,11 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFeatureViewSyncsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -2364,6 +2521,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2383,6 +2541,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -2402,7 +2561,10 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -2435,6 +2597,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -2461,6 +2624,11 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -2483,6 +2651,11 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2502,6 +2675,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2521,7 +2695,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -2541,7 +2715,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -2571,6 +2745,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -2627,7 +2802,9 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::FetchFeatureValuesResponse>| r.into_body(),
+        )
     }
 
     async fn search_nearest_entities(
@@ -2647,7 +2824,9 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SearchNearestEntitiesResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -2670,6 +2849,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2689,6 +2869,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -2708,7 +2889,10 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -2741,6 +2925,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -2767,6 +2952,11 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -2789,6 +2979,11 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2808,6 +3003,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2827,7 +3023,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -2847,7 +3043,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -2877,6 +3073,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -2923,6 +3120,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, Some(req.feature_group), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_feature_group(
@@ -2942,6 +3140,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeatureGroup>| r.into_body())
     }
 
     async fn list_feature_groups(
@@ -2968,6 +3167,9 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFeatureGroupsResponse>| r.into_body(),
+            )
     }
 
     async fn update_feature_group(
@@ -3006,6 +3208,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, Some(req.feature_group), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_feature_group(
@@ -3026,6 +3229,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_feature(
@@ -3049,6 +3253,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, Some(req.feature), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_features(
@@ -3068,7 +3273,10 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_feature(
@@ -3088,6 +3296,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Feature>| r.into_body())
     }
 
     async fn list_features(
@@ -3122,6 +3331,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFeaturesResponse>| r.into_body())
     }
 
     async fn update_feature(
@@ -3160,6 +3370,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, Some(req.feature), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_feature(
@@ -3179,6 +3390,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -3201,6 +3413,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3220,6 +3433,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -3239,7 +3453,10 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -3272,6 +3489,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -3298,6 +3516,11 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -3320,6 +3543,11 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3339,6 +3567,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -3358,7 +3587,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -3378,7 +3607,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -3408,6 +3637,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -3464,7 +3694,9 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ReadFeatureValuesResponse>| r.into_body(),
+        )
     }
 
     async fn write_feature_values(
@@ -3484,7 +3716,9 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::WriteFeatureValuesResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -3507,6 +3741,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3526,6 +3761,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -3545,7 +3781,10 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -3578,6 +3817,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -3604,6 +3844,11 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -3626,6 +3871,11 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3645,6 +3895,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -3664,7 +3915,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -3684,7 +3935,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -3714,6 +3965,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -3760,6 +4012,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, Some(req.featurestore), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_featurestore(
@@ -3779,6 +4032,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Featurestore>| r.into_body())
     }
 
     async fn list_featurestores(
@@ -3815,6 +4069,9 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFeaturestoresResponse>| r.into_body(),
+            )
     }
 
     async fn update_featurestore(
@@ -3853,6 +4110,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, Some(req.featurestore), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_featurestore(
@@ -3873,6 +4131,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_entity_type(
@@ -3896,6 +4155,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, Some(req.entity_type), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_entity_type(
@@ -3915,6 +4175,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn list_entity_types(
@@ -3951,6 +4212,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntityTypesResponse>| r.into_body())
     }
 
     async fn update_entity_type(
@@ -3989,6 +4251,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, Some(req.entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn delete_entity_type(
@@ -4009,6 +4272,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_feature(
@@ -4032,6 +4296,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, Some(req.feature), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_features(
@@ -4051,7 +4316,10 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_feature(
@@ -4071,6 +4339,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Feature>| r.into_body())
     }
 
     async fn list_features(
@@ -4105,6 +4374,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFeaturesResponse>| r.into_body())
     }
 
     async fn update_feature(
@@ -4143,6 +4413,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, Some(req.feature), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Feature>| r.into_body())
     }
 
     async fn delete_feature(
@@ -4162,6 +4433,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_feature_values(
@@ -4181,7 +4453,10 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_read_feature_values(
@@ -4201,7 +4476,10 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_feature_values(
@@ -4221,7 +4499,10 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_feature_values(
@@ -4241,7 +4522,10 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn search_features(
@@ -4267,6 +4551,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchFeaturesResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -4289,6 +4574,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4308,6 +4594,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -4327,7 +4614,10 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -4360,6 +4650,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -4386,6 +4677,11 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -4408,6 +4704,11 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4427,6 +4728,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -4446,7 +4748,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -4466,7 +4768,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -4496,6 +4798,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -4555,6 +4858,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, Some(req.cached_content), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CachedContent>| r.into_body())
     }
 
     async fn get_cached_content(
@@ -4574,6 +4878,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CachedContent>| r.into_body())
     }
 
     async fn update_cached_content(
@@ -4612,6 +4917,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, Some(req.cached_content), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CachedContent>| r.into_body())
     }
 
     async fn delete_cached_content(
@@ -4631,7 +4937,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_cached_contents(
@@ -4656,6 +4962,11 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCachedContentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -4678,6 +4989,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4697,6 +5009,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -4716,7 +5029,10 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -4749,6 +5065,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -4775,6 +5092,11 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -4797,6 +5119,11 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4816,6 +5143,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -4835,7 +5163,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -4855,7 +5183,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -4885,6 +5213,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -4930,6 +5259,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, Some(req.tuning_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TuningJob>| r.into_body())
     }
 
     async fn get_tuning_job(
@@ -4949,6 +5279,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TuningJob>| r.into_body())
     }
 
     async fn list_tuning_jobs(
@@ -4974,6 +5305,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTuningJobsResponse>| r.into_body())
     }
 
     async fn cancel_tuning_job(
@@ -4993,7 +5325,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn rebase_tuned_model(
@@ -5013,7 +5345,10 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -5036,6 +5371,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -5055,6 +5391,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -5074,7 +5411,10 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -5107,6 +5447,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -5133,6 +5474,11 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -5155,6 +5501,11 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -5174,6 +5525,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -5193,7 +5545,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -5213,7 +5565,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -5243,6 +5595,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -5302,6 +5655,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, Some(req.index_endpoint), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_index_endpoint(
@@ -5321,6 +5675,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::IndexEndpoint>| r.into_body())
     }
 
     async fn list_index_endpoints(
@@ -5356,6 +5711,11 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListIndexEndpointsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_index_endpoint(
@@ -5394,6 +5754,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, Some(req.index_endpoint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::IndexEndpoint>| r.into_body())
     }
 
     async fn delete_index_endpoint(
@@ -5413,6 +5774,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn deploy_index(
@@ -5432,7 +5794,10 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undeploy_index(
@@ -5452,7 +5817,10 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn mutate_deployed_index(
@@ -5475,6 +5843,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, Some(req.deployed_index), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -5497,6 +5866,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -5516,6 +5886,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -5535,7 +5906,10 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -5568,6 +5942,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -5594,6 +5969,11 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -5616,6 +5996,11 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -5635,6 +6020,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -5654,7 +6040,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -5674,7 +6060,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -5704,6 +6090,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -5757,7 +6144,10 @@ impl super::stub::IndexService for IndexService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.index), options).await
+        self.inner
+            .execute(builder, Some(req.index), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_index(
@@ -5777,6 +6167,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Index>| r.into_body())
     }
 
     async fn list_indexes(
@@ -5809,6 +6200,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIndexesResponse>| r.into_body())
     }
 
     async fn update_index(
@@ -5844,7 +6236,10 @@ impl super::stub::IndexService for IndexService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.index), options).await
+        self.inner
+            .execute(builder, Some(req.index), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_index(
@@ -5864,6 +6259,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn upsert_datapoints(
@@ -5883,7 +6279,10 @@ impl super::stub::IndexService for IndexService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UpsertDatapointsResponse>| r.into_body())
     }
 
     async fn remove_datapoints(
@@ -5903,7 +6302,10 @@ impl super::stub::IndexService for IndexService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RemoveDatapointsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -5926,6 +6328,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -5945,6 +6348,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -5964,7 +6368,10 @@ impl super::stub::IndexService for IndexService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -5997,6 +6404,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -6023,6 +6431,11 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -6045,6 +6458,11 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -6064,6 +6482,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -6083,7 +6502,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -6103,7 +6522,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -6133,6 +6552,7 @@ impl super::stub::IndexService for IndexService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -6192,6 +6612,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.custom_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomJob>| r.into_body())
     }
 
     async fn get_custom_job(
@@ -6211,6 +6632,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomJob>| r.into_body())
     }
 
     async fn list_custom_jobs(
@@ -6246,6 +6668,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCustomJobsResponse>| r.into_body())
     }
 
     async fn delete_custom_job(
@@ -6265,6 +6688,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_custom_job(
@@ -6284,7 +6708,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_data_labeling_job(
@@ -6307,6 +6731,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.data_labeling_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataLabelingJob>| r.into_body())
     }
 
     async fn get_data_labeling_job(
@@ -6326,6 +6751,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataLabelingJob>| r.into_body())
     }
 
     async fn list_data_labeling_jobs(
@@ -6362,6 +6788,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDataLabelingJobsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_data_labeling_job(
@@ -6381,6 +6812,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_data_labeling_job(
@@ -6400,7 +6832,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_hyperparameter_tuning_job(
@@ -6423,6 +6855,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.hyperparameter_tuning_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::HyperparameterTuningJob>| r.into_body())
     }
 
     async fn get_hyperparameter_tuning_job(
@@ -6442,6 +6875,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::HyperparameterTuningJob>| r.into_body())
     }
 
     async fn list_hyperparameter_tuning_jobs(
@@ -6477,6 +6911,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListHyperparameterTuningJobsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_hyperparameter_tuning_job(
@@ -6496,6 +6935,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_hyperparameter_tuning_job(
@@ -6515,7 +6955,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_nas_job(
@@ -6535,6 +6975,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.nas_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::NasJob>| r.into_body())
     }
 
     async fn get_nas_job(
@@ -6554,6 +6995,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NasJob>| r.into_body())
     }
 
     async fn list_nas_jobs(
@@ -6586,6 +7028,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNasJobsResponse>| r.into_body())
     }
 
     async fn delete_nas_job(
@@ -6605,6 +7048,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_nas_job(
@@ -6624,7 +7068,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_nas_trial_detail(
@@ -6644,6 +7088,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NasTrialDetail>| r.into_body())
     }
 
     async fn list_nas_trial_details(
@@ -6668,6 +7113,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNasTrialDetailsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_batch_prediction_job(
@@ -6690,6 +7140,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.batch_prediction_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BatchPredictionJob>| r.into_body())
     }
 
     async fn get_batch_prediction_job(
@@ -6709,6 +7160,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BatchPredictionJob>| r.into_body())
     }
 
     async fn list_batch_prediction_jobs(
@@ -6744,6 +7196,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBatchPredictionJobsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_batch_prediction_job(
@@ -6763,6 +7220,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_batch_prediction_job(
@@ -6782,7 +7240,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_model_deployment_monitoring_job(
@@ -6805,6 +7263,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.model_deployment_monitoring_job), options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ModelDeploymentMonitoringJob>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_model_deployment_monitoring_stats_anomalies(
@@ -6827,7 +7290,11 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<
+                crate::model::SearchModelDeploymentMonitoringStatsAnomaliesResponse,
+            >| r.into_body(),
+        )
     }
 
     async fn get_model_deployment_monitoring_job(
@@ -6847,6 +7314,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ModelDeploymentMonitoringJob>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_model_deployment_monitoring_jobs(
@@ -6882,6 +7354,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListModelDeploymentMonitoringJobsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn update_model_deployment_monitoring_job(
@@ -6922,6 +7399,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req.model_deployment_monitoring_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_model_deployment_monitoring_job(
@@ -6941,6 +7419,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn pause_model_deployment_monitoring_job(
@@ -6960,7 +7439,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn resume_model_deployment_monitoring_job(
@@ -6980,7 +7459,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -7003,6 +7482,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -7022,6 +7502,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -7041,7 +7522,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -7074,6 +7558,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -7100,6 +7585,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -7122,6 +7612,11 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -7141,6 +7636,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -7160,7 +7656,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -7180,7 +7676,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -7210,6 +7706,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -7266,7 +7763,10 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CountTokensResponse>| r.into_body())
     }
 
     async fn compute_tokens(
@@ -7286,7 +7786,10 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ComputeTokensResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -7309,6 +7812,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -7328,6 +7832,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -7347,7 +7852,10 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -7380,6 +7888,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -7406,6 +7915,11 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -7428,6 +7942,11 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -7447,6 +7966,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -7466,7 +7986,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -7486,7 +8006,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -7516,6 +8036,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -7558,7 +8079,10 @@ impl super::stub::MatchService for MatchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FindNeighborsResponse>| r.into_body())
     }
 
     async fn read_index_datapoints(
@@ -7578,7 +8102,9 @@ impl super::stub::MatchService for MatchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ReadIndexDatapointsResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -7601,6 +8127,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -7620,6 +8147,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -7639,7 +8167,10 @@ impl super::stub::MatchService for MatchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -7672,6 +8203,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -7698,6 +8230,11 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -7720,6 +8257,11 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -7739,6 +8281,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -7758,7 +8301,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -7778,7 +8321,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -7808,6 +8351,7 @@ impl super::stub::MatchService for MatchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -7854,6 +8398,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.metadata_store), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_metadata_store(
@@ -7873,6 +8418,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MetadataStore>| r.into_body())
     }
 
     async fn list_metadata_stores(
@@ -7897,6 +8443,11 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMetadataStoresResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_metadata_store(
@@ -7917,6 +8468,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_artifact(
@@ -7940,6 +8492,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.artifact), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Artifact>| r.into_body())
     }
 
     async fn get_artifact(
@@ -7959,6 +8512,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Artifact>| r.into_body())
     }
 
     async fn list_artifacts(
@@ -7985,6 +8539,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListArtifactsResponse>| r.into_body())
     }
 
     async fn update_artifact(
@@ -8024,6 +8579,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.artifact), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Artifact>| r.into_body())
     }
 
     async fn delete_artifact(
@@ -8044,6 +8600,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_artifacts(
@@ -8063,7 +8620,10 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_context(
@@ -8087,6 +8647,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.context), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Context>| r.into_body())
     }
 
     async fn get_context(
@@ -8106,6 +8667,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Context>| r.into_body())
     }
 
     async fn list_contexts(
@@ -8129,6 +8691,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListContextsResponse>| r.into_body())
     }
 
     async fn update_context(
@@ -8168,6 +8731,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.context), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Context>| r.into_body())
     }
 
     async fn delete_context(
@@ -8189,6 +8753,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_contexts(
@@ -8208,7 +8773,10 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_context_artifacts_and_executions(
@@ -8228,7 +8796,11 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AddContextArtifactsAndExecutionsResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn add_context_children(
@@ -8248,7 +8820,9 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AddContextChildrenResponse>| r.into_body(),
+        )
     }
 
     async fn remove_context_children(
@@ -8268,7 +8842,9 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::RemoveContextChildrenResponse>| r.into_body(),
+        )
     }
 
     async fn query_context_lineage_subgraph(
@@ -8291,6 +8867,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LineageSubgraph>| r.into_body())
     }
 
     async fn create_execution(
@@ -8314,6 +8891,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.execution), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 
     async fn get_execution(
@@ -8333,6 +8911,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 
     async fn list_executions(
@@ -8359,6 +8938,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExecutionsResponse>| r.into_body())
     }
 
     async fn update_execution(
@@ -8398,6 +8978,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.execution), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 
     async fn delete_execution(
@@ -8418,6 +8999,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_executions(
@@ -8437,7 +9019,10 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_execution_events(
@@ -8457,7 +9042,9 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AddExecutionEventsResponse>| r.into_body(),
+        )
     }
 
     async fn query_execution_inputs_and_outputs(
@@ -8480,6 +9067,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LineageSubgraph>| r.into_body())
     }
 
     async fn create_metadata_schema(
@@ -8503,6 +9091,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, Some(req.metadata_schema), options)
             .await
+            .map(|r: gax::response::Response<crate::model::MetadataSchema>| r.into_body())
     }
 
     async fn get_metadata_schema(
@@ -8522,6 +9111,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MetadataSchema>| r.into_body())
     }
 
     async fn list_metadata_schemas(
@@ -8547,6 +9137,11 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMetadataSchemasResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn query_artifact_lineage_subgraph(
@@ -8571,6 +9166,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LineageSubgraph>| r.into_body())
     }
 
     async fn list_locations(
@@ -8593,6 +9189,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -8612,6 +9209,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -8631,7 +9229,10 @@ impl super::stub::MetadataService for MetadataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -8664,6 +9265,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -8690,6 +9292,11 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -8712,6 +9319,11 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -8731,6 +9343,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -8750,7 +9363,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -8770,7 +9383,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -8800,6 +9413,7 @@ impl super::stub::MetadataService for MetadataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -8856,7 +9470,11 @@ impl super::stub::MigrationService for MigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SearchMigratableResourcesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn batch_migrate_resources(
@@ -8876,7 +9494,10 @@ impl super::stub::MigrationService for MigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -8899,6 +9520,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -8918,6 +9540,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -8937,7 +9560,10 @@ impl super::stub::MigrationService for MigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -8970,6 +9596,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -8996,6 +9623,11 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -9018,6 +9650,11 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -9037,6 +9674,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -9056,7 +9694,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -9076,7 +9714,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -9106,6 +9744,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -9166,6 +9805,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PublisherModel>| r.into_body())
     }
 
     async fn list_locations(
@@ -9188,6 +9828,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -9207,6 +9848,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -9226,7 +9868,10 @@ impl super::stub::ModelGardenService for ModelGardenService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -9259,6 +9904,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -9285,6 +9931,11 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -9307,6 +9958,11 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -9326,6 +9982,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -9345,7 +10002,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -9365,7 +10022,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -9395,6 +10052,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -9437,7 +10095,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_model(
@@ -9457,6 +10118,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn list_models(
@@ -9490,6 +10152,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListModelsResponse>| r.into_body())
     }
 
     async fn list_model_versions(
@@ -9526,6 +10189,9 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListModelVersionsResponse>| r.into_body(),
+            )
     }
 
     async fn list_model_version_checkpoints(
@@ -9550,6 +10216,11 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListModelVersionCheckpointsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_model(
@@ -9585,7 +10256,10 @@ impl super::stub::ModelService for ModelService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn update_explanation_dataset(
@@ -9605,7 +10279,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_model(
@@ -9625,6 +10302,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_model_version(
@@ -9647,6 +10325,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn merge_version_aliases(
@@ -9666,7 +10345,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn export_model(
@@ -9683,7 +10365,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn copy_model(
@@ -9703,7 +10388,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_model_evaluation(
@@ -9723,7 +10411,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ModelEvaluation>| r.into_body())
     }
 
     async fn batch_import_model_evaluation_slices(
@@ -9743,7 +10434,11 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchImportModelEvaluationSlicesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn batch_import_evaluated_annotations(
@@ -9763,7 +10458,11 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchImportEvaluatedAnnotationsResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn get_model_evaluation(
@@ -9783,6 +10482,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ModelEvaluation>| r.into_body())
     }
 
     async fn list_model_evaluations(
@@ -9818,6 +10518,11 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListModelEvaluationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_model_evaluation_slice(
@@ -9837,6 +10542,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ModelEvaluationSlice>| r.into_body())
     }
 
     async fn list_model_evaluation_slices(
@@ -9869,6 +10575,11 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListModelEvaluationSlicesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -9891,6 +10602,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -9910,6 +10622,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -9929,7 +10642,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -9962,6 +10678,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -9988,6 +10705,11 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -10010,6 +10732,11 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -10029,6 +10756,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -10048,7 +10776,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -10068,7 +10796,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -10098,6 +10826,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -10161,6 +10890,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, Some(req.notebook_runtime_template), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_notebook_runtime_template(
@@ -10180,6 +10910,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotebookRuntimeTemplate>| r.into_body())
     }
 
     async fn list_notebook_runtime_templates(
@@ -10216,6 +10947,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNotebookRuntimeTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_notebook_runtime_template(
@@ -10235,6 +10971,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_notebook_runtime_template(
@@ -10273,6 +11010,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, Some(req.notebook_runtime_template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotebookRuntimeTemplate>| r.into_body())
     }
 
     async fn assign_notebook_runtime(
@@ -10292,7 +11030,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_notebook_runtime(
@@ -10312,6 +11053,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotebookRuntime>| r.into_body())
     }
 
     async fn list_notebook_runtimes(
@@ -10348,6 +11090,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNotebookRuntimesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_notebook_runtime(
@@ -10367,6 +11114,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn upgrade_notebook_runtime(
@@ -10383,7 +11131,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_notebook_runtime(
@@ -10400,7 +11151,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_notebook_runtime(
@@ -10417,7 +11171,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_notebook_execution_job(
@@ -10441,6 +11198,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, Some(req.notebook_execution_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_notebook_execution_job(
@@ -10461,6 +11219,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotebookExecutionJob>| r.into_body())
     }
 
     async fn list_notebook_execution_jobs(
@@ -10488,6 +11247,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNotebookExecutionJobsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_notebook_execution_job(
@@ -10507,6 +11271,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -10529,6 +11294,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -10548,6 +11314,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -10567,7 +11334,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -10600,6 +11370,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -10626,6 +11397,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -10648,6 +11424,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -10667,6 +11448,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -10686,7 +11468,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -10706,7 +11488,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -10736,6 +11518,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -10796,6 +11579,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, Some(req.persistent_resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_persistent_resource(
@@ -10815,6 +11599,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PersistentResource>| r.into_body())
     }
 
     async fn list_persistent_resources(
@@ -10839,6 +11624,11 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPersistentResourcesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_persistent_resource(
@@ -10858,6 +11648,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_persistent_resource(
@@ -10896,6 +11687,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, Some(req.persistent_resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reboot_persistent_resource(
@@ -10912,7 +11704,10 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -10935,6 +11730,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -10954,6 +11750,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -10973,7 +11770,10 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -11006,6 +11806,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -11032,6 +11833,11 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -11054,6 +11860,11 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -11073,6 +11884,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -11092,7 +11904,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -11112,7 +11924,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -11142,6 +11954,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -11201,6 +12014,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, Some(req.training_pipeline), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TrainingPipeline>| r.into_body())
     }
 
     async fn get_training_pipeline(
@@ -11220,6 +12034,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TrainingPipeline>| r.into_body())
     }
 
     async fn list_training_pipelines(
@@ -11255,6 +12070,11 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTrainingPipelinesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_training_pipeline(
@@ -11274,6 +12094,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_training_pipeline(
@@ -11293,7 +12114,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_pipeline_job(
@@ -11317,6 +12138,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, Some(req.pipeline_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PipelineJob>| r.into_body())
     }
 
     async fn get_pipeline_job(
@@ -11336,6 +12158,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PipelineJob>| r.into_body())
     }
 
     async fn list_pipeline_jobs(
@@ -11372,6 +12195,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPipelineJobsResponse>| r.into_body())
     }
 
     async fn delete_pipeline_job(
@@ -11391,6 +12215,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_delete_pipeline_jobs(
@@ -11410,7 +12235,10 @@ impl super::stub::PipelineService for PipelineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_pipeline_job(
@@ -11430,7 +12258,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_cancel_pipeline_jobs(
@@ -11450,7 +12278,10 @@ impl super::stub::PipelineService for PipelineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -11473,6 +12304,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -11492,6 +12324,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -11511,7 +12344,10 @@ impl super::stub::PipelineService for PipelineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -11544,6 +12380,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -11570,6 +12407,11 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -11592,6 +12434,11 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -11611,6 +12458,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -11630,7 +12478,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -11650,7 +12498,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -11680,6 +12528,7 @@ impl super::stub::PipelineService for PipelineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -11736,7 +12585,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::PredictResponse>| r.into_body())
     }
 
     async fn raw_predict(
@@ -11756,7 +12608,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<api::model::HttpBody>| r.into_body())
     }
 
     async fn direct_predict(
@@ -11776,7 +12631,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DirectPredictResponse>| r.into_body())
     }
 
     async fn direct_raw_predict(
@@ -11796,7 +12654,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DirectRawPredictResponse>| r.into_body())
     }
 
     async fn explain(
@@ -11816,7 +12677,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ExplainResponse>| r.into_body())
     }
 
     async fn generate_content(
@@ -11836,7 +12700,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::GenerateContentResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -11859,6 +12726,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -11878,6 +12746,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -11897,7 +12766,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -11930,6 +12802,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -11956,6 +12829,11 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -11978,6 +12856,11 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -11997,6 +12880,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -12016,7 +12900,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -12036,7 +12920,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -12066,6 +12950,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -12105,7 +12990,9 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::QueryReasoningEngineResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -12128,6 +13015,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -12147,6 +13035,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -12166,7 +13055,10 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -12199,6 +13091,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -12225,6 +13118,11 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -12247,6 +13145,11 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -12266,6 +13169,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -12285,7 +13189,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -12305,7 +13209,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -12335,6 +13239,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -12380,6 +13285,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, Some(req.reasoning_engine), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_reasoning_engine(
@@ -12399,6 +13305,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReasoningEngine>| r.into_body())
     }
 
     async fn list_reasoning_engines(
@@ -12424,6 +13331,11 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReasoningEnginesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_reasoning_engine(
@@ -12462,6 +13374,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, Some(req.reasoning_engine), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_reasoning_engine(
@@ -12482,6 +13395,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -12504,6 +13418,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -12523,6 +13438,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -12542,7 +13458,10 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -12575,6 +13494,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -12601,6 +13521,11 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -12623,6 +13548,11 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -12642,6 +13572,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -12661,7 +13592,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -12681,7 +13612,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -12711,6 +13642,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -12770,6 +13702,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, Some(req.schedule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Schedule>| r.into_body())
     }
 
     async fn delete_schedule(
@@ -12789,6 +13722,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_schedule(
@@ -12808,6 +13742,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Schedule>| r.into_body())
     }
 
     async fn list_schedules(
@@ -12834,6 +13769,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSchedulesResponse>| r.into_body())
     }
 
     async fn pause_schedule(
@@ -12853,7 +13789,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn resume_schedule(
@@ -12873,7 +13809,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_schedule(
@@ -12912,6 +13848,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, Some(req.schedule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Schedule>| r.into_body())
     }
 
     async fn list_locations(
@@ -12934,6 +13871,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -12953,6 +13891,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -12972,7 +13911,10 @@ impl super::stub::ScheduleService for ScheduleService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -13005,6 +13947,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -13031,6 +13974,11 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -13053,6 +14001,11 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -13072,6 +14025,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -13091,7 +14045,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -13111,7 +14065,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -13141,6 +14095,7 @@ impl super::stub::ScheduleService for ScheduleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -13200,6 +14155,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, Some(req.specialist_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_specialist_pool(
@@ -13219,6 +14175,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SpecialistPool>| r.into_body())
     }
 
     async fn list_specialist_pools(
@@ -13253,6 +14210,11 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSpecialistPoolsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_specialist_pool(
@@ -13273,6 +14235,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_specialist_pool(
@@ -13311,6 +14274,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, Some(req.specialist_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -13333,6 +14297,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -13352,6 +14317,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -13371,7 +14337,10 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -13404,6 +14373,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -13430,6 +14400,11 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -13452,6 +14427,11 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -13471,6 +14451,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -13490,7 +14471,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -13510,7 +14491,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -13540,6 +14521,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -13599,6 +14581,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_tensorboard(
@@ -13618,6 +14601,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Tensorboard>| r.into_body())
     }
 
     async fn update_tensorboard(
@@ -13656,6 +14640,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_tensorboards(
@@ -13692,6 +14677,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTensorboardsResponse>| r.into_body())
     }
 
     async fn delete_tensorboard(
@@ -13711,6 +14697,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn read_tensorboard_usage(
@@ -13733,6 +14720,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ReadTensorboardUsageResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn read_tensorboard_size(
@@ -13755,6 +14747,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ReadTensorboardSizeResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_tensorboard_experiment(
@@ -13778,6 +14775,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard_experiment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardExperiment>| r.into_body())
     }
 
     async fn get_tensorboard_experiment(
@@ -13797,6 +14795,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardExperiment>| r.into_body())
     }
 
     async fn update_tensorboard_experiment(
@@ -13835,6 +14834,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard_experiment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardExperiment>| r.into_body())
     }
 
     async fn list_tensorboard_experiments(
@@ -13871,6 +14871,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTensorboardExperimentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_tensorboard_experiment(
@@ -13890,6 +14895,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_tensorboard_run(
@@ -13910,6 +14916,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard_run), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardRun>| r.into_body())
     }
 
     async fn batch_create_tensorboard_runs(
@@ -13929,7 +14936,11 @@ impl super::stub::TensorboardService for TensorboardService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchCreateTensorboardRunsResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn get_tensorboard_run(
@@ -13949,6 +14960,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardRun>| r.into_body())
     }
 
     async fn update_tensorboard_run(
@@ -13987,6 +14999,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard_run), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardRun>| r.into_body())
     }
 
     async fn list_tensorboard_runs(
@@ -14020,6 +15033,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTensorboardRunsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_tensorboard_run(
@@ -14039,6 +15057,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_tensorboard_time_series(
@@ -14058,7 +15077,11 @@ impl super::stub::TensorboardService for TensorboardService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchCreateTensorboardTimeSeriesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn create_tensorboard_time_series(
@@ -14083,6 +15106,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard_time_series), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardTimeSeries>| r.into_body())
     }
 
     async fn get_tensorboard_time_series(
@@ -14102,6 +15126,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardTimeSeries>| r.into_body())
     }
 
     async fn update_tensorboard_time_series(
@@ -14140,6 +15165,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, Some(req.tensorboard_time_series), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TensorboardTimeSeries>| r.into_body())
     }
 
     async fn list_tensorboard_time_series(
@@ -14176,6 +15202,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTensorboardTimeSeriesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_tensorboard_time_series(
@@ -14195,6 +15226,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_read_tensorboard_time_series_data(
@@ -14221,6 +15253,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::BatchReadTensorboardTimeSeriesDataResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn read_tensorboard_time_series_data(
@@ -14245,6 +15282,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ReadTensorboardTimeSeriesDataResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn write_tensorboard_experiment_data(
@@ -14264,7 +15306,11 @@ impl super::stub::TensorboardService for TensorboardService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::WriteTensorboardExperimentDataResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn write_tensorboard_run_data(
@@ -14284,7 +15330,11 @@ impl super::stub::TensorboardService for TensorboardService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::WriteTensorboardRunDataResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn export_tensorboard_time_series_data(
@@ -14307,7 +15357,11 @@ impl super::stub::TensorboardService for TensorboardService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ExportTensorboardTimeSeriesDataResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_locations(
@@ -14330,6 +15384,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -14349,6 +15404,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -14368,7 +15424,10 @@ impl super::stub::TensorboardService for TensorboardService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -14401,6 +15460,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -14427,6 +15487,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -14449,6 +15514,11 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -14468,6 +15538,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -14487,7 +15558,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -14507,7 +15578,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -14537,6 +15608,7 @@ impl super::stub::TensorboardService for TensorboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -14596,6 +15668,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, Some(req.rag_corpus), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_rag_corpus(
@@ -14624,6 +15697,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, Some(req.rag_corpus), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_rag_corpus(
@@ -14643,6 +15717,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RagCorpus>| r.into_body())
     }
 
     async fn list_rag_corpora(
@@ -14667,6 +15742,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRagCorporaResponse>| r.into_body())
     }
 
     async fn delete_rag_corpus(
@@ -14687,6 +15763,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn upload_rag_file(
@@ -14706,7 +15783,10 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UploadRagFileResponse>| r.into_body())
     }
 
     async fn import_rag_files(
@@ -14726,7 +15806,10 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_rag_file(
@@ -14746,6 +15829,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RagFile>| r.into_body())
     }
 
     async fn list_rag_files(
@@ -14767,6 +15851,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRagFilesResponse>| r.into_body())
     }
 
     async fn delete_rag_file(
@@ -14786,6 +15871,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -14808,6 +15894,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -14827,6 +15914,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -14846,7 +15934,10 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -14879,6 +15970,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -14905,6 +15997,11 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -14927,6 +16024,11 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -14946,6 +16048,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -14965,7 +16068,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -14985,7 +16088,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -15015,6 +16118,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -15071,7 +16175,10 @@ impl super::stub::VertexRagService for VertexRagService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RetrieveContextsResponse>| r.into_body())
     }
 
     async fn augment_prompt(
@@ -15091,7 +16198,10 @@ impl super::stub::VertexRagService for VertexRagService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AugmentPromptResponse>| r.into_body())
     }
 
     async fn corroborate_content(
@@ -15111,7 +16221,9 @@ impl super::stub::VertexRagService for VertexRagService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::CorroborateContentResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -15134,6 +16246,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -15153,6 +16266,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -15172,7 +16286,10 @@ impl super::stub::VertexRagService for VertexRagService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -15205,6 +16322,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -15231,6 +16349,11 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -15253,6 +16376,11 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -15272,6 +16400,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -15291,7 +16420,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -15311,7 +16440,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -15341,6 +16470,7 @@ impl super::stub::VertexRagService for VertexRagService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -15380,7 +16510,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.study), options).await
+        self.inner
+            .execute(builder, Some(req.study), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Study>| r.into_body())
     }
 
     async fn get_study(
@@ -15400,6 +16533,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Study>| r.into_body())
     }
 
     async fn list_studies(
@@ -15421,6 +16555,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListStudiesResponse>| r.into_body())
     }
 
     async fn delete_study(
@@ -15440,7 +16575,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn lookup_study(
@@ -15460,7 +16595,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Study>| r.into_body())
     }
 
     async fn suggest_trials(
@@ -15480,7 +16618,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_trial(
@@ -15497,7 +16638,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.trial), options).await
+        self.inner
+            .execute(builder, Some(req.trial), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Trial>| r.into_body())
     }
 
     async fn get_trial(
@@ -15517,6 +16661,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Trial>| r.into_body())
     }
 
     async fn list_trials(
@@ -15538,6 +16683,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTrialsResponse>| r.into_body())
     }
 
     async fn add_trial_measurement(
@@ -15557,7 +16703,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Trial>| r.into_body())
     }
 
     async fn complete_trial(
@@ -15574,7 +16723,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Trial>| r.into_body())
     }
 
     async fn delete_trial(
@@ -15594,7 +16746,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn check_trial_early_stopping_state(
@@ -15614,7 +16766,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_trial(
@@ -15631,7 +16786,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Trial>| r.into_body())
     }
 
     async fn list_optimal_trials(
@@ -15651,7 +16809,9 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ListOptimalTrialsResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -15674,6 +16834,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -15693,6 +16854,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -15712,7 +16874,10 @@ impl super::stub::VizierService for VizierService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -15745,6 +16910,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -15771,6 +16937,11 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -15793,6 +16964,11 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -15812,6 +16988,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -15831,7 +17008,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -15851,7 +17028,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -15881,6 +17058,7 @@ impl super::stub::VizierService for VizierService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/alloydb/v1/src/transport.rs
+++ b/src/generated/cloud/alloydb/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn get_cluster(
@@ -81,6 +82,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn create_cluster(
@@ -106,6 +108,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_cluster(
@@ -147,6 +150,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -170,6 +174,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn promote_cluster(
@@ -186,7 +191,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn switchover_cluster(
@@ -206,7 +214,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_cluster(
@@ -226,7 +237,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_secondary_cluster(
@@ -252,6 +266,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_instances(
@@ -278,6 +293,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -298,6 +314,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -323,6 +340,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_secondary_instance(
@@ -348,6 +366,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_instances(
@@ -371,6 +390,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.requests), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -412,6 +432,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -434,6 +455,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn failover_instance(
@@ -450,7 +472,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn inject_fault(
@@ -470,7 +495,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restart_instance(
@@ -487,7 +515,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn execute_sql(
@@ -507,7 +538,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ExecuteSqlResponse>| r.into_body())
     }
 
     async fn list_backups(
@@ -531,6 +565,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn get_backup(
@@ -550,6 +585,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn create_backup(
@@ -569,7 +605,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         let builder = builder.query(&[("backupId", &req.backup_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_backup(
@@ -608,7 +647,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
         let builder = builder.query(&[("allowMissing", &req.allow_missing)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup(
@@ -631,6 +673,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_supported_database_flags(
@@ -655,6 +698,11 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSupportedDatabaseFlagsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn generate_client_certificate(
@@ -674,7 +722,11 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateClientCertificateResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn get_connection_info(
@@ -698,6 +750,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConnectionInfo>| r.into_body())
     }
 
     async fn list_users(
@@ -721,6 +774,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListUsersResponse>| r.into_body())
     }
 
     async fn get_user(
@@ -740,6 +794,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::User>| r.into_body())
     }
 
     async fn create_user(
@@ -759,7 +814,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         let builder = builder.query(&[("userId", &req.user_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.user), options).await
+        self.inner
+            .execute(builder, Some(req.user), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::User>| r.into_body())
     }
 
     async fn update_user(
@@ -798,7 +856,10 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
         let builder = builder.query(&[("allowMissing", &req.allow_missing)]);
-        self.inner.execute(builder, Some(req.user), options).await
+        self.inner
+            .execute(builder, Some(req.user), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::User>| r.into_body())
     }
 
     async fn delete_user(
@@ -820,7 +881,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_databases(
@@ -846,6 +907,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDatabasesResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -868,6 +930,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -887,6 +950,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -909,6 +973,11 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -928,6 +997,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -947,7 +1017,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -967,7 +1037,7 @@ impl super::stub::AlloyDBAdmin for AlloyDBAdmin {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/apigateway/v1/src/transport.rs
+++ b/src/generated/cloud/apigateway/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGatewaysResponse>| r.into_body())
     }
 
     async fn get_gateway(
@@ -80,6 +81,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Gateway>| r.into_body())
     }
 
     async fn create_gateway(
@@ -103,6 +105,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, Some(req.gateway), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_gateway(
@@ -141,6 +144,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, Some(req.gateway), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_gateway(
@@ -160,6 +164,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_apis(
@@ -183,6 +188,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListApisResponse>| r.into_body())
     }
 
     async fn get_api(
@@ -202,6 +208,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Api>| r.into_body())
     }
 
     async fn create_api(
@@ -219,7 +226,10 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("apiId", &req.api_id)]);
-        self.inner.execute(builder, Some(req.api), options).await
+        self.inner
+            .execute(builder, Some(req.api), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_api(
@@ -255,7 +265,10 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.api), options).await
+        self.inner
+            .execute(builder, Some(req.api), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_api(
@@ -275,6 +288,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_api_configs(
@@ -298,6 +312,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListApiConfigsResponse>| r.into_body())
     }
 
     async fn get_api_config(
@@ -318,6 +333,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ApiConfig>| r.into_body())
     }
 
     async fn create_api_config(
@@ -338,6 +354,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, Some(req.api_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_api_config(
@@ -376,6 +393,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, Some(req.api_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_api_config(
@@ -395,6 +413,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -417,6 +436,11 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -436,6 +460,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -455,7 +480,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -475,7 +500,7 @@ impl super::stub::ApiGatewayService for ApiGatewayService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/apigeeconnect/v1/src/transport.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/transport.rs
@@ -62,5 +62,6 @@ impl super::stub::ConnectionService for ConnectionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectionsResponse>| r.into_body())
     }
 }

--- a/src/generated/cloud/apihub/v1/src/transport.rs
+++ b/src/generated/cloud/apihub/v1/src/transport.rs
@@ -55,7 +55,10 @@ impl super::stub::ApiHub for ApiHub {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("apiId", &req.api_id)]);
-        self.inner.execute(builder, Some(req.api), options).await
+        self.inner
+            .execute(builder, Some(req.api), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Api>| r.into_body())
     }
 
     async fn get_api(
@@ -75,6 +78,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Api>| r.into_body())
     }
 
     async fn list_apis(
@@ -97,6 +101,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListApisResponse>| r.into_body())
     }
 
     async fn update_api(
@@ -132,7 +137,10 @@ impl super::stub::ApiHub for ApiHub {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.api), options).await
+        self.inner
+            .execute(builder, Some(req.api), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Api>| r.into_body())
     }
 
     async fn delete_api(
@@ -153,7 +161,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_version(
@@ -177,6 +185,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn get_version(
@@ -196,6 +205,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn list_versions(
@@ -218,6 +228,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVersionsResponse>| r.into_body())
     }
 
     async fn update_version(
@@ -256,6 +267,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn delete_version(
@@ -276,7 +288,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_spec(
@@ -294,7 +306,10 @@ impl super::stub::ApiHub for ApiHub {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("specId", &req.spec_id)]);
-        self.inner.execute(builder, Some(req.spec), options).await
+        self.inner
+            .execute(builder, Some(req.spec), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Spec>| r.into_body())
     }
 
     async fn get_spec(
@@ -314,6 +329,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Spec>| r.into_body())
     }
 
     async fn get_spec_contents(
@@ -333,6 +349,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SpecContents>| r.into_body())
     }
 
     async fn list_specs(
@@ -355,6 +372,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSpecsResponse>| r.into_body())
     }
 
     async fn update_spec(
@@ -390,7 +408,10 @@ impl super::stub::ApiHub for ApiHub {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.spec), options).await
+        self.inner
+            .execute(builder, Some(req.spec), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Spec>| r.into_body())
     }
 
     async fn delete_spec(
@@ -410,7 +431,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_api_operation(
@@ -430,6 +451,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ApiOperation>| r.into_body())
     }
 
     async fn list_api_operations(
@@ -455,6 +477,9 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListApiOperationsResponse>| r.into_body(),
+            )
     }
 
     async fn get_definition(
@@ -474,6 +499,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Definition>| r.into_body())
     }
 
     async fn create_deployment(
@@ -497,6 +523,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn get_deployment(
@@ -516,6 +543,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn list_deployments(
@@ -541,6 +569,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDeploymentsResponse>| r.into_body())
     }
 
     async fn update_deployment(
@@ -579,6 +608,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn delete_deployment(
@@ -598,7 +628,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_attribute(
@@ -622,6 +652,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.attribute), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attribute>| r.into_body())
     }
 
     async fn get_attribute(
@@ -641,6 +672,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attribute>| r.into_body())
     }
 
     async fn update_attribute(
@@ -679,6 +711,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.attribute), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attribute>| r.into_body())
     }
 
     async fn delete_attribute(
@@ -698,7 +731,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_attributes(
@@ -724,6 +757,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAttributesResponse>| r.into_body())
     }
 
     async fn search_resources(
@@ -743,7 +777,10 @@ impl super::stub::ApiHub for ApiHub {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchResourcesResponse>| r.into_body())
     }
 
     async fn create_external_api(
@@ -767,6 +804,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.external_api), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalApi>| r.into_body())
     }
 
     async fn get_external_api(
@@ -786,6 +824,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalApi>| r.into_body())
     }
 
     async fn update_external_api(
@@ -824,6 +863,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req.external_api), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalApi>| r.into_body())
     }
 
     async fn delete_external_api(
@@ -843,7 +883,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_external_apis(
@@ -868,6 +908,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExternalApisResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -890,6 +931,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -909,6 +951,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -931,6 +974,11 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -950,6 +998,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -969,7 +1018,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -989,7 +1038,7 @@ impl super::stub::ApiHub for ApiHub {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1036,6 +1085,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, Some(req.dependency), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dependency>| r.into_body())
     }
 
     async fn get_dependency(
@@ -1055,6 +1105,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dependency>| r.into_body())
     }
 
     async fn update_dependency(
@@ -1093,6 +1144,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, Some(req.dependency), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dependency>| r.into_body())
     }
 
     async fn delete_dependency(
@@ -1112,7 +1164,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_dependencies(
@@ -1138,6 +1190,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDependenciesResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -1160,6 +1213,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1179,6 +1233,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1201,6 +1256,11 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1220,6 +1280,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1239,7 +1300,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1259,7 +1320,7 @@ impl super::stub::ApiHubDependencies for ApiHubDependencies {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1309,6 +1370,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, Some(req.host_project_registration), options)
             .await
+            .map(|r: gax::response::Response<crate::model::HostProjectRegistration>| r.into_body())
     }
 
     async fn get_host_project_registration(
@@ -1328,6 +1390,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::HostProjectRegistration>| r.into_body())
     }
 
     async fn list_host_project_registrations(
@@ -1354,6 +1417,11 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListHostProjectRegistrationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -1376,6 +1444,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1395,6 +1464,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1417,6 +1487,11 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1436,6 +1511,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1455,7 +1531,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1475,7 +1551,7 @@ impl super::stub::HostProjectRegistrationService for HostProjectRegistrationServ
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1518,6 +1594,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::StyleGuide>| r.into_body())
     }
 
     async fn update_style_guide(
@@ -1556,6 +1633,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, Some(req.style_guide), options)
             .await
+            .map(|r: gax::response::Response<crate::model::StyleGuide>| r.into_body())
     }
 
     async fn get_style_guide_contents(
@@ -1575,6 +1653,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::StyleGuideContents>| r.into_body())
     }
 
     async fn lint_spec(
@@ -1594,7 +1673,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -1617,6 +1696,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1636,6 +1716,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1658,6 +1739,11 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1677,6 +1763,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1696,7 +1783,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1716,7 +1803,7 @@ impl super::stub::LintingService for LintingService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1759,6 +1846,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Plugin>| r.into_body())
     }
 
     async fn enable_plugin(
@@ -1775,7 +1863,10 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Plugin>| r.into_body())
     }
 
     async fn disable_plugin(
@@ -1792,7 +1883,10 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Plugin>| r.into_body())
     }
 
     async fn list_locations(
@@ -1815,6 +1909,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1834,6 +1929,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1856,6 +1952,11 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1875,6 +1976,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1894,7 +1996,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1914,7 +2016,7 @@ impl super::stub::ApiHubPlugin for ApiHubPlugin {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1961,6 +2063,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, Some(req.api_hub_instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_api_hub_instance(
@@ -1980,6 +2083,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ApiHubInstance>| r.into_body())
     }
 
     async fn lookup_api_hub_instance(
@@ -2002,6 +2106,11 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::LookupApiHubInstanceResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -2024,6 +2133,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2043,6 +2153,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2065,6 +2176,11 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2084,6 +2200,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2103,7 +2220,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -2123,7 +2240,7 @@ impl super::stub::Provisioning for Provisioning {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2187,6 +2304,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, Some(req.runtime_project_attachment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::RuntimeProjectAttachment>| r.into_body())
     }
 
     async fn get_runtime_project_attachment(
@@ -2206,6 +2324,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RuntimeProjectAttachment>| r.into_body())
     }
 
     async fn list_runtime_project_attachments(
@@ -2232,6 +2351,11 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListRuntimeProjectAttachmentsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn delete_runtime_project_attachment(
@@ -2251,7 +2375,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn lookup_runtime_project_attachment(
@@ -2274,6 +2398,11 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::LookupRuntimeProjectAttachmentResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn list_locations(
@@ -2296,6 +2425,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2315,6 +2445,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2337,6 +2468,11 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2356,6 +2492,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2375,7 +2512,7 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -2395,6 +2532,6 @@ impl super::stub::RuntimeProjectAttachmentService for RuntimeProjectAttachmentSe
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/apphub/v1/src/transport.rs
+++ b/src/generated/cloud/apphub/v1/src/transport.rs
@@ -60,6 +60,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::LookupServiceProjectAttachmentResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn list_service_project_attachments(
@@ -86,6 +91,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListServiceProjectAttachmentsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn create_service_project_attachment(
@@ -113,6 +123,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.service_project_attachment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_service_project_attachment(
@@ -132,6 +143,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceProjectAttachment>| r.into_body())
     }
 
     async fn delete_service_project_attachment(
@@ -152,6 +164,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn detach_service_project_attachment(
@@ -171,7 +184,11 @@ impl super::stub::AppHub for AppHub {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::DetachServiceProjectAttachmentResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_discovered_services(
@@ -198,6 +215,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDiscoveredServicesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_discovered_service(
@@ -217,6 +239,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DiscoveredService>| r.into_body())
     }
 
     async fn lookup_discovered_service(
@@ -240,6 +263,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::LookupDiscoveredServiceResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_services(
@@ -263,6 +291,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn create_service(
@@ -287,6 +316,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_service(
@@ -306,6 +336,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn update_service(
@@ -345,6 +376,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service(
@@ -365,6 +397,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_discovered_workloads(
@@ -391,6 +424,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDiscoveredWorkloadsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_discovered_workload(
@@ -410,6 +448,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DiscoveredWorkload>| r.into_body())
     }
 
     async fn lookup_discovered_workload(
@@ -433,6 +472,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::LookupDiscoveredWorkloadResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_workloads(
@@ -459,6 +503,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkloadsResponse>| r.into_body())
     }
 
     async fn create_workload(
@@ -483,6 +528,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.workload), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_workload(
@@ -502,6 +548,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Workload>| r.into_body())
     }
 
     async fn update_workload(
@@ -541,6 +588,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.workload), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_workload(
@@ -561,6 +609,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_applications(
@@ -587,6 +636,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListApplicationsResponse>| r.into_body())
     }
 
     async fn create_application(
@@ -611,6 +661,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.application), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_application(
@@ -630,6 +681,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Application>| r.into_body())
     }
 
     async fn update_application(
@@ -669,6 +721,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req.application), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_application(
@@ -689,6 +742,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -711,6 +765,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -730,6 +785,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -749,7 +805,10 @@ impl super::stub::AppHub for AppHub {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -782,6 +841,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -801,7 +861,9 @@ impl super::stub::AppHub for AppHub {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -824,6 +886,11 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -843,6 +910,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -862,7 +930,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -882,7 +950,7 @@ impl super::stub::AppHub for AppHub {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/asset/v1/src/transport.rs
+++ b/src/generated/cloud/asset/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::AssetService for AssetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_assets(
@@ -97,6 +100,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAssetsResponse>| r.into_body())
     }
 
     async fn batch_get_assets_history(
@@ -137,6 +141,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::BatchGetAssetsHistoryResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_feed(
@@ -153,7 +162,10 @@ impl super::stub::AssetService for AssetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Feed>| r.into_body())
     }
 
     async fn get_feed(
@@ -173,6 +185,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Feed>| r.into_body())
     }
 
     async fn list_feeds(
@@ -192,6 +205,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFeedsResponse>| r.into_body())
     }
 
     async fn update_feed(
@@ -217,7 +231,10 @@ impl super::stub::AssetService for AssetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Feed>| r.into_body())
     }
 
     async fn delete_feed(
@@ -237,7 +254,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn search_all_resources(
@@ -278,6 +295,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchAllResourcesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_all_iam_policies(
@@ -308,6 +330,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchAllIamPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn analyze_iam_policy(
@@ -357,6 +384,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnalyzeIamPolicyResponse>| r.into_body())
     }
 
     async fn analyze_iam_policy_longrunning(
@@ -382,7 +410,10 @@ impl super::stub::AssetService for AssetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn analyze_move(
@@ -407,6 +438,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnalyzeMoveResponse>| r.into_body())
     }
 
     async fn query_assets(
@@ -426,7 +458,10 @@ impl super::stub::AssetService for AssetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::QueryAssetsResponse>| r.into_body())
     }
 
     async fn create_saved_query(
@@ -450,6 +485,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, Some(req.saved_query), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SavedQuery>| r.into_body())
     }
 
     async fn get_saved_query(
@@ -469,6 +505,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SavedQuery>| r.into_body())
     }
 
     async fn list_saved_queries(
@@ -494,6 +531,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSavedQueriesResponse>| r.into_body())
     }
 
     async fn update_saved_query(
@@ -532,6 +570,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, Some(req.saved_query), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SavedQuery>| r.into_body())
     }
 
     async fn delete_saved_query(
@@ -551,7 +590,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_get_effective_iam_policies(
@@ -578,6 +617,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::BatchGetEffectiveIamPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn analyze_org_policies(
@@ -607,6 +651,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::AnalyzeOrgPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn analyze_org_policy_governed_containers(
@@ -636,6 +685,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::AnalyzeOrgPolicyGovernedContainersResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn analyze_org_policy_governed_assets(
@@ -665,6 +719,11 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::AnalyzeOrgPolicyGovernedAssetsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_operation(
@@ -684,6 +743,7 @@ impl super::stub::AssetService for AssetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/assuredworkloads/v1/src/transport.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, Some(req.workload), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_workload(
@@ -99,6 +100,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, Some(req.workload), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Workload>| r.into_body())
     }
 
     async fn restrict_allowed_resources(
@@ -118,7 +120,11 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::RestrictAllowedResourcesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn delete_workload(
@@ -139,7 +145,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_workload(
@@ -159,6 +165,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Workload>| r.into_body())
     }
 
     async fn list_workloads(
@@ -184,6 +191,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkloadsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -206,6 +214,11 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -225,6 +238,7 @@ impl super::stub::AssuredWorkloadsService for AssuredWorkloadsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/backupdr/v1/src/transport.rs
+++ b/src/generated/cloud/backupdr/v1/src/transport.rs
@@ -70,6 +70,11 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListManagementServersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_management_server(
@@ -89,6 +94,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ManagementServer>| r.into_body())
     }
 
     async fn create_management_server(
@@ -113,6 +119,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req.management_server), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_management_server(
@@ -133,6 +140,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup_vault(
@@ -158,6 +166,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req.backup_vault), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backup_vaults(
@@ -185,6 +194,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupVaultsResponse>| r.into_body())
     }
 
     async fn fetch_usable_backup_vaults(
@@ -211,6 +221,11 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchUsableBackupVaultsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_backup_vault(
@@ -231,6 +246,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupVault>| r.into_body())
     }
 
     async fn update_backup_vault(
@@ -272,6 +288,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req.backup_vault), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup_vault(
@@ -300,6 +317,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_data_sources(
@@ -326,6 +344,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDataSourcesResponse>| r.into_body())
     }
 
     async fn get_data_source(
@@ -345,6 +364,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataSource>| r.into_body())
     }
 
     async fn update_data_source(
@@ -385,6 +405,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req.data_source), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backups(
@@ -409,6 +430,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn get_backup(
@@ -429,6 +451,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn update_backup(
@@ -465,7 +488,10 @@ impl super::stub::BackupDR for BackupDR {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup(
@@ -486,6 +512,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_backup(
@@ -502,7 +529,10 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup_plan(
@@ -527,6 +557,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req.backup_plan), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup_plan(
@@ -546,6 +577,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupPlan>| r.into_body())
     }
 
     async fn list_backup_plans(
@@ -572,6 +604,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupPlansResponse>| r.into_body())
     }
 
     async fn delete_backup_plan(
@@ -592,6 +625,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup_plan_association(
@@ -617,6 +651,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req.backup_plan_association), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup_plan_association(
@@ -636,6 +671,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupPlanAssociation>| r.into_body())
     }
 
     async fn list_backup_plan_associations(
@@ -661,6 +697,11 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBackupPlanAssociationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_backup_plan_association(
@@ -681,6 +722,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn trigger_backup(
@@ -700,7 +742,10 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn initialize_service(
@@ -720,7 +765,10 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -743,6 +791,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -762,6 +811,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -781,7 +831,10 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -814,6 +867,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -833,7 +887,9 @@ impl super::stub::BackupDR for BackupDR {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -856,6 +912,11 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -875,6 +936,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -894,7 +956,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -914,7 +976,7 @@ impl super::stub::BackupDR for BackupDR {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/baremetalsolution/v2/src/transport.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/transport.rs
@@ -63,6 +63,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -82,6 +83,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn update_instance(
@@ -120,6 +122,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rename_instance(
@@ -136,7 +139,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn reset_instance(
@@ -153,7 +159,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_instance(
@@ -170,7 +179,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_instance(
@@ -187,7 +199,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn enable_interactive_serial_console(
@@ -207,7 +222,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn disable_interactive_serial_console(
@@ -227,7 +245,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn detach_lun(
@@ -247,7 +268,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_ssh_keys(
@@ -269,6 +293,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSSHKeysResponse>| r.into_body())
     }
 
     async fn create_ssh_key(
@@ -289,6 +314,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.ssh_key), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SSHKey>| r.into_body())
     }
 
     async fn delete_ssh_key(
@@ -308,7 +334,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_volumes(
@@ -331,6 +357,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVolumesResponse>| r.into_body())
     }
 
     async fn get_volume(
@@ -350,6 +377,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Volume>| r.into_body())
     }
 
     async fn update_volume(
@@ -385,7 +413,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.volume), options).await
+        self.inner
+            .execute(builder, Some(req.volume), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rename_volume(
@@ -402,7 +433,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Volume>| r.into_body())
     }
 
     async fn evict_volume(
@@ -419,7 +453,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resize_volume(
@@ -436,7 +473,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_networks(
@@ -459,6 +499,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNetworksResponse>| r.into_body())
     }
 
     async fn list_network_usage(
@@ -481,6 +522,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNetworkUsageResponse>| r.into_body())
     }
 
     async fn get_network(
@@ -500,6 +542,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Network>| r.into_body())
     }
 
     async fn update_network(
@@ -538,6 +581,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.network), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_volume_snapshot(
@@ -560,6 +604,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.volume_snapshot), options)
             .await
+            .map(|r: gax::response::Response<crate::model::VolumeSnapshot>| r.into_body())
     }
 
     async fn restore_volume_snapshot(
@@ -579,7 +624,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_volume_snapshot(
@@ -599,7 +647,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_volume_snapshot(
@@ -619,6 +667,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VolumeSnapshot>| r.into_body())
     }
 
     async fn list_volume_snapshots(
@@ -643,6 +692,11 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVolumeSnapshotsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_lun(
@@ -662,6 +716,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Lun>| r.into_body())
     }
 
     async fn list_luns(
@@ -683,6 +738,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLunsResponse>| r.into_body())
     }
 
     async fn evict_lun(
@@ -699,7 +755,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_nfs_share(
@@ -719,6 +778,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NfsShare>| r.into_body())
     }
 
     async fn list_nfs_shares(
@@ -744,6 +804,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNfsSharesResponse>| r.into_body())
     }
 
     async fn update_nfs_share(
@@ -782,6 +843,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.nfs_share), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_nfs_share(
@@ -804,6 +866,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.nfs_share), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rename_nfs_share(
@@ -820,7 +883,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::NfsShare>| r.into_body())
     }
 
     async fn delete_nfs_share(
@@ -840,6 +906,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_provisioning_quotas(
@@ -864,6 +931,11 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListProvisioningQuotasResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn submit_provisioning_config(
@@ -883,7 +955,11 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SubmitProvisioningConfigResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn get_provisioning_config(
@@ -903,6 +979,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProvisioningConfig>| r.into_body())
     }
 
     async fn create_provisioning_config(
@@ -926,6 +1003,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.provisioning_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProvisioningConfig>| r.into_body())
     }
 
     async fn update_provisioning_config(
@@ -965,6 +1043,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, Some(req.provisioning_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProvisioningConfig>| r.into_body())
     }
 
     async fn rename_network(
@@ -981,7 +1060,10 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Network>| r.into_body())
     }
 
     async fn list_os_images(
@@ -1003,6 +1085,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListOSImagesResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -1025,6 +1108,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1044,6 +1128,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn get_operation(
@@ -1063,6 +1148,7 @@ impl super::stub::BareMetalSolution for BareMetalSolution {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAppConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_app_connection(
@@ -83,6 +88,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AppConnection>| r.into_body())
     }
 
     async fn create_app_connection(
@@ -108,6 +114,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, Some(req.app_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_app_connection(
@@ -149,6 +156,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, Some(req.app_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_app_connection(
@@ -170,6 +178,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resolve_app_connections(
@@ -195,6 +204,11 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ResolveAppConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -217,6 +231,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -236,6 +251,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -255,7 +271,10 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -288,6 +307,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -307,7 +327,9 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -330,6 +352,11 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -349,6 +376,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -368,7 +396,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -388,7 +416,7 @@ impl super::stub::AppConnectionsService for AppConnectionsService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/transport.rs
@@ -64,6 +64,9 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAppConnectorsResponse>| r.into_body(),
+            )
     }
 
     async fn get_app_connector(
@@ -83,6 +86,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AppConnector>| r.into_body())
     }
 
     async fn create_app_connector(
@@ -108,6 +112,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, Some(req.app_connector), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_app_connector(
@@ -148,6 +153,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, Some(req.app_connector), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_app_connector(
@@ -169,6 +175,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn report_status(
@@ -188,7 +195,10 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -211,6 +221,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -230,6 +241,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -249,7 +261,10 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -282,6 +297,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -301,7 +317,9 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -324,6 +342,11 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -343,6 +366,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -362,7 +386,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -382,7 +406,7 @@ impl super::stub::AppConnectorsService for AppConnectorsService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAppGatewaysResponse>| r.into_body())
     }
 
     async fn get_app_gateway(
@@ -83,6 +84,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AppGateway>| r.into_body())
     }
 
     async fn create_app_gateway(
@@ -108,6 +110,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, Some(req.app_gateway), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_app_gateway(
@@ -129,6 +132,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -151,6 +155,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -170,6 +175,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -189,7 +195,10 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -222,6 +231,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -241,7 +251,9 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -264,6 +276,11 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -283,6 +300,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -302,7 +320,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -322,7 +340,7 @@ impl super::stub::AppGatewaysService for AppGatewaysService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListClientConnectorServicesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_client_connector_service(
@@ -83,6 +88,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ClientConnectorService>| r.into_body())
     }
 
     async fn create_client_connector_service(
@@ -109,6 +115,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, Some(req.client_connector_service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_client_connector_service(
@@ -150,6 +157,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, Some(req.client_connector_service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_client_connector_service(
@@ -171,6 +179,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -193,6 +202,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -212,6 +222,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -231,7 +242,10 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -264,6 +278,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -283,7 +298,9 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -306,6 +323,11 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -325,6 +347,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -344,7 +367,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -364,7 +387,7 @@ impl super::stub::ClientConnectorServicesService for ClientConnectorServicesServ
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListClientGatewaysResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_client_gateway(
@@ -83,6 +88,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ClientGateway>| r.into_body())
     }
 
     async fn create_client_gateway(
@@ -108,6 +114,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, Some(req.client_gateway), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_client_gateway(
@@ -129,6 +136,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -151,6 +159,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -170,6 +179,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -189,7 +199,10 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -222,6 +235,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -241,7 +255,9 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -264,6 +280,11 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -283,6 +304,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -302,7 +324,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -322,7 +344,7 @@ impl super::stub::ClientGatewaysService for ClientGatewaysService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/transport.rs
@@ -62,6 +62,9 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDataExchangesResponse>| r.into_body(),
+            )
     }
 
     async fn list_org_data_exchanges(
@@ -86,6 +89,11 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListOrgDataExchangesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_data_exchange(
@@ -105,6 +113,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataExchange>| r.into_body())
     }
 
     async fn create_data_exchange(
@@ -128,6 +137,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, Some(req.data_exchange), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataExchange>| r.into_body())
     }
 
     async fn update_data_exchange(
@@ -166,6 +176,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, Some(req.data_exchange), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataExchange>| r.into_body())
     }
 
     async fn delete_data_exchange(
@@ -185,7 +196,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_listings(
@@ -207,6 +218,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListListingsResponse>| r.into_body())
     }
 
     async fn get_listing(
@@ -226,6 +238,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Listing>| r.into_body())
     }
 
     async fn create_listing(
@@ -249,6 +262,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, Some(req.listing), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Listing>| r.into_body())
     }
 
     async fn update_listing(
@@ -287,6 +301,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, Some(req.listing), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Listing>| r.into_body())
     }
 
     async fn delete_listing(
@@ -306,7 +321,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn subscribe_listing(
@@ -323,7 +338,10 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SubscribeListingResponse>| r.into_body())
     }
 
     async fn subscribe_data_exchange(
@@ -340,7 +358,10 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn refresh_subscription(
@@ -357,7 +378,10 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_subscription(
@@ -377,6 +401,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Subscription>| r.into_body())
     }
 
     async fn list_subscriptions(
@@ -402,6 +427,9 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSubscriptionsResponse>| r.into_body(),
+            )
     }
 
     async fn list_shared_resource_subscriptions(
@@ -430,6 +458,11 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListSharedResourceSubscriptionsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn revoke_subscription(
@@ -446,7 +479,9 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::RevokeSubscriptionResponse>| r.into_body(),
+        )
     }
 
     async fn delete_subscription(
@@ -466,6 +501,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -485,7 +521,10 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -505,7 +544,10 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -525,7 +567,9 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -545,6 +589,7 @@ impl super::stub::AnalyticsHubService for AnalyticsHubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/bigquery/connection/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::ConnectionService for ConnectionService {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn get_connection(
@@ -80,6 +81,7 @@ impl super::stub::ConnectionService for ConnectionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn list_connections(
@@ -104,6 +106,7 @@ impl super::stub::ConnectionService for ConnectionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectionsResponse>| r.into_body())
     }
 
     async fn update_connection(
@@ -133,6 +136,7 @@ impl super::stub::ConnectionService for ConnectionService {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn delete_connection(
@@ -152,7 +156,7 @@ impl super::stub::ConnectionService for ConnectionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_iam_policy(
@@ -172,7 +176,10 @@ impl super::stub::ConnectionService for ConnectionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -192,7 +199,10 @@ impl super::stub::ConnectionService for ConnectionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -212,6 +222,8 @@ impl super::stub::ConnectionService for ConnectionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         self.inner
             .execute(builder, Some(req.data_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataPolicy>| r.into_body())
     }
 
     async fn update_data_policy(
@@ -98,6 +99,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         self.inner
             .execute(builder, Some(req.data_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataPolicy>| r.into_body())
     }
 
     async fn rename_data_policy(
@@ -114,7 +116,10 @@ impl super::stub::DataPolicyService for DataPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DataPolicy>| r.into_body())
     }
 
     async fn delete_data_policy(
@@ -134,7 +139,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_data_policy(
@@ -154,6 +159,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataPolicy>| r.into_body())
     }
 
     async fn list_data_policies(
@@ -179,6 +185,7 @@ impl super::stub::DataPolicyService for DataPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDataPoliciesResponse>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -198,7 +205,10 @@ impl super::stub::DataPolicyService for DataPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -218,7 +228,10 @@ impl super::stub::DataPolicyService for DataPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -238,6 +251,8 @@ impl super::stub::DataPolicyService for DataPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataSource>| r.into_body())
     }
 
     async fn list_data_sources(
@@ -81,6 +82,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDataSourcesResponse>| r.into_body())
     }
 
     async fn create_transfer_config(
@@ -106,6 +108,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, Some(req.transfer_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransferConfig>| r.into_body())
     }
 
     async fn update_transfer_config(
@@ -147,6 +150,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, Some(req.transfer_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransferConfig>| r.into_body())
     }
 
     async fn delete_transfer_config(
@@ -166,7 +170,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_transfer_config(
@@ -186,6 +190,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransferConfig>| r.into_body())
     }
 
     async fn list_transfer_configs(
@@ -214,6 +219,11 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTransferConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn schedule_transfer_runs(
@@ -233,7 +243,9 @@ impl super::stub::DataTransferService for DataTransferService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ScheduleTransferRunsResponse>| r.into_body(),
+        )
     }
 
     async fn start_manual_transfer_runs(
@@ -253,7 +265,11 @@ impl super::stub::DataTransferService for DataTransferService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::StartManualTransferRunsResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn get_transfer_run(
@@ -273,6 +289,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransferRun>| r.into_body())
     }
 
     async fn delete_transfer_run(
@@ -292,7 +309,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_transfer_runs(
@@ -318,6 +335,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTransferRunsResponse>| r.into_body())
     }
 
     async fn list_transfer_logs(
@@ -345,6 +363,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTransferLogsResponse>| r.into_body())
     }
 
     async fn check_valid_creds(
@@ -364,7 +383,10 @@ impl super::stub::DataTransferService for DataTransferService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CheckValidCredsResponse>| r.into_body())
     }
 
     async fn enroll_data_sources(
@@ -387,7 +409,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn unenroll_data_sources(
@@ -410,7 +432,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -433,6 +455,7 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -452,5 +475,6 @@ impl super::stub::DataTransferService for DataTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/bigquery/migration/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, Some(req.migration_workflow), options)
             .await
+            .map(|r: gax::response::Response<crate::model::MigrationWorkflow>| r.into_body())
     }
 
     async fn get_migration_workflow(
@@ -89,6 +90,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MigrationWorkflow>| r.into_body())
     }
 
     async fn list_migration_workflows(
@@ -123,6 +125,11 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMigrationWorkflowsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_migration_workflow(
@@ -142,7 +149,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn start_migration_workflow(
@@ -162,7 +169,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_migration_subtask(
@@ -192,6 +199,7 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MigrationSubtask>| r.into_body())
     }
 
     async fn list_migration_subtasks(
@@ -224,5 +232,10 @@ impl super::stub::MigrationService for MigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMigrationSubtasksResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.reservation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Reservation>| r.into_body())
     }
 
     async fn list_reservations(
@@ -85,6 +86,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListReservationsResponse>| r.into_body())
     }
 
     async fn get_reservation(
@@ -104,6 +106,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Reservation>| r.into_body())
     }
 
     async fn delete_reservation(
@@ -123,7 +126,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_reservation(
@@ -162,6 +165,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.reservation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Reservation>| r.into_body())
     }
 
     async fn failover_reservation(
@@ -181,7 +185,10 @@ impl super::stub::ReservationService for ReservationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Reservation>| r.into_body())
     }
 
     async fn create_capacity_commitment(
@@ -209,6 +216,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.capacity_commitment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CapacityCommitment>| r.into_body())
     }
 
     async fn list_capacity_commitments(
@@ -233,6 +241,11 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCapacityCommitmentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_capacity_commitment(
@@ -252,6 +265,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CapacityCommitment>| r.into_body())
     }
 
     async fn delete_capacity_commitment(
@@ -272,7 +286,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_capacity_commitment(
@@ -311,6 +325,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.capacity_commitment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CapacityCommitment>| r.into_body())
     }
 
     async fn split_capacity_commitment(
@@ -327,7 +342,11 @@ impl super::stub::ReservationService for ReservationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SplitCapacityCommitmentResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn merge_capacity_commitments(
@@ -347,7 +366,10 @@ impl super::stub::ReservationService for ReservationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CapacityCommitment>| r.into_body())
     }
 
     async fn create_assignment(
@@ -371,6 +393,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.assignment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Assignment>| r.into_body())
     }
 
     async fn list_assignments(
@@ -395,6 +418,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAssignmentsResponse>| r.into_body())
     }
 
     async fn delete_assignment(
@@ -414,7 +438,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn search_assignments(
@@ -440,6 +464,9 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchAssignmentsResponse>| r.into_body(),
+            )
     }
 
     async fn search_all_assignments(
@@ -465,6 +492,11 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchAllAssignmentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn move_assignment(
@@ -481,7 +513,10 @@ impl super::stub::ReservationService for ReservationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Assignment>| r.into_body())
     }
 
     async fn update_assignment(
@@ -520,6 +555,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.assignment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Assignment>| r.into_body())
     }
 
     async fn get_bi_reservation(
@@ -539,6 +575,7 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BiReservation>| r.into_body())
     }
 
     async fn update_bi_reservation(
@@ -577,5 +614,6 @@ impl super::stub::ReservationService for ReservationService {
         self.inner
             .execute(builder, Some(req.bi_reservation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BiReservation>| r.into_body())
     }
 }

--- a/src/generated/cloud/bigquery/v2/src/transport.rs
+++ b/src/generated/cloud/bigquery/v2/src/transport.rs
@@ -65,6 +65,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn insert_dataset(
@@ -88,6 +89,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn patch_dataset(
@@ -114,6 +116,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn update_dataset(
@@ -140,6 +143,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn delete_dataset(
@@ -166,7 +170,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_datasets(
@@ -202,6 +206,7 @@ impl super::stub::DatasetService for DatasetService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DatasetList>| r.into_body())
     }
 
     async fn undelete_dataset(
@@ -224,7 +229,10 @@ impl super::stub::DatasetService for DatasetService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 }
 
@@ -273,6 +281,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn list_models(
@@ -309,6 +318,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListModelsResponse>| r.into_body())
     }
 
     async fn patch_model(
@@ -331,7 +341,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn delete_model(
@@ -357,7 +370,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -403,6 +416,9 @@ impl super::stub::ProjectService for ProjectService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GetServiceAccountResponse>| r.into_body(),
+            )
     }
 }
 
@@ -451,6 +467,7 @@ impl super::stub::RoutineService for RoutineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Routine>| r.into_body())
     }
 
     async fn insert_routine(
@@ -476,6 +493,7 @@ impl super::stub::RoutineService for RoutineService {
         self.inner
             .execute(builder, Some(req.routine), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Routine>| r.into_body())
     }
 
     async fn update_routine(
@@ -501,6 +519,7 @@ impl super::stub::RoutineService for RoutineService {
         self.inner
             .execute(builder, Some(req.routine), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Routine>| r.into_body())
     }
 
     async fn delete_routine(
@@ -526,7 +545,7 @@ impl super::stub::RoutineService for RoutineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_routines(
@@ -564,6 +583,7 @@ impl super::stub::RoutineService for RoutineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRoutinesResponse>| r.into_body())
     }
 }
 
@@ -614,6 +634,11 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRowAccessPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_row_access_policy(
@@ -639,6 +664,7 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RowAccessPolicy>| r.into_body())
     }
 
     async fn create_row_access_policy(
@@ -664,6 +690,7 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         self.inner
             .execute(builder, Some(req.row_access_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::RowAccessPolicy>| r.into_body())
     }
 
     async fn update_row_access_policy(
@@ -689,6 +716,7 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         self.inner
             .execute(builder, Some(req.row_access_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::RowAccessPolicy>| r.into_body())
     }
 
     async fn delete_row_access_policy(
@@ -718,7 +746,7 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_delete_row_access_policies(
@@ -744,7 +772,7 @@ impl super::stub::RowAccessPolicyService for RowAccessPolicyService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -795,6 +823,7 @@ impl super::stub::TableService for TableService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn insert_table(
@@ -817,7 +846,10 @@ impl super::stub::TableService for TableService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.table), options).await
+        self.inner
+            .execute(builder, Some(req.table), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn patch_table(
@@ -841,7 +873,10 @@ impl super::stub::TableService for TableService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("autodetectSchema", &req.autodetect_schema)]);
-        self.inner.execute(builder, Some(req.table), options).await
+        self.inner
+            .execute(builder, Some(req.table), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn update_table(
@@ -865,7 +900,10 @@ impl super::stub::TableService for TableService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("autodetectSchema", &req.autodetect_schema)]);
-        self.inner.execute(builder, Some(req.table), options).await
+        self.inner
+            .execute(builder, Some(req.table), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Table>| r.into_body())
     }
 
     async fn delete_table(
@@ -891,7 +929,7 @@ impl super::stub::TableService for TableService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_tables(
@@ -928,5 +966,6 @@ impl super::stub::TableService for TableService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TableList>| r.into_body())
     }
 }

--- a/src/generated/cloud/billing/v1/src/transport.rs
+++ b/src/generated/cloud/billing/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BillingAccount>| r.into_body())
     }
 
     async fn list_billing_accounts(
@@ -80,6 +81,11 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBillingAccountsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_billing_account(
@@ -109,6 +115,7 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, Some(req.account), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BillingAccount>| r.into_body())
     }
 
     async fn create_billing_account(
@@ -129,6 +136,7 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, Some(req.billing_account), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BillingAccount>| r.into_body())
     }
 
     async fn list_project_billing_info(
@@ -150,6 +158,11 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListProjectBillingInfoResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_project_billing_info(
@@ -172,6 +185,7 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProjectBillingInfo>| r.into_body())
     }
 
     async fn update_project_billing_info(
@@ -194,6 +208,7 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, Some(req.project_billing_info), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProjectBillingInfo>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -226,6 +241,7 @@ impl super::stub::CloudBilling for CloudBilling {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -245,7 +261,10 @@ impl super::stub::CloudBilling for CloudBilling {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -265,7 +284,9 @@ impl super::stub::CloudBilling for CloudBilling {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn move_billing_account(
@@ -282,7 +303,10 @@ impl super::stub::CloudBilling for CloudBilling {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::BillingAccount>| r.into_body())
     }
 }
 
@@ -327,6 +351,7 @@ impl super::stub::CloudCatalog for CloudCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn list_skus(
@@ -369,5 +394,6 @@ impl super::stub::CloudCatalog for CloudCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSkusResponse>| r.into_body())
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/transport.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn update_policy(
@@ -82,7 +83,10 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn create_attestor(
@@ -106,6 +110,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         self.inner
             .execute(builder, Some(req.attestor), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attestor>| r.into_body())
     }
 
     async fn get_attestor(
@@ -125,6 +130,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attestor>| r.into_body())
     }
 
     async fn update_attestor(
@@ -153,6 +159,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         self.inner
             .execute(builder, Some(req.attestor), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attestor>| r.into_body())
     }
 
     async fn list_attestors(
@@ -177,6 +184,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAttestorsResponse>| r.into_body())
     }
 
     async fn delete_attestor(
@@ -196,7 +204,7 @@ impl super::stub::BinauthzManagementServiceV1 for BinauthzManagementServiceV1 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -239,6 +247,7 @@ impl super::stub::SystemPolicyV1 for SystemPolicyV1 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 }
 
@@ -281,6 +290,10 @@ impl super::stub::ValidationHelperV1 for ValidationHelperV1 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ValidateAttestationOccurrenceResponse>| {
+                r.into_body()
+            },
+        )
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/transport.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCertificatesResponse>| r.into_body())
     }
 
     async fn get_certificate(
@@ -83,6 +84,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Certificate>| r.into_body())
     }
 
     async fn create_certificate(
@@ -106,6 +108,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_certificate(
@@ -144,6 +147,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_certificate(
@@ -163,6 +167,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_certificate_maps(
@@ -189,6 +194,11 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCertificateMapsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_certificate_map(
@@ -208,6 +218,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CertificateMap>| r.into_body())
     }
 
     async fn create_certificate_map(
@@ -231,6 +242,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate_map), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_certificate_map(
@@ -269,6 +281,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate_map), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_certificate_map(
@@ -288,6 +301,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_certificate_map_entries(
@@ -314,6 +328,11 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCertificateMapEntriesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_certificate_map_entry(
@@ -333,6 +352,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CertificateMapEntry>| r.into_body())
     }
 
     async fn create_certificate_map_entry(
@@ -356,6 +376,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate_map_entry), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_certificate_map_entry(
@@ -394,6 +415,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate_map_entry), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_certificate_map_entry(
@@ -413,6 +435,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_dns_authorizations(
@@ -439,6 +462,11 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDnsAuthorizationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_dns_authorization(
@@ -458,6 +486,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DnsAuthorization>| r.into_body())
     }
 
     async fn create_dns_authorization(
@@ -481,6 +510,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.dns_authorization), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_dns_authorization(
@@ -519,6 +549,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.dns_authorization), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_dns_authorization(
@@ -538,6 +569,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_certificate_issuance_configs(
@@ -564,6 +596,11 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListCertificateIssuanceConfigsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_certificate_issuance_config(
@@ -583,6 +620,9 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CertificateIssuanceConfig>| r.into_body(),
+            )
     }
 
     async fn create_certificate_issuance_config(
@@ -609,6 +649,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.certificate_issuance_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_certificate_issuance_config(
@@ -628,6 +669,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_trust_configs(
@@ -654,6 +696,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTrustConfigsResponse>| r.into_body())
     }
 
     async fn get_trust_config(
@@ -673,6 +716,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TrustConfig>| r.into_body())
     }
 
     async fn create_trust_config(
@@ -696,6 +740,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.trust_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_trust_config(
@@ -734,6 +779,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req.trust_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_trust_config(
@@ -754,6 +800,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -776,6 +823,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -795,6 +843,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -817,6 +866,11 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -836,6 +890,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -855,7 +910,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -875,7 +930,7 @@ impl super::stub::CertificateManager for CertificateManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/chronicle/v1/src/transport.rs
+++ b/src/generated/cloud/chronicle/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, Some(req.data_access_label), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataAccessLabel>| r.into_body())
     }
 
     async fn get_data_access_label(
@@ -80,6 +81,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataAccessLabel>| r.into_body())
     }
 
     async fn list_data_access_labels(
@@ -105,6 +107,11 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDataAccessLabelsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_data_access_label(
@@ -143,6 +150,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, Some(req.data_access_label), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataAccessLabel>| r.into_body())
     }
 
     async fn delete_data_access_label(
@@ -162,7 +170,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_data_access_scope(
@@ -186,6 +194,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, Some(req.data_access_scope), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataAccessScope>| r.into_body())
     }
 
     async fn get_data_access_scope(
@@ -205,6 +214,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataAccessScope>| r.into_body())
     }
 
     async fn list_data_access_scopes(
@@ -230,6 +240,11 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDataAccessScopesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_data_access_scope(
@@ -268,6 +283,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, Some(req.data_access_scope), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataAccessScope>| r.into_body())
     }
 
     async fn delete_data_access_scope(
@@ -287,7 +303,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -310,6 +326,11 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -329,6 +350,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -348,7 +370,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -368,7 +390,7 @@ impl super::stub::DataAccessControlService for DataAccessControlService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -411,6 +433,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Watchlist>| r.into_body())
     }
 
     async fn list_watchlists(
@@ -436,6 +459,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWatchlistsResponse>| r.into_body())
     }
 
     async fn create_watchlist(
@@ -459,6 +483,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, Some(req.watchlist), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Watchlist>| r.into_body())
     }
 
     async fn update_watchlist(
@@ -497,6 +522,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, Some(req.watchlist), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Watchlist>| r.into_body())
     }
 
     async fn delete_watchlist(
@@ -517,7 +543,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -540,6 +566,11 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -559,6 +590,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -578,7 +610,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -598,7 +630,7 @@ impl super::stub::EntityService for EntityService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -641,6 +673,7 @@ impl super::stub::InstanceService for InstanceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn list_operations(
@@ -663,6 +696,11 @@ impl super::stub::InstanceService for InstanceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -682,6 +720,7 @@ impl super::stub::InstanceService for InstanceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -701,7 +740,7 @@ impl super::stub::InstanceService for InstanceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -721,7 +760,7 @@ impl super::stub::InstanceService for InstanceService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -765,6 +804,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReferenceList>| r.into_body())
     }
 
     async fn list_reference_lists(
@@ -790,6 +830,11 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReferenceListsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_reference_list(
@@ -813,6 +858,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, Some(req.reference_list), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReferenceList>| r.into_body())
     }
 
     async fn update_reference_list(
@@ -851,6 +897,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, Some(req.reference_list), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReferenceList>| r.into_body())
     }
 
     async fn list_operations(
@@ -873,6 +920,11 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -892,6 +944,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -911,7 +964,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -931,7 +984,7 @@ impl super::stub::ReferenceListService for ReferenceListService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -971,7 +1024,10 @@ impl super::stub::RuleService for RuleService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.rule), options).await
+        self.inner
+            .execute(builder, Some(req.rule), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Rule>| r.into_body())
     }
 
     async fn get_rule(
@@ -992,6 +1048,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Rule>| r.into_body())
     }
 
     async fn list_rules(
@@ -1015,6 +1072,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRulesResponse>| r.into_body())
     }
 
     async fn update_rule(
@@ -1050,7 +1108,10 @@ impl super::stub::RuleService for RuleService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.rule), options).await
+        self.inner
+            .execute(builder, Some(req.rule), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Rule>| r.into_body())
     }
 
     async fn delete_rule(
@@ -1071,7 +1132,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_rule_revisions(
@@ -1097,6 +1158,9 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRuleRevisionsResponse>| r.into_body(),
+            )
     }
 
     async fn create_retrohunt(
@@ -1119,6 +1183,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, Some(req.retrohunt), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_retrohunt(
@@ -1138,6 +1203,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Retrohunt>| r.into_body())
     }
 
     async fn list_retrohunts(
@@ -1163,6 +1229,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRetrohuntsResponse>| r.into_body())
     }
 
     async fn get_rule_deployment(
@@ -1182,6 +1249,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RuleDeployment>| r.into_body())
     }
 
     async fn list_rule_deployments(
@@ -1207,6 +1275,11 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRuleDeploymentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_rule_deployment(
@@ -1245,6 +1318,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, Some(req.rule_deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::RuleDeployment>| r.into_body())
     }
 
     async fn list_operations(
@@ -1267,6 +1341,11 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1286,6 +1365,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1305,7 +1385,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1325,7 +1405,7 @@ impl super::stub::RuleService for RuleService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Workload>| r.into_body())
     }
 
     async fn list_workloads(
@@ -83,6 +84,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkloadsResponse>| r.into_body())
     }
 
     async fn get_customer(
@@ -102,6 +104,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Customer>| r.into_body())
     }
 
     async fn list_customers(
@@ -128,6 +131,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCustomersResponse>| r.into_body())
     }
 
     async fn get_ekm_connections(
@@ -147,6 +151,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EkmConnections>| r.into_body())
     }
 
     async fn get_partner_permissions(
@@ -166,6 +171,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PartnerPermissions>| r.into_body())
     }
 
     async fn list_access_approval_requests(
@@ -192,6 +198,11 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAccessApprovalRequestsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_partner(
@@ -211,6 +222,7 @@ impl super::stub::CloudControlsPartnerCore for CloudControlsPartnerCore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Partner>| r.into_body())
     }
 }
 
@@ -270,6 +282,7 @@ impl super::stub::CloudControlsPartnerMonitoring for CloudControlsPartnerMonitor
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListViolationsResponse>| r.into_body())
     }
 
     async fn get_violation(
@@ -289,5 +302,6 @@ impl super::stub::CloudControlsPartnerMonitoring for CloudControlsPartnerMonitor
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Violation>| r.into_body())
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/transport.rs
+++ b/src/generated/cloud/clouddms/v1/src/transport.rs
@@ -64,6 +64,9 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMigrationJobsResponse>| r.into_body(),
+            )
     }
 
     async fn get_migration_job(
@@ -83,6 +86,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MigrationJob>| r.into_body())
     }
 
     async fn create_migration_job(
@@ -107,6 +111,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.migration_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_migration_job(
@@ -146,6 +151,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.migration_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_migration_job(
@@ -167,6 +173,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_migration_job(
@@ -183,7 +190,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_migration_job(
@@ -200,7 +210,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resume_migration_job(
@@ -217,7 +230,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn promote_migration_job(
@@ -234,7 +250,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn verify_migration_job(
@@ -251,7 +270,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restart_migration_job(
@@ -268,7 +290,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_ssh_script(
@@ -288,7 +313,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SshScript>| r.into_body())
     }
 
     async fn generate_tcp_proxy_script(
@@ -308,7 +336,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::TcpProxyScript>| r.into_body())
     }
 
     async fn list_connection_profiles(
@@ -335,6 +366,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConnectionProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_connection_profile(
@@ -354,6 +390,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConnectionProfile>| r.into_body())
     }
 
     async fn create_connection_profile(
@@ -380,6 +417,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.connection_profile), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_connection_profile(
@@ -421,6 +459,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.connection_profile), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_connection_profile(
@@ -442,6 +481,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_private_connection(
@@ -467,6 +507,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.private_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_private_connection(
@@ -486,6 +527,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PrivateConnection>| r.into_body())
     }
 
     async fn list_private_connections(
@@ -512,6 +554,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPrivateConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_private_connection(
@@ -532,6 +579,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_conversion_workspace(
@@ -551,6 +599,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConversionWorkspace>| r.into_body())
     }
 
     async fn list_conversion_workspaces(
@@ -576,6 +625,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversionWorkspacesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_conversion_workspace(
@@ -600,6 +654,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.conversion_workspace), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_conversion_workspace(
@@ -639,6 +694,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.conversion_workspace), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_conversion_workspace(
@@ -660,6 +716,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_mapping_rule(
@@ -684,6 +741,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req.mapping_rule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::MappingRule>| r.into_body())
     }
 
     async fn delete_mapping_rule(
@@ -704,7 +762,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_mapping_rules(
@@ -729,6 +787,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMappingRulesResponse>| r.into_body())
     }
 
     async fn get_mapping_rule(
@@ -748,6 +807,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MappingRule>| r.into_body())
     }
 
     async fn seed_conversion_workspace(
@@ -764,7 +824,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_mapping_rules(
@@ -784,7 +847,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn convert_conversion_workspace(
@@ -801,7 +867,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn commit_conversion_workspace(
@@ -818,7 +887,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rollback_conversion_workspace(
@@ -835,7 +907,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn apply_conversion_workspace(
@@ -852,7 +927,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn describe_database_entities(
@@ -882,6 +960,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::DescribeDatabaseEntitiesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_background_jobs(
@@ -919,6 +1002,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchBackgroundJobsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn describe_conversion_workspace_revisions(
@@ -945,6 +1033,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::DescribeConversionWorkspaceRevisionsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn fetch_static_ips(
@@ -969,6 +1062,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FetchStaticIpsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -991,6 +1085,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1010,6 +1105,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1029,7 +1125,10 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1062,6 +1161,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1081,7 +1181,9 @@ impl super::stub::DataMigrationService for DataMigrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1104,6 +1206,11 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1123,6 +1230,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1142,7 +1250,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1162,7 +1270,7 @@ impl super::stub::DataMigrationService for DataMigrationService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LicensePool>| r.into_body())
     }
 
     async fn update_license_pool(
@@ -95,6 +96,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         self.inner
             .execute(builder, Some(req.license_pool), options)
             .await
+            .map(|r: gax::response::Response<crate::model::LicensePool>| r.into_body())
     }
 
     async fn assign(
@@ -111,7 +113,10 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AssignResponse>| r.into_body())
     }
 
     async fn unassign(
@@ -131,7 +136,10 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UnassignResponse>| r.into_body())
     }
 
     async fn enumerate_licensed_users(
@@ -156,6 +164,11 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::EnumerateLicensedUsersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -175,6 +188,7 @@ impl super::stub::LicenseManagementService for LicenseManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -217,7 +231,10 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_order(
@@ -237,6 +254,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Order>| r.into_body())
     }
 
     async fn list_orders(
@@ -259,6 +277,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListOrdersResponse>| r.into_body())
     }
 
     async fn modify_order(
@@ -275,7 +294,10 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_order(
@@ -292,7 +314,10 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -312,6 +337,7 @@ impl super::stub::ConsumerProcurementService for ConsumerProcurementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         self.inner
             .execute(builder, Some(req.challenge), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Challenge>| r.into_body())
     }
 
     async fn verify_attestation(
@@ -79,7 +80,9 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::VerifyAttestationResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -102,6 +105,7 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -121,5 +125,6 @@ impl super::stub::ConfidentialComputing for ConfidentialComputing {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/config/v1/src/transport.rs
+++ b/src/generated/cloud/config/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDeploymentsResponse>| r.into_body())
     }
 
     async fn get_deployment(
@@ -83,6 +84,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn create_deployment(
@@ -107,6 +109,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_deployment(
@@ -146,6 +149,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_deployment(
@@ -168,6 +172,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_revisions(
@@ -194,6 +199,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRevisionsResponse>| r.into_body())
     }
 
     async fn get_revision(
@@ -213,6 +219,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Revision>| r.into_body())
     }
 
     async fn get_resource(
@@ -232,6 +239,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Resource>| r.into_body())
     }
 
     async fn list_resources(
@@ -258,6 +266,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListResourcesResponse>| r.into_body())
     }
 
     async fn export_deployment_statefile(
@@ -277,7 +286,10 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Statefile>| r.into_body())
     }
 
     async fn export_revision_statefile(
@@ -297,7 +309,10 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Statefile>| r.into_body())
     }
 
     async fn import_statefile(
@@ -317,7 +332,10 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Statefile>| r.into_body())
     }
 
     async fn delete_statefile(
@@ -340,7 +358,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn lock_deployment(
@@ -357,7 +375,10 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn unlock_deployment(
@@ -374,7 +395,10 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_lock_info(
@@ -394,6 +418,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LockInfo>| r.into_body())
     }
 
     async fn create_preview(
@@ -418,6 +443,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, Some(req.preview), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_preview(
@@ -437,6 +463,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Preview>| r.into_body())
     }
 
     async fn list_previews(
@@ -460,6 +487,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPreviewsResponse>| r.into_body())
     }
 
     async fn delete_preview(
@@ -480,6 +508,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_preview_result(
@@ -496,7 +525,9 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ExportPreviewResultResponse>| r.into_body(),
+        )
     }
 
     async fn list_terraform_versions(
@@ -523,6 +554,11 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTerraformVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_terraform_version(
@@ -542,6 +578,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TerraformVersion>| r.into_body())
     }
 
     async fn list_locations(
@@ -564,6 +601,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -583,6 +621,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -602,7 +641,10 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -635,6 +677,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -654,7 +697,9 @@ impl super::stub::Config for Config {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -677,6 +722,11 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -696,6 +746,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -715,7 +766,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -735,7 +786,7 @@ impl super::stub::Config for Config {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/connectors/v1/src/transport.rs
+++ b/src/generated/cloud/connectors/v1/src/transport.rs
@@ -65,6 +65,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectionsResponse>| r.into_body())
     }
 
     async fn get_connection(
@@ -85,6 +86,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn create_connection(
@@ -108,6 +110,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_connection(
@@ -146,6 +149,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_connection(
@@ -165,6 +169,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_providers(
@@ -189,6 +194,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProvidersResponse>| r.into_body())
     }
 
     async fn get_provider(
@@ -208,6 +214,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Provider>| r.into_body())
     }
 
     async fn list_connectors(
@@ -232,6 +239,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectorsResponse>| r.into_body())
     }
 
     async fn get_connector(
@@ -251,6 +259,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connector>| r.into_body())
     }
 
     async fn list_connector_versions(
@@ -273,6 +282,11 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConnectorVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_connector_version(
@@ -293,6 +307,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConnectorVersion>| r.into_body())
     }
 
     async fn get_connection_schema_metadata(
@@ -312,6 +327,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConnectionSchemaMetadata>| r.into_body())
     }
 
     async fn refresh_connection_schema_metadata(
@@ -328,7 +344,10 @@ impl super::stub::Connectors for Connectors {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_runtime_entity_schemas(
@@ -354,6 +373,11 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRuntimeEntitySchemasResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_runtime_action_schemas(
@@ -379,6 +403,11 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRuntimeActionSchemasResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_runtime_config(
@@ -398,6 +427,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RuntimeConfig>| r.into_body())
     }
 
     async fn get_global_settings(
@@ -417,6 +447,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn list_locations(
@@ -439,6 +470,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -458,6 +490,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -477,7 +510,10 @@ impl super::stub::Connectors for Connectors {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -510,6 +546,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -529,7 +566,9 @@ impl super::stub::Connectors for Connectors {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -552,6 +591,11 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -571,6 +615,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -590,7 +635,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -610,7 +655,7 @@ impl super::stub::Connectors for Connectors {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.conversation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn upload_conversation(
@@ -80,7 +81,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_conversation(
@@ -119,6 +123,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.conversation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn get_conversation(
@@ -139,6 +144,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn list_conversations(
@@ -166,6 +172,9 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversationsResponse>| r.into_body(),
+            )
     }
 
     async fn delete_conversation(
@@ -186,7 +195,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_analysis(
@@ -209,6 +218,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.analysis), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_analysis(
@@ -228,6 +238,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Analysis>| r.into_body())
     }
 
     async fn list_analyses(
@@ -250,6 +261,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAnalysesResponse>| r.into_body())
     }
 
     async fn delete_analysis(
@@ -269,7 +281,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn bulk_analyze_conversations(
@@ -289,7 +301,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn bulk_delete_conversations(
@@ -309,7 +324,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn ingest_conversations(
@@ -329,7 +347,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_insights_data(
@@ -349,7 +370,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_issue_model(
@@ -372,6 +396,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.issue_model), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_issue_model(
@@ -410,6 +435,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.issue_model), options)
             .await
+            .map(|r: gax::response::Response<crate::model::IssueModel>| r.into_body())
     }
 
     async fn get_issue_model(
@@ -429,6 +455,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::IssueModel>| r.into_body())
     }
 
     async fn list_issue_models(
@@ -451,6 +478,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIssueModelsResponse>| r.into_body())
     }
 
     async fn delete_issue_model(
@@ -470,6 +498,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn deploy_issue_model(
@@ -486,7 +515,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undeploy_issue_model(
@@ -503,7 +535,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_issue_model(
@@ -520,7 +555,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_issue_model(
@@ -540,7 +578,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_issue(
@@ -560,6 +601,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Issue>| r.into_body())
     }
 
     async fn list_issues(
@@ -579,6 +621,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIssuesResponse>| r.into_body())
     }
 
     async fn update_issue(
@@ -614,7 +657,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.issue), options).await
+        self.inner
+            .execute(builder, Some(req.issue), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Issue>| r.into_body())
     }
 
     async fn delete_issue(
@@ -634,7 +680,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn calculate_issue_model_stats(
@@ -657,6 +703,11 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CalculateIssueModelStatsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_phrase_matcher(
@@ -679,6 +730,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.phrase_matcher), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PhraseMatcher>| r.into_body())
     }
 
     async fn get_phrase_matcher(
@@ -698,6 +750,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PhraseMatcher>| r.into_body())
     }
 
     async fn list_phrase_matchers(
@@ -723,6 +776,11 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPhraseMatchersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_phrase_matcher(
@@ -742,7 +800,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_phrase_matcher(
@@ -781,6 +839,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.phrase_matcher), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PhraseMatcher>| r.into_body())
     }
 
     async fn calculate_stats(
@@ -804,6 +863,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CalculateStatsResponse>| r.into_body())
     }
 
     async fn get_settings(
@@ -823,6 +883,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn update_settings(
@@ -861,6 +922,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn create_analysis_rule(
@@ -883,6 +945,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.analysis_rule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnalysisRule>| r.into_body())
     }
 
     async fn get_analysis_rule(
@@ -902,6 +965,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnalysisRule>| r.into_body())
     }
 
     async fn list_analysis_rules(
@@ -926,6 +990,9 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAnalysisRulesResponse>| r.into_body(),
+            )
     }
 
     async fn update_analysis_rule(
@@ -964,6 +1031,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.analysis_rule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnalysisRule>| r.into_body())
     }
 
     async fn delete_analysis_rule(
@@ -983,7 +1051,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_encryption_spec(
@@ -1003,6 +1071,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EncryptionSpec>| r.into_body())
     }
 
     async fn initialize_encryption_spec(
@@ -1028,7 +1097,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_view(
@@ -1045,7 +1117,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.view), options).await
+        self.inner
+            .execute(builder, Some(req.view), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::View>| r.into_body())
     }
 
     async fn get_view(
@@ -1065,6 +1140,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::View>| r.into_body())
     }
 
     async fn list_views(
@@ -1086,6 +1162,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListViewsResponse>| r.into_body())
     }
 
     async fn update_view(
@@ -1121,7 +1198,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.view), options).await
+        self.inner
+            .execute(builder, Some(req.view), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::View>| r.into_body())
     }
 
     async fn delete_view(
@@ -1141,7 +1221,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn query_metrics(
@@ -1161,7 +1241,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_qa_question(
@@ -1185,6 +1268,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.qa_question), options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaQuestion>| r.into_body())
     }
 
     async fn get_qa_question(
@@ -1204,6 +1288,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaQuestion>| r.into_body())
     }
 
     async fn update_qa_question(
@@ -1242,6 +1327,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.qa_question), options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaQuestion>| r.into_body())
     }
 
     async fn delete_qa_question(
@@ -1261,7 +1347,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_qa_questions(
@@ -1286,6 +1372,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListQaQuestionsResponse>| r.into_body())
     }
 
     async fn create_qa_scorecard(
@@ -1309,6 +1396,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.qa_scorecard), options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaScorecard>| r.into_body())
     }
 
     async fn get_qa_scorecard(
@@ -1328,6 +1416,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaScorecard>| r.into_body())
     }
 
     async fn update_qa_scorecard(
@@ -1366,6 +1455,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.qa_scorecard), options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaScorecard>| r.into_body())
     }
 
     async fn delete_qa_scorecard(
@@ -1386,7 +1476,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_qa_scorecards(
@@ -1411,6 +1501,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListQaScorecardsResponse>| r.into_body())
     }
 
     async fn create_qa_scorecard_revision(
@@ -1434,6 +1525,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.qa_scorecard_revision), options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaScorecardRevision>| r.into_body())
     }
 
     async fn get_qa_scorecard_revision(
@@ -1453,6 +1545,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::QaScorecardRevision>| r.into_body())
     }
 
     async fn tune_qa_scorecard_revision(
@@ -1472,7 +1565,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn deploy_qa_scorecard_revision(
@@ -1489,7 +1585,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::QaScorecardRevision>| r.into_body())
     }
 
     async fn undeploy_qa_scorecard_revision(
@@ -1506,7 +1605,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::QaScorecardRevision>| r.into_body())
     }
 
     async fn delete_qa_scorecard_revision(
@@ -1527,7 +1629,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_qa_scorecard_revisions(
@@ -1553,6 +1655,11 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListQaScorecardRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_feedback_label(
@@ -1576,6 +1683,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.feedback_label), options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeedbackLabel>| r.into_body())
     }
 
     async fn list_feedback_labels(
@@ -1601,6 +1709,11 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFeedbackLabelsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_feedback_label(
@@ -1620,6 +1733,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeedbackLabel>| r.into_body())
     }
 
     async fn update_feedback_label(
@@ -1658,6 +1772,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, Some(req.feedback_label), options)
             .await
+            .map(|r: gax::response::Response<crate::model::FeedbackLabel>| r.into_body())
     }
 
     async fn delete_feedback_label(
@@ -1677,7 +1792,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_all_feedback_labels(
@@ -1703,6 +1818,11 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAllFeedbackLabelsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn bulk_upload_feedback_labels(
@@ -1722,7 +1842,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn bulk_download_feedback_labels(
@@ -1742,7 +1865,10 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -1765,6 +1891,11 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1784,6 +1915,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1803,7 +1935,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/transport.rs
@@ -61,6 +61,11 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, Some(req.open_lineage), options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ProcessOpenLineageRunEventResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_process(
@@ -84,6 +89,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, Some(req.process), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Process>| r.into_body())
     }
 
     async fn update_process(
@@ -123,6 +129,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, Some(req.process), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Process>| r.into_body())
     }
 
     async fn get_process(
@@ -142,6 +149,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Process>| r.into_body())
     }
 
     async fn list_processes(
@@ -166,6 +174,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProcessesResponse>| r.into_body())
     }
 
     async fn delete_process(
@@ -186,6 +195,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_run(
@@ -203,7 +213,10 @@ impl super::stub::Lineage for Lineage {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.run), options).await
+        self.inner
+            .execute(builder, Some(req.run), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Run>| r.into_body())
     }
 
     async fn update_run(
@@ -240,7 +253,10 @@ impl super::stub::Lineage for Lineage {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("allowMissing", &req.allow_missing)]);
-        self.inner.execute(builder, Some(req.run), options).await
+        self.inner
+            .execute(builder, Some(req.run), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Run>| r.into_body())
     }
 
     async fn get_run(
@@ -260,6 +276,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Run>| r.into_body())
     }
 
     async fn list_runs(
@@ -281,6 +298,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRunsResponse>| r.into_body())
     }
 
     async fn delete_run(
@@ -301,6 +319,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_lineage_event(
@@ -324,6 +343,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, Some(req.lineage_event), options)
             .await
+            .map(|r: gax::response::Response<crate::model::LineageEvent>| r.into_body())
     }
 
     async fn get_lineage_event(
@@ -343,6 +363,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LineageEvent>| r.into_body())
     }
 
     async fn list_lineage_events(
@@ -367,6 +388,9 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListLineageEventsResponse>| r.into_body(),
+            )
     }
 
     async fn delete_lineage_event(
@@ -387,7 +411,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn search_links(
@@ -407,7 +431,10 @@ impl super::stub::Lineage for Lineage {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchLinksResponse>| r.into_body())
     }
 
     async fn batch_search_link_processes(
@@ -427,7 +454,11 @@ impl super::stub::Lineage for Lineage {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchSearchLinkProcessesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_operations(
@@ -450,6 +481,11 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -469,6 +505,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -488,7 +525,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -508,7 +545,7 @@ impl super::stub::Lineage for Lineage {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchCatalogResponse>| r.into_body())
     }
 
     async fn create_entry_group(
@@ -78,6 +81,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, Some(req.entry_group), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntryGroup>| r.into_body())
     }
 
     async fn get_entry_group(
@@ -107,6 +111,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntryGroup>| r.into_body())
     }
 
     async fn update_entry_group(
@@ -145,6 +150,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, Some(req.entry_group), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntryGroup>| r.into_body())
     }
 
     async fn delete_entry_group(
@@ -165,7 +171,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_entry_groups(
@@ -190,6 +196,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntryGroupsResponse>| r.into_body())
     }
 
     async fn create_entry(
@@ -207,7 +214,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("entryId", &req.entry_id)]);
-        self.inner.execute(builder, Some(req.entry), options).await
+        self.inner
+            .execute(builder, Some(req.entry), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Entry>| r.into_body())
     }
 
     async fn update_entry(
@@ -243,7 +253,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.entry), options).await
+        self.inner
+            .execute(builder, Some(req.entry), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Entry>| r.into_body())
     }
 
     async fn delete_entry(
@@ -263,7 +276,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_entry(
@@ -283,6 +296,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Entry>| r.into_body())
     }
 
     async fn lookup_entry(
@@ -320,6 +334,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Entry>| r.into_body())
     }
 
     async fn list_entries(
@@ -351,6 +366,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntriesResponse>| r.into_body())
     }
 
     async fn modify_entry_overview(
@@ -370,7 +386,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::EntryOverview>| r.into_body())
     }
 
     async fn modify_entry_contacts(
@@ -390,7 +409,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Contacts>| r.into_body())
     }
 
     async fn create_tag_template(
@@ -414,6 +436,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, Some(req.tag_template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagTemplate>| r.into_body())
     }
 
     async fn get_tag_template(
@@ -433,6 +456,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagTemplate>| r.into_body())
     }
 
     async fn update_tag_template(
@@ -471,6 +495,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, Some(req.tag_template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagTemplate>| r.into_body())
     }
 
     async fn delete_tag_template(
@@ -491,7 +516,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_tag_template_field(
@@ -512,6 +537,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, Some(req.tag_template_field), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagTemplateField>| r.into_body())
     }
 
     async fn update_tag_template_field(
@@ -541,6 +567,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, Some(req.tag_template_field), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagTemplateField>| r.into_body())
     }
 
     async fn rename_tag_template_field(
@@ -557,7 +584,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::TagTemplateField>| r.into_body())
     }
 
     async fn rename_tag_template_field_enum_value(
@@ -574,7 +604,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::TagTemplateField>| r.into_body())
     }
 
     async fn delete_tag_template_field(
@@ -595,7 +628,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_tag(
@@ -612,7 +645,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.tag), options).await
+        self.inner
+            .execute(builder, Some(req.tag), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Tag>| r.into_body())
     }
 
     async fn update_tag(
@@ -648,7 +684,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.tag), options).await
+        self.inner
+            .execute(builder, Some(req.tag), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Tag>| r.into_body())
     }
 
     async fn delete_tag(
@@ -668,7 +707,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_tags(
@@ -690,6 +729,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTagsResponse>| r.into_body())
     }
 
     async fn reconcile_tags(
@@ -709,7 +749,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn star_entry(
@@ -726,7 +769,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::StarEntryResponse>| r.into_body())
     }
 
     async fn unstar_entry(
@@ -743,7 +789,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UnstarEntryResponse>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -763,7 +812,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -783,7 +835,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -803,7 +858,9 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn import_entries(
@@ -823,7 +880,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn set_config(
@@ -840,7 +900,10 @@ impl super::stub::DataCatalog for DataCatalog {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::MigrationConfig>| r.into_body())
     }
 
     async fn retrieve_config(
@@ -863,6 +926,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::OrganizationConfig>| r.into_body())
     }
 
     async fn retrieve_effective_config(
@@ -885,6 +949,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MigrationConfig>| r.into_body())
     }
 
     async fn list_operations(
@@ -907,6 +972,11 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -926,6 +996,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -945,7 +1016,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -965,7 +1036,7 @@ impl super::stub::DataCatalog for DataCatalog {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1025,6 +1096,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, Some(req.taxonomy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Taxonomy>| r.into_body())
     }
 
     async fn delete_taxonomy(
@@ -1044,7 +1116,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_taxonomy(
@@ -1083,6 +1155,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, Some(req.taxonomy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Taxonomy>| r.into_body())
     }
 
     async fn list_taxonomies(
@@ -1108,6 +1181,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTaxonomiesResponse>| r.into_body())
     }
 
     async fn get_taxonomy(
@@ -1127,6 +1201,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Taxonomy>| r.into_body())
     }
 
     async fn create_policy_tag(
@@ -1149,6 +1224,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, Some(req.policy_tag), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PolicyTag>| r.into_body())
     }
 
     async fn delete_policy_tag(
@@ -1168,7 +1244,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_policy_tag(
@@ -1207,6 +1283,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, Some(req.policy_tag), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PolicyTag>| r.into_body())
     }
 
     async fn list_policy_tags(
@@ -1231,6 +1308,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPolicyTagsResponse>| r.into_body())
     }
 
     async fn get_policy_tag(
@@ -1250,6 +1328,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PolicyTag>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1269,7 +1348,10 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1289,7 +1371,10 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1309,7 +1394,9 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1332,6 +1419,11 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1351,6 +1443,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1370,7 +1463,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1390,7 +1483,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1430,7 +1523,10 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Taxonomy>| r.into_body())
     }
 
     async fn import_taxonomies(
@@ -1450,7 +1546,10 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ImportTaxonomiesResponse>| r.into_body())
     }
 
     async fn export_taxonomies(
@@ -1483,6 +1582,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExportTaxonomiesResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1505,6 +1605,11 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1524,6 +1629,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1543,7 +1649,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1563,6 +1669,6 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/transport.rs
+++ b/src/generated/cloud/datafusion/v1/src/transport.rs
@@ -60,6 +60,11 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAvailableVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_instances(
@@ -86,6 +91,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -105,6 +111,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -128,6 +135,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -147,6 +155,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -185,6 +194,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restart_instance(
@@ -201,7 +211,10 @@ impl super::stub::DataFusion for DataFusion {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -224,6 +237,11 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -243,6 +261,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -262,7 +281,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -282,7 +301,7 @@ impl super::stub::DataFusion for DataFusion {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AutoscalingPolicy>| r.into_body())
     }
 
     async fn update_autoscaling_policy(
@@ -83,7 +86,10 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AutoscalingPolicy>| r.into_body())
     }
 
     async fn get_autoscaling_policy(
@@ -103,6 +109,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AutoscalingPolicy>| r.into_body())
     }
 
     async fn list_autoscaling_policies(
@@ -127,6 +134,11 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAutoscalingPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_autoscaling_policy(
@@ -146,7 +158,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -166,7 +178,10 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -186,7 +201,10 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -206,7 +224,9 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -229,6 +249,11 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -248,6 +273,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -267,7 +293,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -287,7 +313,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -329,7 +355,10 @@ impl super::stub::BatchController for BatchController {
             );
         let builder = builder.query(&[("batchId", &req.batch_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.batch), options).await
+        self.inner
+            .execute(builder, Some(req.batch), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_batch(
@@ -349,6 +378,7 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Batch>| r.into_body())
     }
 
     async fn list_batches(
@@ -372,6 +402,7 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBatchesResponse>| r.into_body())
     }
 
     async fn delete_batch(
@@ -391,7 +422,7 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -411,7 +442,10 @@ impl super::stub::BatchController for BatchController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -431,7 +465,10 @@ impl super::stub::BatchController for BatchController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -451,7 +488,9 @@ impl super::stub::BatchController for BatchController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -474,6 +513,11 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -493,6 +537,7 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -512,7 +557,7 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -532,7 +577,7 @@ impl super::stub::BatchController for BatchController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -600,6 +645,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_cluster(
@@ -646,6 +692,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_cluster(
@@ -668,7 +715,10 @@ impl super::stub::ClusterController for ClusterController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_cluster(
@@ -691,7 +741,10 @@ impl super::stub::ClusterController for ClusterController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -719,6 +772,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_cluster(
@@ -744,6 +798,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn list_clusters(
@@ -772,6 +827,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn diagnose_cluster(
@@ -794,7 +850,10 @@ impl super::stub::ClusterController for ClusterController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -814,7 +873,10 @@ impl super::stub::ClusterController for ClusterController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -834,7 +896,10 @@ impl super::stub::ClusterController for ClusterController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -854,7 +919,9 @@ impl super::stub::ClusterController for ClusterController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -877,6 +944,11 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -896,6 +968,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -915,7 +988,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -935,7 +1008,7 @@ impl super::stub::ClusterController for ClusterController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -995,7 +1068,10 @@ impl super::stub::JobController for JobController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn submit_job_as_operation(
@@ -1018,7 +1094,10 @@ impl super::stub::JobController for JobController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_job(
@@ -1044,6 +1123,7 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn list_jobs(
@@ -1074,6 +1154,7 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobsResponse>| r.into_body())
     }
 
     async fn update_job(
@@ -1106,7 +1187,10 @@ impl super::stub::JobController for JobController {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn cancel_job(
@@ -1129,7 +1213,10 @@ impl super::stub::JobController for JobController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn delete_job(
@@ -1155,7 +1242,7 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -1175,7 +1262,10 @@ impl super::stub::JobController for JobController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1195,7 +1285,10 @@ impl super::stub::JobController for JobController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1215,7 +1308,9 @@ impl super::stub::JobController for JobController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1238,6 +1333,11 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1257,6 +1357,7 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1276,7 +1377,7 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1296,7 +1397,7 @@ impl super::stub::JobController for JobController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1358,6 +1459,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         self.inner
             .execute(builder, Some(req.node_group), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resize_node_group(
@@ -1374,7 +1476,10 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_node_group(
@@ -1394,6 +1499,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NodeGroup>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1413,7 +1519,10 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1433,7 +1542,10 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1453,7 +1565,9 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1476,6 +1590,11 @@ impl super::stub::NodeGroupController for NodeGroupController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1495,6 +1614,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1514,7 +1634,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1534,7 +1654,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1594,6 +1714,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, Some(req.session_template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionTemplate>| r.into_body())
     }
 
     async fn update_session_template(
@@ -1622,6 +1743,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, Some(req.session_template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionTemplate>| r.into_body())
     }
 
     async fn get_session_template(
@@ -1641,6 +1763,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionTemplate>| r.into_body())
     }
 
     async fn list_session_templates(
@@ -1666,6 +1789,11 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSessionTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_session_template(
@@ -1685,7 +1813,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -1705,7 +1833,10 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1725,7 +1856,10 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1745,7 +1879,9 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1768,6 +1904,11 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1787,6 +1928,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1806,7 +1948,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1826,7 +1968,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1874,6 +2016,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, Some(req.session), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_session(
@@ -1893,6 +2036,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Session>| r.into_body())
     }
 
     async fn list_sessions(
@@ -1915,6 +2059,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSessionsResponse>| r.into_body())
     }
 
     async fn terminate_session(
@@ -1931,7 +2076,10 @@ impl super::stub::SessionController for SessionController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_session(
@@ -1952,6 +2100,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1971,7 +2120,10 @@ impl super::stub::SessionController for SessionController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1991,7 +2143,10 @@ impl super::stub::SessionController for SessionController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -2011,7 +2166,9 @@ impl super::stub::SessionController for SessionController {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -2034,6 +2191,11 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2053,6 +2215,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2072,7 +2235,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -2092,7 +2255,7 @@ impl super::stub::SessionController for SessionController {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2152,6 +2315,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, Some(req.template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::WorkflowTemplate>| r.into_body())
     }
 
     async fn get_workflow_template(
@@ -2172,6 +2336,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::WorkflowTemplate>| r.into_body())
     }
 
     async fn instantiate_workflow_template(
@@ -2191,7 +2356,10 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn instantiate_inline_workflow_template(
@@ -2215,6 +2383,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, Some(req.template), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_workflow_template(
@@ -2243,6 +2412,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, Some(req.template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::WorkflowTemplate>| r.into_body())
     }
 
     async fn list_workflow_templates(
@@ -2267,6 +2437,11 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListWorkflowTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_workflow_template(
@@ -2287,7 +2462,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -2307,7 +2482,10 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -2327,7 +2505,10 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -2347,7 +2528,9 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -2370,6 +2553,11 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2389,6 +2577,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2408,7 +2597,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -2428,7 +2617,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/datastream/v1/src/transport.rs
+++ b/src/generated/cloud/datastream/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConnectionProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_connection_profile(
@@ -83,6 +88,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConnectionProfile>| r.into_body())
     }
 
     async fn create_connection_profile(
@@ -109,6 +115,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, Some(req.connection_profile), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_connection_profile(
@@ -150,6 +157,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, Some(req.connection_profile), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_connection_profile(
@@ -170,6 +178,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn discover_connection_profile(
@@ -189,7 +198,11 @@ impl super::stub::Datastream for Datastream {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::DiscoverConnectionProfileResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_streams(
@@ -213,6 +226,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListStreamsResponse>| r.into_body())
     }
 
     async fn get_stream(
@@ -232,6 +246,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Stream>| r.into_body())
     }
 
     async fn create_stream(
@@ -252,7 +267,10 @@ impl super::stub::Datastream for Datastream {
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
         let builder = builder.query(&[("force", &req.force)]);
-        self.inner.execute(builder, Some(req.stream), options).await
+        self.inner
+            .execute(builder, Some(req.stream), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_stream(
@@ -291,7 +309,10 @@ impl super::stub::Datastream for Datastream {
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
         let builder = builder.query(&[("force", &req.force)]);
-        self.inner.execute(builder, Some(req.stream), options).await
+        self.inner
+            .execute(builder, Some(req.stream), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_stream(
@@ -312,6 +333,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn run_stream(
@@ -328,7 +350,10 @@ impl super::stub::Datastream for Datastream {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_stream_object(
@@ -348,6 +373,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::StreamObject>| r.into_body())
     }
 
     async fn lookup_stream_object(
@@ -367,7 +393,10 @@ impl super::stub::Datastream for Datastream {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::StreamObject>| r.into_body())
     }
 
     async fn list_stream_objects(
@@ -389,6 +418,9 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListStreamObjectsResponse>| r.into_body(),
+            )
     }
 
     async fn start_backfill_job(
@@ -408,7 +440,10 @@ impl super::stub::Datastream for Datastream {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::StartBackfillJobResponse>| r.into_body())
     }
 
     async fn stop_backfill_job(
@@ -428,7 +463,10 @@ impl super::stub::Datastream for Datastream {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::StopBackfillJobResponse>| r.into_body())
     }
 
     async fn fetch_static_ips(
@@ -453,6 +491,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FetchStaticIpsResponse>| r.into_body())
     }
 
     async fn create_private_connection(
@@ -478,6 +517,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, Some(req.private_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_private_connection(
@@ -497,6 +537,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PrivateConnection>| r.into_body())
     }
 
     async fn list_private_connections(
@@ -523,6 +564,11 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPrivateConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_private_connection(
@@ -544,6 +590,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_route(
@@ -562,7 +609,10 @@ impl super::stub::Datastream for Datastream {
             );
         let builder = builder.query(&[("routeId", &req.route_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.route), options).await
+        self.inner
+            .execute(builder, Some(req.route), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_route(
@@ -582,6 +632,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Route>| r.into_body())
     }
 
     async fn list_routes(
@@ -605,6 +656,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRoutesResponse>| r.into_body())
     }
 
     async fn delete_route(
@@ -625,6 +677,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -647,6 +700,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -666,6 +720,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -688,6 +743,11 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -707,6 +767,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -726,7 +787,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -746,7 +807,7 @@ impl super::stub::Datastream for Datastream {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/deploy/v1/src/transport.rs
+++ b/src/generated/cloud/deploy/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDeliveryPipelinesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_delivery_pipeline(
@@ -83,6 +88,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DeliveryPipeline>| r.into_body())
     }
 
     async fn create_delivery_pipeline(
@@ -108,6 +114,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.delivery_pipeline), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_delivery_pipeline(
@@ -149,6 +156,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.delivery_pipeline), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_delivery_pipeline(
@@ -173,6 +181,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_targets(
@@ -196,6 +205,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTargetsResponse>| r.into_body())
     }
 
     async fn rollback_target(
@@ -215,7 +225,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RollbackTargetResponse>| r.into_body())
     }
 
     async fn get_target(
@@ -235,6 +248,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Target>| r.into_body())
     }
 
     async fn create_target(
@@ -254,7 +268,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
         let builder = builder.query(&[("targetId", &req.target_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.target), options).await
+        self.inner
+            .execute(builder, Some(req.target), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_target(
@@ -293,7 +310,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
         let builder = builder.query(&[("requestId", &req.request_id)]);
         let builder = builder.query(&[("allowMissing", &req.allow_missing)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.target), options).await
+        self.inner
+            .execute(builder, Some(req.target), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_target(
@@ -317,6 +337,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_custom_target_types(
@@ -343,6 +364,11 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCustomTargetTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_custom_target_type(
@@ -362,6 +388,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomTargetType>| r.into_body())
     }
 
     async fn create_custom_target_type(
@@ -387,6 +414,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.custom_target_type), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_custom_target_type(
@@ -428,6 +456,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.custom_target_type), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_custom_target_type(
@@ -451,6 +480,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_releases(
@@ -474,6 +504,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListReleasesResponse>| r.into_body())
     }
 
     async fn get_release(
@@ -493,6 +524,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Release>| r.into_body())
     }
 
     async fn create_release(
@@ -524,6 +556,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.release), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn abandon_release(
@@ -540,7 +573,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AbandonReleaseResponse>| r.into_body())
     }
 
     async fn create_deploy_policy(
@@ -566,6 +602,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.deploy_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_deploy_policy(
@@ -607,6 +644,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.deploy_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_deploy_policy(
@@ -630,6 +668,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_deploy_policies(
@@ -656,6 +695,11 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDeployPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_deploy_policy(
@@ -675,6 +719,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DeployPolicy>| r.into_body())
     }
 
     async fn approve_rollout(
@@ -691,7 +736,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ApproveRolloutResponse>| r.into_body())
     }
 
     async fn advance_rollout(
@@ -708,7 +756,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AdvanceRolloutResponse>| r.into_body())
     }
 
     async fn cancel_rollout(
@@ -725,7 +776,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CancelRolloutResponse>| r.into_body())
     }
 
     async fn list_rollouts(
@@ -749,6 +803,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRolloutsResponse>| r.into_body())
     }
 
     async fn get_rollout(
@@ -768,6 +823,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Rollout>| r.into_body())
     }
 
     async fn create_rollout(
@@ -800,6 +856,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.rollout), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn ignore_job(
@@ -819,7 +876,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::IgnoreJobResponse>| r.into_body())
     }
 
     async fn retry_job(
@@ -839,7 +899,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RetryJobResponse>| r.into_body())
     }
 
     async fn list_job_runs(
@@ -863,6 +926,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobRunsResponse>| r.into_body())
     }
 
     async fn get_job_run(
@@ -882,6 +946,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::JobRun>| r.into_body())
     }
 
     async fn terminate_job_run(
@@ -898,7 +963,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::TerminateJobRunResponse>| r.into_body())
     }
 
     async fn get_config(
@@ -918,6 +986,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Config>| r.into_body())
     }
 
     async fn create_automation(
@@ -943,6 +1012,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.automation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_automation(
@@ -984,6 +1054,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req.automation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_automation(
@@ -1007,6 +1078,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_automation(
@@ -1026,6 +1098,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Automation>| r.into_body())
     }
 
     async fn list_automations(
@@ -1052,6 +1125,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAutomationsResponse>| r.into_body())
     }
 
     async fn get_automation_run(
@@ -1071,6 +1145,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AutomationRun>| r.into_body())
     }
 
     async fn list_automation_runs(
@@ -1097,6 +1172,11 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAutomationRunsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn cancel_automation_run(
@@ -1113,7 +1193,9 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::CancelAutomationRunResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -1136,6 +1218,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1155,6 +1238,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1174,7 +1258,10 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1207,6 +1294,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1226,7 +1314,9 @@ impl super::stub::CloudDeploy for CloudDeploy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1249,6 +1339,11 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1268,6 +1363,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1287,7 +1383,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1307,7 +1403,7 @@ impl super::stub::CloudDeploy for CloudDeploy {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/developerconnect/v1/src/transport.rs
+++ b/src/generated/cloud/developerconnect/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectionsResponse>| r.into_body())
     }
 
     async fn get_connection(
@@ -83,6 +84,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn create_connection(
@@ -108,6 +110,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_connection(
@@ -149,6 +152,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_connection(
@@ -171,6 +175,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_git_repository_link(
@@ -196,6 +201,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, Some(req.git_repository_link), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_git_repository_link(
@@ -218,6 +224,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_git_repository_links(
@@ -244,6 +251,11 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListGitRepositoryLinksResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_git_repository_link(
@@ -263,6 +275,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GitRepositoryLink>| r.into_body())
     }
 
     async fn fetch_read_write_token(
@@ -282,7 +295,9 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::FetchReadWriteTokenResponse>| r.into_body(),
+        )
     }
 
     async fn fetch_read_token(
@@ -302,7 +317,10 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FetchReadTokenResponse>| r.into_body())
     }
 
     async fn fetch_linkable_git_repositories(
@@ -327,6 +345,11 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchLinkableGitRepositoriesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn fetch_git_hub_installations(
@@ -349,6 +372,11 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchGitHubInstallationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn fetch_git_refs(
@@ -374,6 +402,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FetchGitRefsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -396,6 +425,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -415,6 +445,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -437,6 +468,11 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -456,6 +492,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -475,7 +512,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -495,7 +532,7 @@ impl super::stub::DeveloperConnect for DeveloperConnect {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAgentsResponse>| r.into_body())
     }
 
     async fn get_agent(
@@ -78,6 +79,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Agent>| r.into_body())
     }
 
     async fn create_agent(
@@ -94,7 +96,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.agent), options).await
+        self.inner
+            .execute(builder, Some(req.agent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Agent>| r.into_body())
     }
 
     async fn update_agent(
@@ -130,7 +135,10 @@ impl super::stub::Agents for Agents {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.agent), options).await
+        self.inner
+            .execute(builder, Some(req.agent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Agent>| r.into_body())
     }
 
     async fn delete_agent(
@@ -150,7 +158,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn export_agent(
@@ -167,7 +175,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_agent(
@@ -184,7 +195,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn validate_agent(
@@ -201,7 +215,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AgentValidationResult>| r.into_body())
     }
 
     async fn get_agent_validation_result(
@@ -222,6 +239,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AgentValidationResult>| r.into_body())
     }
 
     async fn get_generative_settings(
@@ -242,6 +260,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GenerativeSettings>| r.into_body())
     }
 
     async fn update_generative_settings(
@@ -280,6 +299,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, Some(req.generative_settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::GenerativeSettings>| r.into_body())
     }
 
     async fn list_locations(
@@ -302,6 +322,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -321,6 +342,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -343,6 +365,11 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -362,6 +389,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -381,7 +409,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -444,6 +472,7 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListChangelogsResponse>| r.into_body())
     }
 
     async fn get_changelog(
@@ -463,6 +492,7 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Changelog>| r.into_body())
     }
 
     async fn list_locations(
@@ -485,6 +515,7 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -504,6 +535,7 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -526,6 +558,11 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -545,6 +582,7 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -564,7 +602,7 @@ impl super::stub::Changelogs for Changelogs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -612,6 +650,7 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDeploymentsResponse>| r.into_body())
     }
 
     async fn get_deployment(
@@ -631,6 +670,7 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn list_locations(
@@ -653,6 +693,7 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -672,6 +713,7 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -694,6 +736,11 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -713,6 +760,7 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -732,7 +780,7 @@ impl super::stub::Deployments for Deployments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -776,6 +824,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn create_entity_type(
@@ -799,6 +848,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, Some(req.entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn update_entity_type(
@@ -838,6 +888,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, Some(req.entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn delete_entity_type(
@@ -858,7 +909,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_entity_types(
@@ -884,6 +935,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntityTypesResponse>| r.into_body())
     }
 
     async fn export_entity_types(
@@ -903,7 +955,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_entity_types(
@@ -923,7 +978,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -946,6 +1004,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -965,6 +1024,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -987,6 +1047,11 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1006,6 +1071,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1025,7 +1091,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1087,6 +1153,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEnvironmentsResponse>| r.into_body())
     }
 
     async fn get_environment(
@@ -1106,6 +1173,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Environment>| r.into_body())
     }
 
     async fn create_environment(
@@ -1128,6 +1196,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.environment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_environment(
@@ -1166,6 +1235,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.environment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_environment(
@@ -1185,7 +1255,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn lookup_environment_history(
@@ -1210,6 +1280,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::LookupEnvironmentHistoryResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn run_continuous_test(
@@ -1229,7 +1304,10 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_continuous_test_results(
@@ -1254,6 +1332,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListContinuousTestResultsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn deploy_flow(
@@ -1273,7 +1356,10 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1296,6 +1382,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1315,6 +1402,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1337,6 +1425,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1356,6 +1449,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1375,7 +1469,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1437,6 +1531,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExperimentsResponse>| r.into_body())
     }
 
     async fn get_experiment(
@@ -1456,6 +1551,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Experiment>| r.into_body())
     }
 
     async fn create_experiment(
@@ -1478,6 +1574,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, Some(req.experiment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Experiment>| r.into_body())
     }
 
     async fn update_experiment(
@@ -1516,6 +1613,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, Some(req.experiment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Experiment>| r.into_body())
     }
 
     async fn delete_experiment(
@@ -1535,7 +1633,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn start_experiment(
@@ -1552,7 +1650,10 @@ impl super::stub::Experiments for Experiments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Experiment>| r.into_body())
     }
 
     async fn stop_experiment(
@@ -1569,7 +1670,10 @@ impl super::stub::Experiments for Experiments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Experiment>| r.into_body())
     }
 
     async fn list_locations(
@@ -1592,6 +1696,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1611,6 +1716,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1633,6 +1739,11 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1652,6 +1763,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1671,7 +1783,7 @@ impl super::stub::Experiments for Experiments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1710,7 +1822,10 @@ impl super::stub::Flows for Flows {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        self.inner.execute(builder, Some(req.flow), options).await
+        self.inner
+            .execute(builder, Some(req.flow), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Flow>| r.into_body())
     }
 
     async fn delete_flow(
@@ -1731,7 +1846,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_flows(
@@ -1754,6 +1869,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFlowsResponse>| r.into_body())
     }
 
     async fn get_flow(
@@ -1774,6 +1890,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Flow>| r.into_body())
     }
 
     async fn update_flow(
@@ -1810,7 +1927,10 @@ impl super::stub::Flows for Flows {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        self.inner.execute(builder, Some(req.flow), options).await
+        self.inner
+            .execute(builder, Some(req.flow), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Flow>| r.into_body())
     }
 
     async fn train_flow(
@@ -1827,7 +1947,10 @@ impl super::stub::Flows for Flows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn validate_flow(
@@ -1844,7 +1967,10 @@ impl super::stub::Flows for Flows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FlowValidationResult>| r.into_body())
     }
 
     async fn get_flow_validation_result(
@@ -1865,6 +1991,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FlowValidationResult>| r.into_body())
     }
 
     async fn import_flow(
@@ -1884,7 +2011,10 @@ impl super::stub::Flows for Flows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_flow(
@@ -1901,7 +2031,10 @@ impl super::stub::Flows for Flows {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1924,6 +2057,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1943,6 +2077,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1965,6 +2100,11 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1984,6 +2124,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2003,7 +2144,7 @@ impl super::stub::Flows for Flows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2066,6 +2207,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGeneratorsResponse>| r.into_body())
     }
 
     async fn get_generator(
@@ -2086,6 +2228,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Generator>| r.into_body())
     }
 
     async fn create_generator(
@@ -2109,6 +2252,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, Some(req.generator), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Generator>| r.into_body())
     }
 
     async fn update_generator(
@@ -2148,6 +2292,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, Some(req.generator), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Generator>| r.into_body())
     }
 
     async fn delete_generator(
@@ -2168,7 +2313,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -2191,6 +2336,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2210,6 +2356,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2232,6 +2379,11 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2251,6 +2403,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2270,7 +2423,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -2317,6 +2470,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIntentsResponse>| r.into_body())
     }
 
     async fn get_intent(
@@ -2337,6 +2491,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Intent>| r.into_body())
     }
 
     async fn create_intent(
@@ -2354,7 +2509,10 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        self.inner.execute(builder, Some(req.intent), options).await
+        self.inner
+            .execute(builder, Some(req.intent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Intent>| r.into_body())
     }
 
     async fn update_intent(
@@ -2391,7 +2549,10 @@ impl super::stub::Intents for Intents {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.intent), options).await
+        self.inner
+            .execute(builder, Some(req.intent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Intent>| r.into_body())
     }
 
     async fn delete_intent(
@@ -2411,7 +2572,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn import_intents(
@@ -2431,7 +2592,10 @@ impl super::stub::Intents for Intents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_intents(
@@ -2451,7 +2615,10 @@ impl super::stub::Intents for Intents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -2474,6 +2641,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2493,6 +2661,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2515,6 +2684,11 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2534,6 +2708,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2553,7 +2728,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2611,6 +2786,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPagesResponse>| r.into_body())
     }
 
     async fn get_page(
@@ -2631,6 +2807,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Page>| r.into_body())
     }
 
     async fn create_page(
@@ -2648,7 +2825,10 @@ impl super::stub::Pages for Pages {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
-        self.inner.execute(builder, Some(req.page), options).await
+        self.inner
+            .execute(builder, Some(req.page), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Page>| r.into_body())
     }
 
     async fn update_page(
@@ -2685,7 +2865,10 @@ impl super::stub::Pages for Pages {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.page), options).await
+        self.inner
+            .execute(builder, Some(req.page), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Page>| r.into_body())
     }
 
     async fn delete_page(
@@ -2706,7 +2889,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -2729,6 +2912,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2748,6 +2932,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2770,6 +2955,11 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2789,6 +2979,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2808,7 +2999,7 @@ impl super::stub::Pages for Pages {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -2854,6 +3045,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, Some(req.security_settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecuritySettings>| r.into_body())
     }
 
     async fn get_security_settings(
@@ -2873,6 +3065,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecuritySettings>| r.into_body())
     }
 
     async fn update_security_settings(
@@ -2911,6 +3104,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, Some(req.security_settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecuritySettings>| r.into_body())
     }
 
     async fn list_security_settings(
@@ -2935,6 +3129,11 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSecuritySettingsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_security_settings(
@@ -2954,7 +3153,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -2977,6 +3176,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2996,6 +3196,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3018,6 +3219,11 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3037,6 +3243,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3056,7 +3263,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -3099,7 +3306,10 @@ impl super::stub::Sessions for Sessions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DetectIntentResponse>| r.into_body())
     }
 
     async fn match_intent(
@@ -3119,7 +3329,10 @@ impl super::stub::Sessions for Sessions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::MatchIntentResponse>| r.into_body())
     }
 
     async fn fulfill_intent(
@@ -3145,7 +3358,10 @@ impl super::stub::Sessions for Sessions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FulfillIntentResponse>| r.into_body())
     }
 
     async fn submit_answer_feedback(
@@ -3165,7 +3381,10 @@ impl super::stub::Sessions for Sessions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AnswerFeedback>| r.into_body())
     }
 
     async fn list_locations(
@@ -3188,6 +3407,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3207,6 +3427,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3229,6 +3450,11 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3248,6 +3474,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3267,7 +3494,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -3315,6 +3542,11 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSessionEntityTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_session_entity_type(
@@ -3334,6 +3566,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionEntityType>| r.into_body())
     }
 
     async fn create_session_entity_type(
@@ -3356,6 +3589,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, Some(req.session_entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionEntityType>| r.into_body())
     }
 
     async fn update_session_entity_type(
@@ -3394,6 +3628,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, Some(req.session_entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionEntityType>| r.into_body())
     }
 
     async fn delete_session_entity_type(
@@ -3413,7 +3648,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -3436,6 +3671,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3455,6 +3691,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3477,6 +3714,11 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3496,6 +3738,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3515,7 +3758,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -3564,6 +3807,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTestCasesResponse>| r.into_body())
     }
 
     async fn batch_delete_test_cases(
@@ -3586,7 +3830,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_test_case(
@@ -3606,6 +3850,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TestCase>| r.into_body())
     }
 
     async fn create_test_case(
@@ -3628,6 +3873,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, Some(req.test_case), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TestCase>| r.into_body())
     }
 
     async fn update_test_case(
@@ -3666,6 +3912,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, Some(req.test_case), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TestCase>| r.into_body())
     }
 
     async fn run_test_case(
@@ -3682,7 +3929,10 @@ impl super::stub::TestCases for TestCases {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_run_test_cases(
@@ -3702,7 +3952,10 @@ impl super::stub::TestCases for TestCases {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn calculate_coverage(
@@ -3726,6 +3979,9 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CalculateCoverageResponse>| r.into_body(),
+            )
     }
 
     async fn import_test_cases(
@@ -3745,7 +4001,10 @@ impl super::stub::TestCases for TestCases {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_test_cases(
@@ -3765,7 +4024,10 @@ impl super::stub::TestCases for TestCases {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_test_case_results(
@@ -3788,6 +4050,11 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTestCaseResultsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_test_case_result(
@@ -3807,6 +4074,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TestCaseResult>| r.into_body())
     }
 
     async fn list_locations(
@@ -3829,6 +4097,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3848,6 +4117,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3870,6 +4140,11 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3889,6 +4164,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3908,7 +4184,7 @@ impl super::stub::TestCases for TestCases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -3971,6 +4247,11 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTransitionRouteGroupsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_transition_route_group(
@@ -3991,6 +4272,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransitionRouteGroup>| r.into_body())
     }
 
     async fn create_transition_route_group(
@@ -4014,6 +4296,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, Some(req.transition_route_group), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransitionRouteGroup>| r.into_body())
     }
 
     async fn update_transition_route_group(
@@ -4053,6 +4336,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, Some(req.transition_route_group), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransitionRouteGroup>| r.into_body())
     }
 
     async fn delete_transition_route_group(
@@ -4073,7 +4357,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -4096,6 +4380,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4115,6 +4400,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4137,6 +4423,11 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4156,6 +4447,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4175,7 +4467,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -4220,6 +4512,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVersionsResponse>| r.into_body())
     }
 
     async fn get_version(
@@ -4239,6 +4532,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn create_version(
@@ -4261,6 +4555,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_version(
@@ -4299,6 +4594,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn delete_version(
@@ -4318,7 +4614,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn load_version(
@@ -4335,7 +4631,10 @@ impl super::stub::Versions for Versions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn compare_versions(
@@ -4355,7 +4654,10 @@ impl super::stub::Versions for Versions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CompareVersionsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -4378,6 +4680,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4397,6 +4700,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4419,6 +4723,11 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4438,6 +4747,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4457,7 +4767,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -4516,6 +4826,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWebhooksResponse>| r.into_body())
     }
 
     async fn get_webhook(
@@ -4535,6 +4846,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Webhook>| r.into_body())
     }
 
     async fn create_webhook(
@@ -4557,6 +4869,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, Some(req.webhook), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Webhook>| r.into_body())
     }
 
     async fn update_webhook(
@@ -4595,6 +4908,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, Some(req.webhook), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Webhook>| r.into_body())
     }
 
     async fn delete_webhook(
@@ -4615,7 +4929,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -4638,6 +4952,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4657,6 +4972,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4679,6 +4995,11 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4698,6 +5019,7 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4717,6 +5039,6 @@ impl super::stub::Webhooks for Webhooks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Agent>| r.into_body())
     }
 
     async fn set_agent(
@@ -92,7 +93,10 @@ impl super::stub::Agents for Agents {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.agent), options).await
+        self.inner
+            .execute(builder, Some(req.agent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Agent>| r.into_body())
     }
 
     async fn delete_agent(
@@ -112,7 +116,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn search_agents(
@@ -137,6 +141,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchAgentsResponse>| r.into_body())
     }
 
     async fn train_agent(
@@ -156,7 +161,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_agent(
@@ -176,7 +184,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_agent(
@@ -196,7 +207,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_agent(
@@ -216,7 +230,10 @@ impl super::stub::Agents for Agents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_validation_result(
@@ -240,6 +257,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ValidationResult>| r.into_body())
     }
 
     async fn list_locations(
@@ -262,6 +280,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -281,6 +300,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -303,6 +323,11 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -322,6 +347,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -341,7 +367,7 @@ impl super::stub::Agents for Agents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -404,6 +430,9 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAnswerRecordsResponse>| r.into_body(),
+            )
     }
 
     async fn update_answer_record(
@@ -442,6 +471,7 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, Some(req.answer_record), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AnswerRecord>| r.into_body())
     }
 
     async fn list_locations(
@@ -464,6 +494,7 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -483,6 +514,7 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -505,6 +537,11 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -524,6 +561,7 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -543,7 +581,7 @@ impl super::stub::AnswerRecords for AnswerRecords {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -588,6 +626,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListContextsResponse>| r.into_body())
     }
 
     async fn get_context(
@@ -607,6 +646,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Context>| r.into_body())
     }
 
     async fn create_context(
@@ -629,6 +669,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, Some(req.context), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Context>| r.into_body())
     }
 
     async fn update_context(
@@ -667,6 +708,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, Some(req.context), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Context>| r.into_body())
     }
 
     async fn delete_context(
@@ -686,7 +728,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn delete_all_contexts(
@@ -709,7 +751,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -732,6 +774,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -751,6 +794,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -773,6 +817,11 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -792,6 +841,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -811,7 +861,7 @@ impl super::stub::Contexts for Contexts {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -858,6 +908,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, Some(req.conversation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn list_conversations(
@@ -883,6 +934,9 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversationsResponse>| r.into_body(),
+            )
     }
 
     async fn get_conversation(
@@ -902,6 +956,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn complete_conversation(
@@ -918,7 +973,10 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn ingest_context_references(
@@ -938,7 +996,11 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::IngestContextReferencesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_messages(
@@ -961,6 +1023,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMessagesResponse>| r.into_body())
     }
 
     async fn suggest_conversation_summary(
@@ -983,7 +1046,11 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SuggestConversationSummaryResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn generate_stateless_summary(
@@ -1009,7 +1076,11 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateStatelessSummaryResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn generate_stateless_suggestion(
@@ -1029,7 +1100,11 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateStatelessSuggestionResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn search_knowledge(
@@ -1049,7 +1124,10 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchKnowledgeResponse>| r.into_body())
     }
 
     async fn generate_suggestions(
@@ -1069,7 +1147,9 @@ impl super::stub::Conversations for Conversations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateSuggestionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -1092,6 +1172,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1111,6 +1192,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1133,6 +1215,11 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1152,6 +1239,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1171,7 +1259,7 @@ impl super::stub::Conversations for Conversations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1217,6 +1305,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, Some(req.conversation_dataset), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_conversation_dataset(
@@ -1236,6 +1325,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConversationDataset>| r.into_body())
     }
 
     async fn list_conversation_datasets(
@@ -1260,6 +1350,11 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversationDatasetsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_conversation_dataset(
@@ -1279,6 +1374,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_conversation_data(
@@ -1298,7 +1394,10 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1321,6 +1420,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1340,6 +1440,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1362,6 +1463,11 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1381,6 +1487,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1400,7 +1507,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1460,6 +1567,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, Some(req.conversation_model), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_conversation_model(
@@ -1479,6 +1587,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConversationModel>| r.into_body())
     }
 
     async fn list_conversation_models(
@@ -1503,6 +1612,11 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversationModelsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_conversation_model(
@@ -1522,6 +1636,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn deploy_conversation_model(
@@ -1538,7 +1653,10 @@ impl super::stub::ConversationModels for ConversationModels {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undeploy_conversation_model(
@@ -1555,7 +1673,10 @@ impl super::stub::ConversationModels for ConversationModels {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_conversation_model_evaluation(
@@ -1575,6 +1696,11 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ConversationModelEvaluation>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_conversation_model_evaluations(
@@ -1599,6 +1725,11 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListConversationModelEvaluationsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn create_conversation_model_evaluation(
@@ -1618,7 +1749,10 @@ impl super::stub::ConversationModels for ConversationModels {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1641,6 +1775,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1660,6 +1795,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1682,6 +1818,11 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1701,6 +1842,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1720,7 +1862,7 @@ impl super::stub::ConversationModels for ConversationModels {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1782,6 +1924,11 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversationProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_conversation_profile(
@@ -1801,6 +1948,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConversationProfile>| r.into_body())
     }
 
     async fn create_conversation_profile(
@@ -1823,6 +1971,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, Some(req.conversation_profile), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConversationProfile>| r.into_body())
     }
 
     async fn update_conversation_profile(
@@ -1861,6 +2010,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, Some(req.conversation_profile), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConversationProfile>| r.into_body())
     }
 
     async fn delete_conversation_profile(
@@ -1880,7 +2030,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_suggestion_feature_config(
@@ -1903,7 +2053,10 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn clear_suggestion_feature_config(
@@ -1926,7 +2079,10 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1949,6 +2105,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1968,6 +2125,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1990,6 +2148,11 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2009,6 +2172,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2028,7 +2192,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2091,6 +2255,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDocumentsResponse>| r.into_body())
     }
 
     async fn get_document(
@@ -2110,6 +2275,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Document>| r.into_body())
     }
 
     async fn create_document(
@@ -2132,6 +2298,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, Some(req.document), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_documents(
@@ -2151,7 +2318,10 @@ impl super::stub::Documents for Documents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_document(
@@ -2171,6 +2341,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_document(
@@ -2209,6 +2380,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, Some(req.document), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reload_document(
@@ -2225,7 +2397,10 @@ impl super::stub::Documents for Documents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_document(
@@ -2242,7 +2417,10 @@ impl super::stub::Documents for Documents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -2265,6 +2443,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2284,6 +2463,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2306,6 +2486,11 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2325,6 +2510,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2344,7 +2530,7 @@ impl super::stub::Documents for Documents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2401,6 +2587,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EncryptionSpec>| r.into_body())
     }
 
     async fn initialize_encryption_spec(
@@ -2426,7 +2613,10 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -2449,6 +2639,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2468,6 +2659,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2490,6 +2682,11 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2509,6 +2706,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2528,7 +2726,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2591,6 +2789,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntityTypesResponse>| r.into_body())
     }
 
     async fn get_entity_type(
@@ -2611,6 +2810,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn create_entity_type(
@@ -2634,6 +2834,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, Some(req.entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn update_entity_type(
@@ -2673,6 +2874,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, Some(req.entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EntityType>| r.into_body())
     }
 
     async fn delete_entity_type(
@@ -2692,7 +2894,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_update_entity_types(
@@ -2712,7 +2914,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_delete_entity_types(
@@ -2732,7 +2937,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_entities(
@@ -2752,7 +2960,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_update_entities(
@@ -2772,7 +2983,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_delete_entities(
@@ -2792,7 +3006,10 @@ impl super::stub::EntityTypes for EntityTypes {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -2815,6 +3032,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -2834,6 +3052,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -2856,6 +3075,11 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2875,6 +3099,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2894,7 +3119,7 @@ impl super::stub::EntityTypes for EntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2956,6 +3181,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEnvironmentsResponse>| r.into_body())
     }
 
     async fn get_environment(
@@ -2975,6 +3201,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Environment>| r.into_body())
     }
 
     async fn create_environment(
@@ -2998,6 +3225,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.environment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Environment>| r.into_body())
     }
 
     async fn update_environment(
@@ -3040,6 +3268,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.environment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Environment>| r.into_body())
     }
 
     async fn delete_environment(
@@ -3059,7 +3288,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_environment_history(
@@ -3081,6 +3310,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EnvironmentHistory>| r.into_body())
     }
 
     async fn list_locations(
@@ -3103,6 +3333,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3122,6 +3353,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3144,6 +3376,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3163,6 +3400,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3182,7 +3420,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -3225,6 +3463,7 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Fulfillment>| r.into_body())
     }
 
     async fn update_fulfillment(
@@ -3263,6 +3502,7 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, Some(req.fulfillment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Fulfillment>| r.into_body())
     }
 
     async fn list_locations(
@@ -3285,6 +3525,7 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3304,6 +3545,7 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3326,6 +3568,11 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3345,6 +3592,7 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3364,7 +3612,7 @@ impl super::stub::Fulfillments for Fulfillments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -3411,6 +3659,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, Some(req.generator), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Generator>| r.into_body())
     }
 
     async fn get_generator(
@@ -3430,6 +3679,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Generator>| r.into_body())
     }
 
     async fn list_generators(
@@ -3454,6 +3704,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGeneratorsResponse>| r.into_body())
     }
 
     async fn delete_generator(
@@ -3473,7 +3724,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_generator(
@@ -3512,6 +3763,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, Some(req.generator), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Generator>| r.into_body())
     }
 
     async fn list_locations(
@@ -3534,6 +3786,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3553,6 +3806,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3575,6 +3829,11 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3594,6 +3853,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3613,7 +3873,7 @@ impl super::stub::Generators for Generators {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -3660,6 +3920,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIntentsResponse>| r.into_body())
     }
 
     async fn get_intent(
@@ -3681,6 +3942,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Intent>| r.into_body())
     }
 
     async fn create_intent(
@@ -3699,7 +3961,10 @@ impl super::stub::Intents for Intents {
             );
         let builder = builder.query(&[("languageCode", &req.language_code)]);
         let builder = builder.query(&[("intentView", &req.intent_view.value())]);
-        self.inner.execute(builder, Some(req.intent), options).await
+        self.inner
+            .execute(builder, Some(req.intent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Intent>| r.into_body())
     }
 
     async fn update_intent(
@@ -3737,7 +4002,10 @@ impl super::stub::Intents for Intents {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("intentView", &req.intent_view.value())]);
-        self.inner.execute(builder, Some(req.intent), options).await
+        self.inner
+            .execute(builder, Some(req.intent), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Intent>| r.into_body())
     }
 
     async fn delete_intent(
@@ -3757,7 +4025,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_update_intents(
@@ -3777,7 +4045,10 @@ impl super::stub::Intents for Intents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_delete_intents(
@@ -3797,7 +4068,10 @@ impl super::stub::Intents for Intents {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -3820,6 +4094,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -3839,6 +4114,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -3861,6 +4137,11 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3880,6 +4161,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3899,7 +4181,7 @@ impl super::stub::Intents for Intents {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -3962,6 +4244,11 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListKnowledgeBasesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_knowledge_base(
@@ -3981,6 +4268,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::KnowledgeBase>| r.into_body())
     }
 
     async fn create_knowledge_base(
@@ -4003,6 +4291,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, Some(req.knowledge_base), options)
             .await
+            .map(|r: gax::response::Response<crate::model::KnowledgeBase>| r.into_body())
     }
 
     async fn delete_knowledge_base(
@@ -4023,7 +4312,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_knowledge_base(
@@ -4062,6 +4351,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, Some(req.knowledge_base), options)
             .await
+            .map(|r: gax::response::Response<crate::model::KnowledgeBase>| r.into_body())
     }
 
     async fn list_locations(
@@ -4084,6 +4374,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4103,6 +4394,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4125,6 +4417,11 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4144,6 +4441,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4163,7 +4461,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -4209,6 +4507,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, Some(req.participant), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Participant>| r.into_body())
     }
 
     async fn get_participant(
@@ -4228,6 +4527,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Participant>| r.into_body())
     }
 
     async fn list_participants(
@@ -4252,6 +4552,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListParticipantsResponse>| r.into_body())
     }
 
     async fn update_participant(
@@ -4290,6 +4591,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, Some(req.participant), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Participant>| r.into_body())
     }
 
     async fn analyze_content(
@@ -4309,7 +4611,10 @@ impl super::stub::Participants for Participants {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AnalyzeContentResponse>| r.into_body())
     }
 
     async fn suggest_articles(
@@ -4329,7 +4634,10 @@ impl super::stub::Participants for Participants {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SuggestArticlesResponse>| r.into_body())
     }
 
     async fn suggest_faq_answers(
@@ -4349,7 +4657,9 @@ impl super::stub::Participants for Participants {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SuggestFaqAnswersResponse>| r.into_body(),
+        )
     }
 
     async fn suggest_smart_replies(
@@ -4369,7 +4679,9 @@ impl super::stub::Participants for Participants {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SuggestSmartRepliesResponse>| r.into_body(),
+        )
     }
 
     async fn suggest_knowledge_assist(
@@ -4389,7 +4701,11 @@ impl super::stub::Participants for Participants {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SuggestKnowledgeAssistResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_locations(
@@ -4412,6 +4728,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4431,6 +4748,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4453,6 +4771,11 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4472,6 +4795,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4491,7 +4815,7 @@ impl super::stub::Participants for Participants {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -4534,7 +4858,10 @@ impl super::stub::Sessions for Sessions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DetectIntentResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -4557,6 +4884,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4576,6 +4904,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4598,6 +4927,11 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4617,6 +4951,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4636,7 +4971,7 @@ impl super::stub::Sessions for Sessions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -4684,6 +5019,11 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSessionEntityTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_session_entity_type(
@@ -4703,6 +5043,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionEntityType>| r.into_body())
     }
 
     async fn create_session_entity_type(
@@ -4725,6 +5066,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, Some(req.session_entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionEntityType>| r.into_body())
     }
 
     async fn update_session_entity_type(
@@ -4763,6 +5105,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, Some(req.session_entity_type), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SessionEntityType>| r.into_body())
     }
 
     async fn delete_session_entity_type(
@@ -4782,7 +5125,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -4805,6 +5148,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -4824,6 +5168,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -4846,6 +5191,11 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -4865,6 +5215,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -4884,7 +5235,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -4929,6 +5280,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVersionsResponse>| r.into_body())
     }
 
     async fn get_version(
@@ -4948,6 +5300,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn create_version(
@@ -4970,6 +5323,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn update_version(
@@ -5008,6 +5362,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn delete_version(
@@ -5027,7 +5382,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -5050,6 +5405,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -5069,6 +5425,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -5091,6 +5448,11 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -5110,6 +5472,7 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -5129,6 +5492,6 @@ impl super::stub::Versions for Versions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/discoveryengine/v1/src/transport.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CompleteQueryResponse>| r.into_body())
     }
 
     async fn import_suggestion_deny_list_entries(
@@ -83,7 +84,10 @@ impl super::stub::CompletionService for CompletionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_suggestion_deny_list_entries(
@@ -103,7 +107,10 @@ impl super::stub::CompletionService for CompletionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_completion_suggestions(
@@ -123,7 +130,10 @@ impl super::stub::CompletionService for CompletionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_completion_suggestions(
@@ -143,7 +153,10 @@ impl super::stub::CompletionService for CompletionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -166,6 +179,11 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -185,6 +203,7 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -204,7 +223,7 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -265,6 +284,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, Some(req.control), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Control>| r.into_body())
     }
 
     async fn delete_control(
@@ -284,7 +304,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_control(
@@ -323,6 +343,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, Some(req.control), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Control>| r.into_body())
     }
 
     async fn get_control(
@@ -342,6 +363,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Control>| r.into_body())
     }
 
     async fn list_controls(
@@ -364,6 +386,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListControlsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -386,6 +409,11 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -405,6 +433,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -424,7 +453,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -464,7 +493,9 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ConverseConversationResponse>| r.into_body(),
+        )
     }
 
     async fn create_conversation(
@@ -487,6 +518,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, Some(req.conversation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn delete_conversation(
@@ -506,7 +538,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_conversation(
@@ -545,6 +577,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, Some(req.conversation), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn get_conversation(
@@ -564,6 +597,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Conversation>| r.into_body())
     }
 
     async fn list_conversations(
@@ -590,6 +624,9 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConversationsResponse>| r.into_body(),
+            )
     }
 
     async fn answer_query(
@@ -609,7 +646,10 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AnswerQueryResponse>| r.into_body())
     }
 
     async fn get_answer(
@@ -629,6 +669,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Answer>| r.into_body())
     }
 
     async fn create_session(
@@ -651,6 +692,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, Some(req.session), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Session>| r.into_body())
     }
 
     async fn delete_session(
@@ -670,7 +712,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_session(
@@ -709,6 +751,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, Some(req.session), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Session>| r.into_body())
     }
 
     async fn get_session(
@@ -729,6 +772,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Session>| r.into_body())
     }
 
     async fn list_sessions(
@@ -752,6 +796,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSessionsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -774,6 +819,11 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -793,6 +843,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -812,7 +863,7 @@ impl super::stub::ConversationalSearchService for ConversationalSearchService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -865,6 +916,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, Some(req.data_store), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_data_store(
@@ -884,6 +936,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataStore>| r.into_body())
     }
 
     async fn list_data_stores(
@@ -909,6 +962,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDataStoresResponse>| r.into_body())
     }
 
     async fn delete_data_store(
@@ -928,6 +982,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_data_store(
@@ -966,6 +1021,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, Some(req.data_store), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataStore>| r.into_body())
     }
 
     async fn list_operations(
@@ -988,6 +1044,11 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1007,6 +1068,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1026,7 +1088,7 @@ impl super::stub::DataStoreService for DataStoreService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1083,6 +1145,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Document>| r.into_body())
     }
 
     async fn list_documents(
@@ -1107,6 +1170,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDocumentsResponse>| r.into_body())
     }
 
     async fn create_document(
@@ -1130,6 +1194,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, Some(req.document), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Document>| r.into_body())
     }
 
     async fn update_document(
@@ -1169,6 +1234,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, Some(req.document), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Document>| r.into_body())
     }
 
     async fn delete_document(
@@ -1188,7 +1254,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn import_documents(
@@ -1208,7 +1274,10 @@ impl super::stub::DocumentService for DocumentService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_documents(
@@ -1228,7 +1297,10 @@ impl super::stub::DocumentService for DocumentService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_get_documents_metadata(
@@ -1261,6 +1333,11 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::BatchGetDocumentsMetadataResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -1283,6 +1360,11 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1302,6 +1384,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1321,7 +1404,7 @@ impl super::stub::DocumentService for DocumentService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1376,7 +1459,10 @@ impl super::stub::EngineService for EngineService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("engineId", &req.engine_id)]);
-        self.inner.execute(builder, Some(req.engine), options).await
+        self.inner
+            .execute(builder, Some(req.engine), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_engine(
@@ -1396,6 +1482,7 @@ impl super::stub::EngineService for EngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_engine(
@@ -1431,7 +1518,10 @@ impl super::stub::EngineService for EngineService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.engine), options).await
+        self.inner
+            .execute(builder, Some(req.engine), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Engine>| r.into_body())
     }
 
     async fn get_engine(
@@ -1451,6 +1541,7 @@ impl super::stub::EngineService for EngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Engine>| r.into_body())
     }
 
     async fn list_engines(
@@ -1473,6 +1564,7 @@ impl super::stub::EngineService for EngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEnginesResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1495,6 +1587,11 @@ impl super::stub::EngineService for EngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1514,6 +1611,7 @@ impl super::stub::EngineService for EngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1533,7 +1631,7 @@ impl super::stub::EngineService for EngineService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1590,7 +1688,11 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateGroundedContentResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn check_grounding(
@@ -1610,7 +1712,10 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CheckGroundingResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1633,6 +1738,11 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1652,6 +1762,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1671,7 +1782,7 @@ impl super::stub::GroundedGenerationService for GroundedGenerationService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1711,7 +1822,10 @@ impl super::stub::ProjectService for ProjectService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -1734,6 +1848,11 @@ impl super::stub::ProjectService for ProjectService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1753,6 +1872,7 @@ impl super::stub::ProjectService for ProjectService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1772,7 +1892,7 @@ impl super::stub::ProjectService for ProjectService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1829,7 +1949,10 @@ impl super::stub::RankService for RankService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RankResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1852,6 +1975,11 @@ impl super::stub::RankService for RankService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1871,6 +1999,7 @@ impl super::stub::RankService for RankService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1890,7 +2019,7 @@ impl super::stub::RankService for RankService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1933,7 +2062,10 @@ impl super::stub::RecommendationService for RecommendationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RecommendResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1956,6 +2088,11 @@ impl super::stub::RecommendationService for RecommendationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1975,6 +2112,7 @@ impl super::stub::RecommendationService for RecommendationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1994,7 +2132,7 @@ impl super::stub::RecommendationService for RecommendationService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -2037,6 +2175,7 @@ impl super::stub::SchemaService for SchemaService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Schema>| r.into_body())
     }
 
     async fn list_schemas(
@@ -2058,6 +2197,7 @@ impl super::stub::SchemaService for SchemaService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSchemasResponse>| r.into_body())
     }
 
     async fn create_schema(
@@ -2075,7 +2215,10 @@ impl super::stub::SchemaService for SchemaService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("schemaId", &req.schema_id)]);
-        self.inner.execute(builder, Some(req.schema), options).await
+        self.inner
+            .execute(builder, Some(req.schema), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_schema(
@@ -2102,7 +2245,10 @@ impl super::stub::SchemaService for SchemaService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("allowMissing", &req.allow_missing)]);
-        self.inner.execute(builder, Some(req.schema), options).await
+        self.inner
+            .execute(builder, Some(req.schema), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_schema(
@@ -2122,6 +2268,7 @@ impl super::stub::SchemaService for SchemaService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -2144,6 +2291,11 @@ impl super::stub::SchemaService for SchemaService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2163,6 +2315,7 @@ impl super::stub::SchemaService for SchemaService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2182,7 +2335,7 @@ impl super::stub::SchemaService for SchemaService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2239,7 +2392,10 @@ impl super::stub::SearchService for SearchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchResponse>| r.into_body())
     }
 
     async fn search_lite(
@@ -2259,7 +2415,10 @@ impl super::stub::SearchService for SearchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -2282,6 +2441,11 @@ impl super::stub::SearchService for SearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2301,6 +2465,7 @@ impl super::stub::SearchService for SearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2320,7 +2485,7 @@ impl super::stub::SearchService for SearchService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -2363,7 +2528,10 @@ impl super::stub::SearchTuningService for SearchTuningService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_custom_models(
@@ -2386,6 +2554,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCustomModelsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -2408,6 +2577,11 @@ impl super::stub::SearchTuningService for SearchTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2427,6 +2601,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2446,7 +2621,7 @@ impl super::stub::SearchTuningService for SearchTuningService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -2522,6 +2697,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, Some(req.serving_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServingConfig>| r.into_body())
     }
 
     async fn list_operations(
@@ -2544,6 +2720,11 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2563,6 +2744,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2582,7 +2764,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -2625,6 +2807,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SiteSearchEngine>| r.into_body())
     }
 
     async fn create_target_site(
@@ -2647,6 +2830,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, Some(req.target_site), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_target_sites(
@@ -2666,7 +2850,10 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_target_site(
@@ -2686,6 +2873,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TargetSite>| r.into_body())
     }
 
     async fn update_target_site(
@@ -2714,6 +2902,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, Some(req.target_site), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_target_site(
@@ -2733,6 +2922,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_target_sites(
@@ -2757,6 +2947,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTargetSitesResponse>| r.into_body())
     }
 
     async fn create_sitemap(
@@ -2779,6 +2970,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, Some(req.sitemap), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_sitemap(
@@ -2798,6 +2990,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_sitemaps(
@@ -2830,6 +3023,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FetchSitemapsResponse>| r.into_body())
     }
 
     async fn enable_advanced_site_search(
@@ -2849,7 +3043,10 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn disable_advanced_site_search(
@@ -2869,7 +3066,10 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn recrawl_uris(
@@ -2889,7 +3089,10 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_verify_target_sites(
@@ -2909,7 +3112,10 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_domain_verification_status(
@@ -2937,6 +3143,11 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::FetchDomainVerificationStatusResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn list_operations(
@@ -2959,6 +3170,11 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2978,6 +3194,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -2997,7 +3214,7 @@ impl super::stub::SiteSearchEngineService for SiteSearchEngineService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -3058,6 +3275,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, Some(req.user_event), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserEvent>| r.into_body())
     }
 
     async fn collect_user_event(
@@ -3089,6 +3307,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<api::model::HttpBody>| r.into_body())
     }
 
     async fn purge_user_events(
@@ -3108,7 +3327,10 @@ impl super::stub::UserEventService for UserEventService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_user_events(
@@ -3128,7 +3350,10 @@ impl super::stub::UserEventService for UserEventService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -3151,6 +3376,11 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -3170,6 +3400,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -3189,7 +3420,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/documentai/v1/src/transport.rs
+++ b/src/generated/cloud/documentai/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ProcessResponse>| r.into_body())
     }
 
     async fn batch_process_documents(
@@ -74,7 +77,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_processor_types(
@@ -97,6 +103,11 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchProcessorTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_processor_types(
@@ -121,6 +132,11 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListProcessorTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_processor_type(
@@ -140,6 +156,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProcessorType>| r.into_body())
     }
 
     async fn list_processors(
@@ -164,6 +181,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProcessorsResponse>| r.into_body())
     }
 
     async fn get_processor(
@@ -183,6 +201,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Processor>| r.into_body())
     }
 
     async fn train_processor_version(
@@ -202,7 +221,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_processor_version(
@@ -222,6 +244,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProcessorVersion>| r.into_body())
     }
 
     async fn list_processor_versions(
@@ -246,6 +269,11 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListProcessorVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_processor_version(
@@ -265,6 +293,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn deploy_processor_version(
@@ -281,7 +310,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undeploy_processor_version(
@@ -298,7 +330,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_processor(
@@ -321,6 +356,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, Some(req.processor), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Processor>| r.into_body())
     }
 
     async fn delete_processor(
@@ -340,6 +376,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn enable_processor(
@@ -356,7 +393,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn disable_processor(
@@ -373,7 +413,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn set_default_processor_version(
@@ -393,7 +436,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn review_document(
@@ -413,7 +459,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn evaluate_processor_version(
@@ -433,7 +482,10 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_evaluation(
@@ -453,6 +505,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Evaluation>| r.into_body())
     }
 
     async fn list_evaluations(
@@ -477,6 +530,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEvaluationsResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -499,6 +553,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -518,6 +573,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -540,6 +596,11 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -559,6 +620,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -578,7 +640,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/domains/v1/src/transport.rs
+++ b/src/generated/cloud/domains/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchDomainsResponse>| r.into_body())
     }
 
     async fn retrieve_register_parameters(
@@ -87,6 +88,11 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::RetrieveRegisterParametersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn register_domain(
@@ -106,7 +112,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn retrieve_transfer_parameters(
@@ -133,6 +142,11 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::RetrieveTransferParametersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn transfer_domain(
@@ -152,7 +166,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_registrations(
@@ -178,6 +195,9 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRegistrationsResponse>| r.into_body(),
+            )
     }
 
     async fn get_registration(
@@ -197,6 +217,7 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Registration>| r.into_body())
     }
 
     async fn update_registration(
@@ -235,6 +256,7 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, Some(req.registration), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn configure_management_settings(
@@ -254,7 +276,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn configure_dns_settings(
@@ -274,7 +299,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn configure_contact_settings(
@@ -294,7 +322,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_registration(
@@ -311,7 +342,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_registration(
@@ -331,6 +365,7 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn retrieve_authorization_code(
@@ -353,6 +388,7 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AuthorizationCode>| r.into_body())
     }
 
     async fn reset_authorization_code(
@@ -372,7 +408,10 @@ impl super::stub::Domains for Domains {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AuthorizationCode>| r.into_body())
     }
 
     async fn list_operations(
@@ -395,6 +434,11 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -414,6 +458,7 @@ impl super::stub::Domains for Domains {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/edgecontainer/v1/src/transport.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn get_cluster(
@@ -80,6 +81,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn create_cluster(
@@ -104,6 +106,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_cluster(
@@ -143,6 +146,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn upgrade_cluster(
@@ -159,7 +163,10 @@ impl super::stub::EdgeContainer for EdgeContainer {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -180,6 +187,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_access_token(
@@ -202,6 +210,11 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerateAccessTokenResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn generate_offline_credential(
@@ -224,6 +237,11 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerateOfflineCredentialResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_node_pools(
@@ -250,6 +268,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNodePoolsResponse>| r.into_body())
     }
 
     async fn get_node_pool(
@@ -269,6 +288,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NodePool>| r.into_body())
     }
 
     async fn create_node_pool(
@@ -293,6 +313,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, Some(req.node_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_node_pool(
@@ -332,6 +353,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, Some(req.node_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_node_pool(
@@ -352,6 +374,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_machines(
@@ -375,6 +398,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMachinesResponse>| r.into_body())
     }
 
     async fn get_machine(
@@ -394,6 +418,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Machine>| r.into_body())
     }
 
     async fn list_vpn_connections(
@@ -420,6 +445,11 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVpnConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_vpn_connection(
@@ -439,6 +469,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VpnConnection>| r.into_body())
     }
 
     async fn create_vpn_connection(
@@ -463,6 +494,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, Some(req.vpn_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_vpn_connection(
@@ -483,6 +515,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_server_config(
@@ -505,6 +538,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServerConfig>| r.into_body())
     }
 
     async fn list_locations(
@@ -527,6 +561,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -546,6 +581,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -568,6 +604,11 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -587,6 +628,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -606,7 +648,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -626,7 +668,7 @@ impl super::stub::EdgeContainer for EdgeContainer {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/edgenetwork/v1/src/transport.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::InitializeZoneResponse>| r.into_body())
     }
 
     async fn list_zones(
@@ -81,6 +84,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListZonesResponse>| r.into_body())
     }
 
     async fn get_zone(
@@ -100,6 +104,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Zone>| r.into_body())
     }
 
     async fn list_networks(
@@ -123,6 +128,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNetworksResponse>| r.into_body())
     }
 
     async fn get_network(
@@ -142,6 +148,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Network>| r.into_body())
     }
 
     async fn diagnose_network(
@@ -161,6 +168,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DiagnoseNetworkResponse>| r.into_body())
     }
 
     async fn create_network(
@@ -185,6 +193,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, Some(req.network), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_network(
@@ -205,6 +214,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_subnets(
@@ -228,6 +238,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSubnetsResponse>| r.into_body())
     }
 
     async fn get_subnet(
@@ -247,6 +258,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Subnet>| r.into_body())
     }
 
     async fn create_subnet(
@@ -265,7 +277,10 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
             );
         let builder = builder.query(&[("subnetId", &req.subnet_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.subnet), options).await
+        self.inner
+            .execute(builder, Some(req.subnet), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_subnet(
@@ -302,7 +317,10 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.subnet), options).await
+        self.inner
+            .execute(builder, Some(req.subnet), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_subnet(
@@ -323,6 +341,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_interconnects(
@@ -349,6 +368,9 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListInterconnectsResponse>| r.into_body(),
+            )
     }
 
     async fn get_interconnect(
@@ -368,6 +390,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Interconnect>| r.into_body())
     }
 
     async fn diagnose_interconnect(
@@ -387,6 +410,11 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::DiagnoseInterconnectResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_interconnect_attachments(
@@ -413,6 +441,11 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListInterconnectAttachmentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_interconnect_attachment(
@@ -432,6 +465,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InterconnectAttachment>| r.into_body())
     }
 
     async fn create_interconnect_attachment(
@@ -457,6 +491,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, Some(req.interconnect_attachment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_interconnect_attachment(
@@ -477,6 +512,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_routers(
@@ -500,6 +536,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRoutersResponse>| r.into_body())
     }
 
     async fn get_router(
@@ -519,6 +556,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Router>| r.into_body())
     }
 
     async fn diagnose_router(
@@ -538,6 +576,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DiagnoseRouterResponse>| r.into_body())
     }
 
     async fn create_router(
@@ -556,7 +595,10 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
             );
         let builder = builder.query(&[("routerId", &req.router_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.router), options).await
+        self.inner
+            .execute(builder, Some(req.router), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_router(
@@ -593,7 +635,10 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.router), options).await
+        self.inner
+            .execute(builder, Some(req.router), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_router(
@@ -614,6 +659,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -636,6 +682,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -655,6 +702,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -677,6 +725,11 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -696,6 +749,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -715,7 +769,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -735,7 +789,7 @@ impl super::stub::EdgeNetwork for EdgeNetwork {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/essentialcontacts/v1/src/transport.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, Some(req.contact), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Contact>| r.into_body())
     }
 
     async fn update_contact(
@@ -98,6 +99,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, Some(req.contact), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Contact>| r.into_body())
     }
 
     async fn list_contacts(
@@ -119,6 +121,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListContactsResponse>| r.into_body())
     }
 
     async fn get_contact(
@@ -138,6 +141,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Contact>| r.into_body())
     }
 
     async fn delete_contact(
@@ -157,7 +161,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn compute_contacts(
@@ -188,6 +192,7 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ComputeContactsResponse>| r.into_body())
     }
 
     async fn send_test_message(
@@ -210,6 +215,6 @@ impl super::stub::EssentialContactsService for EssentialContactsService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/eventarc/v1/src/transport.rs
+++ b/src/generated/cloud/eventarc/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Trigger>| r.into_body())
     }
 
     async fn list_triggers(
@@ -80,6 +81,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTriggersResponse>| r.into_body())
     }
 
     async fn create_trigger(
@@ -104,6 +106,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.trigger), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_trigger(
@@ -144,6 +147,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.trigger), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_trigger(
@@ -166,6 +170,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_channel(
@@ -185,6 +190,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Channel>| r.into_body())
     }
 
     async fn list_channels(
@@ -207,6 +213,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListChannelsResponse>| r.into_body())
     }
 
     async fn create_channel(
@@ -231,6 +238,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.channel), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_channel(
@@ -270,6 +278,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.channel), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_channel(
@@ -290,6 +299,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_provider(
@@ -309,6 +319,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Provider>| r.into_body())
     }
 
     async fn list_providers(
@@ -335,6 +346,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProvidersResponse>| r.into_body())
     }
 
     async fn get_channel_connection(
@@ -354,6 +366,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ChannelConnection>| r.into_body())
     }
 
     async fn list_channel_connections(
@@ -378,6 +391,11 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListChannelConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_channel_connection(
@@ -401,6 +419,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.channel_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_channel_connection(
@@ -420,6 +439,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_google_channel_config(
@@ -439,6 +459,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GoogleChannelConfig>| r.into_body())
     }
 
     async fn update_google_channel_config(
@@ -477,6 +498,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.google_channel_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::GoogleChannelConfig>| r.into_body())
     }
 
     async fn get_message_bus(
@@ -496,6 +518,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MessageBus>| r.into_body())
     }
 
     async fn list_message_buses(
@@ -522,6 +545,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMessageBusesResponse>| r.into_body())
     }
 
     async fn list_message_bus_enrollments(
@@ -546,6 +570,11 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMessageBusEnrollmentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_message_bus(
@@ -570,6 +599,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.message_bus), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_message_bus(
@@ -610,6 +640,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.message_bus), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_message_bus(
@@ -632,6 +663,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_enrollment(
@@ -651,6 +683,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Enrollment>| r.into_body())
     }
 
     async fn list_enrollments(
@@ -677,6 +710,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEnrollmentsResponse>| r.into_body())
     }
 
     async fn create_enrollment(
@@ -701,6 +735,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.enrollment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_enrollment(
@@ -741,6 +776,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.enrollment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_enrollment(
@@ -763,6 +799,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_pipeline(
@@ -782,6 +819,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Pipeline>| r.into_body())
     }
 
     async fn list_pipelines(
@@ -808,6 +846,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPipelinesResponse>| r.into_body())
     }
 
     async fn create_pipeline(
@@ -832,6 +871,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.pipeline), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_pipeline(
@@ -872,6 +912,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.pipeline), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_pipeline(
@@ -894,6 +935,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_google_api_source(
@@ -913,6 +955,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GoogleApiSource>| r.into_body())
     }
 
     async fn list_google_api_sources(
@@ -939,6 +982,11 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListGoogleApiSourcesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_google_api_source(
@@ -963,6 +1011,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.google_api_source), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_google_api_source(
@@ -1003,6 +1052,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req.google_api_source), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_google_api_source(
@@ -1025,6 +1075,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1047,6 +1098,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1066,6 +1118,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1085,7 +1138,10 @@ impl super::stub::Eventarc for Eventarc {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1118,6 +1174,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1137,7 +1194,9 @@ impl super::stub::Eventarc for Eventarc {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1160,6 +1219,11 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1179,6 +1243,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1198,7 +1263,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1218,7 +1283,7 @@ impl super::stub::Eventarc for Eventarc {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/filestore/v1/src/transport.rs
+++ b/src/generated/cloud/filestore/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -83,6 +84,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -106,6 +108,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -144,6 +147,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_instance(
@@ -160,7 +164,10 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn revert_instance(
@@ -177,7 +184,10 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -198,6 +208,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_snapshots(
@@ -225,6 +236,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSnapshotsResponse>| r.into_body())
     }
 
     async fn get_snapshot(
@@ -244,6 +256,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Snapshot>| r.into_body())
     }
 
     async fn create_snapshot(
@@ -267,6 +280,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, Some(req.snapshot), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_snapshot(
@@ -286,6 +300,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_snapshot(
@@ -324,6 +339,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, Some(req.snapshot), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backups(
@@ -347,6 +363,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn get_backup(
@@ -366,6 +383,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn create_backup(
@@ -383,7 +401,10 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("backupId", &req.backup_id)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup(
@@ -403,6 +424,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_backup(
@@ -438,7 +460,10 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn promote_replica(
@@ -458,7 +483,10 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -481,6 +509,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -500,6 +529,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -522,6 +552,11 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -541,6 +576,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -560,7 +596,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -580,7 +616,7 @@ impl super::stub::CloudFilestoreManager for CloudFilestoreManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/financialservices/v1/src/transport.rs
+++ b/src/generated/cloud/financialservices/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -81,6 +82,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -105,6 +107,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -144,6 +147,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -164,6 +168,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_registered_parties(
@@ -183,7 +188,10 @@ impl super::stub::Aml for Aml {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_registered_parties(
@@ -203,7 +211,10 @@ impl super::stub::Aml for Aml {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_datasets(
@@ -227,6 +238,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDatasetsResponse>| r.into_body())
     }
 
     async fn get_dataset(
@@ -246,6 +258,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn create_dataset(
@@ -270,6 +283,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_dataset(
@@ -309,6 +323,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_dataset(
@@ -329,6 +344,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_models(
@@ -352,6 +368,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListModelsResponse>| r.into_body())
     }
 
     async fn get_model(
@@ -371,6 +388,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn create_model(
@@ -389,7 +407,10 @@ impl super::stub::Aml for Aml {
             );
         let builder = builder.query(&[("modelId", &req.model_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_model(
@@ -426,7 +447,10 @@ impl super::stub::Aml for Aml {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_model_metadata(
@@ -446,7 +470,10 @@ impl super::stub::Aml for Aml {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_model(
@@ -467,6 +494,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_engine_configs(
@@ -493,6 +521,9 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListEngineConfigsResponse>| r.into_body(),
+            )
     }
 
     async fn get_engine_config(
@@ -512,6 +543,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EngineConfig>| r.into_body())
     }
 
     async fn create_engine_config(
@@ -536,6 +568,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.engine_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_engine_config(
@@ -575,6 +608,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.engine_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_engine_config_metadata(
@@ -594,7 +628,10 @@ impl super::stub::Aml for Aml {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_engine_config(
@@ -615,6 +652,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_engine_version(
@@ -634,6 +672,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EngineVersion>| r.into_body())
     }
 
     async fn list_engine_versions(
@@ -660,6 +699,11 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListEngineVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_prediction_results(
@@ -686,6 +730,11 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPredictionResultsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_prediction_result(
@@ -705,6 +754,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PredictionResult>| r.into_body())
     }
 
     async fn create_prediction_result(
@@ -729,6 +779,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.prediction_result), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_prediction_result(
@@ -768,6 +819,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.prediction_result), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_prediction_result_metadata(
@@ -787,7 +839,10 @@ impl super::stub::Aml for Aml {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_prediction_result(
@@ -808,6 +863,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backtest_results(
@@ -834,6 +890,11 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBacktestResultsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_backtest_result(
@@ -853,6 +914,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BacktestResult>| r.into_body())
     }
 
     async fn create_backtest_result(
@@ -877,6 +939,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.backtest_result), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_backtest_result(
@@ -916,6 +979,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req.backtest_result), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_backtest_result_metadata(
@@ -935,7 +999,10 @@ impl super::stub::Aml for Aml {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backtest_result(
@@ -956,6 +1023,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -978,6 +1046,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -997,6 +1066,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1019,6 +1089,11 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1038,6 +1113,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1057,7 +1133,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1077,7 +1153,7 @@ impl super::stub::Aml for Aml {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/functions/v2/src/transport.rs
+++ b/src/generated/cloud/functions/v2/src/transport.rs
@@ -58,6 +58,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Function>| r.into_body())
     }
 
     async fn list_functions(
@@ -84,6 +85,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFunctionsResponse>| r.into_body())
     }
 
     async fn create_function(
@@ -107,6 +109,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, Some(req.function), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_function(
@@ -145,6 +148,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, Some(req.function), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_function(
@@ -164,6 +168,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_upload_url(
@@ -183,7 +188,9 @@ impl super::stub::FunctionService for FunctionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateUploadUrlResponse>| r.into_body(),
+        )
     }
 
     async fn generate_download_url(
@@ -203,7 +210,9 @@ impl super::stub::FunctionService for FunctionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateDownloadUrlResponse>| r.into_body(),
+        )
     }
 
     async fn list_runtimes(
@@ -224,6 +233,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRuntimesResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -246,6 +256,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -265,7 +276,10 @@ impl super::stub::FunctionService for FunctionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -298,6 +312,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -317,7 +332,9 @@ impl super::stub::FunctionService for FunctionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -340,6 +357,11 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -359,6 +381,7 @@ impl super::stub::FunctionService for FunctionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/gkebackup/v1/src/transport.rs
+++ b/src/generated/cloud/gkebackup/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req.backup_plan), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backup_plans(
@@ -87,6 +88,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupPlansResponse>| r.into_body())
     }
 
     async fn get_backup_plan(
@@ -106,6 +108,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupPlan>| r.into_body())
     }
 
     async fn update_backup_plan(
@@ -144,6 +147,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req.backup_plan), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup_plan(
@@ -164,6 +168,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup(
@@ -181,7 +186,10 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("backupId", &req.backup_id)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backups(
@@ -205,6 +213,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn get_backup(
@@ -224,6 +233,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn update_backup(
@@ -259,7 +269,10 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup(
@@ -281,6 +294,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_volume_backups(
@@ -307,6 +321,9 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVolumeBackupsResponse>| r.into_body(),
+            )
     }
 
     async fn get_volume_backup(
@@ -326,6 +343,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VolumeBackup>| r.into_body())
     }
 
     async fn create_restore_plan(
@@ -349,6 +367,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req.restore_plan), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_restore_plans(
@@ -375,6 +394,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRestorePlansResponse>| r.into_body())
     }
 
     async fn get_restore_plan(
@@ -394,6 +414,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RestorePlan>| r.into_body())
     }
 
     async fn update_restore_plan(
@@ -432,6 +453,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req.restore_plan), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_restore_plan(
@@ -453,6 +475,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_restore(
@@ -476,6 +499,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req.restore), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_restores(
@@ -499,6 +523,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRestoresResponse>| r.into_body())
     }
 
     async fn get_restore(
@@ -518,6 +543,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Restore>| r.into_body())
     }
 
     async fn update_restore(
@@ -556,6 +582,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req.restore), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_restore(
@@ -577,6 +604,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_volume_restores(
@@ -603,6 +631,11 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVolumeRestoresResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_volume_restore(
@@ -622,6 +655,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VolumeRestore>| r.into_body())
     }
 
     async fn get_backup_index_download_url(
@@ -644,6 +678,11 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GetBackupIndexDownloadUrlResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -666,6 +705,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -685,6 +725,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -704,7 +745,10 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -737,6 +781,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -756,7 +801,9 @@ impl super::stub::BackupForGKE for BackupForGKE {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -779,6 +826,11 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -798,6 +850,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -817,7 +870,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -837,7 +890,7 @@ impl super::stub::BackupForGKE for BackupForGKE {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/transport.rs
@@ -64,5 +64,10 @@ impl super::stub::GatewayControl for GatewayControl {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerateCredentialsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/transport.rs
+++ b/src/generated/cloud/gkehub/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMembershipsResponse>| r.into_body())
     }
 
     async fn list_features(
@@ -87,6 +88,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFeaturesResponse>| r.into_body())
     }
 
     async fn get_membership(
@@ -106,6 +108,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Membership>| r.into_body())
     }
 
     async fn get_feature(
@@ -125,6 +128,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Feature>| r.into_body())
     }
 
     async fn create_membership(
@@ -149,6 +153,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, Some(req.resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_feature(
@@ -173,6 +178,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, Some(req.resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_membership(
@@ -194,6 +200,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_feature(
@@ -215,6 +222,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_membership(
@@ -245,6 +253,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, Some(req.resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_feature(
@@ -275,6 +284,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, Some(req.resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_connect_manifest(
@@ -303,6 +313,11 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerateConnectManifestResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -325,6 +340,11 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -344,6 +364,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -363,7 +384,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -383,7 +404,7 @@ impl super::stub::GkeHub for GkeHub {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/gkemulticloud/v1/src/transport.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, Some(req.attached_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_attached_cluster(
@@ -101,6 +102,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, Some(req.attached_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_attached_cluster(
@@ -120,7 +122,10 @@ impl super::stub::AttachedClusters for AttachedClusters {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_attached_cluster(
@@ -140,6 +145,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AttachedCluster>| r.into_body())
     }
 
     async fn list_attached_clusters(
@@ -164,6 +170,11 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAttachedClustersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_attached_cluster(
@@ -187,6 +198,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_attached_server_config(
@@ -206,6 +218,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AttachedServerConfig>| r.into_body())
     }
 
     async fn generate_attached_cluster_install_manifest(
@@ -240,6 +253,11 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::GenerateAttachedClusterInstallManifestResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn generate_attached_cluster_agent_token(
@@ -262,7 +280,11 @@ impl super::stub::AttachedClusters for AttachedClusters {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<
+                crate::model::GenerateAttachedClusterAgentTokenResponse,
+            >| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -285,6 +307,11 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -304,6 +331,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -323,7 +351,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -343,7 +371,7 @@ impl super::stub::AttachedClusters for AttachedClusters {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -405,6 +433,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, Some(req.aws_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_aws_cluster(
@@ -444,6 +473,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, Some(req.aws_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_aws_cluster(
@@ -463,6 +493,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AwsCluster>| r.into_body())
     }
 
     async fn list_aws_clusters(
@@ -487,6 +518,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAwsClustersResponse>| r.into_body())
     }
 
     async fn delete_aws_cluster(
@@ -510,6 +542,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_aws_cluster_agent_token(
@@ -529,7 +562,11 @@ impl super::stub::AwsClusters for AwsClusters {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateAwsClusterAgentTokenResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn generate_aws_access_token(
@@ -552,6 +589,11 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerateAwsAccessTokenResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_aws_node_pool(
@@ -576,6 +618,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, Some(req.aws_node_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_aws_node_pool(
@@ -615,6 +658,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, Some(req.aws_node_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rollback_aws_node_pool_update(
@@ -631,7 +675,10 @@ impl super::stub::AwsClusters for AwsClusters {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_aws_node_pool(
@@ -651,6 +698,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AwsNodePool>| r.into_body())
     }
 
     async fn list_aws_node_pools(
@@ -675,6 +723,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAwsNodePoolsResponse>| r.into_body())
     }
 
     async fn delete_aws_node_pool(
@@ -698,6 +747,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_aws_open_id_config(
@@ -720,6 +770,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AwsOpenIdConfig>| r.into_body())
     }
 
     async fn get_aws_json_web_keys(
@@ -742,6 +793,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AwsJsonWebKeys>| r.into_body())
     }
 
     async fn get_aws_server_config(
@@ -761,6 +813,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AwsServerConfig>| r.into_body())
     }
 
     async fn list_operations(
@@ -783,6 +836,11 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -802,6 +860,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -821,7 +880,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -841,7 +900,7 @@ impl super::stub::AwsClusters for AwsClusters {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -903,6 +962,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, Some(req.azure_client), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_azure_client(
@@ -922,6 +982,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AzureClient>| r.into_body())
     }
 
     async fn list_azure_clients(
@@ -946,6 +1007,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAzureClientsResponse>| r.into_body())
     }
 
     async fn delete_azure_client(
@@ -967,6 +1029,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_azure_cluster(
@@ -991,6 +1054,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, Some(req.azure_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_azure_cluster(
@@ -1030,6 +1094,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, Some(req.azure_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_azure_cluster(
@@ -1049,6 +1114,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AzureCluster>| r.into_body())
     }
 
     async fn list_azure_clusters(
@@ -1073,6 +1139,9 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAzureClustersResponse>| r.into_body(),
+            )
     }
 
     async fn delete_azure_cluster(
@@ -1096,6 +1165,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_azure_cluster_agent_token(
@@ -1115,7 +1185,11 @@ impl super::stub::AzureClusters for AzureClusters {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateAzureClusterAgentTokenResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn generate_azure_access_token(
@@ -1138,6 +1212,11 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerateAzureAccessTokenResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_azure_node_pool(
@@ -1162,6 +1241,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, Some(req.azure_node_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_azure_node_pool(
@@ -1201,6 +1281,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, Some(req.azure_node_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_azure_node_pool(
@@ -1220,6 +1301,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AzureNodePool>| r.into_body())
     }
 
     async fn list_azure_node_pools(
@@ -1244,6 +1326,11 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAzureNodePoolsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_azure_node_pool(
@@ -1267,6 +1354,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_azure_open_id_config(
@@ -1289,6 +1377,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AzureOpenIdConfig>| r.into_body())
     }
 
     async fn get_azure_json_web_keys(
@@ -1311,6 +1400,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AzureJsonWebKeys>| r.into_body())
     }
 
     async fn get_azure_server_config(
@@ -1330,6 +1420,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AzureServerConfig>| r.into_body())
     }
 
     async fn list_operations(
@@ -1352,6 +1443,11 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1371,6 +1467,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1390,7 +1487,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1410,7 +1507,7 @@ impl super::stub::AzureClusters for AzureClusters {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Authorization>| r.into_body())
     }
 
     async fn create_deployment(
@@ -80,6 +81,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn replace_deployment(
@@ -108,6 +110,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn get_deployment(
@@ -127,6 +130,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn list_deployments(
@@ -151,6 +155,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDeploymentsResponse>| r.into_body())
     }
 
     async fn delete_deployment(
@@ -171,7 +176,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn install_deployment(
@@ -191,7 +196,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn uninstall_deployment(
@@ -211,7 +216,7 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_install_status(
@@ -231,5 +236,6 @@ impl super::stub::GSuiteAddOns for GSuiteAddOns {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InstallStatus>| r.into_body())
     }
 }

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -77,7 +80,10 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -97,7 +103,9 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_iap_settings(
@@ -120,6 +128,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::IapSettings>| r.into_body())
     }
 
     async fn update_iap_settings(
@@ -158,6 +167,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, Some(req.iap_settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::IapSettings>| r.into_body())
     }
 
     async fn list_tunnel_dest_groups(
@@ -182,6 +192,11 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTunnelDestGroupsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_tunnel_dest_group(
@@ -205,6 +220,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, Some(req.tunnel_dest_group), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TunnelDestGroup>| r.into_body())
     }
 
     async fn get_tunnel_dest_group(
@@ -224,6 +240,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TunnelDestGroup>| r.into_body())
     }
 
     async fn delete_tunnel_dest_group(
@@ -243,7 +260,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_tunnel_dest_group(
@@ -282,6 +299,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
         self.inner
             .execute(builder, Some(req.tunnel_dest_group), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TunnelDestGroup>| r.into_body())
     }
 }
 
@@ -324,6 +342,7 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBrandsResponse>| r.into_body())
     }
 
     async fn create_brand(
@@ -340,7 +359,10 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.brand), options).await
+        self.inner
+            .execute(builder, Some(req.brand), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Brand>| r.into_body())
     }
 
     async fn get_brand(
@@ -360,6 +382,7 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Brand>| r.into_body())
     }
 
     async fn create_identity_aware_proxy_client(
@@ -382,6 +405,7 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         self.inner
             .execute(builder, Some(req.identity_aware_proxy_client), options)
             .await
+            .map(|r: gax::response::Response<crate::model::IdentityAwareProxyClient>| r.into_body())
     }
 
     async fn list_identity_aware_proxy_clients(
@@ -406,6 +430,11 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListIdentityAwareProxyClientsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_identity_aware_proxy_client(
@@ -425,6 +454,7 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::IdentityAwareProxyClient>| r.into_body())
     }
 
     async fn reset_identity_aware_proxy_client_secret(
@@ -444,7 +474,10 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::IdentityAwareProxyClient>| r.into_body())
     }
 
     async fn delete_identity_aware_proxy_client(
@@ -464,6 +497,6 @@ impl super::stub::IdentityAwareProxyOAuthService for IdentityAwareProxyOAuthServ
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/ids/v1/src/transport.rs
+++ b/src/generated/cloud/ids/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEndpointsResponse>| r.into_body())
     }
 
     async fn get_endpoint(
@@ -81,6 +82,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Endpoint>| r.into_body())
     }
 
     async fn create_endpoint(
@@ -105,6 +107,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, Some(req.endpoint), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_endpoint(
@@ -125,6 +128,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -147,6 +151,11 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -166,6 +175,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -185,7 +195,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -205,7 +215,7 @@ impl super::stub::Ids for Ids {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/kms/inventory/v1/src/transport.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::KeyDashboardService for KeyDashboardService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCryptoKeysResponse>| r.into_body())
     }
 }
 
@@ -107,6 +108,9 @@ impl super::stub::KeyTrackingService for KeyTrackingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ProtectedResourcesSummary>| r.into_body(),
+            )
     }
 
     async fn search_protected_resources(
@@ -136,5 +140,10 @@ impl super::stub::KeyTrackingService for KeyTrackingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchProtectedResourcesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/cloud/kms/v1/src/transport.rs
+++ b/src/generated/cloud/kms/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, Some(req.key_handle), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_key_handle(
@@ -80,6 +81,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::KeyHandle>| r.into_body())
     }
 
     async fn list_key_handles(
@@ -105,6 +107,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListKeyHandlesResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -127,6 +130,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -146,6 +150,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -165,7 +170,10 @@ impl super::stub::Autokey for Autokey {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -198,6 +206,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -217,7 +226,9 @@ impl super::stub::Autokey for Autokey {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -237,6 +248,7 @@ impl super::stub::Autokey for Autokey {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -312,6 +324,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, Some(req.autokey_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AutokeyConfig>| r.into_body())
     }
 
     async fn get_autokey_config(
@@ -331,6 +344,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AutokeyConfig>| r.into_body())
     }
 
     async fn show_effective_autokey_config(
@@ -353,6 +367,11 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ShowEffectiveAutokeyConfigResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -375,6 +394,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -394,6 +414,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -413,7 +434,10 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -446,6 +470,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -465,7 +490,9 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -485,6 +512,7 @@ impl super::stub::AutokeyAdmin for AutokeyAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -534,6 +562,11 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListEkmConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_ekm_connection(
@@ -553,6 +586,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EkmConnection>| r.into_body())
     }
 
     async fn create_ekm_connection(
@@ -576,6 +610,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, Some(req.ekm_connection), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EkmConnection>| r.into_body())
     }
 
     async fn update_ekm_connection(
@@ -614,6 +649,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, Some(req.ekm_connection), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EkmConnection>| r.into_body())
     }
 
     async fn get_ekm_config(
@@ -633,6 +669,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EkmConfig>| r.into_body())
     }
 
     async fn update_ekm_config(
@@ -671,6 +708,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, Some(req.ekm_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::EkmConfig>| r.into_body())
     }
 
     async fn verify_connectivity(
@@ -693,6 +731,11 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::VerifyConnectivityResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -715,6 +758,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -734,6 +778,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -753,7 +798,10 @@ impl super::stub::EkmService for EkmService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -786,6 +834,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -805,7 +854,9 @@ impl super::stub::EkmService for EkmService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -825,6 +876,7 @@ impl super::stub::EkmService for EkmService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -871,6 +923,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListKeyRingsResponse>| r.into_body())
     }
 
     async fn list_crypto_keys(
@@ -898,6 +951,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCryptoKeysResponse>| r.into_body())
     }
 
     async fn list_crypto_key_versions(
@@ -925,6 +979,11 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCryptoKeyVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_import_jobs(
@@ -951,6 +1010,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListImportJobsResponse>| r.into_body())
     }
 
     async fn get_key_ring(
@@ -970,6 +1030,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::KeyRing>| r.into_body())
     }
 
     async fn get_crypto_key(
@@ -989,6 +1050,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CryptoKey>| r.into_body())
     }
 
     async fn get_crypto_key_version(
@@ -1008,6 +1070,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CryptoKeyVersion>| r.into_body())
     }
 
     async fn get_public_key(
@@ -1028,6 +1091,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PublicKey>| r.into_body())
     }
 
     async fn get_import_job(
@@ -1047,6 +1111,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ImportJob>| r.into_body())
     }
 
     async fn create_key_ring(
@@ -1070,6 +1135,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, Some(req.key_ring), options)
             .await
+            .map(|r: gax::response::Response<crate::model::KeyRing>| r.into_body())
     }
 
     async fn create_crypto_key(
@@ -1097,6 +1163,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, Some(req.crypto_key), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CryptoKey>| r.into_body())
     }
 
     async fn create_crypto_key_version(
@@ -1119,6 +1186,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, Some(req.crypto_key_version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CryptoKeyVersion>| r.into_body())
     }
 
     async fn import_crypto_key_version(
@@ -1138,7 +1206,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CryptoKeyVersion>| r.into_body())
     }
 
     async fn create_import_job(
@@ -1162,6 +1233,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, Some(req.import_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ImportJob>| r.into_body())
     }
 
     async fn update_crypto_key(
@@ -1200,6 +1272,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, Some(req.crypto_key), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CryptoKey>| r.into_body())
     }
 
     async fn update_crypto_key_version(
@@ -1238,6 +1311,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, Some(req.crypto_key_version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CryptoKeyVersion>| r.into_body())
     }
 
     async fn update_crypto_key_primary_version(
@@ -1257,7 +1331,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CryptoKey>| r.into_body())
     }
 
     async fn destroy_crypto_key_version(
@@ -1274,7 +1351,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CryptoKeyVersion>| r.into_body())
     }
 
     async fn restore_crypto_key_version(
@@ -1291,7 +1371,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CryptoKeyVersion>| r.into_body())
     }
 
     async fn encrypt(
@@ -1308,7 +1391,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::EncryptResponse>| r.into_body())
     }
 
     async fn decrypt(
@@ -1325,7 +1411,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DecryptResponse>| r.into_body())
     }
 
     async fn raw_encrypt(
@@ -1345,7 +1434,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RawEncryptResponse>| r.into_body())
     }
 
     async fn raw_decrypt(
@@ -1365,7 +1457,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RawDecryptResponse>| r.into_body())
     }
 
     async fn asymmetric_sign(
@@ -1385,7 +1480,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AsymmetricSignResponse>| r.into_body())
     }
 
     async fn asymmetric_decrypt(
@@ -1405,7 +1503,9 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AsymmetricDecryptResponse>| r.into_body(),
+        )
     }
 
     async fn mac_sign(
@@ -1422,7 +1522,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::MacSignResponse>| r.into_body())
     }
 
     async fn mac_verify(
@@ -1439,7 +1542,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::MacVerifyResponse>| r.into_body())
     }
 
     async fn generate_random_bytes(
@@ -1459,7 +1565,9 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateRandomBytesResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -1482,6 +1590,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1501,6 +1610,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1520,7 +1630,10 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1553,6 +1666,7 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1572,7 +1686,9 @@ impl super::stub::KeyManagementService for KeyManagementService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -1592,5 +1708,6 @@ impl super::stub::KeyManagementService for KeyManagementService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }

--- a/src/generated/cloud/language/v2/src/transport.rs
+++ b/src/generated/cloud/language/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::LanguageService for LanguageService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AnalyzeSentimentResponse>| r.into_body())
     }
 
     async fn analyze_entities(
@@ -77,7 +80,10 @@ impl super::stub::LanguageService for LanguageService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AnalyzeEntitiesResponse>| r.into_body())
     }
 
     async fn classify_text(
@@ -97,7 +103,10 @@ impl super::stub::LanguageService for LanguageService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ClassifyTextResponse>| r.into_body())
     }
 
     async fn moderate_text(
@@ -117,7 +126,10 @@ impl super::stub::LanguageService for LanguageService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ModerateTextResponse>| r.into_body())
     }
 
     async fn annotate_text(
@@ -137,6 +149,9 @@ impl super::stub::LanguageService for LanguageService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AnnotateTextResponse>| r.into_body())
     }
 }

--- a/src/generated/cloud/licensemanager/v1/src/transport.rs
+++ b/src/generated/cloud/licensemanager/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConfigurationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_configuration(
@@ -83,6 +88,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Configuration>| r.into_body())
     }
 
     async fn create_configuration(
@@ -107,6 +113,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, Some(req.configuration), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_configuration(
@@ -146,6 +153,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, Some(req.configuration), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_configuration(
@@ -166,6 +174,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_instances(
@@ -192,6 +201,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -211,6 +221,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn deactivate_configuration(
@@ -230,7 +241,10 @@ impl super::stub::LicenseManager for LicenseManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reactivate_configuration(
@@ -250,7 +264,10 @@ impl super::stub::LicenseManager for LicenseManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn query_configuration_license_usage(
@@ -293,6 +310,11 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::QueryConfigurationLicenseUsageResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn aggregate_usage(
@@ -339,6 +361,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AggregateUsageResponse>| r.into_body())
     }
 
     async fn list_products(
@@ -362,6 +385,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProductsResponse>| r.into_body())
     }
 
     async fn get_product(
@@ -381,6 +405,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn list_locations(
@@ -403,6 +428,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -422,6 +448,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -444,6 +471,11 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -463,6 +495,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -482,7 +515,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -502,7 +535,7 @@ impl super::stub::LicenseManager for LicenseManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/location/src/transport.rs
+++ b/src/generated/cloud/location/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::Locations for Locations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -79,5 +80,6 @@ impl super::stub::Locations for Locations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/managedidentities/v1/src/transport.rs
+++ b/src/generated/cloud/managedidentities/v1/src/transport.rs
@@ -55,7 +55,10 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("domainName", &req.domain_name)]);
-        self.inner.execute(builder, Some(req.domain), options).await
+        self.inner
+            .execute(builder, Some(req.domain), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reset_admin_password(
@@ -75,7 +78,9 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ResetAdminPasswordResponse>| r.into_body(),
+        )
     }
 
     async fn list_domains(
@@ -99,6 +104,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDomainsResponse>| r.into_body())
     }
 
     async fn get_domain(
@@ -118,6 +124,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Domain>| r.into_body())
     }
 
     async fn update_domain(
@@ -153,7 +160,10 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.domain), options).await
+        self.inner
+            .execute(builder, Some(req.domain), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_domain(
@@ -173,6 +183,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn attach_trust(
@@ -192,7 +203,10 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reconfigure_trust(
@@ -212,7 +226,10 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn detach_trust(
@@ -232,7 +249,10 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn validate_trust(
@@ -252,7 +272,10 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -275,6 +298,11 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -294,6 +322,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -313,7 +342,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -333,7 +362,7 @@ impl super::stub::ManagedIdentitiesService for ManagedIdentitiesService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/memcache/v1/src/transport.rs
+++ b/src/generated/cloud/memcache/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -83,6 +84,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -106,6 +108,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -144,6 +147,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_parameters(
@@ -163,7 +167,10 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -183,6 +190,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn apply_parameters(
@@ -202,7 +210,10 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reschedule_maintenance(
@@ -222,7 +233,10 @@ impl super::stub::CloudMemcache for CloudMemcache {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -245,6 +259,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -264,6 +279,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -286,6 +302,11 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -305,6 +326,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -324,7 +346,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -344,7 +366,7 @@ impl super::stub::CloudMemcache for CloudMemcache {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -83,6 +84,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -107,6 +109,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -146,6 +149,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -166,6 +170,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_certificate_authority(
@@ -188,6 +193,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CertificateAuthority>| r.into_body())
     }
 
     async fn list_locations(
@@ -210,6 +216,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -229,6 +236,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -251,6 +259,11 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -270,6 +283,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -289,7 +303,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -309,7 +323,7 @@ impl super::stub::Memorystore for Memorystore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/metastore/v1/src/transport.rs
+++ b/src/generated/cloud/metastore/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn get_service(
@@ -80,6 +81,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn create_service(
@@ -104,6 +106,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_service(
@@ -143,6 +146,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service(
@@ -163,6 +167,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_metadata_imports(
@@ -189,6 +194,11 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMetadataImportsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_metadata_import(
@@ -208,6 +218,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MetadataImport>| r.into_body())
     }
 
     async fn create_metadata_import(
@@ -232,6 +243,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, Some(req.metadata_import), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_metadata_import(
@@ -271,6 +283,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, Some(req.metadata_import), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_metadata(
@@ -290,7 +303,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_service(
@@ -310,7 +326,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backups(
@@ -334,6 +353,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn get_backup(
@@ -353,6 +373,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn create_backup(
@@ -371,7 +392,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
             );
         let builder = builder.query(&[("backupId", &req.backup_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup(
@@ -392,6 +416,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn query_metadata(
@@ -411,7 +436,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn move_table_to_database(
@@ -431,7 +459,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn alter_metadata_resource_location(
@@ -451,7 +482,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -474,6 +508,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -493,6 +528,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -512,7 +548,10 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -545,6 +584,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -564,7 +604,9 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -587,6 +629,11 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -606,6 +653,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -625,7 +673,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -645,7 +693,7 @@ impl super::stub::DataprocMetastore for DataprocMetastore {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -709,6 +757,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFederationsResponse>| r.into_body())
     }
 
     async fn get_federation(
@@ -728,6 +777,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Federation>| r.into_body())
     }
 
     async fn create_federation(
@@ -752,6 +802,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, Some(req.federation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_federation(
@@ -791,6 +842,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, Some(req.federation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_federation(
@@ -811,6 +863,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -833,6 +886,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -852,6 +906,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -871,7 +926,10 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -904,6 +962,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -923,7 +982,9 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -946,6 +1007,11 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -965,6 +1031,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -984,7 +1051,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1004,7 +1071,7 @@ impl super::stub::DataprocMetastoreFederation for DataprocMetastoreFederation {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/migrationcenter/v1/src/transport.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAssetsResponse>| r.into_body())
     }
 
     async fn get_asset(
@@ -82,6 +83,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Asset>| r.into_body())
     }
 
     async fn update_asset(
@@ -118,7 +120,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.asset), options).await
+        self.inner
+            .execute(builder, Some(req.asset), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Asset>| r.into_body())
     }
 
     async fn batch_update_assets(
@@ -138,7 +143,9 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchUpdateAssetsResponse>| r.into_body(),
+        )
     }
 
     async fn delete_asset(
@@ -159,7 +166,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_delete_assets(
@@ -182,7 +189,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn report_asset_frames(
@@ -203,7 +210,12 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("source", &req.source)]);
-        self.inner.execute(builder, Some(req.frames), options).await
+        self.inner
+            .execute(builder, Some(req.frames), options)
+            .await
+            .map(
+                |r: gax::response::Response<crate::model::ReportAssetFramesResponse>| r.into_body(),
+            )
     }
 
     async fn aggregate_assets_values(
@@ -223,7 +235,9 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AggregateAssetsValuesResponse>| r.into_body(),
+        )
     }
 
     async fn create_import_job(
@@ -248,6 +262,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.import_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_import_jobs(
@@ -275,6 +290,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListImportJobsResponse>| r.into_body())
     }
 
     async fn get_import_job(
@@ -295,6 +311,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ImportJob>| r.into_body())
     }
 
     async fn delete_import_job(
@@ -316,6 +333,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_import_job(
@@ -355,6 +373,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.import_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn validate_import_job(
@@ -371,7 +390,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn run_import_job(
@@ -388,7 +410,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_import_data_file(
@@ -408,6 +433,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ImportDataFile>| r.into_body())
     }
 
     async fn list_import_data_files(
@@ -434,6 +460,11 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListImportDataFilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_import_data_file(
@@ -458,6 +489,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.import_data_file), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_import_data_file(
@@ -478,6 +510,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_groups(
@@ -501,6 +534,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGroupsResponse>| r.into_body())
     }
 
     async fn get_group(
@@ -520,6 +554,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Group>| r.into_body())
     }
 
     async fn create_group(
@@ -538,7 +573,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
             );
         let builder = builder.query(&[("groupId", &req.group_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_group(
@@ -575,7 +613,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_group(
@@ -596,6 +637,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_assets_to_group(
@@ -615,7 +657,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn remove_assets_from_group(
@@ -635,7 +680,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_error_frames(
@@ -661,6 +709,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListErrorFramesResponse>| r.into_body())
     }
 
     async fn get_error_frame(
@@ -681,6 +730,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ErrorFrame>| r.into_body())
     }
 
     async fn list_sources(
@@ -704,6 +754,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSourcesResponse>| r.into_body())
     }
 
     async fn get_source(
@@ -723,6 +774,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Source>| r.into_body())
     }
 
     async fn create_source(
@@ -741,7 +793,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
             );
         let builder = builder.query(&[("sourceId", &req.source_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_source(
@@ -778,7 +833,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_source(
@@ -799,6 +857,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_preference_sets(
@@ -824,6 +883,11 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPreferenceSetsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_preference_set(
@@ -843,6 +907,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PreferenceSet>| r.into_body())
     }
 
     async fn create_preference_set(
@@ -867,6 +932,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.preference_set), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_preference_set(
@@ -906,6 +972,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.preference_set), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_preference_set(
@@ -926,6 +993,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_settings(
@@ -945,6 +1013,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn update_settings(
@@ -984,6 +1053,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.settings), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_report_config(
@@ -1008,6 +1078,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req.report_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_report_config(
@@ -1027,6 +1098,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReportConfig>| r.into_body())
     }
 
     async fn list_report_configs(
@@ -1053,6 +1125,9 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReportConfigsResponse>| r.into_body(),
+            )
     }
 
     async fn delete_report_config(
@@ -1074,6 +1149,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_report(
@@ -1092,7 +1168,10 @@ impl super::stub::MigrationCenter for MigrationCenter {
             );
         let builder = builder.query(&[("reportId", &req.report_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.report), options).await
+        self.inner
+            .execute(builder, Some(req.report), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_report(
@@ -1113,6 +1192,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Report>| r.into_body())
     }
 
     async fn list_reports(
@@ -1137,6 +1217,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListReportsResponse>| r.into_body())
     }
 
     async fn delete_report(
@@ -1157,6 +1238,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1179,6 +1261,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1198,6 +1281,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1220,6 +1304,11 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1239,6 +1328,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1258,7 +1348,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1278,7 +1368,7 @@ impl super::stub::MigrationCenter for MigrationCenter {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/modelarmor/v1/src/transport.rs
+++ b/src/generated/cloud/modelarmor/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTemplatesResponse>| r.into_body())
     }
 
     async fn get_template(
@@ -83,6 +84,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Template>| r.into_body())
     }
 
     async fn create_template(
@@ -107,6 +109,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, Some(req.template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Template>| r.into_body())
     }
 
     async fn update_template(
@@ -146,6 +149,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, Some(req.template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Template>| r.into_body())
     }
 
     async fn delete_template(
@@ -166,7 +170,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_floor_setting(
@@ -186,6 +190,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FloorSetting>| r.into_body())
     }
 
     async fn update_floor_setting(
@@ -224,6 +229,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, Some(req.floor_setting), options)
             .await
+            .map(|r: gax::response::Response<crate::model::FloorSetting>| r.into_body())
     }
 
     async fn sanitize_user_prompt(
@@ -243,7 +249,9 @@ impl super::stub::ModelArmor for ModelArmor {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SanitizeUserPromptResponse>| r.into_body(),
+        )
     }
 
     async fn sanitize_model_response(
@@ -263,7 +271,9 @@ impl super::stub::ModelArmor for ModelArmor {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::SanitizeModelResponseResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -286,6 +296,7 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -305,5 +316,6 @@ impl super::stub::ModelArmor for ModelArmor {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/netapp/v1/src/transport.rs
+++ b/src/generated/cloud/netapp/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListStoragePoolsResponse>| r.into_body())
     }
 
     async fn create_storage_pool(
@@ -87,6 +88,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.storage_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_storage_pool(
@@ -106,6 +108,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::StoragePool>| r.into_body())
     }
 
     async fn update_storage_pool(
@@ -144,6 +147,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.storage_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_storage_pool(
@@ -163,6 +167,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn validate_directory_service(
@@ -182,7 +187,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn switch_active_replica_zone(
@@ -199,7 +207,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_volumes(
@@ -223,6 +234,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVolumesResponse>| r.into_body())
     }
 
     async fn get_volume(
@@ -242,6 +254,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Volume>| r.into_body())
     }
 
     async fn create_volume(
@@ -259,7 +272,10 @@ impl super::stub::NetApp for NetApp {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("volumeId", &req.volume_id)]);
-        self.inner.execute(builder, Some(req.volume), options).await
+        self.inner
+            .execute(builder, Some(req.volume), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_volume(
@@ -295,7 +311,10 @@ impl super::stub::NetApp for NetApp {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.volume), options).await
+        self.inner
+            .execute(builder, Some(req.volume), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_volume(
@@ -316,6 +335,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn revert_volume(
@@ -332,7 +352,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_snapshots(
@@ -359,6 +382,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSnapshotsResponse>| r.into_body())
     }
 
     async fn get_snapshot(
@@ -378,6 +402,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Snapshot>| r.into_body())
     }
 
     async fn create_snapshot(
@@ -401,6 +426,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.snapshot), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_snapshot(
@@ -420,6 +446,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_snapshot(
@@ -458,6 +485,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.snapshot), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_active_directories(
@@ -484,6 +512,11 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListActiveDirectoriesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_active_directory(
@@ -503,6 +536,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ActiveDirectory>| r.into_body())
     }
 
     async fn create_active_directory(
@@ -526,6 +560,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.active_directory), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_active_directory(
@@ -564,6 +599,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.active_directory), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_active_directory(
@@ -583,6 +619,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_kms_configs(
@@ -609,6 +646,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListKmsConfigsResponse>| r.into_body())
     }
 
     async fn create_kms_config(
@@ -632,6 +670,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.kms_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_kms_config(
@@ -651,6 +690,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::KmsConfig>| r.into_body())
     }
 
     async fn update_kms_config(
@@ -689,6 +729,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.kms_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn encrypt_volumes(
@@ -705,7 +746,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn verify_kms_config(
@@ -722,7 +766,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::VerifyKmsConfigResponse>| r.into_body())
     }
 
     async fn delete_kms_config(
@@ -742,6 +789,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_replications(
@@ -768,6 +816,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListReplicationsResponse>| r.into_body())
     }
 
     async fn get_replication(
@@ -787,6 +836,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Replication>| r.into_body())
     }
 
     async fn create_replication(
@@ -810,6 +860,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.replication), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_replication(
@@ -829,6 +880,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_replication(
@@ -867,6 +919,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.replication), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_replication(
@@ -883,7 +936,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resume_replication(
@@ -900,7 +956,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reverse_replication_direction(
@@ -920,7 +979,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn establish_peering(
@@ -940,7 +1002,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn sync_replication(
@@ -957,7 +1022,10 @@ impl super::stub::NetApp for NetApp {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup_vault(
@@ -981,6 +1049,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.backup_vault), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup_vault(
@@ -1000,6 +1069,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupVault>| r.into_body())
     }
 
     async fn list_backup_vaults(
@@ -1026,6 +1096,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupVaultsResponse>| r.into_body())
     }
 
     async fn update_backup_vault(
@@ -1064,6 +1135,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.backup_vault), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup_vault(
@@ -1083,6 +1155,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup(
@@ -1100,7 +1173,10 @@ impl super::stub::NetApp for NetApp {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("backupId", &req.backup_id)]);
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup(
@@ -1120,6 +1196,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn list_backups(
@@ -1143,6 +1220,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn delete_backup(
@@ -1162,6 +1240,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_backup(
@@ -1197,7 +1276,10 @@ impl super::stub::NetApp for NetApp {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup_policy(
@@ -1221,6 +1303,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.backup_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup_policy(
@@ -1240,6 +1323,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupPolicy>| r.into_body())
     }
 
     async fn list_backup_policies(
@@ -1266,6 +1350,11 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBackupPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_backup_policy(
@@ -1304,6 +1393,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.backup_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_backup_policy(
@@ -1323,6 +1413,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_quota_rules(
@@ -1349,6 +1440,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListQuotaRulesResponse>| r.into_body())
     }
 
     async fn get_quota_rule(
@@ -1368,6 +1460,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::QuotaRule>| r.into_body())
     }
 
     async fn create_quota_rule(
@@ -1391,6 +1484,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.quota_rule), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_quota_rule(
@@ -1429,6 +1523,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req.quota_rule), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_quota_rule(
@@ -1448,6 +1543,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1470,6 +1566,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1489,6 +1586,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1511,6 +1609,11 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1530,6 +1633,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1549,7 +1653,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1569,7 +1673,7 @@ impl super::stub::NetApp for NetApp {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/networkconnectivity/v1/src/transport.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceConnectionMapsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_connection_map(
@@ -83,6 +88,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceConnectionMap>| r.into_body())
     }
 
     async fn create_service_connection_map(
@@ -107,6 +113,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req.service_connection_map), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_service_connection_map(
@@ -146,6 +153,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req.service_connection_map), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service_connection_map(
@@ -170,6 +178,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_service_connection_policies(
@@ -196,6 +205,11 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListServiceConnectionPoliciesResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_service_connection_policy(
@@ -215,6 +229,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceConnectionPolicy>| r.into_body())
     }
 
     async fn create_service_connection_policy(
@@ -242,6 +257,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req.service_connection_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_service_connection_policy(
@@ -281,6 +297,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req.service_connection_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service_connection_policy(
@@ -305,6 +322,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_service_classes(
@@ -331,6 +349,11 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceClassesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_class(
@@ -350,6 +373,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceClass>| r.into_body())
     }
 
     async fn update_service_class(
@@ -389,6 +413,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req.service_class), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service_class(
@@ -413,6 +438,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_service_connection_token(
@@ -432,6 +458,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceConnectionToken>| r.into_body())
     }
 
     async fn list_service_connection_tokens(
@@ -458,6 +485,11 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceConnectionTokensResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_service_connection_token(
@@ -483,6 +515,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req.service_connection_token), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service_connection_token(
@@ -507,6 +540,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -529,6 +563,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -548,6 +583,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -567,7 +603,10 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -600,6 +639,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -619,7 +659,9 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -642,6 +684,11 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -661,6 +708,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -680,7 +728,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -700,7 +748,7 @@ impl super::stub::CrossNetworkAutomationService for CrossNetworkAutomationServic
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -761,6 +809,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListHubsResponse>| r.into_body())
     }
 
     async fn get_hub(
@@ -780,6 +829,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Hub>| r.into_body())
     }
 
     async fn create_hub(
@@ -798,7 +848,10 @@ impl super::stub::HubService for HubService {
             );
         let builder = builder.query(&[("hubId", &req.hub_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.hub), options).await
+        self.inner
+            .execute(builder, Some(req.hub), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_hub(
@@ -835,7 +888,10 @@ impl super::stub::HubService for HubService {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.hub), options).await
+        self.inner
+            .execute(builder, Some(req.hub), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_hub(
@@ -856,6 +912,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_hub_spokes(
@@ -883,6 +940,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListHubSpokesResponse>| r.into_body())
     }
 
     async fn query_hub_status(
@@ -910,6 +968,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::QueryHubStatusResponse>| r.into_body())
     }
 
     async fn list_spokes(
@@ -933,6 +992,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSpokesResponse>| r.into_body())
     }
 
     async fn get_spoke(
@@ -952,6 +1012,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Spoke>| r.into_body())
     }
 
     async fn create_spoke(
@@ -970,7 +1031,10 @@ impl super::stub::HubService for HubService {
             );
         let builder = builder.query(&[("spokeId", &req.spoke_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.spoke), options).await
+        self.inner
+            .execute(builder, Some(req.spoke), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_spoke(
@@ -1007,7 +1071,10 @@ impl super::stub::HubService for HubService {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.spoke), options).await
+        self.inner
+            .execute(builder, Some(req.spoke), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reject_hub_spoke(
@@ -1027,7 +1094,10 @@ impl super::stub::HubService for HubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn accept_hub_spoke(
@@ -1047,7 +1117,10 @@ impl super::stub::HubService for HubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn accept_spoke_update(
@@ -1067,7 +1140,10 @@ impl super::stub::HubService for HubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reject_spoke_update(
@@ -1087,7 +1163,10 @@ impl super::stub::HubService for HubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_spoke(
@@ -1108,6 +1187,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_route_table(
@@ -1127,6 +1207,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RouteTable>| r.into_body())
     }
 
     async fn get_route(
@@ -1146,6 +1227,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Route>| r.into_body())
     }
 
     async fn list_routes(
@@ -1169,6 +1251,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRoutesResponse>| r.into_body())
     }
 
     async fn list_route_tables(
@@ -1195,6 +1278,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRouteTablesResponse>| r.into_body())
     }
 
     async fn get_group(
@@ -1214,6 +1298,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Group>| r.into_body())
     }
 
     async fn list_groups(
@@ -1237,6 +1322,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGroupsResponse>| r.into_body())
     }
 
     async fn update_group(
@@ -1273,7 +1359,10 @@ impl super::stub::HubService for HubService {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1296,6 +1385,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1315,6 +1405,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1334,7 +1425,10 @@ impl super::stub::HubService for HubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1367,6 +1461,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1386,7 +1481,9 @@ impl super::stub::HubService for HubService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1409,6 +1506,11 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1428,6 +1530,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1447,7 +1550,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1467,7 +1570,7 @@ impl super::stub::HubService for HubService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1531,6 +1634,11 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPolicyBasedRoutesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_policy_based_route(
@@ -1550,6 +1658,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PolicyBasedRoute>| r.into_body())
     }
 
     async fn create_policy_based_route(
@@ -1574,6 +1683,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, Some(req.policy_based_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_policy_based_route(
@@ -1594,6 +1704,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1616,6 +1727,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1635,6 +1747,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1654,7 +1767,10 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1687,6 +1803,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1706,7 +1823,9 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1729,6 +1848,11 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1748,6 +1872,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1767,7 +1892,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1787,7 +1912,7 @@ impl super::stub::PolicyBasedRoutingService for PolicyBasedRoutingService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/networkmanagement/v1/src/transport.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListConnectivityTestsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_connectivity_test(
@@ -83,6 +88,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ConnectivityTest>| r.into_body())
     }
 
     async fn create_connectivity_test(
@@ -106,6 +112,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, Some(req.resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_connectivity_test(
@@ -144,6 +151,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, Some(req.resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rerun_connectivity_test(
@@ -160,7 +168,10 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_connectivity_test(
@@ -180,6 +191,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -202,6 +214,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -221,6 +234,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -240,7 +254,10 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -273,6 +290,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -292,7 +310,9 @@ impl super::stub::ReachabilityService for ReachabilityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -315,6 +335,11 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -334,6 +359,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -353,7 +379,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -373,7 +399,7 @@ impl super::stub::ReachabilityService for ReachabilityService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -437,6 +463,11 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVpcFlowLogsConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_vpc_flow_logs_config(
@@ -456,6 +487,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VpcFlowLogsConfig>| r.into_body())
     }
 
     async fn create_vpc_flow_logs_config(
@@ -479,6 +511,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, Some(req.vpc_flow_logs_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_vpc_flow_logs_config(
@@ -517,6 +550,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, Some(req.vpc_flow_logs_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_vpc_flow_logs_config(
@@ -536,6 +570,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -558,6 +593,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -577,6 +613,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -596,7 +633,10 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -629,6 +669,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -648,7 +689,9 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -671,6 +714,11 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -690,6 +738,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -709,7 +758,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -729,7 +778,7 @@ impl super::stub::VpcFlowLogsService for VpcFlowLogsService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/networksecurity/v1/src/transport.rs
+++ b/src/generated/cloud/networksecurity/v1/src/transport.rs
@@ -62,6 +62,11 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAuthorizationPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_authorization_policy(
@@ -81,6 +86,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AuthorizationPolicy>| r.into_body())
     }
 
     async fn create_authorization_policy(
@@ -104,6 +110,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req.authorization_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_authorization_policy(
@@ -142,6 +149,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req.authorization_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_authorization_policy(
@@ -161,6 +169,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_server_tls_policies(
@@ -185,6 +194,11 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServerTlsPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_server_tls_policy(
@@ -204,6 +218,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServerTlsPolicy>| r.into_body())
     }
 
     async fn create_server_tls_policy(
@@ -227,6 +242,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req.server_tls_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_server_tls_policy(
@@ -265,6 +281,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req.server_tls_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_server_tls_policy(
@@ -284,6 +301,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_client_tls_policies(
@@ -308,6 +326,11 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListClientTlsPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_client_tls_policy(
@@ -327,6 +350,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ClientTlsPolicy>| r.into_body())
     }
 
     async fn create_client_tls_policy(
@@ -350,6 +374,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req.client_tls_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_client_tls_policy(
@@ -388,6 +413,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req.client_tls_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_client_tls_policy(
@@ -407,6 +433,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -429,6 +456,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -448,6 +476,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -467,7 +496,10 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -500,6 +532,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -519,7 +552,9 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -542,6 +577,11 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -561,6 +601,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -580,7 +621,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -600,7 +641,7 @@ impl super::stub::NetworkSecurity for NetworkSecurity {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/networkservices/v1/src/transport.rs
+++ b/src/generated/cloud/networkservices/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListLbTrafficExtensionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_lb_traffic_extension(
@@ -83,6 +88,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LbTrafficExtension>| r.into_body())
     }
 
     async fn create_lb_traffic_extension(
@@ -107,6 +113,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, Some(req.lb_traffic_extension), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_lb_traffic_extension(
@@ -146,6 +153,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, Some(req.lb_traffic_extension), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_lb_traffic_extension(
@@ -166,6 +174,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_lb_route_extensions(
@@ -192,6 +201,11 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListLbRouteExtensionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_lb_route_extension(
@@ -211,6 +225,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LbRouteExtension>| r.into_body())
     }
 
     async fn create_lb_route_extension(
@@ -235,6 +250,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, Some(req.lb_route_extension), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_lb_route_extension(
@@ -274,6 +290,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, Some(req.lb_route_extension), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_lb_route_extension(
@@ -294,6 +311,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -316,6 +334,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -335,6 +354,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -354,7 +374,10 @@ impl super::stub::DepService for DepService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -387,6 +410,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -406,7 +430,9 @@ impl super::stub::DepService for DepService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -429,6 +455,11 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -448,6 +479,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -467,7 +499,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -487,7 +519,7 @@ impl super::stub::DepService for DepService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -549,6 +581,11 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListEndpointPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_endpoint_policy(
@@ -568,6 +605,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EndpointPolicy>| r.into_body())
     }
 
     async fn create_endpoint_policy(
@@ -591,6 +629,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.endpoint_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_endpoint_policy(
@@ -629,6 +668,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.endpoint_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_endpoint_policy(
@@ -648,6 +688,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_gateways(
@@ -669,6 +710,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGatewaysResponse>| r.into_body())
     }
 
     async fn get_gateway(
@@ -688,6 +730,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Gateway>| r.into_body())
     }
 
     async fn create_gateway(
@@ -711,6 +754,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.gateway), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_gateway(
@@ -749,6 +793,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.gateway), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_gateway(
@@ -768,6 +813,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_grpc_routes(
@@ -792,6 +838,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGrpcRoutesResponse>| r.into_body())
     }
 
     async fn get_grpc_route(
@@ -811,6 +858,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GrpcRoute>| r.into_body())
     }
 
     async fn create_grpc_route(
@@ -834,6 +882,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.grpc_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_grpc_route(
@@ -872,6 +921,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.grpc_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_grpc_route(
@@ -891,6 +941,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_http_routes(
@@ -915,6 +966,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListHttpRoutesResponse>| r.into_body())
     }
 
     async fn get_http_route(
@@ -934,6 +986,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::HttpRoute>| r.into_body())
     }
 
     async fn create_http_route(
@@ -957,6 +1010,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.http_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_http_route(
@@ -995,6 +1049,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.http_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_http_route(
@@ -1014,6 +1069,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_tcp_routes(
@@ -1038,6 +1094,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTcpRoutesResponse>| r.into_body())
     }
 
     async fn get_tcp_route(
@@ -1057,6 +1114,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TcpRoute>| r.into_body())
     }
 
     async fn create_tcp_route(
@@ -1080,6 +1138,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.tcp_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_tcp_route(
@@ -1118,6 +1177,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.tcp_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_tcp_route(
@@ -1137,6 +1197,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_tls_routes(
@@ -1161,6 +1222,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTlsRoutesResponse>| r.into_body())
     }
 
     async fn get_tls_route(
@@ -1180,6 +1242,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TlsRoute>| r.into_body())
     }
 
     async fn create_tls_route(
@@ -1203,6 +1266,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.tls_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_tls_route(
@@ -1241,6 +1305,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.tls_route), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_tls_route(
@@ -1260,6 +1325,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_service_bindings(
@@ -1284,6 +1350,11 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceBindingsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_binding(
@@ -1303,6 +1374,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceBinding>| r.into_body())
     }
 
     async fn create_service_binding(
@@ -1326,6 +1398,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req.service_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service_binding(
@@ -1345,6 +1418,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_meshes(
@@ -1366,6 +1440,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMeshesResponse>| r.into_body())
     }
 
     async fn get_mesh(
@@ -1385,6 +1460,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Mesh>| r.into_body())
     }
 
     async fn create_mesh(
@@ -1402,7 +1478,10 @@ impl super::stub::NetworkServices for NetworkServices {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("meshId", &req.mesh_id)]);
-        self.inner.execute(builder, Some(req.mesh), options).await
+        self.inner
+            .execute(builder, Some(req.mesh), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_mesh(
@@ -1438,7 +1517,10 @@ impl super::stub::NetworkServices for NetworkServices {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.mesh), options).await
+        self.inner
+            .execute(builder, Some(req.mesh), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_mesh(
@@ -1458,6 +1540,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1480,6 +1563,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1499,6 +1583,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1518,7 +1603,10 @@ impl super::stub::NetworkServices for NetworkServices {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1551,6 +1639,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1570,7 +1659,9 @@ impl super::stub::NetworkServices for NetworkServices {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1593,6 +1684,11 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1612,6 +1708,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1631,7 +1728,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1651,7 +1748,7 @@ impl super::stub::NetworkServices for NetworkServices {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/notebooks/v2/src/transport.rs
+++ b/src/generated/cloud/notebooks/v2/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -83,6 +84,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -107,6 +109,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -146,6 +149,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -166,6 +170,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_instance(
@@ -182,7 +187,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_instance(
@@ -199,7 +207,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reset_instance(
@@ -216,7 +227,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn check_instance_upgradability(
@@ -239,6 +253,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CheckInstanceUpgradabilityResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn upgrade_instance(
@@ -255,7 +274,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rollback_instance(
@@ -272,7 +294,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn diagnose_instance(
@@ -289,7 +314,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -312,6 +340,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -331,6 +360,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -350,7 +380,10 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -383,6 +416,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -402,7 +436,9 @@ impl super::stub::NotebookService for NotebookService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -425,6 +461,11 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -444,6 +485,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -463,7 +505,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -483,7 +525,7 @@ impl super::stub::NotebookService for NotebookService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/optimization/v1/src/transport.rs
+++ b/src/generated/cloud/optimization/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::FleetRouting for FleetRouting {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::OptimizeToursResponse>| r.into_body())
     }
 
     async fn batch_optimize_tours(
@@ -77,7 +80,10 @@ impl super::stub::FleetRouting for FleetRouting {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -97,6 +103,7 @@ impl super::stub::FleetRouting for FleetRouting {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/oracledatabase/v1/src/transport.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/transport.rs
@@ -62,6 +62,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListCloudExadataInfrastructuresResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_cloud_exadata_infrastructure(
@@ -81,6 +86,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CloudExadataInfrastructure>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_cloud_exadata_infrastructure(
@@ -108,6 +118,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, Some(req.cloud_exadata_infrastructure), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cloud_exadata_infrastructure(
@@ -129,6 +140,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_cloud_vm_clusters(
@@ -154,6 +166,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCloudVmClustersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_cloud_vm_cluster(
@@ -173,6 +190,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CloudVmCluster>| r.into_body())
     }
 
     async fn create_cloud_vm_cluster(
@@ -197,6 +215,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, Some(req.cloud_vm_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cloud_vm_cluster(
@@ -218,6 +237,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_entitlements(
@@ -242,6 +262,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntitlementsResponse>| r.into_body())
     }
 
     async fn list_db_servers(
@@ -266,6 +287,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDbServersResponse>| r.into_body())
     }
 
     async fn list_db_nodes(
@@ -287,6 +309,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDbNodesResponse>| r.into_body())
     }
 
     async fn list_gi_versions(
@@ -311,6 +334,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGiVersionsResponse>| r.into_body())
     }
 
     async fn list_db_system_shapes(
@@ -335,6 +359,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDbSystemShapesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_autonomous_databases(
@@ -361,6 +390,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAutonomousDatabasesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_autonomous_database(
@@ -380,6 +414,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AutonomousDatabase>| r.into_body())
     }
 
     async fn create_autonomous_database(
@@ -404,6 +439,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, Some(req.autonomous_database), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_autonomous_database(
@@ -424,6 +460,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn restore_autonomous_database(
@@ -440,7 +477,10 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_autonomous_database_wallet(
@@ -460,7 +500,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateAutonomousDatabaseWalletResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_autonomous_db_versions(
@@ -485,6 +529,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAutonomousDbVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_autonomous_database_character_sets(
@@ -510,6 +559,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListAutonomousDatabaseCharacterSetsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn list_autonomous_database_backups(
@@ -535,6 +589,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListAutonomousDatabaseBackupsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn list_locations(
@@ -557,6 +616,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -576,6 +636,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -598,6 +659,11 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -617,6 +683,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -636,7 +703,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -656,7 +723,7 @@ impl super::stub::OracleDatabase for OracleDatabase {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.environment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_environment(
@@ -79,6 +80,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Environment>| r.into_body())
     }
 
     async fn list_environments(
@@ -103,6 +105,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEnvironmentsResponse>| r.into_body())
     }
 
     async fn update_environment(
@@ -132,6 +135,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.environment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_environment(
@@ -151,6 +155,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn execute_airflow_command(
@@ -170,7 +175,9 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ExecuteAirflowCommandResponse>| r.into_body(),
+        )
     }
 
     async fn stop_airflow_command(
@@ -190,7 +197,9 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::StopAirflowCommandResponse>| r.into_body(),
+        )
     }
 
     async fn poll_airflow_command(
@@ -210,7 +219,9 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::PollAirflowCommandResponse>| r.into_body(),
+        )
     }
 
     async fn list_workloads(
@@ -236,6 +247,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkloadsResponse>| r.into_body())
     }
 
     async fn check_upgrade(
@@ -255,7 +267,10 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_user_workloads_secret(
@@ -278,6 +293,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.user_workloads_secret), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserWorkloadsSecret>| r.into_body())
     }
 
     async fn get_user_workloads_secret(
@@ -297,6 +313,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserWorkloadsSecret>| r.into_body())
     }
 
     async fn list_user_workloads_secrets(
@@ -321,6 +338,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUserWorkloadsSecretsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_user_workloads_secret(
@@ -349,6 +371,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.user_workloads_secret), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserWorkloadsSecret>| r.into_body())
     }
 
     async fn delete_user_workloads_secret(
@@ -368,7 +391,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_user_workloads_config_map(
@@ -391,6 +414,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.user_workloads_config_map), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserWorkloadsConfigMap>| r.into_body())
     }
 
     async fn get_user_workloads_config_map(
@@ -410,6 +434,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserWorkloadsConfigMap>| r.into_body())
     }
 
     async fn list_user_workloads_config_maps(
@@ -434,6 +459,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUserWorkloadsConfigMapsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_user_workloads_config_map(
@@ -462,6 +492,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, Some(req.user_workloads_config_map), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserWorkloadsConfigMap>| r.into_body())
     }
 
     async fn delete_user_workloads_config_map(
@@ -481,7 +512,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn save_snapshot(
@@ -501,7 +532,10 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn load_snapshot(
@@ -521,7 +555,10 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn database_failover(
@@ -541,7 +578,10 @@ impl super::stub::Environments for Environments {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_database_properties(
@@ -564,6 +604,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchDatabasePropertiesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -586,6 +631,11 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -605,6 +655,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -624,7 +675,7 @@ impl super::stub::Environments for Environments {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -687,6 +738,9 @@ impl super::stub::ImageVersions for ImageVersions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListImageVersionsResponse>| r.into_body(),
+            )
     }
 
     async fn list_operations(
@@ -709,6 +763,11 @@ impl super::stub::ImageVersions for ImageVersions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -728,6 +787,7 @@ impl super::stub::ImageVersions for ImageVersions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -747,6 +807,6 @@ impl super::stub::ImageVersions for ImageVersions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/orgpolicy/v2/src/transport.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConstraintsResponse>| r.into_body())
     }
 
     async fn list_policies(
@@ -83,6 +84,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPoliciesResponse>| r.into_body())
     }
 
     async fn get_policy(
@@ -102,6 +104,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_effective_policy(
@@ -124,6 +127,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn create_policy(
@@ -143,7 +147,10 @@ impl super::stub::OrgPolicy for OrgPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn update_policy(
@@ -179,7 +186,10 @@ impl super::stub::OrgPolicy for OrgPolicy {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn delete_policy(
@@ -200,7 +210,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_custom_constraint(
@@ -223,6 +233,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, Some(req.custom_constraint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomConstraint>| r.into_body())
     }
 
     async fn update_custom_constraint(
@@ -251,6 +262,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, Some(req.custom_constraint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomConstraint>| r.into_body())
     }
 
     async fn get_custom_constraint(
@@ -270,6 +282,7 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomConstraint>| r.into_body())
     }
 
     async fn list_custom_constraints(
@@ -294,6 +307,11 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCustomConstraintsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_custom_constraint(
@@ -313,6 +331,6 @@ impl super::stub::OrgPolicy for OrgPolicy {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/transport.rs
+++ b/src/generated/cloud/osconfig/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::OsConfigService for OsConfigService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::PatchJob>| r.into_body())
     }
 
     async fn get_patch_job(
@@ -77,6 +80,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PatchJob>| r.into_body())
     }
 
     async fn cancel_patch_job(
@@ -93,7 +97,10 @@ impl super::stub::OsConfigService for OsConfigService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::PatchJob>| r.into_body())
     }
 
     async fn list_patch_jobs(
@@ -119,6 +126,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPatchJobsResponse>| r.into_body())
     }
 
     async fn list_patch_job_instance_details(
@@ -144,6 +152,11 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPatchJobInstanceDetailsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_patch_deployment(
@@ -167,6 +180,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, Some(req.patch_deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PatchDeployment>| r.into_body())
     }
 
     async fn get_patch_deployment(
@@ -186,6 +200,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PatchDeployment>| r.into_body())
     }
 
     async fn list_patch_deployments(
@@ -210,6 +225,11 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPatchDeploymentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_patch_deployment(
@@ -229,7 +249,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_patch_deployment(
@@ -268,6 +288,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, Some(req.patch_deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::PatchDeployment>| r.into_body())
     }
 
     async fn pause_patch_deployment(
@@ -284,7 +305,10 @@ impl super::stub::OsConfigService for OsConfigService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::PatchDeployment>| r.into_body())
     }
 
     async fn resume_patch_deployment(
@@ -301,7 +325,10 @@ impl super::stub::OsConfigService for OsConfigService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::PatchDeployment>| r.into_body())
     }
 
     async fn get_operation(
@@ -321,6 +348,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -340,7 +368,7 @@ impl super::stub::OsConfigService for OsConfigService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -387,6 +415,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, Some(req.os_policy_assignment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_os_policy_assignment(
@@ -425,6 +454,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, Some(req.os_policy_assignment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_os_policy_assignment(
@@ -444,6 +474,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::OSPolicyAssignment>| r.into_body())
     }
 
     async fn list_os_policy_assignments(
@@ -468,6 +499,11 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListOSPolicyAssignmentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_os_policy_assignment_revisions(
@@ -492,6 +528,11 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListOSPolicyAssignmentRevisionsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn delete_os_policy_assignment(
@@ -511,6 +552,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_os_policy_assignment_report(
@@ -530,6 +572,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::OSPolicyAssignmentReport>| r.into_body())
     }
 
     async fn list_os_policy_assignment_reports(
@@ -552,6 +595,11 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListOSPolicyAssignmentReportsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_inventory(
@@ -572,6 +620,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Inventory>| r.into_body())
     }
 
     async fn list_inventories(
@@ -598,6 +647,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInventoriesResponse>| r.into_body())
     }
 
     async fn get_vulnerability_report(
@@ -617,6 +667,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VulnerabilityReport>| r.into_body())
     }
 
     async fn list_vulnerability_reports(
@@ -642,6 +693,11 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVulnerabilityReportsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -661,6 +717,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -680,7 +737,7 @@ impl super::stub::OsConfigZonalService for OsConfigZonalService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/oslogin/v1/src/transport.rs
+++ b/src/generated/cloud/oslogin/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, Some(req.ssh_public_key), options)
             .await
+            .map(|r: gax::response::Response<oslogin_common::model::SshPublicKey>| r.into_body())
     }
 
     async fn delete_posix_account(
@@ -79,7 +80,7 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn delete_ssh_public_key(
@@ -99,7 +100,7 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_login_profile(
@@ -124,6 +125,7 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LoginProfile>| r.into_body())
     }
 
     async fn get_ssh_public_key(
@@ -143,6 +145,7 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<oslogin_common::model::SshPublicKey>| r.into_body())
     }
 
     async fn import_ssh_public_key(
@@ -170,6 +173,11 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, Some(req.ssh_public_key), options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ImportSshPublicKeyResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_ssh_public_key(
@@ -199,5 +207,6 @@ impl super::stub::OsLoginService for OsLoginService {
         self.inner
             .execute(builder, Some(req.ssh_public_key), options)
             .await
+            .map(|r: gax::response::Response<oslogin_common::model::SshPublicKey>| r.into_body())
     }
 }

--- a/src/generated/cloud/parallelstore/v1/src/transport.rs
+++ b/src/generated/cloud/parallelstore/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -83,6 +84,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -107,6 +109,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -146,6 +149,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -166,6 +170,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_data(
@@ -185,7 +190,10 @@ impl super::stub::Parallelstore for Parallelstore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_data(
@@ -205,7 +213,10 @@ impl super::stub::Parallelstore for Parallelstore {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -228,6 +239,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -247,6 +259,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -269,6 +282,11 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -288,6 +306,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -307,7 +326,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -327,7 +346,7 @@ impl super::stub::Parallelstore for Parallelstore {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/parametermanager/v1/src/transport.rs
+++ b/src/generated/cloud/parametermanager/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListParametersResponse>| r.into_body())
     }
 
     async fn get_parameter(
@@ -83,6 +84,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Parameter>| r.into_body())
     }
 
     async fn create_parameter(
@@ -107,6 +109,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, Some(req.parameter), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Parameter>| r.into_body())
     }
 
     async fn update_parameter(
@@ -146,6 +149,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, Some(req.parameter), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Parameter>| r.into_body())
     }
 
     async fn delete_parameter(
@@ -166,7 +170,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_parameter_versions(
@@ -190,6 +194,11 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListParameterVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_parameter_version(
@@ -210,6 +219,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ParameterVersion>| r.into_body())
     }
 
     async fn render_parameter_version(
@@ -229,6 +239,11 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::RenderParameterVersionResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_parameter_version(
@@ -253,6 +268,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, Some(req.parameter_version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ParameterVersion>| r.into_body())
     }
 
     async fn update_parameter_version(
@@ -292,6 +308,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, Some(req.parameter_version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ParameterVersion>| r.into_body())
     }
 
     async fn delete_parameter_version(
@@ -312,7 +329,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_locations(
@@ -335,6 +352,7 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -354,5 +372,6 @@ impl super::stub::ParameterManager for ParameterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/policysimulator/v1/src/transport.rs
+++ b/src/generated/cloud/policysimulator/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Simulator for Simulator {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Replay>| r.into_body())
     }
 
     async fn create_replay(
@@ -73,7 +74,10 @@ impl super::stub::Simulator for Simulator {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.replay), options).await
+        self.inner
+            .execute(builder, Some(req.replay), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_replay_results(
@@ -95,6 +99,9 @@ impl super::stub::Simulator for Simulator {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReplayResultsResponse>| r.into_body(),
+            )
     }
 
     async fn list_operations(
@@ -117,6 +124,11 @@ impl super::stub::Simulator for Simulator {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -136,6 +148,7 @@ impl super::stub::Simulator for Simulator {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/transport.rs
@@ -54,6 +54,8 @@ impl super::stub::PolicyTroubleshooter for PolicyTroubleshooter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::TroubleshootIamPolicyResponse>| r.into_body(),
+        )
     }
 }

--- a/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/transport.rs
@@ -54,6 +54,8 @@ impl super::stub::IamChecker for IamChecker {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::TroubleshootIamPolicyResponse>| r.into_body(),
+        )
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/transport.rs
@@ -60,6 +60,11 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CheckOnboardingStatusResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_entitlements(
@@ -86,6 +91,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEntitlementsResponse>| r.into_body())
     }
 
     async fn search_entitlements(
@@ -112,6 +118,11 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchEntitlementsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_entitlement(
@@ -131,6 +142,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Entitlement>| r.into_body())
     }
 
     async fn create_entitlement(
@@ -155,6 +167,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, Some(req.entitlement), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_entitlement(
@@ -176,6 +189,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_entitlement(
@@ -214,6 +228,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, Some(req.entitlement), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_grants(
@@ -237,6 +252,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGrantsResponse>| r.into_body())
     }
 
     async fn search_grants(
@@ -263,6 +279,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchGrantsResponse>| r.into_body())
     }
 
     async fn get_grant(
@@ -282,6 +299,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Grant>| r.into_body())
     }
 
     async fn create_grant(
@@ -299,7 +317,10 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.grant), options).await
+        self.inner
+            .execute(builder, Some(req.grant), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Grant>| r.into_body())
     }
 
     async fn approve_grant(
@@ -316,7 +337,10 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Grant>| r.into_body())
     }
 
     async fn deny_grant(
@@ -333,7 +357,10 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Grant>| r.into_body())
     }
 
     async fn revoke_grant(
@@ -350,7 +377,10 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -373,6 +403,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -392,6 +423,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -414,6 +446,11 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -433,6 +470,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -452,7 +490,7 @@ impl super::stub::PrivilegedAccessManager for PrivilegedAccessManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, Some(req.collector), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_annotation(
@@ -85,6 +86,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, Some(req.annotation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_annotation(
@@ -104,6 +106,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Annotation>| r.into_body())
     }
 
     async fn list_collectors(
@@ -130,6 +133,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCollectorsResponse>| r.into_body())
     }
 
     async fn get_collector(
@@ -149,6 +153,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Collector>| r.into_body())
     }
 
     async fn update_collector(
@@ -188,6 +193,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, Some(req.collector), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_collector(
@@ -208,6 +214,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resume_collector(
@@ -224,7 +231,10 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn register_collector(
@@ -241,7 +251,10 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn pause_collector(
@@ -258,7 +271,10 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -281,6 +297,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -300,6 +317,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -322,6 +340,11 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -341,6 +364,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -360,7 +384,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -380,7 +404,7 @@ impl super::stub::RapidMigrationAssessment for RapidMigrationAssessment {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, Some(req.assessment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Assessment>| r.into_body())
     }
 
     async fn annotate_assessment(
@@ -76,7 +77,9 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AnnotateAssessmentResponse>| r.into_body(),
+        )
     }
 
     async fn create_key(
@@ -93,7 +96,10 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.key), options).await
+        self.inner
+            .execute(builder, Some(req.key), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Key>| r.into_body())
     }
 
     async fn list_keys(
@@ -115,6 +121,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListKeysResponse>| r.into_body())
     }
 
     async fn retrieve_legacy_secret_key(
@@ -137,6 +144,11 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::RetrieveLegacySecretKeyResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_key(
@@ -156,6 +168,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Key>| r.into_body())
     }
 
     async fn update_key(
@@ -191,7 +204,10 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.key), options).await
+        self.inner
+            .execute(builder, Some(req.key), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Key>| r.into_body())
     }
 
     async fn delete_key(
@@ -211,7 +227,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn migrate_key(
@@ -228,7 +244,10 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Key>| r.into_body())
     }
 
     async fn add_ip_override(
@@ -248,7 +267,10 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AddIpOverrideResponse>| r.into_body())
     }
 
     async fn remove_ip_override(
@@ -268,7 +290,10 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RemoveIpOverrideResponse>| r.into_body())
     }
 
     async fn list_ip_overrides(
@@ -293,6 +318,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIpOverridesResponse>| r.into_body())
     }
 
     async fn get_metrics(
@@ -312,6 +338,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Metrics>| r.into_body())
     }
 
     async fn create_firewall_policy(
@@ -334,6 +361,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, Some(req.firewall_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::FirewallPolicy>| r.into_body())
     }
 
     async fn list_firewall_policies(
@@ -358,6 +386,11 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFirewallPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_firewall_policy(
@@ -377,6 +410,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FirewallPolicy>| r.into_body())
     }
 
     async fn update_firewall_policy(
@@ -415,6 +449,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, Some(req.firewall_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::FirewallPolicy>| r.into_body())
     }
 
     async fn delete_firewall_policy(
@@ -434,7 +469,7 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn reorder_firewall_policies(
@@ -454,7 +489,11 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ReorderFirewallPoliciesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_related_account_groups(
@@ -479,6 +518,11 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRelatedAccountGroupsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_related_account_group_memberships(
@@ -503,6 +547,11 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListRelatedAccountGroupMembershipsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn search_related_account_group_memberships(
@@ -522,6 +571,10 @@ impl super::stub::RecaptchaEnterpriseService for RecaptchaEnterpriseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<
+                crate::model::SearchRelatedAccountGroupMembershipsResponse,
+            >| r.into_body(),
+        )
     }
 }

--- a/src/generated/cloud/recommender/v1/src/transport.rs
+++ b/src/generated/cloud/recommender/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInsightsResponse>| r.into_body())
     }
 
     async fn get_insight(
@@ -79,6 +80,7 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Insight>| r.into_body())
     }
 
     async fn mark_insight_accepted(
@@ -98,7 +100,10 @@ impl super::stub::Recommender for Recommender {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Insight>| r.into_body())
     }
 
     async fn list_recommendations(
@@ -124,6 +129,11 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRecommendationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_recommendation(
@@ -143,6 +153,7 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Recommendation>| r.into_body())
     }
 
     async fn mark_recommendation_dismissed(
@@ -162,7 +173,10 @@ impl super::stub::Recommender for Recommender {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Recommendation>| r.into_body())
     }
 
     async fn mark_recommendation_claimed(
@@ -182,7 +196,10 @@ impl super::stub::Recommender for Recommender {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Recommendation>| r.into_body())
     }
 
     async fn mark_recommendation_succeeded(
@@ -202,7 +219,10 @@ impl super::stub::Recommender for Recommender {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Recommendation>| r.into_body())
     }
 
     async fn mark_recommendation_failed(
@@ -222,7 +242,10 @@ impl super::stub::Recommender for Recommender {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Recommendation>| r.into_body())
     }
 
     async fn get_recommender_config(
@@ -242,6 +265,7 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RecommenderConfig>| r.into_body())
     }
 
     async fn update_recommender_config(
@@ -281,6 +305,7 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, Some(req.recommender_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::RecommenderConfig>| r.into_body())
     }
 
     async fn get_insight_type_config(
@@ -300,6 +325,7 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InsightTypeConfig>| r.into_body())
     }
 
     async fn update_insight_type_config(
@@ -339,5 +365,6 @@ impl super::stub::Recommender for Recommender {
         self.inner
             .execute(builder, Some(req.insight_type_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::InsightTypeConfig>| r.into_body())
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn get_cluster(
@@ -78,6 +79,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn update_cluster(
@@ -117,6 +119,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -137,6 +140,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_cluster(
@@ -161,6 +165,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_cluster_certificate_authority(
@@ -180,6 +185,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CertificateAuthority>| r.into_body())
     }
 
     async fn reschedule_cluster_maintenance(
@@ -199,7 +205,10 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_backup_collections(
@@ -224,6 +233,11 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBackupCollectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_backup_collection(
@@ -243,6 +257,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupCollection>| r.into_body())
     }
 
     async fn list_backups(
@@ -264,6 +279,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn get_backup(
@@ -283,6 +299,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn delete_backup(
@@ -303,6 +320,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_backup(
@@ -319,7 +337,10 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn backup_cluster(
@@ -336,7 +357,10 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -359,6 +383,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -378,6 +403,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -400,6 +426,11 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -419,6 +450,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -438,7 +470,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -458,7 +490,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -81,6 +82,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn get_instance_auth_string(
@@ -100,6 +102,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InstanceAuthString>| r.into_body())
     }
 
     async fn create_instance(
@@ -123,6 +126,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -161,6 +165,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn upgrade_instance(
@@ -177,7 +182,10 @@ impl super::stub::CloudRedis for CloudRedis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_instance(
@@ -194,7 +202,10 @@ impl super::stub::CloudRedis for CloudRedis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_instance(
@@ -211,7 +222,10 @@ impl super::stub::CloudRedis for CloudRedis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn failover_instance(
@@ -228,7 +242,10 @@ impl super::stub::CloudRedis for CloudRedis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -248,6 +265,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reschedule_maintenance(
@@ -267,7 +285,10 @@ impl super::stub::CloudRedis for CloudRedis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -290,6 +311,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -309,6 +331,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -331,6 +354,11 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -350,6 +378,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -369,7 +398,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -389,7 +418,7 @@ impl super::stub::CloudRedis for CloudRedis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/resourcemanager/v3/src/transport.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Folders for Folders {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Folder>| r.into_body())
     }
 
     async fn list_folders(
@@ -80,6 +81,7 @@ impl super::stub::Folders for Folders {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFoldersResponse>| r.into_body())
     }
 
     async fn search_folders(
@@ -102,6 +104,7 @@ impl super::stub::Folders for Folders {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchFoldersResponse>| r.into_body())
     }
 
     async fn create_folder(
@@ -118,7 +121,10 @@ impl super::stub::Folders for Folders {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.folder), options).await
+        self.inner
+            .execute(builder, Some(req.folder), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_folder(
@@ -154,7 +160,10 @@ impl super::stub::Folders for Folders {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.folder), options).await
+        self.inner
+            .execute(builder, Some(req.folder), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn move_folder(
@@ -171,7 +180,10 @@ impl super::stub::Folders for Folders {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_folder(
@@ -191,6 +203,7 @@ impl super::stub::Folders for Folders {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_folder(
@@ -207,7 +220,10 @@ impl super::stub::Folders for Folders {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -227,7 +243,10 @@ impl super::stub::Folders for Folders {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -247,7 +266,10 @@ impl super::stub::Folders for Folders {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -267,7 +289,9 @@ impl super::stub::Folders for Folders {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -287,6 +311,7 @@ impl super::stub::Folders for Folders {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -343,6 +368,7 @@ impl super::stub::Organizations for Organizations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Organization>| r.into_body())
     }
 
     async fn search_organizations(
@@ -365,6 +391,11 @@ impl super::stub::Organizations for Organizations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchOrganizationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_iam_policy(
@@ -384,7 +415,10 @@ impl super::stub::Organizations for Organizations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -404,7 +438,10 @@ impl super::stub::Organizations for Organizations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -424,7 +461,9 @@ impl super::stub::Organizations for Organizations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -444,6 +483,7 @@ impl super::stub::Organizations for Organizations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -486,6 +526,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Project>| r.into_body())
     }
 
     async fn list_projects(
@@ -509,6 +550,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProjectsResponse>| r.into_body())
     }
 
     async fn search_projects(
@@ -531,6 +573,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchProjectsResponse>| r.into_body())
     }
 
     async fn create_project(
@@ -550,6 +593,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, Some(req.project), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_project(
@@ -588,6 +632,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, Some(req.project), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn move_project(
@@ -604,7 +649,10 @@ impl super::stub::Projects for Projects {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_project(
@@ -624,6 +672,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_project(
@@ -640,7 +689,10 @@ impl super::stub::Projects for Projects {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -660,7 +712,10 @@ impl super::stub::Projects for Projects {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -680,7 +735,10 @@ impl super::stub::Projects for Projects {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -700,7 +758,9 @@ impl super::stub::Projects for Projects {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -720,6 +780,7 @@ impl super::stub::Projects for Projects {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -779,6 +840,7 @@ impl super::stub::TagBindings for TagBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTagBindingsResponse>| r.into_body())
     }
 
     async fn create_tag_binding(
@@ -799,6 +861,7 @@ impl super::stub::TagBindings for TagBindings {
         self.inner
             .execute(builder, Some(req.tag_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_tag_binding(
@@ -818,6 +881,7 @@ impl super::stub::TagBindings for TagBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_effective_tags(
@@ -840,6 +904,9 @@ impl super::stub::TagBindings for TagBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListEffectiveTagsResponse>| r.into_body(),
+            )
     }
 
     async fn get_operation(
@@ -859,6 +926,7 @@ impl super::stub::TagBindings for TagBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -919,6 +987,7 @@ impl super::stub::TagHolds for TagHolds {
         self.inner
             .execute(builder, Some(req.tag_hold), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_tag_hold(
@@ -939,6 +1008,7 @@ impl super::stub::TagHolds for TagHolds {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_tag_holds(
@@ -961,6 +1031,7 @@ impl super::stub::TagHolds for TagHolds {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTagHoldsResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -980,6 +1051,7 @@ impl super::stub::TagHolds for TagHolds {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1039,6 +1111,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTagKeysResponse>| r.into_body())
     }
 
     async fn get_tag_key(
@@ -1058,6 +1131,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagKey>| r.into_body())
     }
 
     async fn get_namespaced_tag_key(
@@ -1078,6 +1152,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagKey>| r.into_body())
     }
 
     async fn create_tag_key(
@@ -1098,6 +1173,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, Some(req.tag_key), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_tag_key(
@@ -1137,6 +1213,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, Some(req.tag_key), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_tag_key(
@@ -1158,6 +1235,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1177,7 +1255,10 @@ impl super::stub::TagKeys for TagKeys {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1197,7 +1278,10 @@ impl super::stub::TagKeys for TagKeys {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1217,7 +1301,9 @@ impl super::stub::TagKeys for TagKeys {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -1237,6 +1323,7 @@ impl super::stub::TagKeys for TagKeys {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1296,6 +1383,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTagValuesResponse>| r.into_body())
     }
 
     async fn get_tag_value(
@@ -1315,6 +1403,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagValue>| r.into_body())
     }
 
     async fn get_namespaced_tag_value(
@@ -1335,6 +1424,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TagValue>| r.into_body())
     }
 
     async fn create_tag_value(
@@ -1355,6 +1445,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, Some(req.tag_value), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_tag_value(
@@ -1394,6 +1485,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, Some(req.tag_value), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_tag_value(
@@ -1415,6 +1507,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1434,7 +1527,10 @@ impl super::stub::TagValues for TagValues {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1454,7 +1550,10 @@ impl super::stub::TagValues for TagValues {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1474,7 +1573,9 @@ impl super::stub::TagValues for TagValues {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -1494,6 +1595,7 @@ impl super::stub::TagValues for TagValues {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/retail/v2/src/transport.rs
+++ b/src/generated/cloud/retail/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::AnalyticsService for AnalyticsService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -80,6 +83,11 @@ impl super::stub::AnalyticsService for AnalyticsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -99,6 +107,7 @@ impl super::stub::AnalyticsService for AnalyticsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -157,6 +166,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCatalogsResponse>| r.into_body())
     }
 
     async fn update_catalog(
@@ -195,6 +205,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, Some(req.catalog), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Catalog>| r.into_body())
     }
 
     async fn set_default_branch(
@@ -217,7 +228,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_default_branch(
@@ -240,6 +251,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GetDefaultBranchResponse>| r.into_body())
     }
 
     async fn get_completion_config(
@@ -259,6 +271,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CompletionConfig>| r.into_body())
     }
 
     async fn update_completion_config(
@@ -297,6 +310,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, Some(req.completion_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CompletionConfig>| r.into_body())
     }
 
     async fn get_attributes_config(
@@ -316,6 +330,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AttributesConfig>| r.into_body())
     }
 
     async fn update_attributes_config(
@@ -354,6 +369,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, Some(req.attributes_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AttributesConfig>| r.into_body())
     }
 
     async fn add_catalog_attribute(
@@ -373,7 +389,10 @@ impl super::stub::CatalogService for CatalogService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AttributesConfig>| r.into_body())
     }
 
     async fn remove_catalog_attribute(
@@ -393,7 +412,10 @@ impl super::stub::CatalogService for CatalogService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AttributesConfig>| r.into_body())
     }
 
     async fn replace_catalog_attribute(
@@ -413,7 +435,10 @@ impl super::stub::CatalogService for CatalogService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AttributesConfig>| r.into_body())
     }
 
     async fn list_operations(
@@ -436,6 +461,11 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -455,6 +485,7 @@ impl super::stub::CatalogService for CatalogService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -514,6 +545,7 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CompleteQueryResponse>| r.into_body())
     }
 
     async fn import_completion_data(
@@ -533,7 +565,10 @@ impl super::stub::CompletionService for CompletionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -556,6 +591,11 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -575,6 +615,7 @@ impl super::stub::CompletionService for CompletionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -635,6 +676,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, Some(req.control), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Control>| r.into_body())
     }
 
     async fn delete_control(
@@ -654,7 +696,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_control(
@@ -693,6 +735,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, Some(req.control), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Control>| r.into_body())
     }
 
     async fn get_control(
@@ -712,6 +755,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Control>| r.into_body())
     }
 
     async fn list_controls(
@@ -734,6 +778,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListControlsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -756,6 +801,11 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -775,6 +825,7 @@ impl super::stub::ControlService for ControlService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -842,6 +893,11 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
                 options,
             )
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerativeQuestionsFeatureConfig>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_generative_questions_feature_config(
@@ -864,6 +920,11 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::GenerativeQuestionsFeatureConfig>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_generative_question_configs(
@@ -886,6 +947,11 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListGenerativeQuestionConfigsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn update_generative_question_config(
@@ -924,6 +990,7 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         self.inner
             .execute(builder, Some(req.generative_question_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::GenerativeQuestionConfig>| r.into_body())
     }
 
     async fn batch_update_generative_question_configs(
@@ -943,7 +1010,11 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<
+                crate::model::BatchUpdateGenerativeQuestionConfigsResponse,
+            >| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -966,6 +1037,11 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -985,6 +1061,7 @@ impl super::stub::GenerativeQuestionService for GenerativeQuestionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -1025,7 +1102,10 @@ impl super::stub::ModelService for ModelService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("dryRun", &req.dry_run)]);
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_model(
@@ -1045,6 +1125,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn pause_model(
@@ -1061,7 +1142,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn resume_model(
@@ -1078,7 +1162,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn delete_model(
@@ -1098,7 +1185,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_models(
@@ -1120,6 +1207,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListModelsResponse>| r.into_body())
     }
 
     async fn update_model(
@@ -1155,7 +1243,10 @@ impl super::stub::ModelService for ModelService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn tune_model(
@@ -1172,7 +1263,10 @@ impl super::stub::ModelService for ModelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -1195,6 +1289,11 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1214,6 +1313,7 @@ impl super::stub::ModelService for ModelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1270,7 +1370,10 @@ impl super::stub::PredictionService for PredictionService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::PredictResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1293,6 +1396,11 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1312,6 +1420,7 @@ impl super::stub::PredictionService for PredictionService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -1358,6 +1467,7 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, Some(req.product), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn get_product(
@@ -1377,6 +1487,7 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn list_products(
@@ -1409,6 +1520,7 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProductsResponse>| r.into_body())
     }
 
     async fn update_product(
@@ -1448,6 +1560,7 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, Some(req.product), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn delete_product(
@@ -1467,7 +1580,7 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn purge_products(
@@ -1487,7 +1600,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_products(
@@ -1507,7 +1623,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn set_inventory(
@@ -1533,7 +1652,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_fulfillment_places(
@@ -1553,7 +1675,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn remove_fulfillment_places(
@@ -1573,7 +1698,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_local_inventories(
@@ -1593,7 +1721,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn remove_local_inventories(
@@ -1613,7 +1744,10 @@ impl super::stub::ProductService for ProductService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -1636,6 +1770,11 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1655,6 +1794,7 @@ impl super::stub::ProductService for ProductService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1711,7 +1851,10 @@ impl super::stub::SearchService for SearchService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1734,6 +1877,11 @@ impl super::stub::SearchService for SearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1753,6 +1901,7 @@ impl super::stub::SearchService for SearchService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -1799,6 +1948,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, Some(req.serving_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServingConfig>| r.into_body())
     }
 
     async fn delete_serving_config(
@@ -1818,7 +1968,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_serving_config(
@@ -1857,6 +2007,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, Some(req.serving_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServingConfig>| r.into_body())
     }
 
     async fn get_serving_config(
@@ -1876,6 +2027,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServingConfig>| r.into_body())
     }
 
     async fn list_serving_configs(
@@ -1900,6 +2052,11 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServingConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn add_control(
@@ -1919,7 +2076,10 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServingConfig>| r.into_body())
     }
 
     async fn remove_control(
@@ -1939,7 +2099,10 @@ impl super::stub::ServingConfigService for ServingConfigService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServingConfig>| r.into_body())
     }
 
     async fn list_operations(
@@ -1962,6 +2125,11 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1981,6 +2149,7 @@ impl super::stub::ServingConfigService for ServingConfigService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -2027,6 +2196,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, Some(req.user_event), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserEvent>| r.into_body())
     }
 
     async fn collect_user_event(
@@ -2057,6 +2227,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<api::model::HttpBody>| r.into_body())
     }
 
     async fn purge_user_events(
@@ -2076,7 +2247,10 @@ impl super::stub::UserEventService for UserEventService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_user_events(
@@ -2096,7 +2270,10 @@ impl super::stub::UserEventService for UserEventService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn rejoin_user_events(
@@ -2116,7 +2293,10 @@ impl super::stub::UserEventService for UserEventService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -2139,6 +2319,11 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2158,6 +2343,7 @@ impl super::stub::UserEventService for UserEventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/run/v2/src/transport.rs
+++ b/src/generated/cloud/run/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::Builds for Builds {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SubmitBuildResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -80,6 +83,11 @@ impl super::stub::Builds for Builds {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -99,6 +107,7 @@ impl super::stub::Builds for Builds {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -118,7 +127,7 @@ impl super::stub::Builds for Builds {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -135,7 +144,10 @@ impl super::stub::Builds for Builds {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -178,6 +190,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 
     async fn list_executions(
@@ -203,6 +216,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExecutionsResponse>| r.into_body())
     }
 
     async fn delete_execution(
@@ -224,6 +238,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_execution(
@@ -240,7 +255,10 @@ impl super::stub::Executions for Executions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -263,6 +281,11 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -282,6 +305,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -301,7 +325,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -318,7 +342,10 @@ impl super::stub::Executions for Executions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -372,7 +399,10 @@ impl super::stub::Jobs for Jobs {
             );
         let builder = builder.query(&[("jobId", &req.job_id)]);
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_job(
@@ -392,6 +422,7 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn list_jobs(
@@ -414,6 +445,7 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobsResponse>| r.into_body())
     }
 
     async fn update_job(
@@ -441,7 +473,10 @@ impl super::stub::Jobs for Jobs {
             );
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
         let builder = builder.query(&[("allowMissing", &req.allow_missing)]);
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_job(
@@ -463,6 +498,7 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn run_job(
@@ -479,7 +515,10 @@ impl super::stub::Jobs for Jobs {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -512,6 +551,7 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -531,7 +571,10 @@ impl super::stub::Jobs for Jobs {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -551,7 +594,9 @@ impl super::stub::Jobs for Jobs {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -574,6 +619,11 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -593,6 +643,7 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -612,7 +663,7 @@ impl super::stub::Jobs for Jobs {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -629,7 +680,10 @@ impl super::stub::Jobs for Jobs {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -686,6 +740,7 @@ impl super::stub::Revisions for Revisions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Revision>| r.into_body())
     }
 
     async fn list_revisions(
@@ -711,6 +766,7 @@ impl super::stub::Revisions for Revisions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRevisionsResponse>| r.into_body())
     }
 
     async fn delete_revision(
@@ -732,6 +788,7 @@ impl super::stub::Revisions for Revisions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -754,6 +811,11 @@ impl super::stub::Revisions for Revisions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -773,6 +835,7 @@ impl super::stub::Revisions for Revisions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -792,7 +855,7 @@ impl super::stub::Revisions for Revisions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -809,7 +872,10 @@ impl super::stub::Revisions for Revisions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -871,6 +937,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_service(
@@ -890,6 +957,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn list_services(
@@ -912,6 +980,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn update_service(
@@ -952,6 +1021,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service(
@@ -973,6 +1043,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1005,6 +1076,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1024,7 +1096,10 @@ impl super::stub::Services for Services {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1044,7 +1119,9 @@ impl super::stub::Services for Services {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1067,6 +1144,11 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1086,6 +1168,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1105,7 +1188,7 @@ impl super::stub::Services for Services {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -1122,7 +1205,10 @@ impl super::stub::Services for Services {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -1177,6 +1263,7 @@ impl super::stub::Tasks for Tasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Task>| r.into_body())
     }
 
     async fn list_tasks(
@@ -1199,6 +1286,7 @@ impl super::stub::Tasks for Tasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTasksResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -1221,6 +1309,11 @@ impl super::stub::Tasks for Tasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1240,6 +1333,7 @@ impl super::stub::Tasks for Tasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1259,7 +1353,7 @@ impl super::stub::Tasks for Tasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -1276,6 +1370,9 @@ impl super::stub::Tasks for Tasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/transport.rs
+++ b/src/generated/cloud/scheduler/v1/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobsResponse>| r.into_body())
     }
 
     async fn get_job(
@@ -78,6 +79,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn create_job(
@@ -94,7 +96,10 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn update_job(
@@ -130,7 +135,10 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn delete_job(
@@ -150,7 +158,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn pause_job(
@@ -167,7 +175,10 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn resume_job(
@@ -184,7 +195,10 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn run_job(
@@ -201,7 +215,10 @@ impl super::stub::CloudScheduler for CloudScheduler {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn list_locations(
@@ -224,6 +241,7 @@ impl super::stub::CloudScheduler for CloudScheduler {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -243,5 +261,6 @@ impl super::stub::CloudScheduler for CloudScheduler {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/transport.rs
+++ b/src/generated/cloud/secretmanager/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSecretsResponse>| r.into_body())
     }
 
     async fn create_secret(
@@ -77,7 +78,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("secretId", &req.secret_id)]);
-        self.inner.execute(builder, Some(req.secret), options).await
+        self.inner
+            .execute(builder, Some(req.secret), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn add_secret_version(
@@ -97,7 +101,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn get_secret(
@@ -117,6 +124,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn update_secret(
@@ -152,7 +160,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.secret), options).await
+        self.inner
+            .execute(builder, Some(req.secret), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn delete_secret(
@@ -173,7 +184,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_secret_versions(
@@ -196,6 +207,11 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSecretVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_secret_version(
@@ -215,6 +231,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn access_secret_version(
@@ -234,6 +251,11 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::AccessSecretVersionResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn disable_secret_version(
@@ -250,7 +272,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn enable_secret_version(
@@ -267,7 +292,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn destroy_secret_version(
@@ -284,7 +312,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -304,7 +335,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -337,6 +371,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -356,7 +391,9 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -379,6 +416,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -398,5 +436,6 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/transport.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn get_instance(
@@ -83,6 +84,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -107,6 +109,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, Some(req.instance), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -127,6 +130,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_repositories(
@@ -153,6 +157,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRepositoriesResponse>| r.into_body())
     }
 
     async fn get_repository(
@@ -172,6 +177,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Repository>| r.into_body())
     }
 
     async fn create_repository(
@@ -195,6 +201,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, Some(req.repository), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_repository(
@@ -215,6 +222,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_iam_policy_repo(
@@ -247,6 +255,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy_repo(
@@ -266,7 +275,10 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions_repo(
@@ -286,7 +298,9 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn create_branch_rule(
@@ -310,6 +324,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, Some(req.branch_rule), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_branch_rules(
@@ -334,6 +349,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBranchRulesResponse>| r.into_body())
     }
 
     async fn get_branch_rule(
@@ -353,6 +369,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BranchRule>| r.into_body())
     }
 
     async fn update_branch_rule(
@@ -392,6 +409,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, Some(req.branch_rule), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_branch_rule(
@@ -412,6 +430,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -434,6 +453,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -453,6 +473,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -472,7 +493,10 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -505,6 +529,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -524,7 +549,9 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -547,6 +574,11 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -566,6 +598,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -585,7 +618,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -605,7 +638,7 @@ impl super::stub::SecureSourceManager for SecureSourceManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/security/privateca/v1/src/transport.rs
+++ b/src/generated/cloud/security/privateca/v1/src/transport.rs
@@ -67,6 +67,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Certificate>| r.into_body())
     }
 
     async fn get_certificate(
@@ -86,6 +87,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Certificate>| r.into_body())
     }
 
     async fn list_certificates(
@@ -112,6 +114,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCertificatesResponse>| r.into_body())
     }
 
     async fn revoke_certificate(
@@ -128,7 +131,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Certificate>| r.into_body())
     }
 
     async fn update_certificate(
@@ -168,6 +174,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Certificate>| r.into_body())
     }
 
     async fn activate_certificate_authority(
@@ -184,7 +191,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_certificate_authority(
@@ -209,6 +219,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate_authority), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn disable_certificate_authority(
@@ -225,7 +236,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn enable_certificate_authority(
@@ -242,7 +256,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_certificate_authority_csr(
@@ -262,6 +279,11 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchCertificateAuthorityCsrResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_certificate_authority(
@@ -281,6 +303,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CertificateAuthority>| r.into_body())
     }
 
     async fn list_certificate_authorities(
@@ -307,6 +330,11 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCertificateAuthoritiesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn undelete_certificate_authority(
@@ -323,7 +351,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_certificate_authority(
@@ -349,6 +380,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_certificate_authority(
@@ -388,6 +420,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate_authority), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_ca_pool(
@@ -409,6 +442,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.ca_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_ca_pool(
@@ -448,6 +482,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.ca_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_ca_pool(
@@ -467,6 +502,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CaPool>| r.into_body())
     }
 
     async fn list_ca_pools(
@@ -490,6 +526,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCaPoolsResponse>| r.into_body())
     }
 
     async fn delete_ca_pool(
@@ -512,6 +549,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_ca_certs(
@@ -531,7 +569,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FetchCaCertsResponse>| r.into_body())
     }
 
     async fn get_certificate_revocation_list(
@@ -551,6 +592,9 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CertificateRevocationList>| r.into_body(),
+            )
     }
 
     async fn list_certificate_revocation_lists(
@@ -577,6 +621,11 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListCertificateRevocationListsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn update_certificate_revocation_list(
@@ -618,6 +667,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate_revocation_list), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_certificate_template(
@@ -642,6 +692,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate_template), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_certificate_template(
@@ -662,6 +713,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_certificate_template(
@@ -681,6 +733,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CertificateTemplate>| r.into_body())
     }
 
     async fn list_certificate_templates(
@@ -707,6 +760,11 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCertificateTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_certificate_template(
@@ -746,6 +804,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req.certificate_template), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -768,6 +827,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -787,6 +847,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -806,7 +867,10 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -839,6 +903,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -858,7 +923,9 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -881,6 +948,11 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -900,6 +972,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -919,7 +992,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -939,7 +1012,7 @@ impl super::stub::CertificateAuthorityService for CertificateAuthorityService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/security/publicca/v1/src/transport.rs
+++ b/src/generated/cloud/security/publicca/v1/src/transport.rs
@@ -60,5 +60,6 @@ impl super::stub::PublicCertificateAuthorityService for PublicCertificateAuthori
         self.inner
             .execute(builder, Some(req.external_account_key), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalAccountKey>| r.into_body())
     }
 }

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -57,7 +57,11 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchCreateResourceValueConfigsResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn bulk_mute_findings(
@@ -77,7 +81,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_big_query_export(
@@ -101,6 +108,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.big_query_export), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BigQueryExport>| r.into_body())
     }
 
     async fn create_finding(
@@ -124,6 +132,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.finding), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Finding>| r.into_body())
     }
 
     async fn create_mute_config(
@@ -147,6 +156,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.mute_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::MuteConfig>| r.into_body())
     }
 
     async fn create_notification_config(
@@ -170,6 +180,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.notification_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotificationConfig>| r.into_body())
     }
 
     async fn create_source(
@@ -186,7 +197,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Source>| r.into_body())
     }
 
     async fn delete_big_query_export(
@@ -206,7 +220,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn delete_mute_config(
@@ -226,7 +240,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn delete_notification_config(
@@ -246,7 +260,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn delete_resource_value_config(
@@ -266,7 +280,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_big_query_export(
@@ -286,6 +300,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BigQueryExport>| r.into_body())
     }
 
     async fn get_simulation(
@@ -305,6 +320,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Simulation>| r.into_body())
     }
 
     async fn get_valued_resource(
@@ -324,6 +340,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ValuedResource>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -343,7 +360,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_mute_config(
@@ -363,6 +383,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MuteConfig>| r.into_body())
     }
 
     async fn get_notification_config(
@@ -382,6 +403,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotificationConfig>| r.into_body())
     }
 
     async fn get_resource_value_config(
@@ -401,6 +423,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ResourceValueConfig>| r.into_body())
     }
 
     async fn get_source(
@@ -420,6 +443,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Source>| r.into_body())
     }
 
     async fn group_findings(
@@ -439,7 +463,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::GroupFindingsResponse>| r.into_body())
     }
 
     async fn list_attack_paths(
@@ -465,6 +492,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAttackPathsResponse>| r.into_body())
     }
 
     async fn list_big_query_exports(
@@ -489,6 +517,11 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBigQueryExportsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_findings(
@@ -522,6 +555,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFindingsResponse>| r.into_body())
     }
 
     async fn list_mute_configs(
@@ -546,6 +580,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMuteConfigsResponse>| r.into_body())
     }
 
     async fn list_notification_configs(
@@ -570,6 +605,11 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNotificationConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_resource_value_configs(
@@ -594,6 +634,11 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListResourceValueConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_sources(
@@ -615,6 +660,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSourcesResponse>| r.into_body())
     }
 
     async fn list_valued_resources(
@@ -641,6 +687,11 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListValuedResourcesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn set_finding_state(
@@ -657,7 +708,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Finding>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -677,7 +731,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_mute(
@@ -694,7 +751,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Finding>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -714,7 +774,9 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn update_big_query_export(
@@ -753,6 +815,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.big_query_export), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BigQueryExport>| r.into_body())
     }
 
     async fn update_external_system(
@@ -791,6 +854,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.external_system), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalSystem>| r.into_body())
     }
 
     async fn update_finding(
@@ -829,6 +893,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.finding), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Finding>| r.into_body())
     }
 
     async fn update_mute_config(
@@ -867,6 +932,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.mute_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::MuteConfig>| r.into_body())
     }
 
     async fn update_notification_config(
@@ -905,6 +971,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.notification_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotificationConfig>| r.into_body())
     }
 
     async fn update_resource_value_config(
@@ -943,6 +1010,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.resource_value_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ResourceValueConfig>| r.into_body())
     }
 
     async fn update_security_marks(
@@ -981,6 +1049,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, Some(req.security_marks), options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecurityMarks>| r.into_body())
     }
 
     async fn update_source(
@@ -1016,7 +1085,10 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Source>| r.into_body())
     }
 
     async fn list_operations(
@@ -1039,6 +1111,11 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1058,6 +1135,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1077,7 +1155,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1097,7 +1175,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/securityposture/v1/src/transport.rs
+++ b/src/generated/cloud/securityposture/v1/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPosturesResponse>| r.into_body())
     }
 
     async fn list_posture_revisions(
@@ -83,6 +84,11 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPostureRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_posture(
@@ -103,6 +109,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Posture>| r.into_body())
     }
 
     async fn create_posture(
@@ -126,6 +133,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, Some(req.posture), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_posture(
@@ -165,6 +173,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, Some(req.posture), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_posture(
@@ -185,6 +194,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn extract_posture(
@@ -204,7 +214,10 @@ impl super::stub::SecurityPosture for SecurityPosture {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_posture_deployments(
@@ -230,6 +243,11 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPostureDeploymentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_posture_deployment(
@@ -249,6 +267,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PostureDeployment>| r.into_body())
     }
 
     async fn create_posture_deployment(
@@ -272,6 +291,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, Some(req.posture_deployment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_posture_deployment(
@@ -310,6 +330,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, Some(req.posture_deployment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_posture_deployment(
@@ -330,6 +351,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_posture_templates(
@@ -355,6 +377,11 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPostureTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_posture_template(
@@ -375,6 +402,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PostureTemplate>| r.into_body())
     }
 
     async fn list_locations(
@@ -397,6 +425,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -416,6 +445,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -438,6 +468,11 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -457,6 +492,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -476,7 +512,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -496,7 +532,7 @@ impl super::stub::SecurityPosture for SecurityPosture {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/servicedirectory/v1/src/transport.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::LookupService for LookupService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ResolveServiceResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -77,6 +80,7 @@ impl super::stub::LookupService for LookupService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -96,6 +100,7 @@ impl super::stub::LookupService for LookupService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }
 
@@ -142,6 +147,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, Some(req.namespace), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Namespace>| r.into_body())
     }
 
     async fn list_namespaces(
@@ -168,6 +174,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNamespacesResponse>| r.into_body())
     }
 
     async fn get_namespace(
@@ -187,6 +194,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Namespace>| r.into_body())
     }
 
     async fn update_namespace(
@@ -225,6 +233,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, Some(req.namespace), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Namespace>| r.into_body())
     }
 
     async fn delete_namespace(
@@ -244,7 +253,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_service(
@@ -268,6 +277,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn list_services(
@@ -291,6 +301,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn get_service(
@@ -310,6 +321,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn update_service(
@@ -348,6 +360,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn delete_service(
@@ -367,7 +380,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_endpoint(
@@ -391,6 +404,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, Some(req.endpoint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Endpoint>| r.into_body())
     }
 
     async fn list_endpoints(
@@ -417,6 +431,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEndpointsResponse>| r.into_body())
     }
 
     async fn get_endpoint(
@@ -436,6 +451,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Endpoint>| r.into_body())
     }
 
     async fn update_endpoint(
@@ -474,6 +490,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, Some(req.endpoint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Endpoint>| r.into_body())
     }
 
     async fn delete_endpoint(
@@ -493,7 +510,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_iam_policy(
@@ -513,7 +530,10 @@ impl super::stub::RegistrationService for RegistrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -533,7 +553,10 @@ impl super::stub::RegistrationService for RegistrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -553,7 +576,9 @@ impl super::stub::RegistrationService for RegistrationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -576,6 +601,7 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -595,5 +621,6 @@ impl super::stub::RegistrationService for RegistrationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/transport.rs
+++ b/src/generated/cloud/servicehealth/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEventsResponse>| r.into_body())
     }
 
     async fn get_event(
@@ -80,6 +81,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Event>| r.into_body())
     }
 
     async fn list_organization_events(
@@ -106,6 +108,11 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListOrganizationEventsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_organization_event(
@@ -125,6 +132,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::OrganizationEvent>| r.into_body())
     }
 
     async fn list_organization_impacts(
@@ -150,6 +158,11 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListOrganizationImpactsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_organization_impact(
@@ -169,6 +182,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::OrganizationImpact>| r.into_body())
     }
 
     async fn list_locations(
@@ -191,6 +205,7 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -210,5 +225,6 @@ impl super::stub::ServiceHealth for ServiceHealth {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/shell/v1/src/transport.rs
+++ b/src/generated/cloud/shell/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::CloudShellService for CloudShellService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Environment>| r.into_body())
     }
 
     async fn start_environment(
@@ -73,7 +74,10 @@ impl super::stub::CloudShellService for CloudShellService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn authorize_environment(
@@ -90,7 +94,10 @@ impl super::stub::CloudShellService for CloudShellService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_public_key(
@@ -110,7 +117,10 @@ impl super::stub::CloudShellService for CloudShellService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn remove_public_key(
@@ -130,7 +140,10 @@ impl super::stub::CloudShellService for CloudShellService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -150,6 +163,7 @@ impl super::stub::CloudShellService for CloudShellService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/speech/v2/src/transport.rs
+++ b/src/generated/cloud/speech/v2/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req.recognizer), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_recognizers(
@@ -87,6 +88,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRecognizersResponse>| r.into_body())
     }
 
     async fn get_recognizer(
@@ -106,6 +108,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Recognizer>| r.into_body())
     }
 
     async fn update_recognizer(
@@ -145,6 +148,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req.recognizer), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_recognizer(
@@ -167,6 +171,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_recognizer(
@@ -183,7 +188,10 @@ impl super::stub::Speech for Speech {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn recognize(
@@ -203,7 +211,10 @@ impl super::stub::Speech for Speech {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RecognizeResponse>| r.into_body())
     }
 
     async fn batch_recognize(
@@ -223,7 +234,10 @@ impl super::stub::Speech for Speech {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_config(
@@ -243,6 +257,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Config>| r.into_body())
     }
 
     async fn update_config(
@@ -278,7 +293,10 @@ impl super::stub::Speech for Speech {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.config), options).await
+        self.inner
+            .execute(builder, Some(req.config), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Config>| r.into_body())
     }
 
     async fn create_custom_class(
@@ -303,6 +321,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req.custom_class), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_custom_classes(
@@ -328,6 +347,9 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListCustomClassesResponse>| r.into_body(),
+            )
     }
 
     async fn get_custom_class(
@@ -347,6 +369,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CustomClass>| r.into_body())
     }
 
     async fn update_custom_class(
@@ -386,6 +409,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req.custom_class), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_custom_class(
@@ -408,6 +432,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_custom_class(
@@ -424,7 +449,10 @@ impl super::stub::Speech for Speech {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_phrase_set(
@@ -449,6 +477,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req.phrase_set), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_phrase_sets(
@@ -474,6 +503,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPhraseSetsResponse>| r.into_body())
     }
 
     async fn get_phrase_set(
@@ -493,6 +523,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PhraseSet>| r.into_body())
     }
 
     async fn update_phrase_set(
@@ -532,6 +563,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req.phrase_set), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_phrase_set(
@@ -554,6 +586,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_phrase_set(
@@ -570,7 +603,10 @@ impl super::stub::Speech for Speech {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -593,6 +629,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -612,6 +649,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -634,6 +672,11 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -653,6 +696,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -672,7 +716,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -692,7 +736,7 @@ impl super::stub::Speech for Speech {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/sql/v1/src/transport.rs
+++ b/src/generated/cloud/sql/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get(
@@ -90,6 +91,7 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::BackupRun>| r.into_body())
     }
 
     async fn insert(
@@ -115,6 +117,7 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list(
@@ -142,6 +145,7 @@ impl super::stub::SqlBackupRunsService for SqlBackupRunsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::BackupRunsListResponse>| r.into_body())
     }
 
 }
@@ -192,6 +196,7 @@ impl super::stub::SqlConnectService for SqlConnectService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::ConnectSettings>| r.into_body())
     }
 
     async fn generate_ephemeral_cert(
@@ -217,6 +222,7 @@ impl super::stub::SqlConnectService for SqlConnectService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::GenerateEphemeralCertResponse>| r.into_body())
     }
 
 }
@@ -267,6 +273,7 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get(
@@ -293,6 +300,7 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Database>| r.into_body())
     }
 
     async fn insert(
@@ -318,6 +326,7 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list(
@@ -343,6 +352,7 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::DatabasesListResponse>| r.into_body())
     }
 
     async fn patch(
@@ -369,6 +379,7 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn update(
@@ -395,6 +406,7 @@ impl super::stub::SqlDatabasesService for SqlDatabasesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
 }
@@ -442,6 +454,7 @@ impl super::stub::SqlFlagsService for SqlFlagsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::FlagsListResponse>| r.into_body())
     }
 
 }
@@ -491,6 +504,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn clone(
@@ -516,6 +530,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn delete(
@@ -541,6 +556,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn demote_master(
@@ -566,6 +582,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn demote(
@@ -591,6 +608,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn export(
@@ -616,6 +634,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn failover(
@@ -641,6 +660,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn reencrypt(
@@ -666,6 +686,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get(
@@ -691,6 +712,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::DatabaseInstance>| r.into_body())
     }
 
     async fn import(
@@ -716,6 +738,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn insert(
@@ -740,6 +763,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list(
@@ -767,6 +791,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::InstancesListResponse>| r.into_body())
     }
 
     async fn list_server_cas(
@@ -792,6 +817,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::InstancesListServerCasResponse>| r.into_body())
     }
 
     async fn patch(
@@ -817,6 +843,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn promote_replica(
@@ -843,6 +870,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn switchover(
@@ -869,6 +897,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn reset_ssl_config(
@@ -894,6 +923,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn restart(
@@ -919,6 +949,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn restore_backup(
@@ -944,6 +975,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn rotate_server_ca(
@@ -969,6 +1001,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn start_replica(
@@ -994,6 +1027,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn stop_replica(
@@ -1019,6 +1053,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn truncate_log(
@@ -1044,6 +1079,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn update(
@@ -1069,6 +1105,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn create_ephemeral(
@@ -1094,6 +1131,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SslCert>| r.into_body())
     }
 
     async fn reschedule_maintenance(
@@ -1119,6 +1157,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn verify_external_sync_settings(
@@ -1144,6 +1183,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SqlInstancesVerifyExternalSyncSettingsResponse>| r.into_body())
     }
 
     async fn start_external_sync(
@@ -1169,6 +1209,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn perform_disk_shrink(
@@ -1194,6 +1235,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get_disk_shrink_config(
@@ -1219,6 +1261,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SqlInstancesGetDiskShrinkConfigResponse>| r.into_body())
     }
 
     async fn reset_replica_size(
@@ -1244,6 +1287,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get_latest_recovery_time(
@@ -1269,6 +1313,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SqlInstancesGetLatestRecoveryTimeResponse>| r.into_body())
     }
 
     async fn acquire_ssrs_lease(
@@ -1294,6 +1339,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SqlInstancesAcquireSsrsLeaseResponse>| r.into_body())
     }
 
     async fn release_ssrs_lease(
@@ -1319,6 +1365,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SqlInstancesReleaseSsrsLeaseResponse>| r.into_body())
     }
 
 }
@@ -1368,6 +1415,7 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list(
@@ -1395,6 +1443,7 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::OperationsListResponse>| r.into_body())
     }
 
     async fn cancel(
@@ -1420,7 +1469,7 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
-        .map(|_: wkt::Empty| ())
+        .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
 }
@@ -1471,6 +1520,7 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get(
@@ -1497,6 +1547,7 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SslCert>| r.into_body())
     }
 
     async fn insert(
@@ -1522,6 +1573,7 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SslCertsInsertResponse>| r.into_body())
     }
 
     async fn list(
@@ -1547,6 +1599,7 @@ impl super::stub::SqlSslCertsService for SqlSslCertsService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::SslCertsListResponse>| r.into_body())
     }
 
 }
@@ -1595,6 +1648,7 @@ impl super::stub::SqlTiersService for SqlTiersService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::TiersListResponse>| r.into_body())
     }
 
 }
@@ -1646,6 +1700,7 @@ impl super::stub::SqlUsersService for SqlUsersService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn get(
@@ -1673,6 +1728,7 @@ impl super::stub::SqlUsersService for SqlUsersService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::User>| r.into_body())
     }
 
     async fn insert(
@@ -1698,6 +1754,7 @@ impl super::stub::SqlUsersService for SqlUsersService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list(
@@ -1723,6 +1780,7 @@ impl super::stub::SqlUsersService for SqlUsersService {
             None::<gaxi::http::NoBody>,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::UsersListResponse>| r.into_body())
     }
 
     async fn update(
@@ -1750,6 +1808,7 @@ impl super::stub::SqlUsersService for SqlUsersService {
             ,
             options,
         ).await
+        .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
 }

--- a/src/generated/cloud/storagebatchoperations/v1/src/transport.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobsResponse>| r.into_body())
     }
 
     async fn get_job(
@@ -80,6 +81,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn create_job(
@@ -98,7 +100,10 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
             );
         let builder = builder.query(&[("jobId", &req.job_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_job(
@@ -119,7 +124,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_job(
@@ -136,7 +141,10 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::CancelJobResponse>| r.into_body())
     }
 
     async fn list_locations(
@@ -159,6 +167,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -178,6 +187,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -200,6 +210,11 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -219,6 +234,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -238,7 +254,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -258,7 +274,7 @@ impl super::stub::StorageBatchOperations for StorageBatchOperations {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/storageinsights/v1/src/transport.rs
+++ b/src/generated/cloud/storageinsights/v1/src/transport.rs
@@ -64,6 +64,9 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReportConfigsResponse>| r.into_body(),
+            )
     }
 
     async fn get_report_config(
@@ -83,6 +86,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReportConfig>| r.into_body())
     }
 
     async fn create_report_config(
@@ -106,6 +110,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, Some(req.report_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReportConfig>| r.into_body())
     }
 
     async fn update_report_config(
@@ -145,6 +150,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, Some(req.report_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReportConfig>| r.into_body())
     }
 
     async fn delete_report_config(
@@ -166,7 +172,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_report_details(
@@ -193,6 +199,9 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReportDetailsResponse>| r.into_body(),
+            )
     }
 
     async fn get_report_detail(
@@ -212,6 +221,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReportDetail>| r.into_body())
     }
 
     async fn list_locations(
@@ -234,6 +244,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -253,6 +264,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -275,6 +287,11 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -294,6 +311,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -313,7 +331,7 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -333,6 +351,6 @@ impl super::stub::StorageInsights for StorageInsights {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/support/v2/src/transport.rs
+++ b/src/generated/cloud/support/v2/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::CaseAttachmentService for CaseAttachmentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAttachmentsResponse>| r.into_body())
     }
 }
 
@@ -104,6 +105,7 @@ impl super::stub::CaseService for CaseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Case>| r.into_body())
     }
 
     async fn list_cases(
@@ -126,6 +128,7 @@ impl super::stub::CaseService for CaseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCasesResponse>| r.into_body())
     }
 
     async fn search_cases(
@@ -151,6 +154,7 @@ impl super::stub::CaseService for CaseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchCasesResponse>| r.into_body())
     }
 
     async fn create_case(
@@ -167,7 +171,10 @@ impl super::stub::CaseService for CaseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.case), options).await
+        self.inner
+            .execute(builder, Some(req.case), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Case>| r.into_body())
     }
 
     async fn update_case(
@@ -203,7 +210,10 @@ impl super::stub::CaseService for CaseService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.case), options).await
+        self.inner
+            .execute(builder, Some(req.case), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Case>| r.into_body())
     }
 
     async fn escalate_case(
@@ -220,7 +230,10 @@ impl super::stub::CaseService for CaseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Case>| r.into_body())
     }
 
     async fn close_case(
@@ -237,7 +250,10 @@ impl super::stub::CaseService for CaseService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Case>| r.into_body())
     }
 
     async fn search_case_classifications(
@@ -263,6 +279,11 @@ impl super::stub::CaseService for CaseService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchCaseClassificationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }
 
@@ -307,6 +328,7 @@ impl super::stub::CommentService for CommentService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCommentsResponse>| r.into_body())
     }
 
     async fn create_comment(
@@ -329,5 +351,6 @@ impl super::stub::CommentService for CommentService {
         self.inner
             .execute(builder, Some(req.comment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Comment>| r.into_body())
     }
 }

--- a/src/generated/cloud/talent/v4/src/transport.rs
+++ b/src/generated/cloud/talent/v4/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::CompanyService for CompanyService {
         self.inner
             .execute(builder, Some(req.company), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Company>| r.into_body())
     }
 
     async fn get_company(
@@ -79,6 +80,7 @@ impl super::stub::CompanyService for CompanyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Company>| r.into_body())
     }
 
     async fn update_company(
@@ -117,6 +119,7 @@ impl super::stub::CompanyService for CompanyService {
         self.inner
             .execute(builder, Some(req.company), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Company>| r.into_body())
     }
 
     async fn delete_company(
@@ -136,7 +139,7 @@ impl super::stub::CompanyService for CompanyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_companies(
@@ -162,6 +165,7 @@ impl super::stub::CompanyService for CompanyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCompaniesResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -181,6 +185,7 @@ impl super::stub::CompanyService for CompanyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -235,6 +240,7 @@ impl super::stub::Completion for Completion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CompleteQueryResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -254,6 +260,7 @@ impl super::stub::Completion for Completion {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -299,6 +306,7 @@ impl super::stub::EventService for EventService {
         self.inner
             .execute(builder, Some(req.client_event), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ClientEvent>| r.into_body())
     }
 
     async fn get_operation(
@@ -318,6 +326,7 @@ impl super::stub::EventService for EventService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -357,7 +366,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn batch_create_jobs(
@@ -377,7 +389,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_job(
@@ -397,6 +412,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn update_job(
@@ -432,7 +448,10 @@ impl super::stub::JobService for JobService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn batch_update_jobs(
@@ -452,7 +471,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_job(
@@ -472,7 +494,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn batch_delete_jobs(
@@ -492,7 +514,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_jobs(
@@ -516,6 +541,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobsResponse>| r.into_body())
     }
 
     async fn search_jobs(
@@ -535,7 +561,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchJobsResponse>| r.into_body())
     }
 
     async fn search_jobs_for_alert(
@@ -555,7 +584,10 @@ impl super::stub::JobService for JobService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SearchJobsResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -575,6 +607,7 @@ impl super::stub::JobService for JobService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -628,7 +661,10 @@ impl super::stub::TenantService for TenantService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.tenant), options).await
+        self.inner
+            .execute(builder, Some(req.tenant), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Tenant>| r.into_body())
     }
 
     async fn get_tenant(
@@ -648,6 +684,7 @@ impl super::stub::TenantService for TenantService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Tenant>| r.into_body())
     }
 
     async fn update_tenant(
@@ -683,7 +720,10 @@ impl super::stub::TenantService for TenantService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.tenant), options).await
+        self.inner
+            .execute(builder, Some(req.tenant), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Tenant>| r.into_body())
     }
 
     async fn delete_tenant(
@@ -703,7 +743,7 @@ impl super::stub::TenantService for TenantService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_tenants(
@@ -725,6 +765,7 @@ impl super::stub::TenantService for TenantService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTenantsResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -744,5 +785,6 @@ impl super::stub::TenantService for TenantService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }

--- a/src/generated/cloud/tasks/v2/src/transport.rs
+++ b/src/generated/cloud/tasks/v2/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListQueuesResponse>| r.into_body())
     }
 
     async fn get_queue(
@@ -79,6 +80,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Queue>| r.into_body())
     }
 
     async fn create_queue(
@@ -95,7 +97,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.queue), options).await
+        self.inner
+            .execute(builder, Some(req.queue), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Queue>| r.into_body())
     }
 
     async fn update_queue(
@@ -131,7 +136,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.queue), options).await
+        self.inner
+            .execute(builder, Some(req.queue), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Queue>| r.into_body())
     }
 
     async fn delete_queue(
@@ -151,7 +159,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn purge_queue(
@@ -168,7 +176,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Queue>| r.into_body())
     }
 
     async fn pause_queue(
@@ -185,7 +196,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Queue>| r.into_body())
     }
 
     async fn resume_queue(
@@ -202,7 +216,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Queue>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -222,7 +239,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -242,7 +262,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -262,7 +285,9 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_tasks(
@@ -285,6 +310,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTasksResponse>| r.into_body())
     }
 
     async fn get_task(
@@ -305,6 +331,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Task>| r.into_body())
     }
 
     async fn create_task(
@@ -321,7 +348,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Task>| r.into_body())
     }
 
     async fn delete_task(
@@ -341,7 +371,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn run_task(
@@ -358,7 +388,10 @@ impl super::stub::CloudTasks for CloudTasks {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Task>| r.into_body())
     }
 
     async fn list_locations(
@@ -381,6 +414,7 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -400,5 +434,6 @@ impl super::stub::CloudTasks for CloudTasks {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 }

--- a/src/generated/cloud/telcoautomation/v1/src/transport.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/transport.rs
@@ -64,6 +64,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListOrchestrationClustersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_orchestration_cluster(
@@ -83,6 +88,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::OrchestrationCluster>| r.into_body())
     }
 
     async fn create_orchestration_cluster(
@@ -107,6 +113,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.orchestration_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_orchestration_cluster(
@@ -127,6 +134,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_edge_slms(
@@ -150,6 +158,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEdgeSlmsResponse>| r.into_body())
     }
 
     async fn get_edge_slm(
@@ -169,6 +178,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::EdgeSlm>| r.into_body())
     }
 
     async fn create_edge_slm(
@@ -193,6 +203,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.edge_slm), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_edge_slm(
@@ -213,6 +224,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_blueprint(
@@ -236,6 +248,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.blueprint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Blueprint>| r.into_body())
     }
 
     async fn update_blueprint(
@@ -274,6 +287,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.blueprint), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Blueprint>| r.into_body())
     }
 
     async fn get_blueprint(
@@ -294,6 +308,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Blueprint>| r.into_body())
     }
 
     async fn delete_blueprint(
@@ -313,7 +328,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_blueprints(
@@ -339,6 +354,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBlueprintsResponse>| r.into_body())
     }
 
     async fn approve_blueprint(
@@ -355,7 +371,10 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Blueprint>| r.into_body())
     }
 
     async fn propose_blueprint(
@@ -372,7 +391,10 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Blueprint>| r.into_body())
     }
 
     async fn reject_blueprint(
@@ -389,7 +411,10 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Blueprint>| r.into_body())
     }
 
     async fn list_blueprint_revisions(
@@ -414,6 +439,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBlueprintRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_blueprint_revisions(
@@ -439,6 +469,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchBlueprintRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_deployment_revisions(
@@ -464,6 +499,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchDeploymentRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn discard_blueprint_changes(
@@ -480,7 +520,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::DiscardBlueprintChangesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_public_blueprints(
@@ -505,6 +549,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPublicBlueprintsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_public_blueprint(
@@ -524,6 +573,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PublicBlueprint>| r.into_body())
     }
 
     async fn create_deployment(
@@ -547,6 +597,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn update_deployment(
@@ -585,6 +636,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn get_deployment(
@@ -605,6 +657,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn remove_deployment(
@@ -624,7 +677,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_deployments(
@@ -650,6 +703,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDeploymentsResponse>| r.into_body())
     }
 
     async fn list_deployment_revisions(
@@ -674,6 +728,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDeploymentRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn discard_deployment_changes(
@@ -690,7 +749,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::DiscardDeploymentChangesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn apply_deployment(
@@ -707,7 +770,10 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn compute_deployment_status(
@@ -730,6 +796,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ComputeDeploymentStatusResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn rollback_deployment(
@@ -746,7 +817,10 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Deployment>| r.into_body())
     }
 
     async fn get_hydrated_deployment(
@@ -766,6 +840,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::HydratedDeployment>| r.into_body())
     }
 
     async fn list_hydrated_deployments(
@@ -790,6 +865,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListHydratedDeploymentsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_hydrated_deployment(
@@ -828,6 +908,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req.hydrated_deployment), options)
             .await
+            .map(|r: gax::response::Response<crate::model::HydratedDeployment>| r.into_body())
     }
 
     async fn apply_hydrated_deployment(
@@ -844,7 +925,10 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::HydratedDeployment>| r.into_body())
     }
 
     async fn list_locations(
@@ -867,6 +951,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -886,6 +971,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -908,6 +994,11 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -927,6 +1018,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -946,7 +1038,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -966,7 +1058,7 @@ impl super::stub::TelcoAutomation for TelcoAutomation {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/texttospeech/v1/src/transport.rs
+++ b/src/generated/cloud/texttospeech/v1/src/transport.rs
@@ -58,6 +58,7 @@ impl super::stub::TextToSpeech for TextToSpeech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVoicesResponse>| r.into_body())
     }
 
     async fn synthesize_speech(
@@ -74,7 +75,10 @@ impl super::stub::TextToSpeech for TextToSpeech {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SynthesizeSpeechResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -97,6 +101,11 @@ impl super::stub::TextToSpeech for TextToSpeech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -116,6 +125,7 @@ impl super::stub::TextToSpeech for TextToSpeech {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 }
 
@@ -158,7 +168,10 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -181,6 +194,11 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -200,6 +218,7 @@ impl super::stub::TextToSpeechLongAudioSynthesize for TextToSpeechLongAudioSynth
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDataSetsResponse>| r.into_body())
     }
 
     async fn create_data_set(
@@ -81,6 +82,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<crate::model::DataSet>| r.into_body())
     }
 
     async fn delete_data_set(
@@ -100,7 +102,7 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn append_events(
@@ -120,7 +122,10 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AppendEventsResponse>| r.into_body())
     }
 
     async fn query_data_set(
@@ -137,7 +142,10 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::QueryDataSetResponse>| r.into_body())
     }
 
     async fn evaluate_slice(
@@ -157,7 +165,10 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::EvaluatedSlice>| r.into_body())
     }
 
     async fn evaluate_timeseries(
@@ -177,6 +188,9 @@ impl super::stub::TimeseriesInsightsController for TimeseriesInsightsController 
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::EvaluatedSlice>| r.into_body())
     }
 }

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNodesResponse>| r.into_body())
     }
 
     async fn get_node(
@@ -76,6 +77,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Node>| r.into_body())
     }
 
     async fn create_node(
@@ -93,7 +95,10 @@ impl super::stub::Tpu for Tpu {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("nodeId", &req.node_id)]);
-        self.inner.execute(builder, Some(req.node), options).await
+        self.inner
+            .execute(builder, Some(req.node), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_node(
@@ -113,6 +118,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_node(
@@ -129,7 +135,10 @@ impl super::stub::Tpu for Tpu {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_node(
@@ -146,7 +155,10 @@ impl super::stub::Tpu for Tpu {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_node(
@@ -182,7 +194,10 @@ impl super::stub::Tpu for Tpu {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.node), options).await
+        self.inner
+            .execute(builder, Some(req.node), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_queued_resources(
@@ -207,6 +222,11 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListQueuedResourcesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_queued_resource(
@@ -226,6 +246,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::QueuedResource>| r.into_body())
     }
 
     async fn create_queued_resource(
@@ -250,6 +271,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, Some(req.queued_resource), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_queued_resource(
@@ -271,6 +293,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reset_queued_resource(
@@ -287,7 +310,10 @@ impl super::stub::Tpu for Tpu {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_service_identity(
@@ -307,7 +333,11 @@ impl super::stub::Tpu for Tpu {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateServiceIdentityResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn list_accelerator_types(
@@ -334,6 +364,11 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAcceleratorTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_accelerator_type(
@@ -353,6 +388,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AcceleratorType>| r.into_body())
     }
 
     async fn list_runtime_versions(
@@ -379,6 +415,11 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListRuntimeVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_runtime_version(
@@ -398,6 +439,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::RuntimeVersion>| r.into_body())
     }
 
     async fn get_guest_attributes(
@@ -417,7 +459,9 @@ impl super::stub::Tpu for Tpu {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GetGuestAttributesResponse>| r.into_body(),
+        )
     }
 
     async fn list_locations(
@@ -440,6 +484,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -459,6 +504,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -481,6 +527,11 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -500,6 +551,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -519,7 +571,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -539,7 +591,7 @@ impl super::stub::Tpu for Tpu {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/translate/v3/src/transport.rs
+++ b/src/generated/cloud/translate/v3/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::TranslateTextResponse>| r.into_body())
     }
 
     async fn romanize_text(
@@ -77,7 +80,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RomanizeTextResponse>| r.into_body())
     }
 
     async fn detect_language(
@@ -97,7 +103,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DetectLanguageResponse>| r.into_body())
     }
 
     async fn get_supported_languages(
@@ -122,6 +131,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SupportedLanguages>| r.into_body())
     }
 
     async fn translate_document(
@@ -141,7 +151,9 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::TranslateDocumentResponse>| r.into_body(),
+        )
     }
 
     async fn batch_translate_text(
@@ -161,7 +173,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_translate_document(
@@ -181,7 +196,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_glossary(
@@ -204,6 +222,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req.glossary), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_glossary(
@@ -242,6 +261,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req.glossary), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_glossaries(
@@ -267,6 +287,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGlossariesResponse>| r.into_body())
     }
 
     async fn get_glossary(
@@ -286,6 +307,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Glossary>| r.into_body())
     }
 
     async fn delete_glossary(
@@ -305,6 +327,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_glossary_entry(
@@ -324,6 +347,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GlossaryEntry>| r.into_body())
     }
 
     async fn list_glossary_entries(
@@ -348,6 +372,11 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListGlossaryEntriesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_glossary_entry(
@@ -370,6 +399,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req.glossary_entry), options)
             .await
+            .map(|r: gax::response::Response<crate::model::GlossaryEntry>| r.into_body())
     }
 
     async fn update_glossary_entry(
@@ -398,6 +428,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req.glossary_entry), options)
             .await
+            .map(|r: gax::response::Response<crate::model::GlossaryEntry>| r.into_body())
     }
 
     async fn delete_glossary_entry(
@@ -417,7 +448,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_dataset(
@@ -440,6 +471,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req.dataset), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_dataset(
@@ -459,6 +491,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dataset>| r.into_body())
     }
 
     async fn list_datasets(
@@ -480,6 +513,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDatasetsResponse>| r.into_body())
     }
 
     async fn delete_dataset(
@@ -499,6 +533,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_adaptive_mt_dataset(
@@ -521,6 +556,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req.adaptive_mt_dataset), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AdaptiveMtDataset>| r.into_body())
     }
 
     async fn delete_adaptive_mt_dataset(
@@ -540,7 +576,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_adaptive_mt_dataset(
@@ -560,6 +596,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AdaptiveMtDataset>| r.into_body())
     }
 
     async fn list_adaptive_mt_datasets(
@@ -585,6 +622,11 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAdaptiveMtDatasetsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn adaptive_mt_translate(
@@ -604,7 +646,9 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::AdaptiveMtTranslateResponse>| r.into_body(),
+        )
     }
 
     async fn get_adaptive_mt_file(
@@ -624,6 +668,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AdaptiveMtFile>| r.into_body())
     }
 
     async fn delete_adaptive_mt_file(
@@ -643,7 +688,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn import_adaptive_mt_file(
@@ -663,7 +708,9 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ImportAdaptiveMtFileResponse>| r.into_body(),
+        )
     }
 
     async fn list_adaptive_mt_files(
@@ -688,6 +735,11 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAdaptiveMtFilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_adaptive_mt_sentences(
@@ -712,6 +764,11 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAdaptiveMtSentencesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn import_data(
@@ -731,7 +788,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn export_data(
@@ -751,7 +811,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_examples(
@@ -774,6 +837,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExamplesResponse>| r.into_body())
     }
 
     async fn create_model(
@@ -790,7 +854,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.model), options).await
+        self.inner
+            .execute(builder, Some(req.model), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_models(
@@ -813,6 +880,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListModelsResponse>| r.into_body())
     }
 
     async fn get_model(
@@ -832,6 +900,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Model>| r.into_body())
     }
 
     async fn delete_model(
@@ -851,6 +920,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -873,6 +943,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -892,6 +963,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -914,6 +986,11 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -933,6 +1010,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -952,7 +1030,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -972,7 +1050,7 @@ impl super::stub::TranslationService for TranslationService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn wait_operation(
@@ -989,7 +1067,10 @@ impl super::stub::TranslationService for TranslationService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/video/livestream/v1/src/transport.rs
+++ b/src/generated/cloud/video/livestream/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, Some(req.channel), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_channels(
@@ -85,6 +86,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListChannelsResponse>| r.into_body())
     }
 
     async fn get_channel(
@@ -104,6 +106,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Channel>| r.into_body())
     }
 
     async fn delete_channel(
@@ -125,6 +128,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_channel(
@@ -164,6 +168,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, Some(req.channel), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_channel(
@@ -180,7 +185,10 @@ impl super::stub::LivestreamService for LivestreamService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_channel(
@@ -197,7 +205,10 @@ impl super::stub::LivestreamService for LivestreamService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_input(
@@ -216,7 +227,10 @@ impl super::stub::LivestreamService for LivestreamService {
             );
         let builder = builder.query(&[("inputId", &req.input_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.input), options).await
+        self.inner
+            .execute(builder, Some(req.input), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_inputs(
@@ -240,6 +254,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInputsResponse>| r.into_body())
     }
 
     async fn get_input(
@@ -259,6 +274,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Input>| r.into_body())
     }
 
     async fn delete_input(
@@ -279,6 +295,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_input(
@@ -315,7 +332,10 @@ impl super::stub::LivestreamService for LivestreamService {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.input), options).await
+        self.inner
+            .execute(builder, Some(req.input), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_event(
@@ -334,7 +354,10 @@ impl super::stub::LivestreamService for LivestreamService {
             );
         let builder = builder.query(&[("eventId", &req.event_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.event), options).await
+        self.inner
+            .execute(builder, Some(req.event), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Event>| r.into_body())
     }
 
     async fn list_events(
@@ -358,6 +381,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListEventsResponse>| r.into_body())
     }
 
     async fn get_event(
@@ -377,6 +401,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Event>| r.into_body())
     }
 
     async fn delete_event(
@@ -397,7 +422,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_clips(
@@ -421,6 +446,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClipsResponse>| r.into_body())
     }
 
     async fn get_clip(
@@ -440,6 +466,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Clip>| r.into_body())
     }
 
     async fn create_clip(
@@ -458,7 +485,10 @@ impl super::stub::LivestreamService for LivestreamService {
             );
         let builder = builder.query(&[("clipId", &req.clip_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.clip), options).await
+        self.inner
+            .execute(builder, Some(req.clip), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_clip(
@@ -479,6 +509,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_asset(
@@ -497,7 +528,10 @@ impl super::stub::LivestreamService for LivestreamService {
             );
         let builder = builder.query(&[("assetId", &req.asset_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.asset), options).await
+        self.inner
+            .execute(builder, Some(req.asset), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_asset(
@@ -518,6 +552,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_asset(
@@ -537,6 +572,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Asset>| r.into_body())
     }
 
     async fn list_assets(
@@ -560,6 +596,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAssetsResponse>| r.into_body())
     }
 
     async fn get_pool(
@@ -579,6 +616,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Pool>| r.into_body())
     }
 
     async fn update_pool(
@@ -615,7 +653,10 @@ impl super::stub::LivestreamService for LivestreamService {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.pool), options).await
+        self.inner
+            .execute(builder, Some(req.pool), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -638,6 +679,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -657,6 +699,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -679,6 +722,11 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -698,6 +746,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -717,7 +766,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -737,7 +786,7 @@ impl super::stub::LivestreamService for LivestreamService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/video/stitcher/v1/src/transport.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/transport.rs
@@ -58,6 +58,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.cdn_key), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_cdn_keys(
@@ -81,6 +82,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCdnKeysResponse>| r.into_body())
     }
 
     async fn get_cdn_key(
@@ -100,6 +102,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CdnKey>| r.into_body())
     }
 
     async fn delete_cdn_key(
@@ -119,6 +122,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_cdn_key(
@@ -157,6 +161,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.cdn_key), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_vod_session(
@@ -179,6 +184,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.vod_session), options)
             .await
+            .map(|r: gax::response::Response<crate::model::VodSession>| r.into_body())
     }
 
     async fn get_vod_session(
@@ -198,6 +204,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VodSession>| r.into_body())
     }
 
     async fn list_vod_stitch_details(
@@ -222,6 +229,11 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVodStitchDetailsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_vod_stitch_detail(
@@ -241,6 +253,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VodStitchDetail>| r.into_body())
     }
 
     async fn list_vod_ad_tag_details(
@@ -265,6 +278,11 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVodAdTagDetailsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_vod_ad_tag_detail(
@@ -284,6 +302,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VodAdTagDetail>| r.into_body())
     }
 
     async fn list_live_ad_tag_details(
@@ -308,6 +327,11 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListLiveAdTagDetailsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_live_ad_tag_detail(
@@ -327,6 +351,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LiveAdTagDetail>| r.into_body())
     }
 
     async fn create_slate(
@@ -345,7 +370,10 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
             );
         let builder = builder.query(&[("slateId", &req.slate_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.slate), options).await
+        self.inner
+            .execute(builder, Some(req.slate), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_slates(
@@ -369,6 +397,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSlatesResponse>| r.into_body())
     }
 
     async fn get_slate(
@@ -388,6 +417,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Slate>| r.into_body())
     }
 
     async fn update_slate(
@@ -423,7 +453,10 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.slate), options).await
+        self.inner
+            .execute(builder, Some(req.slate), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_slate(
@@ -443,6 +476,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_live_session(
@@ -465,6 +499,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.live_session), options)
             .await
+            .map(|r: gax::response::Response<crate::model::LiveSession>| r.into_body())
     }
 
     async fn get_live_session(
@@ -484,6 +519,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LiveSession>| r.into_body())
     }
 
     async fn create_live_config(
@@ -508,6 +544,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.live_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_live_configs(
@@ -534,6 +571,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLiveConfigsResponse>| r.into_body())
     }
 
     async fn get_live_config(
@@ -553,6 +591,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LiveConfig>| r.into_body())
     }
 
     async fn delete_live_config(
@@ -572,6 +611,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_live_config(
@@ -610,6 +650,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.live_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_vod_config(
@@ -634,6 +675,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.vod_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_vod_configs(
@@ -660,6 +702,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVodConfigsResponse>| r.into_body())
     }
 
     async fn get_vod_config(
@@ -679,6 +722,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VodConfig>| r.into_body())
     }
 
     async fn delete_vod_config(
@@ -698,6 +742,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_vod_config(
@@ -736,6 +781,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req.vod_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -758,6 +804,11 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -777,6 +828,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -796,7 +848,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -816,7 +868,7 @@ impl super::stub::VideoStitcherService for VideoStitcherService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/video/transcoder/v1/src/transport.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::TranscoderService for TranscoderService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.job), options).await
+        self.inner
+            .execute(builder, Some(req.job), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn list_jobs(
@@ -78,6 +81,7 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobsResponse>| r.into_body())
     }
 
     async fn get_job(
@@ -97,6 +101,7 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Job>| r.into_body())
     }
 
     async fn delete_job(
@@ -117,7 +122,7 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_job_template(
@@ -141,6 +146,7 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, Some(req.job_template), options)
             .await
+            .map(|r: gax::response::Response<crate::model::JobTemplate>| r.into_body())
     }
 
     async fn list_job_templates(
@@ -167,6 +173,7 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobTemplatesResponse>| r.into_body())
     }
 
     async fn get_job_template(
@@ -186,6 +193,7 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::JobTemplate>| r.into_body())
     }
 
     async fn delete_job_template(
@@ -206,6 +214,6 @@ impl super::stub::TranscoderService for TranscoderService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/cloud/videointelligence/v1/src/transport.rs
+++ b/src/generated/cloud/videointelligence/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -77,6 +80,11 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -96,6 +104,7 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -115,7 +124,7 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -135,7 +144,7 @@ impl super::stub::VideoIntelligenceService for VideoIntelligenceService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/vision/v1/src/transport.rs
+++ b/src/generated/cloud/vision/v1/src/transport.rs
@@ -54,7 +54,9 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchAnnotateImagesResponse>| r.into_body(),
+        )
     }
 
     async fn batch_annotate_files(
@@ -71,7 +73,9 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchAnnotateFilesResponse>| r.into_body(),
+        )
     }
 
     async fn async_batch_annotate_images(
@@ -91,7 +95,10 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn async_batch_annotate_files(
@@ -111,7 +118,10 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -131,6 +141,7 @@ impl super::stub::ImageAnnotator for ImageAnnotator {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -191,6 +202,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req.product_set), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProductSet>| r.into_body())
     }
 
     async fn list_product_sets(
@@ -215,6 +227,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProductSetsResponse>| r.into_body())
     }
 
     async fn get_product_set(
@@ -234,6 +247,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProductSet>| r.into_body())
     }
 
     async fn update_product_set(
@@ -272,6 +286,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req.product_set), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProductSet>| r.into_body())
     }
 
     async fn delete_product_set(
@@ -291,7 +306,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_product(
@@ -315,6 +330,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req.product), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn list_products(
@@ -336,6 +352,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProductsResponse>| r.into_body())
     }
 
     async fn get_product(
@@ -355,6 +372,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn update_product(
@@ -393,6 +411,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req.product), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Product>| r.into_body())
     }
 
     async fn delete_product(
@@ -412,7 +431,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_reference_image(
@@ -436,6 +455,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req.reference_image), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReferenceImage>| r.into_body())
     }
 
     async fn delete_reference_image(
@@ -455,7 +475,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_reference_images(
@@ -480,6 +500,11 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReferenceImagesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_reference_image(
@@ -499,6 +524,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReferenceImage>| r.into_body())
     }
 
     async fn add_product_to_product_set(
@@ -521,7 +547,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn remove_product_from_product_set(
@@ -544,7 +570,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_products_in_product_set(
@@ -566,6 +592,11 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListProductsInProductSetResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn import_product_sets(
@@ -585,7 +616,10 @@ impl super::stub::ProductSearch for ProductSearch {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn purge_products(
@@ -605,7 +639,10 @@ impl super::stub::ProductSearch for ProductSearch {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -625,6 +662,7 @@ impl super::stub::ProductSearch for ProductSearch {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/vmmigration/v1/src/transport.rs
+++ b/src/generated/cloud/vmmigration/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSourcesResponse>| r.into_body())
     }
 
     async fn get_source(
@@ -80,6 +81,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Source>| r.into_body())
     }
 
     async fn create_source(
@@ -98,7 +100,10 @@ impl super::stub::VmMigration for VmMigration {
             );
         let builder = builder.query(&[("sourceId", &req.source_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_source(
@@ -135,7 +140,10 @@ impl super::stub::VmMigration for VmMigration {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_source(
@@ -156,6 +164,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_inventory(
@@ -179,6 +188,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FetchInventoryResponse>| r.into_body())
     }
 
     async fn list_utilization_reports(
@@ -206,6 +216,11 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUtilizationReportsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_utilization_report(
@@ -226,6 +241,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::UtilizationReport>| r.into_body())
     }
 
     async fn create_utilization_report(
@@ -250,6 +266,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.utilization_report), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_utilization_report(
@@ -270,6 +287,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_datacenter_connectors(
@@ -296,6 +314,11 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDatacenterConnectorsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_datacenter_connector(
@@ -315,6 +338,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DatacenterConnector>| r.into_body())
     }
 
     async fn create_datacenter_connector(
@@ -339,6 +363,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.datacenter_connector), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_datacenter_connector(
@@ -359,6 +384,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn upgrade_appliance(
@@ -378,7 +404,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_migrating_vm(
@@ -403,6 +432,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.migrating_vm), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_migrating_vms(
@@ -430,6 +460,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListMigratingVmsResponse>| r.into_body())
     }
 
     async fn get_migrating_vm(
@@ -450,6 +481,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MigratingVm>| r.into_body())
     }
 
     async fn update_migrating_vm(
@@ -489,6 +521,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.migrating_vm), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_migrating_vm(
@@ -508,6 +541,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_migration(
@@ -527,7 +561,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn resume_migration(
@@ -547,7 +584,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn pause_migration(
@@ -567,7 +607,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn finalize_migration(
@@ -587,7 +630,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_clone_job(
@@ -612,6 +658,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.clone_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_clone_job(
@@ -628,7 +675,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_clone_jobs(
@@ -655,6 +705,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCloneJobsResponse>| r.into_body())
     }
 
     async fn get_clone_job(
@@ -674,6 +725,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CloneJob>| r.into_body())
     }
 
     async fn create_cutover_job(
@@ -698,6 +750,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.cutover_job), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_cutover_job(
@@ -714,7 +767,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_cutover_jobs(
@@ -741,6 +797,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCutoverJobsResponse>| r.into_body())
     }
 
     async fn get_cutover_job(
@@ -760,6 +817,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CutoverJob>| r.into_body())
     }
 
     async fn list_groups(
@@ -783,6 +841,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGroupsResponse>| r.into_body())
     }
 
     async fn get_group(
@@ -802,6 +861,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Group>| r.into_body())
     }
 
     async fn create_group(
@@ -820,7 +880,10 @@ impl super::stub::VmMigration for VmMigration {
             );
         let builder = builder.query(&[("groupId", &req.group_id)]);
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_group(
@@ -857,7 +920,10 @@ impl super::stub::VmMigration for VmMigration {
                 v.add(builder, "updateMask")
             });
         let builder = builder.query(&[("requestId", &req.request_id)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_group(
@@ -878,6 +944,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn add_group_migration(
@@ -897,7 +964,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn remove_group_migration(
@@ -917,7 +987,10 @@ impl super::stub::VmMigration for VmMigration {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_target_projects(
@@ -944,6 +1017,11 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTargetProjectsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_target_project(
@@ -963,6 +1041,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TargetProject>| r.into_body())
     }
 
     async fn create_target_project(
@@ -987,6 +1066,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.target_project), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_target_project(
@@ -1026,6 +1106,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req.target_project), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_target_project(
@@ -1046,6 +1127,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_replication_cycles(
@@ -1072,6 +1154,11 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListReplicationCyclesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_replication_cycle(
@@ -1091,6 +1178,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ReplicationCycle>| r.into_body())
     }
 
     async fn list_locations(
@@ -1113,6 +1201,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1132,6 +1221,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -1154,6 +1244,11 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1173,6 +1268,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -1192,7 +1288,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -1212,7 +1308,7 @@ impl super::stub::VmMigration for VmMigration {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/vmwareengine/v1/src/transport.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/transport.rs
@@ -64,6 +64,9 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPrivateCloudsResponse>| r.into_body(),
+            )
     }
 
     async fn get_private_cloud(
@@ -83,6 +86,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PrivateCloud>| r.into_body())
     }
 
     async fn create_private_cloud(
@@ -108,6 +112,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.private_cloud), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_private_cloud(
@@ -147,6 +152,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.private_cloud), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_private_cloud(
@@ -172,6 +178,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn undelete_private_cloud(
@@ -188,7 +195,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_clusters(
@@ -212,6 +222,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn get_cluster(
@@ -231,6 +242,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn create_cluster(
@@ -256,6 +268,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_cluster(
@@ -296,6 +309,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -316,6 +330,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_nodes(
@@ -337,6 +352,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNodesResponse>| r.into_body())
     }
 
     async fn get_node(
@@ -356,6 +372,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Node>| r.into_body())
     }
 
     async fn list_external_addresses(
@@ -382,6 +399,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListExternalAddressesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn fetch_network_policy_external_addresses(
@@ -406,6 +428,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::FetchNetworkPolicyExternalAddressesResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_external_address(
@@ -425,6 +452,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalAddress>| r.into_body())
     }
 
     async fn create_external_address(
@@ -449,6 +477,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.external_address), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_external_address(
@@ -488,6 +517,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.external_address), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_external_address(
@@ -508,6 +538,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_subnets(
@@ -529,6 +560,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSubnetsResponse>| r.into_body())
     }
 
     async fn get_subnet(
@@ -548,6 +580,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Subnet>| r.into_body())
     }
 
     async fn update_subnet(
@@ -583,7 +616,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.subnet), options).await
+        self.inner
+            .execute(builder, Some(req.subnet), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_external_access_rules(
@@ -610,6 +646,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListExternalAccessRulesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_external_access_rule(
@@ -629,6 +670,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ExternalAccessRule>| r.into_body())
     }
 
     async fn create_external_access_rule(
@@ -653,6 +695,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.external_access_rule), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_external_access_rule(
@@ -692,6 +735,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.external_access_rule), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_external_access_rule(
@@ -712,6 +756,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_logging_servers(
@@ -738,6 +783,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListLoggingServersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_logging_server(
@@ -757,6 +807,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LoggingServer>| r.into_body())
     }
 
     async fn create_logging_server(
@@ -781,6 +832,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.logging_server), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_logging_server(
@@ -820,6 +872,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.logging_server), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_logging_server(
@@ -840,6 +893,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_node_types(
@@ -865,6 +919,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNodeTypesResponse>| r.into_body())
     }
 
     async fn get_node_type(
@@ -884,6 +939,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NodeType>| r.into_body())
     }
 
     async fn show_nsx_credentials(
@@ -906,6 +962,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Credentials>| r.into_body())
     }
 
     async fn show_vcenter_credentials(
@@ -929,6 +986,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Credentials>| r.into_body())
     }
 
     async fn reset_nsx_credentials(
@@ -948,7 +1006,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn reset_vcenter_credentials(
@@ -968,7 +1029,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_dns_forwarding(
@@ -988,6 +1052,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DnsForwarding>| r.into_body())
     }
 
     async fn update_dns_forwarding(
@@ -1027,6 +1092,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.dns_forwarding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_network_peering(
@@ -1046,6 +1112,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NetworkPeering>| r.into_body())
     }
 
     async fn list_network_peerings(
@@ -1072,6 +1139,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNetworkPeeringsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_network_peering(
@@ -1096,6 +1168,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.network_peering), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_network_peering(
@@ -1116,6 +1189,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_network_peering(
@@ -1155,6 +1229,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.network_peering), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_peering_routes(
@@ -1180,6 +1255,9 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPeeringRoutesResponse>| r.into_body(),
+            )
     }
 
     async fn create_hcx_activation_key(
@@ -1204,6 +1282,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.hcx_activation_key), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_hcx_activation_keys(
@@ -1228,6 +1307,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListHcxActivationKeysResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_hcx_activation_key(
@@ -1247,6 +1331,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::HcxActivationKey>| r.into_body())
     }
 
     async fn get_network_policy(
@@ -1266,6 +1351,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NetworkPolicy>| r.into_body())
     }
 
     async fn list_network_policies(
@@ -1292,6 +1378,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNetworkPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_network_policy(
@@ -1316,6 +1407,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.network_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_network_policy(
@@ -1355,6 +1447,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.network_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_network_policy(
@@ -1375,6 +1468,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_management_dns_zone_bindings(
@@ -1401,6 +1495,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListManagementDnsZoneBindingsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_management_dns_zone_binding(
@@ -1420,6 +1519,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ManagementDnsZoneBinding>| r.into_body())
     }
 
     async fn create_management_dns_zone_binding(
@@ -1447,6 +1547,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.management_dns_zone_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_management_dns_zone_binding(
@@ -1488,6 +1589,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.management_dns_zone_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_management_dns_zone_binding(
@@ -1508,6 +1610,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn repair_management_dns_zone_binding(
@@ -1524,7 +1627,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_vmware_engine_network(
@@ -1549,6 +1655,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.vmware_engine_network), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_vmware_engine_network(
@@ -1588,6 +1695,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.vmware_engine_network), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_vmware_engine_network(
@@ -1609,6 +1717,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_vmware_engine_network(
@@ -1628,6 +1737,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VmwareEngineNetwork>| r.into_body())
     }
 
     async fn list_vmware_engine_networks(
@@ -1654,6 +1764,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListVmwareEngineNetworksResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_private_connection(
@@ -1678,6 +1793,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.private_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_private_connection(
@@ -1697,6 +1813,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PrivateConnection>| r.into_body())
     }
 
     async fn list_private_connections(
@@ -1723,6 +1840,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPrivateConnectionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_private_connection(
@@ -1762,6 +1884,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, Some(req.private_connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_private_connection(
@@ -1782,6 +1905,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_private_connection_peering_routes(
@@ -1806,6 +1930,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListPrivateConnectionPeeringRoutesResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn grant_dns_bind_permission(
@@ -1822,7 +1951,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_dns_bind_permission(
@@ -1842,6 +1974,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DnsBindPermission>| r.into_body())
     }
 
     async fn revoke_dns_bind_permission(
@@ -1858,7 +1991,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1881,6 +2017,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1900,6 +2037,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -1919,7 +2057,10 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -1952,6 +2093,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -1971,7 +2113,9 @@ impl super::stub::VmwareEngine for VmwareEngine {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -1994,6 +2138,11 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -2013,6 +2162,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -2032,7 +2182,7 @@ impl super::stub::VmwareEngine for VmwareEngine {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/vpcaccess/v1/src/transport.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, Some(req.connector), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_connector(
@@ -80,6 +81,7 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connector>| r.into_body())
     }
 
     async fn list_connectors(
@@ -104,6 +106,7 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectorsResponse>| r.into_body())
     }
 
     async fn delete_connector(
@@ -123,6 +126,7 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -145,6 +149,7 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -167,6 +172,11 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -186,6 +196,7 @@ impl super::stub::VpcAccessService for VpcAccessService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/webrisk/v1/src/transport.rs
+++ b/src/generated/cloud/webrisk/v1/src/transport.rs
@@ -72,6 +72,11 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ComputeThreatListDiffResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_uris(
@@ -95,6 +100,7 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchUrisResponse>| r.into_body())
     }
 
     async fn search_hashes(
@@ -118,6 +124,7 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SearchHashesResponse>| r.into_body())
     }
 
     async fn create_submission(
@@ -140,6 +147,7 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, Some(req.submission), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Submission>| r.into_body())
     }
 
     async fn submit_uri(
@@ -159,7 +167,10 @@ impl super::stub::WebRiskService for WebRiskService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -182,6 +193,11 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -201,6 +217,7 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -220,7 +237,7 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -240,7 +257,7 @@ impl super::stub::WebRiskService for WebRiskService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/websecurityscanner/v1/src/transport.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, Some(req.scan_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ScanConfig>| r.into_body())
     }
 
     async fn delete_scan_config(
@@ -79,7 +80,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_scan_config(
@@ -99,6 +100,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ScanConfig>| r.into_body())
     }
 
     async fn list_scan_configs(
@@ -123,6 +125,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListScanConfigsResponse>| r.into_body())
     }
 
     async fn update_scan_config(
@@ -161,6 +164,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, Some(req.scan_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ScanConfig>| r.into_body())
     }
 
     async fn start_scan_run(
@@ -177,7 +181,10 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ScanRun>| r.into_body())
     }
 
     async fn get_scan_run(
@@ -197,6 +204,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ScanRun>| r.into_body())
     }
 
     async fn list_scan_runs(
@@ -218,6 +226,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListScanRunsResponse>| r.into_body())
     }
 
     async fn stop_scan_run(
@@ -234,7 +243,10 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ScanRun>| r.into_body())
     }
 
     async fn list_crawled_urls(
@@ -259,6 +271,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListCrawledUrlsResponse>| r.into_body())
     }
 
     async fn get_finding(
@@ -278,6 +291,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Finding>| r.into_body())
     }
 
     async fn list_findings(
@@ -300,6 +314,7 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFindingsResponse>| r.into_body())
     }
 
     async fn list_finding_type_stats(
@@ -322,5 +337,10 @@ impl super::stub::WebSecurityScanner for WebSecurityScanner {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFindingTypeStatsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/transport.rs
@@ -65,6 +65,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExecutionsResponse>| r.into_body())
     }
 
     async fn create_execution(
@@ -87,6 +88,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, Some(req.execution), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 
     async fn get_execution(
@@ -107,6 +109,7 @@ impl super::stub::Executions for Executions {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 
     async fn cancel_execution(
@@ -123,6 +126,9 @@ impl super::stub::Executions for Executions {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Execution>| r.into_body())
     }
 }

--- a/src/generated/cloud/workflows/v1/src/transport.rs
+++ b/src/generated/cloud/workflows/v1/src/transport.rs
@@ -64,6 +64,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkflowsResponse>| r.into_body())
     }
 
     async fn get_workflow(
@@ -84,6 +85,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Workflow>| r.into_body())
     }
 
     async fn create_workflow(
@@ -107,6 +109,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, Some(req.workflow), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_workflow(
@@ -126,6 +129,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_workflow(
@@ -164,6 +168,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, Some(req.workflow), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_workflow_revisions(
@@ -188,6 +193,11 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListWorkflowRevisionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_locations(
@@ -210,6 +220,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -229,6 +240,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn list_operations(
@@ -251,6 +263,11 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -270,6 +287,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -289,7 +307,7 @@ impl super::stub::Workflows for Workflows {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/cloud/workstations/v1/src/transport.rs
+++ b/src/generated/cloud/workstations/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::WorkstationCluster>| r.into_body())
     }
 
     async fn list_workstation_clusters(
@@ -81,6 +82,11 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListWorkstationClustersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_workstation_cluster(
@@ -105,6 +111,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req.workstation_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_workstation_cluster(
@@ -145,6 +152,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req.workstation_cluster), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_workstation_cluster(
@@ -167,6 +175,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_workstation_config(
@@ -186,6 +195,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::WorkstationConfig>| r.into_body())
     }
 
     async fn list_workstation_configs(
@@ -210,6 +220,11 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListWorkstationConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_usable_workstation_configs(
@@ -234,6 +249,11 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUsableWorkstationConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_workstation_config(
@@ -258,6 +278,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req.workstation_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_workstation_config(
@@ -298,6 +319,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req.workstation_config), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_workstation_config(
@@ -320,6 +342,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_workstation(
@@ -339,6 +362,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Workstation>| r.into_body())
     }
 
     async fn list_workstations(
@@ -363,6 +387,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkstationsResponse>| r.into_body())
     }
 
     async fn list_usable_workstations(
@@ -387,6 +412,11 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUsableWorkstationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_workstation(
@@ -411,6 +441,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req.workstation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_workstation(
@@ -451,6 +482,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req.workstation), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_workstation(
@@ -472,6 +504,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn start_workstation(
@@ -488,7 +521,10 @@ impl super::stub::Workstations for Workstations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn stop_workstation(
@@ -505,7 +541,10 @@ impl super::stub::Workstations for Workstations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn generate_access_token(
@@ -525,7 +564,9 @@ impl super::stub::Workstations for Workstations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateAccessTokenResponse>| r.into_body(),
+        )
     }
 
     async fn set_iam_policy(
@@ -545,7 +586,10 @@ impl super::stub::Workstations for Workstations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -578,6 +622,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -597,7 +642,9 @@ impl super::stub::Workstations for Workstations {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn list_operations(
@@ -620,6 +667,11 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -639,6 +691,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -658,7 +711,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -678,7 +731,7 @@ impl super::stub::Workstations for Workstations {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/container/v1/src/transport.rs
+++ b/src/generated/container/v1/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListClustersResponse>| r.into_body())
     }
 
     async fn get_cluster(
@@ -81,6 +82,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Cluster>| r.into_body())
     }
 
     async fn create_cluster(
@@ -100,7 +102,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn update_cluster(
@@ -117,7 +122,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn update_node_pool(
@@ -134,7 +142,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_node_pool_autoscaling(
@@ -154,7 +165,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_logging_service(
@@ -174,7 +188,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_monitoring_service(
@@ -194,7 +211,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_addons_config(
@@ -211,7 +231,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_locations(
@@ -231,7 +254,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn update_master(
@@ -251,7 +277,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_master_auth(
@@ -271,7 +300,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn delete_cluster(
@@ -294,6 +326,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -318,6 +351,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListOperationsResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -340,6 +374,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -359,7 +394,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_server_config(
@@ -384,6 +419,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServerConfig>| r.into_body())
     }
 
     async fn get_json_web_keys(
@@ -403,6 +439,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GetJSONWebKeysResponse>| r.into_body())
     }
 
     async fn list_node_pools(
@@ -428,6 +465,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNodePoolsResponse>| r.into_body())
     }
 
     async fn get_node_pool(
@@ -451,6 +489,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NodePool>| r.into_body())
     }
 
     async fn create_node_pool(
@@ -470,7 +509,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn delete_node_pool(
@@ -494,6 +536,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn complete_node_pool_upgrade(
@@ -516,7 +559,7 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn rollback_node_pool_upgrade(
@@ -533,7 +576,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_node_pool_management(
@@ -553,7 +599,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_labels(
@@ -573,7 +622,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_legacy_abac(
@@ -593,7 +645,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn start_ip_rotation(
@@ -613,7 +668,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn complete_ip_rotation(
@@ -633,7 +691,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_node_pool_size(
@@ -650,7 +711,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_network_policy(
@@ -670,7 +734,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn set_maintenance_policy(
@@ -690,7 +757,10 @@ impl super::stub::ClusterManager for ClusterManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn list_usable_subnetworks(
@@ -716,6 +786,11 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUsableSubnetworksResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn check_autopilot_compatibility(
@@ -738,5 +813,10 @@ impl super::stub::ClusterManager for ClusterManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::CheckAutopilotCompatibilityResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/datastore/admin/v1/src/transport.rs
+++ b/src/generated/datastore/admin/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_entities(
@@ -77,7 +80,10 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_index(
@@ -97,7 +103,10 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.index), options).await
+        self.inner
+            .execute(builder, Some(req.index), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_index(
@@ -120,6 +129,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_index(
@@ -142,6 +152,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Index>| r.into_body())
     }
 
     async fn list_indexes(
@@ -167,6 +178,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIndexesResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -189,6 +201,11 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -208,6 +225,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -227,7 +245,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -247,7 +265,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/devtools/artifactregistry/v1/src/transport.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/transport.rs
@@ -63,6 +63,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDockerImagesResponse>| r.into_body())
     }
 
     async fn get_docker_image(
@@ -82,6 +83,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DockerImage>| r.into_body())
     }
 
     async fn list_maven_artifacts(
@@ -106,6 +108,11 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMavenArtifactsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_maven_artifact(
@@ -125,6 +132,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MavenArtifact>| r.into_body())
     }
 
     async fn list_npm_packages(
@@ -149,6 +157,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNpmPackagesResponse>| r.into_body())
     }
 
     async fn get_npm_package(
@@ -168,6 +177,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NpmPackage>| r.into_body())
     }
 
     async fn list_python_packages(
@@ -192,6 +202,11 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPythonPackagesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_python_package(
@@ -211,6 +226,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PythonPackage>| r.into_body())
     }
 
     async fn import_apt_artifacts(
@@ -230,7 +246,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_yum_artifacts(
@@ -250,7 +269,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_repositories(
@@ -277,6 +299,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRepositoriesResponse>| r.into_body())
     }
 
     async fn get_repository(
@@ -296,6 +319,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Repository>| r.into_body())
     }
 
     async fn create_repository(
@@ -319,6 +343,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.repository), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_repository(
@@ -357,6 +382,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.repository), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Repository>| r.into_body())
     }
 
     async fn delete_repository(
@@ -376,6 +402,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_packages(
@@ -399,6 +426,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPackagesResponse>| r.into_body())
     }
 
     async fn get_package(
@@ -418,6 +446,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Package>| r.into_body())
     }
 
     async fn delete_package(
@@ -437,6 +466,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_versions(
@@ -461,6 +491,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListVersionsResponse>| r.into_body())
     }
 
     async fn get_version(
@@ -481,6 +512,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn delete_version(
@@ -501,6 +533,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_delete_versions(
@@ -520,7 +553,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_version(
@@ -559,6 +595,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.version), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Version>| r.into_body())
     }
 
     async fn list_files(
@@ -582,6 +619,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFilesResponse>| r.into_body())
     }
 
     async fn get_file(
@@ -601,6 +639,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::File>| r.into_body())
     }
 
     async fn delete_file(
@@ -620,6 +659,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_file(
@@ -655,7 +695,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.file), options).await
+        self.inner
+            .execute(builder, Some(req.file), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::File>| r.into_body())
     }
 
     async fn list_tags(
@@ -678,6 +721,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTagsResponse>| r.into_body())
     }
 
     async fn get_tag(
@@ -697,6 +741,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Tag>| r.into_body())
     }
 
     async fn create_tag(
@@ -714,7 +759,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("tagId", &req.tag_id)]);
-        self.inner.execute(builder, Some(req.tag), options).await
+        self.inner
+            .execute(builder, Some(req.tag), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Tag>| r.into_body())
     }
 
     async fn update_tag(
@@ -750,7 +798,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.tag), options).await
+        self.inner
+            .execute(builder, Some(req.tag), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Tag>| r.into_body())
     }
 
     async fn delete_tag(
@@ -770,7 +821,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_rule(
@@ -788,7 +839,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("ruleId", &req.rule_id)]);
-        self.inner.execute(builder, Some(req.rule), options).await
+        self.inner
+            .execute(builder, Some(req.rule), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Rule>| r.into_body())
     }
 
     async fn list_rules(
@@ -810,6 +864,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRulesResponse>| r.into_body())
     }
 
     async fn get_rule(
@@ -829,6 +884,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Rule>| r.into_body())
     }
 
     async fn update_rule(
@@ -864,7 +920,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.rule), options).await
+        self.inner
+            .execute(builder, Some(req.rule), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Rule>| r.into_body())
     }
 
     async fn delete_rule(
@@ -884,7 +943,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -904,7 +963,10 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -937,6 +999,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -956,7 +1019,9 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_project_settings(
@@ -976,6 +1041,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProjectSettings>| r.into_body())
     }
 
     async fn update_project_settings(
@@ -1014,6 +1080,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.project_settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProjectSettings>| r.into_body())
     }
 
     async fn get_vpcsc_config(
@@ -1033,6 +1100,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::VPCSCConfig>| r.into_body())
     }
 
     async fn update_vpcsc_config(
@@ -1071,6 +1139,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.vpcsc_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::VPCSCConfig>| r.into_body())
     }
 
     async fn update_package(
@@ -1109,6 +1178,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.package), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Package>| r.into_body())
     }
 
     async fn list_attachments(
@@ -1134,6 +1204,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAttachmentsResponse>| r.into_body())
     }
 
     async fn get_attachment(
@@ -1153,6 +1224,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Attachment>| r.into_body())
     }
 
     async fn create_attachment(
@@ -1176,6 +1248,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, Some(req.attachment), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_attachment(
@@ -1195,6 +1268,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_locations(
@@ -1217,6 +1291,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -1236,6 +1311,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<location::model::Location>| r.into_body())
     }
 
     async fn get_operation(
@@ -1255,6 +1331,7 @@ impl super::stub::ArtifactRegistry for ArtifactRegistry {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/devtools/cloudbuild/v1/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/transport.rs
@@ -58,7 +58,10 @@ impl super::stub::CloudBuild for CloudBuild {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("parent", &req.parent)]);
-        self.inner.execute(builder, Some(req.build), options).await
+        self.inner
+            .execute(builder, Some(req.build), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_build(
@@ -82,6 +85,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Build>| r.into_body())
     }
 
     async fn list_builds(
@@ -108,6 +112,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBuildsResponse>| r.into_body())
     }
 
     async fn cancel_build(
@@ -127,7 +132,10 @@ impl super::stub::CloudBuild for CloudBuild {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Build>| r.into_body())
     }
 
     async fn retry_build(
@@ -147,7 +155,10 @@ impl super::stub::CloudBuild for CloudBuild {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn approve_build(
@@ -164,7 +175,10 @@ impl super::stub::CloudBuild for CloudBuild {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_build_trigger(
@@ -188,6 +202,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, Some(req.trigger), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BuildTrigger>| r.into_body())
     }
 
     async fn get_build_trigger(
@@ -214,6 +229,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BuildTrigger>| r.into_body())
     }
 
     async fn list_build_triggers(
@@ -239,6 +255,9 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBuildTriggersResponse>| r.into_body(),
+            )
     }
 
     async fn delete_build_trigger(
@@ -265,7 +284,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_build_trigger(
@@ -301,6 +320,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, Some(req.trigger), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BuildTrigger>| r.into_body())
     }
 
     async fn run_build_trigger(
@@ -324,7 +344,10 @@ impl super::stub::CloudBuild for CloudBuild {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("name", &req.name)]);
-        self.inner.execute(builder, Some(req.source), options).await
+        self.inner
+            .execute(builder, Some(req.source), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn receive_trigger_webhook(
@@ -349,7 +372,14 @@ impl super::stub::CloudBuild for CloudBuild {
             );
         let builder = builder.query(&[("name", &req.name)]);
         let builder = builder.query(&[("secret", &req.secret)]);
-        self.inner.execute(builder, Some(req.body), options).await
+        self.inner
+            .execute(builder, Some(req.body), options)
+            .await
+            .map(
+                |r: gax::response::Response<crate::model::ReceiveTriggerWebhookResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn create_worker_pool(
@@ -374,6 +404,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, Some(req.worker_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_worker_pool(
@@ -393,6 +424,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::WorkerPool>| r.into_body())
     }
 
     async fn delete_worker_pool(
@@ -415,6 +447,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_worker_pool(
@@ -454,6 +487,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, Some(req.worker_pool), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_worker_pools(
@@ -478,6 +512,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListWorkerPoolsResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -497,6 +532,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -516,7 +552,7 @@ impl super::stub::CloudBuild for CloudBuild {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/devtools/cloudbuild/v2/src/transport.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_connection(
@@ -80,6 +81,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn list_connections(
@@ -104,6 +106,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectionsResponse>| r.into_body())
     }
 
     async fn update_connection(
@@ -144,6 +147,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, Some(req.connection), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_connection(
@@ -165,6 +169,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_repository(
@@ -188,6 +193,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, Some(req.repository), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn batch_create_repositories(
@@ -207,7 +213,10 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_repository(
@@ -227,6 +236,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Repository>| r.into_body())
     }
 
     async fn list_repositories(
@@ -252,6 +262,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRepositoriesResponse>| r.into_body())
     }
 
     async fn delete_repository(
@@ -273,6 +284,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn fetch_read_write_token(
@@ -292,7 +304,9 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::FetchReadWriteTokenResponse>| r.into_body(),
+        )
     }
 
     async fn fetch_read_token(
@@ -312,7 +326,10 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::FetchReadTokenResponse>| r.into_body())
     }
 
     async fn fetch_linkable_repositories(
@@ -337,6 +354,11 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::FetchLinkableRepositoriesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn fetch_git_refs(
@@ -360,6 +382,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FetchGitRefsResponse>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -379,7 +402,10 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -412,6 +438,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -431,7 +458,9 @@ impl super::stub::RepositoryManager for RepositoryManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -451,6 +480,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -470,7 +500,7 @@ impl super::stub::RepositoryManager for RepositoryManager {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/devtools/cloudprofiler/v2/src/transport.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::ProfilerService for ProfilerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Profile>| r.into_body())
     }
 
     async fn create_offline_profile(
@@ -80,6 +83,7 @@ impl super::stub::ProfilerService for ProfilerService {
         self.inner
             .execute(builder, Some(req.profile), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Profile>| r.into_body())
     }
 
     async fn update_profile(
@@ -118,6 +122,7 @@ impl super::stub::ProfilerService for ProfilerService {
         self.inner
             .execute(builder, Some(req.profile), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Profile>| r.into_body())
     }
 }
 
@@ -162,5 +167,6 @@ impl super::stub::ExportService for ExportService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListProfilesResponse>| r.into_body())
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/transport.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/transport.rs
@@ -60,7 +60,7 @@ impl super::stub::TraceService for TraceService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_span(
@@ -77,6 +77,9 @@ impl super::stub::TraceService for TraceService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Span>| r.into_body())
     }
 }

--- a/src/generated/devtools/containeranalysis/v1/src/transport.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -77,7 +80,10 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -97,7 +103,9 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_vulnerability_occurrences_summary(
@@ -121,6 +129,11 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::VulnerabilityOccurrencesSummary>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn export_sbom(
@@ -140,6 +153,9 @@ impl super::stub::ContainerAnalysis for ContainerAnalysis {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ExportSBOMResponse>| r.into_body())
     }
 }

--- a/src/generated/firestore/admin/v1/src/transport.rs
+++ b/src/generated/firestore/admin/v1/src/transport.rs
@@ -54,7 +54,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.index), options).await
+        self.inner
+            .execute(builder, Some(req.index), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_indexes(
@@ -77,6 +80,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListIndexesResponse>| r.into_body())
     }
 
     async fn get_index(
@@ -96,6 +100,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Index>| r.into_body())
     }
 
     async fn delete_index(
@@ -115,7 +120,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_field(
@@ -135,6 +140,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Field>| r.into_body())
     }
 
     async fn update_field(
@@ -170,7 +176,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.field), options).await
+        self.inner
+            .execute(builder, Some(req.field), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_fields(
@@ -193,6 +202,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListFieldsResponse>| r.into_body())
     }
 
     async fn export_documents(
@@ -212,7 +222,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn import_documents(
@@ -232,7 +245,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn bulk_delete_documents(
@@ -252,7 +268,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_database(
@@ -276,6 +295,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, Some(req.database), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_database(
@@ -295,6 +315,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Database>| r.into_body())
     }
 
     async fn list_databases(
@@ -318,6 +339,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDatabasesResponse>| r.into_body())
     }
 
     async fn update_database(
@@ -356,6 +378,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, Some(req.database), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_database(
@@ -376,6 +399,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_user_creds(
@@ -399,6 +423,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, Some(req.user_creds), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserCreds>| r.into_body())
     }
 
     async fn get_user_creds(
@@ -418,6 +443,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::UserCreds>| r.into_body())
     }
 
     async fn list_user_creds(
@@ -440,6 +466,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListUserCredsResponse>| r.into_body())
     }
 
     async fn enable_user_creds(
@@ -456,7 +483,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UserCreds>| r.into_body())
     }
 
     async fn disable_user_creds(
@@ -473,7 +503,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UserCreds>| r.into_body())
     }
 
     async fn reset_user_password(
@@ -493,7 +526,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::UserCreds>| r.into_body())
     }
 
     async fn delete_user_creds(
@@ -513,7 +549,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_backup(
@@ -533,6 +569,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn list_backups(
@@ -553,6 +590,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn delete_backup(
@@ -572,7 +610,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn restore_database(
@@ -592,7 +630,10 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_backup_schedule(
@@ -615,6 +656,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, Some(req.backup_schedule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupSchedule>| r.into_body())
     }
 
     async fn get_backup_schedule(
@@ -634,6 +676,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupSchedule>| r.into_body())
     }
 
     async fn list_backup_schedules(
@@ -656,6 +699,11 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBackupSchedulesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_backup_schedule(
@@ -694,6 +742,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, Some(req.backup_schedule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupSchedule>| r.into_body())
     }
 
     async fn delete_backup_schedule(
@@ -713,7 +762,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -736,6 +785,11 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -755,6 +809,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -774,7 +829,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -794,7 +849,7 @@ impl super::stub::FirestoreAdmin for FirestoreAdmin {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/grafeas/v1/src/transport.rs
+++ b/src/generated/grafeas/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Occurrence>| r.into_body())
     }
 
     async fn list_occurrences(
@@ -82,6 +83,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListOccurrencesResponse>| r.into_body())
     }
 
     async fn delete_occurrence(
@@ -101,7 +103,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_occurrence(
@@ -124,6 +126,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, Some(req.occurrence), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Occurrence>| r.into_body())
     }
 
     async fn batch_create_occurrences(
@@ -143,7 +146,11 @@ impl super::stub::Grafeas for Grafeas {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::BatchCreateOccurrencesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn update_occurrence(
@@ -173,6 +180,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, Some(req.occurrence), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Occurrence>| r.into_body())
     }
 
     async fn get_occurrence_note(
@@ -192,6 +200,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Note>| r.into_body())
     }
 
     async fn get_note(
@@ -211,6 +220,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Note>| r.into_body())
     }
 
     async fn list_notes(
@@ -233,6 +243,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListNotesResponse>| r.into_body())
     }
 
     async fn delete_note(
@@ -252,7 +263,7 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_note(
@@ -270,7 +281,10 @@ impl super::stub::Grafeas for Grafeas {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("noteId", &req.note_id)]);
-        self.inner.execute(builder, Some(req.note), options).await
+        self.inner
+            .execute(builder, Some(req.note), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Note>| r.into_body())
     }
 
     async fn batch_create_notes(
@@ -290,7 +304,10 @@ impl super::stub::Grafeas for Grafeas {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::BatchCreateNotesResponse>| r.into_body())
     }
 
     async fn update_note(
@@ -317,7 +334,10 @@ impl super::stub::Grafeas for Grafeas {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.note), options).await
+        self.inner
+            .execute(builder, Some(req.note), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Note>| r.into_body())
     }
 
     async fn list_note_occurrences(
@@ -343,5 +363,10 @@ impl super::stub::Grafeas for Grafeas {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNoteOccurrencesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -60,6 +60,11 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceAccountsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_account(
@@ -79,6 +84,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccount>| r.into_body())
     }
 
     async fn create_service_account(
@@ -98,7 +104,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccount>| r.into_body())
     }
 
     async fn update_service_account(
@@ -115,7 +124,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccount>| r.into_body())
     }
 
     async fn patch_service_account(
@@ -141,7 +153,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccount>| r.into_body())
     }
 
     async fn delete_service_account(
@@ -161,7 +176,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn undelete_service_account(
@@ -178,7 +193,11 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::UndeleteServiceAccountResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn enable_service_account(
@@ -198,7 +217,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn disable_service_account(
@@ -218,7 +237,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_service_account_keys(
@@ -241,6 +260,11 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceAccountKeysResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_account_key(
@@ -261,6 +285,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccountKey>| r.into_body())
     }
 
     async fn create_service_account_key(
@@ -277,7 +302,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccountKey>| r.into_body())
     }
 
     async fn upload_service_account_key(
@@ -297,7 +325,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ServiceAccountKey>| r.into_body())
     }
 
     async fn delete_service_account_key(
@@ -317,7 +348,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn disable_service_account_key(
@@ -337,7 +368,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn enable_service_account_key(
@@ -357,7 +388,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn sign_blob(
@@ -374,7 +405,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SignBlobResponse>| r.into_body())
     }
 
     async fn sign_jwt(
@@ -391,7 +425,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SignJwtResponse>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -424,6 +461,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -443,7 +481,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -463,7 +504,9 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn query_grantable_roles(
@@ -483,7 +526,9 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::QueryGrantableRolesResponse>| r.into_body(),
+        )
     }
 
     async fn list_roles(
@@ -508,6 +553,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListRolesResponse>| r.into_body())
     }
 
     async fn get_role(
@@ -527,6 +573,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Role>| r.into_body())
     }
 
     async fn create_role(
@@ -543,7 +590,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Role>| r.into_body())
     }
 
     async fn update_role(
@@ -570,7 +620,10 @@ impl super::stub::Iam for Iam {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.role), options).await
+        self.inner
+            .execute(builder, Some(req.role), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Role>| r.into_body())
     }
 
     async fn delete_role(
@@ -591,6 +644,7 @@ impl super::stub::Iam for Iam {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Role>| r.into_body())
     }
 
     async fn undelete_role(
@@ -607,7 +661,10 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Role>| r.into_body())
     }
 
     async fn query_testable_permissions(
@@ -627,7 +684,11 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::QueryTestablePermissionsResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn query_auditable_services(
@@ -647,7 +708,11 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::QueryAuditableServicesResponse>| {
+                r.into_body()
+            },
+        )
     }
 
     async fn lint_policy(
@@ -667,6 +732,9 @@ impl super::stub::Iam for Iam {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LintPolicyResponse>| r.into_body())
     }
 }

--- a/src/generated/iam/credentials/v1/src/transport.rs
+++ b/src/generated/iam/credentials/v1/src/transport.rs
@@ -57,7 +57,9 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::GenerateAccessTokenResponse>| r.into_body(),
+        )
     }
 
     async fn generate_id_token(
@@ -77,7 +79,10 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::GenerateIdTokenResponse>| r.into_body())
     }
 
     async fn sign_blob(
@@ -94,7 +99,10 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SignBlobResponse>| r.into_body())
     }
 
     async fn sign_jwt(
@@ -111,6 +119,9 @@ impl super::stub::IAMCredentials for IAMCredentials {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SignJwtResponse>| r.into_body())
     }
 }

--- a/src/generated/iam/v1/src/transport.rs
+++ b/src/generated/iam/v1/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -77,7 +80,10 @@ impl super::stub::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -97,6 +103,8 @@ impl super::stub::IAMPolicy for IAMPolicy {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 }

--- a/src/generated/iam/v2/src/transport.rs
+++ b/src/generated/iam/v2/src/transport.rs
@@ -59,6 +59,7 @@ impl super::stub::Policies for Policies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListPoliciesResponse>| r.into_body())
     }
 
     async fn get_policy(
@@ -78,6 +79,7 @@ impl super::stub::Policies for Policies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn create_policy(
@@ -95,7 +97,10 @@ impl super::stub::Policies for Policies {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("policyId", &req.policy_id)]);
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_policy(
@@ -121,7 +126,10 @@ impl super::stub::Policies for Policies {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_policy(
@@ -142,6 +150,7 @@ impl super::stub::Policies for Policies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -161,6 +170,7 @@ impl super::stub::Policies for Policies {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/iam/v3/src/transport.rs
+++ b/src/generated/iam/v3/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, Some(req.policy_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_policy_binding(
@@ -81,6 +82,7 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::PolicyBinding>| r.into_body())
     }
 
     async fn update_policy_binding(
@@ -120,6 +122,7 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, Some(req.policy_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_policy_binding(
@@ -141,6 +144,7 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_policy_bindings(
@@ -166,6 +170,11 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListPolicyBindingsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn search_target_policy_bindings(
@@ -194,6 +203,11 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchTargetPolicyBindingsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -213,6 +227,7 @@ impl super::stub::PolicyBindings for PolicyBindings {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(
@@ -277,6 +292,7 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, Some(req.principal_access_boundary_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_principal_access_boundary_policy(
@@ -296,6 +312,11 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::PrincipalAccessBoundaryPolicy>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_principal_access_boundary_policy(
@@ -337,6 +358,7 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, Some(req.principal_access_boundary_policy), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_principal_access_boundary_policy(
@@ -359,6 +381,7 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_principal_access_boundary_policies(
@@ -383,6 +406,11 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListPrincipalAccessBoundaryPoliciesResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn search_principal_access_boundary_policy_bindings(
@@ -407,6 +435,11 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::SearchPrincipalAccessBoundaryPolicyBindingsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_operation(
@@ -426,6 +459,7 @@ impl super::stub::PrincipalAccessBoundaryPolicies for PrincipalAccessBoundaryPol
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/identity/accesscontextmanager/v1/src/transport.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/transport.rs
@@ -60,6 +60,11 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAccessPoliciesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_access_policy(
@@ -79,6 +84,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AccessPolicy>| r.into_body())
     }
 
     async fn create_access_policy(
@@ -95,7 +101,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_access_policy(
@@ -131,7 +140,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.policy), options).await
+        self.inner
+            .execute(builder, Some(req.policy), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_access_policy(
@@ -151,6 +163,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_access_levels(
@@ -176,6 +189,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAccessLevelsResponse>| r.into_body())
     }
 
     async fn get_access_level(
@@ -196,6 +210,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AccessLevel>| r.into_body())
     }
 
     async fn create_access_level(
@@ -218,6 +233,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, Some(req.access_level), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_access_level(
@@ -256,6 +272,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, Some(req.access_level), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_access_level(
@@ -275,6 +292,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn replace_access_levels(
@@ -294,7 +312,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_service_perimeters(
@@ -319,6 +340,11 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServicePerimetersResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_service_perimeter(
@@ -338,6 +364,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServicePerimeter>| r.into_body())
     }
 
     async fn create_service_perimeter(
@@ -360,6 +387,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, Some(req.service_perimeter), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_service_perimeter(
@@ -398,6 +426,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, Some(req.service_perimeter), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_service_perimeter(
@@ -417,6 +446,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn replace_service_perimeters(
@@ -436,7 +466,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn commit_service_perimeters(
@@ -456,7 +489,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_gcp_user_access_bindings(
@@ -481,6 +517,11 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListGcpUserAccessBindingsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_gcp_user_access_binding(
@@ -500,6 +541,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GcpUserAccessBinding>| r.into_body())
     }
 
     async fn create_gcp_user_access_binding(
@@ -522,6 +564,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, Some(req.gcp_user_access_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_gcp_user_access_binding(
@@ -560,6 +603,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, Some(req.gcp_user_access_binding), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_gcp_user_access_binding(
@@ -579,6 +623,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -598,7 +643,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -618,7 +666,10 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -638,7 +689,9 @@ impl super::stub::AccessContextManager for AccessContextManager {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_operation(
@@ -658,6 +711,7 @@ impl super::stub::AccessContextManager for AccessContextManager {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/logging/v2/src/transport.rs
+++ b/src/generated/logging/v2/src/transport.rs
@@ -57,7 +57,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn write_log_entries(
@@ -74,7 +74,10 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::WriteLogEntriesResponse>| r.into_body())
     }
 
     async fn list_log_entries(
@@ -91,7 +94,10 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::ListLogEntriesResponse>| r.into_body())
     }
 
     async fn list_monitored_resource_descriptors(
@@ -116,6 +122,11 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListMonitoredResourceDescriptorsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn list_logs(
@@ -141,6 +152,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLogsResponse>| r.into_body())
     }
 
     async fn list_operations(
@@ -163,6 +175,11 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -182,6 +199,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -201,7 +219,7 @@ impl super::stub::LoggingServiceV2 for LoggingServiceV2 {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -246,6 +264,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBucketsResponse>| r.into_body())
     }
 
     async fn get_bucket(
@@ -265,6 +284,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogBucket>| r.into_body())
     }
 
     async fn create_bucket_async(
@@ -285,7 +305,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("bucketId", &req.bucket_id)]);
-        self.inner.execute(builder, Some(req.bucket), options).await
+        self.inner
+            .execute(builder, Some(req.bucket), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_bucket_async(
@@ -315,7 +338,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.bucket), options).await
+        self.inner
+            .execute(builder, Some(req.bucket), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn create_bucket(
@@ -333,7 +359,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("bucketId", &req.bucket_id)]);
-        self.inner.execute(builder, Some(req.bucket), options).await
+        self.inner
+            .execute(builder, Some(req.bucket), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogBucket>| r.into_body())
     }
 
     async fn update_bucket(
@@ -360,7 +389,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.bucket), options).await
+        self.inner
+            .execute(builder, Some(req.bucket), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogBucket>| r.into_body())
     }
 
     async fn delete_bucket(
@@ -380,7 +412,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn undelete_bucket(
@@ -400,7 +432,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_views(
@@ -422,6 +454,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListViewsResponse>| r.into_body())
     }
 
     async fn get_view(
@@ -441,6 +474,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogView>| r.into_body())
     }
 
     async fn create_view(
@@ -458,7 +492,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("viewId", &req.view_id)]);
-        self.inner.execute(builder, Some(req.view), options).await
+        self.inner
+            .execute(builder, Some(req.view), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogView>| r.into_body())
     }
 
     async fn update_view(
@@ -485,7 +522,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.view), options).await
+        self.inner
+            .execute(builder, Some(req.view), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogView>| r.into_body())
     }
 
     async fn delete_view(
@@ -505,7 +545,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_sinks(
@@ -527,6 +567,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSinksResponse>| r.into_body())
     }
 
     async fn get_sink(
@@ -546,6 +587,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogSink>| r.into_body())
     }
 
     async fn create_sink(
@@ -563,7 +605,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("uniqueWriterIdentity", &req.unique_writer_identity)]);
-        self.inner.execute(builder, Some(req.sink), options).await
+        self.inner
+            .execute(builder, Some(req.sink), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogSink>| r.into_body())
     }
 
     async fn update_sink(
@@ -591,7 +636,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.sink), options).await
+        self.inner
+            .execute(builder, Some(req.sink), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogSink>| r.into_body())
     }
 
     async fn delete_sink(
@@ -611,7 +659,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_link(
@@ -629,7 +677,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("linkId", &req.link_id)]);
-        self.inner.execute(builder, Some(req.link), options).await
+        self.inner
+            .execute(builder, Some(req.link), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_link(
@@ -649,6 +700,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_links(
@@ -670,6 +722,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLinksResponse>| r.into_body())
     }
 
     async fn get_link(
@@ -689,6 +742,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Link>| r.into_body())
     }
 
     async fn list_exclusions(
@@ -713,6 +767,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListExclusionsResponse>| r.into_body())
     }
 
     async fn get_exclusion(
@@ -732,6 +787,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogExclusion>| r.into_body())
     }
 
     async fn create_exclusion(
@@ -754,6 +810,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, Some(req.exclusion), options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogExclusion>| r.into_body())
     }
 
     async fn update_exclusion(
@@ -783,6 +840,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, Some(req.exclusion), options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogExclusion>| r.into_body())
     }
 
     async fn delete_exclusion(
@@ -802,7 +860,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_cmek_settings(
@@ -825,6 +883,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::CmekSettings>| r.into_body())
     }
 
     async fn update_cmek_settings(
@@ -857,6 +916,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, Some(req.cmek_settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::CmekSettings>| r.into_body())
     }
 
     async fn get_settings(
@@ -876,6 +936,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn update_settings(
@@ -905,6 +966,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, Some(req.settings), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Settings>| r.into_body())
     }
 
     async fn copy_log_entries(
@@ -921,7 +983,10 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -944,6 +1009,11 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -963,6 +1033,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -982,7 +1053,7 @@ impl super::stub::ConfigServiceV2 for ConfigServiceV2 {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(
@@ -1041,6 +1112,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLogMetricsResponse>| r.into_body())
     }
 
     async fn get_log_metric(
@@ -1060,6 +1132,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::LogMetric>| r.into_body())
     }
 
     async fn create_log_metric(
@@ -1076,7 +1149,10 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.metric), options).await
+        self.inner
+            .execute(builder, Some(req.metric), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogMetric>| r.into_body())
     }
 
     async fn update_log_metric(
@@ -1093,7 +1169,10 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.metric), options).await
+        self.inner
+            .execute(builder, Some(req.metric), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::LogMetric>| r.into_body())
     }
 
     async fn delete_log_metric(
@@ -1113,7 +1192,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -1136,6 +1215,11 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -1155,6 +1239,7 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -1174,6 +1259,6 @@ impl super::stub::MetricsServiceV2 for MetricsServiceV2 {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/longrunning/src/transport.rs
+++ b/src/generated/longrunning/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::Operations for Operations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListOperationsResponse>| r.into_body())
     }
 
     async fn get_operation(
@@ -79,6 +80,7 @@ impl super::stub::Operations for Operations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -98,7 +100,7 @@ impl super::stub::Operations for Operations {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -118,6 +120,6 @@ impl super::stub::Operations for Operations {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }

--- a/src/generated/monitoring/dashboard/v1/src/transport.rs
+++ b/src/generated/monitoring/dashboard/v1/src/transport.rs
@@ -61,6 +61,7 @@ impl super::stub::DashboardsService for DashboardsService {
         self.inner
             .execute(builder, Some(req.dashboard), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dashboard>| r.into_body())
     }
 
     async fn list_dashboards(
@@ -85,6 +86,7 @@ impl super::stub::DashboardsService for DashboardsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDashboardsResponse>| r.into_body())
     }
 
     async fn get_dashboard(
@@ -104,6 +106,7 @@ impl super::stub::DashboardsService for DashboardsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dashboard>| r.into_body())
     }
 
     async fn delete_dashboard(
@@ -123,7 +126,7 @@ impl super::stub::DashboardsService for DashboardsService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_dashboard(
@@ -153,5 +156,6 @@ impl super::stub::DashboardsService for DashboardsService {
         self.inner
             .execute(builder, Some(req.dashboard), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Dashboard>| r.into_body())
     }
 }

--- a/src/generated/monitoring/metricsscope/v1/src/transport.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/transport.rs
@@ -57,6 +57,7 @@ impl super::stub::MetricsScopes for MetricsScopes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::MetricsScope>| r.into_body())
     }
 
     async fn list_metrics_scopes_by_monitored_project(
@@ -84,6 +85,11 @@ impl super::stub::MetricsScopes for MetricsScopes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListMetricsScopesByMonitoredProjectResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn create_monitored_project(
@@ -106,6 +112,7 @@ impl super::stub::MetricsScopes for MetricsScopes {
         self.inner
             .execute(builder, Some(req.monitored_project), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_monitored_project(
@@ -125,6 +132,7 @@ impl super::stub::MetricsScopes for MetricsScopes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_operation(
@@ -144,6 +152,7 @@ impl super::stub::MetricsScopes for MetricsScopes {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/monitoring/v3/src/transport.rs
+++ b/src/generated/monitoring/v3/src/transport.rs
@@ -64,6 +64,9 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListAlertPoliciesResponse>| r.into_body(),
+            )
     }
 
     async fn get_alert_policy(
@@ -83,6 +86,7 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AlertPolicy>| r.into_body())
     }
 
     async fn create_alert_policy(
@@ -105,6 +109,7 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         self.inner
             .execute(builder, Some(req.alert_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AlertPolicy>| r.into_body())
     }
 
     async fn delete_alert_policy(
@@ -124,7 +129,7 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_alert_policy(
@@ -163,6 +168,7 @@ impl super::stub::AlertPolicyService for AlertPolicyService {
         self.inner
             .execute(builder, Some(req.alert_policy), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AlertPolicy>| r.into_body())
     }
 }
 
@@ -225,6 +231,7 @@ impl super::stub::GroupService for GroupService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGroupsResponse>| r.into_body())
     }
 
     async fn get_group(
@@ -244,6 +251,7 @@ impl super::stub::GroupService for GroupService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Group>| r.into_body())
     }
 
     async fn create_group(
@@ -261,7 +269,10 @@ impl super::stub::GroupService for GroupService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Group>| r.into_body())
     }
 
     async fn update_group(
@@ -288,7 +299,10 @@ impl super::stub::GroupService for GroupService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         let builder = builder.query(&[("validateOnly", &req.validate_only)]);
-        self.inner.execute(builder, Some(req.group), options).await
+        self.inner
+            .execute(builder, Some(req.group), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Group>| r.into_body())
     }
 
     async fn delete_group(
@@ -309,7 +323,7 @@ impl super::stub::GroupService for GroupService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_group_members(
@@ -342,6 +356,7 @@ impl super::stub::GroupService for GroupService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListGroupMembersResponse>| r.into_body())
     }
 }
 
@@ -390,6 +405,11 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListMonitoredResourceDescriptorsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_monitored_resource_descriptor(
@@ -409,6 +429,9 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<api::model::MonitoredResourceDescriptor>| r.into_body(),
+            )
     }
 
     async fn list_metric_descriptors(
@@ -435,6 +458,11 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListMetricDescriptorsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_metric_descriptor(
@@ -454,6 +482,7 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<api::model::MetricDescriptor>| r.into_body())
     }
 
     async fn create_metric_descriptor(
@@ -476,6 +505,7 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, Some(req.metric_descriptor), options)
             .await
+            .map(|r: gax::response::Response<api::model::MetricDescriptor>| r.into_body())
     }
 
     async fn delete_metric_descriptor(
@@ -495,7 +525,7 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_time_series(
@@ -550,6 +580,7 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTimeSeriesResponse>| r.into_body())
     }
 
     async fn create_time_series(
@@ -572,7 +603,7 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_service_time_series(
@@ -595,7 +626,7 @@ impl super::stub::MetricService for MetricService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -643,6 +674,11 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListNotificationChannelDescriptorsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn get_notification_channel_descriptor(
@@ -662,6 +698,11 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::NotificationChannelDescriptor>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_notification_channels(
@@ -688,6 +729,11 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListNotificationChannelsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_notification_channel(
@@ -707,6 +753,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotificationChannel>| r.into_body())
     }
 
     async fn create_notification_channel(
@@ -729,6 +776,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, Some(req.notification_channel), options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotificationChannel>| r.into_body())
     }
 
     async fn update_notification_channel(
@@ -767,6 +815,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, Some(req.notification_channel), options)
             .await
+            .map(|r: gax::response::Response<crate::model::NotificationChannel>| r.into_body())
     }
 
     async fn delete_notification_channel(
@@ -787,7 +836,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn send_notification_channel_verification_code(
@@ -810,7 +859,7 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_notification_channel_verification_code(
@@ -830,7 +879,11 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<
+                crate::model::GetNotificationChannelVerificationCodeResponse,
+            >| r.into_body(),
+        )
     }
 
     async fn verify_notification_channel(
@@ -847,7 +900,10 @@ impl super::stub::NotificationChannelService for NotificationChannelService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::NotificationChannel>| r.into_body())
     }
 }
 
@@ -890,7 +946,10 @@ impl super::stub::QueryService for QueryService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::QueryTimeSeriesResponse>| r.into_body())
     }
 }
 
@@ -937,6 +996,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn get_service(
@@ -956,6 +1016,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn list_services(
@@ -978,6 +1039,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListServicesResponse>| r.into_body())
     }
 
     async fn update_service(
@@ -1016,6 +1078,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, Some(req.service), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Service>| r.into_body())
     }
 
     async fn delete_service(
@@ -1035,7 +1098,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_service_level_objective(
@@ -1060,6 +1123,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, Some(req.service_level_objective), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceLevelObjective>| r.into_body())
     }
 
     async fn get_service_level_objective(
@@ -1080,6 +1144,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceLevelObjective>| r.into_body())
     }
 
     async fn list_service_level_objectives(
@@ -1106,6 +1171,11 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListServiceLevelObjectivesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn update_service_level_objective(
@@ -1144,6 +1214,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, Some(req.service_level_objective), options)
             .await
+            .map(|r: gax::response::Response<crate::model::ServiceLevelObjective>| r.into_body())
     }
 
     async fn delete_service_level_objective(
@@ -1163,7 +1234,7 @@ impl super::stub::ServiceMonitoringService for ServiceMonitoringService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 }
 
@@ -1203,7 +1274,10 @@ impl super::stub::SnoozeService for SnoozeService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req.snooze), options).await
+        self.inner
+            .execute(builder, Some(req.snooze), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Snooze>| r.into_body())
     }
 
     async fn list_snoozes(
@@ -1226,6 +1300,7 @@ impl super::stub::SnoozeService for SnoozeService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSnoozesResponse>| r.into_body())
     }
 
     async fn get_snooze(
@@ -1245,6 +1320,7 @@ impl super::stub::SnoozeService for SnoozeService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Snooze>| r.into_body())
     }
 
     async fn update_snooze(
@@ -1280,7 +1356,10 @@ impl super::stub::SnoozeService for SnoozeService {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.snooze), options).await
+        self.inner
+            .execute(builder, Some(req.snooze), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Snooze>| r.into_body())
     }
 }
 
@@ -1329,6 +1408,11 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUptimeCheckConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_uptime_check_config(
@@ -1348,6 +1432,7 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::UptimeCheckConfig>| r.into_body())
     }
 
     async fn create_uptime_check_config(
@@ -1370,6 +1455,7 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         self.inner
             .execute(builder, Some(req.uptime_check_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UptimeCheckConfig>| r.into_body())
     }
 
     async fn update_uptime_check_config(
@@ -1408,6 +1494,7 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         self.inner
             .execute(builder, Some(req.uptime_check_config), options)
             .await
+            .map(|r: gax::response::Response<crate::model::UptimeCheckConfig>| r.into_body())
     }
 
     async fn delete_uptime_check_config(
@@ -1427,7 +1514,7 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_uptime_check_ips(
@@ -1449,5 +1536,10 @@ impl super::stub::UptimeCheckService for UptimeCheckService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListUptimeCheckIpsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 }

--- a/src/generated/openapi-validation/src/transport.rs
+++ b/src/generated/openapi-validation/src/transport.rs
@@ -72,6 +72,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListLocationsResponse>| r.into_body())
     }
 
     async fn get_location(
@@ -94,6 +95,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Location>| r.into_body())
     }
 
     async fn list_secrets(
@@ -128,6 +130,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSecretsResponse>| r.into_body())
     }
 
     async fn create_secret(
@@ -151,6 +154,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn list_secrets_by_project_and_location(
@@ -188,6 +192,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListSecretsResponse>| r.into_body())
     }
 
     async fn create_secret_by_project_and_location(
@@ -214,6 +219,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn add_secret_version(
@@ -236,7 +242,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn add_secret_version_by_project_and_location_and_secret(
@@ -259,7 +268,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn get_secret(
@@ -282,6 +294,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn delete_secret(
@@ -308,6 +321,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Empty>| r.into_body())
     }
 
     async fn update_secret(
@@ -336,6 +350,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn get_secret_by_project_and_location_and_secret(
@@ -361,6 +376,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn delete_secret_by_project_and_location_and_secret(
@@ -390,6 +406,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Empty>| r.into_body())
     }
 
     async fn update_secret_by_project_and_location_and_secret(
@@ -421,6 +438,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, Some(req.request_body), options)
             .await
+            .map(|r: gax::response::Response<crate::model::Secret>| r.into_body())
     }
 
     async fn list_secret_versions(
@@ -458,6 +476,11 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSecretVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_secret_versions_by_project_and_location_and_secret(
@@ -495,6 +518,11 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListSecretVersionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_secret_version(
@@ -520,6 +548,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn get_secret_version_by_project_and_location_and_secret_and_version(
@@ -545,6 +574,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn access_secret_version(
@@ -570,6 +600,11 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::AccessSecretVersionResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn access_secret_version_by_project_and_location_and_secret_and_version(
@@ -595,6 +630,11 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::AccessSecretVersionResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn disable_secret_version(
@@ -617,7 +657,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn disable_secret_version_by_project_and_location_and_secret_and_version(
@@ -640,7 +683,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn enable_secret_version(
@@ -663,7 +709,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn enable_secret_version_by_project_and_location_and_secret_and_version(
@@ -686,7 +735,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn destroy_secret_version(
@@ -709,7 +761,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn destroy_secret_version_by_project_and_location_and_secret_and_version(
@@ -732,7 +787,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::SecretVersion>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -755,7 +813,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn set_iam_policy_by_project_and_location_and_secret(
@@ -778,7 +839,10 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -810,6 +874,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy_by_project_and_location_and_secret(
@@ -841,6 +906,7 @@ impl super::stub::SecretManagerService for SecretManagerService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -863,7 +929,9 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn test_iam_permissions_by_project_and_location_and_secret(
@@ -886,6 +954,8 @@ impl super::stub::SecretManagerService for SecretManagerService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 }

--- a/src/generated/privacy/dlp/v2/src/transport.rs
+++ b/src/generated/privacy/dlp/v2/src/transport.rs
@@ -57,7 +57,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::InspectContentResponse>| r.into_body())
     }
 
     async fn redact_image(
@@ -77,7 +80,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::RedactImageResponse>| r.into_body())
     }
 
     async fn deidentify_content(
@@ -97,7 +103,9 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::DeidentifyContentResponse>| r.into_body(),
+        )
     }
 
     async fn reidentify_content(
@@ -117,7 +125,9 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<crate::model::ReidentifyContentResponse>| r.into_body(),
+        )
     }
 
     async fn list_info_types(
@@ -141,6 +151,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInfoTypesResponse>| r.into_body())
     }
 
     async fn create_inspect_template(
@@ -160,7 +171,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::InspectTemplate>| r.into_body())
     }
 
     async fn update_inspect_template(
@@ -177,7 +191,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::InspectTemplate>| r.into_body())
     }
 
     async fn get_inspect_template(
@@ -197,6 +214,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InspectTemplate>| r.into_body())
     }
 
     async fn list_inspect_templates(
@@ -223,6 +241,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListInspectTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_inspect_template(
@@ -242,7 +265,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_deidentify_template(
@@ -262,7 +285,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DeidentifyTemplate>| r.into_body())
     }
 
     async fn update_deidentify_template(
@@ -279,7 +305,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DeidentifyTemplate>| r.into_body())
     }
 
     async fn get_deidentify_template(
@@ -299,6 +328,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DeidentifyTemplate>| r.into_body())
     }
 
     async fn list_deidentify_templates(
@@ -325,6 +355,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDeidentifyTemplatesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_deidentify_template(
@@ -344,7 +379,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_job_trigger(
@@ -364,7 +399,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::JobTrigger>| r.into_body())
     }
 
     async fn update_job_trigger(
@@ -381,7 +419,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::JobTrigger>| r.into_body())
     }
 
     async fn hybrid_inspect_job_trigger(
@@ -401,7 +442,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::HybridInspectResponse>| r.into_body())
     }
 
     async fn get_job_trigger(
@@ -421,6 +465,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::JobTrigger>| r.into_body())
     }
 
     async fn list_job_triggers(
@@ -449,6 +494,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListJobTriggersResponse>| r.into_body())
     }
 
     async fn delete_job_trigger(
@@ -468,7 +514,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn activate_job_trigger(
@@ -485,7 +531,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DlpJob>| r.into_body())
     }
 
     async fn create_discovery_config(
@@ -505,7 +554,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DiscoveryConfig>| r.into_body())
     }
 
     async fn update_discovery_config(
@@ -522,7 +574,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DiscoveryConfig>| r.into_body())
     }
 
     async fn get_discovery_config(
@@ -542,6 +597,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DiscoveryConfig>| r.into_body())
     }
 
     async fn list_discovery_configs(
@@ -567,6 +623,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDiscoveryConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_discovery_config(
@@ -586,7 +647,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_dlp_job(
@@ -603,7 +664,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::DlpJob>| r.into_body())
     }
 
     async fn list_dlp_jobs(
@@ -629,6 +693,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDlpJobsResponse>| r.into_body())
     }
 
     async fn get_dlp_job(
@@ -648,6 +713,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::DlpJob>| r.into_body())
     }
 
     async fn delete_dlp_job(
@@ -667,7 +733,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_dlp_job(
@@ -687,7 +753,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_stored_info_type(
@@ -707,7 +773,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::StoredInfoType>| r.into_body())
     }
 
     async fn update_stored_info_type(
@@ -724,7 +793,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::StoredInfoType>| r.into_body())
     }
 
     async fn get_stored_info_type(
@@ -744,6 +816,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::StoredInfoType>| r.into_body())
     }
 
     async fn list_stored_info_types(
@@ -770,6 +843,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListStoredInfoTypesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn delete_stored_info_type(
@@ -789,7 +867,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_project_data_profiles(
@@ -816,6 +894,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListProjectDataProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_table_data_profiles(
@@ -842,6 +925,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListTableDataProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_column_data_profiles(
@@ -868,6 +956,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListColumnDataProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_project_data_profile(
@@ -887,6 +980,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ProjectDataProfile>| r.into_body())
     }
 
     async fn list_file_store_data_profiles(
@@ -913,6 +1007,11 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListFileStoreDataProfilesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_file_store_data_profile(
@@ -932,6 +1031,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::FileStoreDataProfile>| r.into_body())
     }
 
     async fn delete_file_store_data_profile(
@@ -951,7 +1051,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_table_data_profile(
@@ -971,6 +1071,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TableDataProfile>| r.into_body())
     }
 
     async fn get_column_data_profile(
@@ -990,6 +1091,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ColumnDataProfile>| r.into_body())
     }
 
     async fn delete_table_data_profile(
@@ -1009,7 +1111,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn hybrid_inspect_dlp_job(
@@ -1029,7 +1131,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::HybridInspectResponse>| r.into_body())
     }
 
     async fn finish_dlp_job(
@@ -1049,7 +1154,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_connection(
@@ -1069,7 +1174,10 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn get_connection(
@@ -1089,6 +1197,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 
     async fn list_connections(
@@ -1114,6 +1223,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListConnectionsResponse>| r.into_body())
     }
 
     async fn search_connections(
@@ -1139,6 +1249,9 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::SearchConnectionsResponse>| r.into_body(),
+            )
     }
 
     async fn delete_connection(
@@ -1158,7 +1271,7 @@ impl super::stub::DlpService for DlpService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_connection(
@@ -1175,6 +1288,9 @@ impl super::stub::DlpService for DlpService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Connection>| r.into_body())
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -62,6 +62,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListDatabasesResponse>| r.into_body())
     }
 
     async fn create_database(
@@ -81,7 +82,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_database(
@@ -101,6 +105,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Database>| r.into_body())
     }
 
     async fn update_database(
@@ -139,6 +144,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, Some(req.database), options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_database_ddl(
@@ -155,7 +161,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn drop_database(
@@ -175,7 +184,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn get_database_ddl(
@@ -195,6 +204,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GetDatabaseDdlResponse>| r.into_body())
     }
 
     async fn set_iam_policy(
@@ -214,7 +224,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -234,7 +247,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -254,7 +270,9 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn create_backup(
@@ -282,7 +300,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "encryptionConfig")
             });
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn copy_backup(
@@ -302,7 +323,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn get_backup(
@@ -322,6 +346,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn update_backup(
@@ -357,7 +382,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 use gaxi::query_parameter::QueryParameter;
                 v.add(builder, "updateMask")
             });
-        self.inner.execute(builder, Some(req.backup), options).await
+        self.inner
+            .execute(builder, Some(req.backup), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::Backup>| r.into_body())
     }
 
     async fn delete_backup(
@@ -377,7 +405,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_backups(
@@ -400,6 +428,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListBackupsResponse>| r.into_body())
     }
 
     async fn restore_database(
@@ -419,7 +448,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_database_operations(
@@ -445,6 +477,11 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDatabaseOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_backup_operations(
@@ -470,6 +507,11 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBackupOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_database_roles(
@@ -494,6 +536,9 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListDatabaseRolesResponse>| r.into_body(),
+            )
     }
 
     async fn add_split_points(
@@ -513,7 +558,10 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::AddSplitPointsResponse>| r.into_body())
     }
 
     async fn create_backup_schedule(
@@ -537,6 +585,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, Some(req.backup_schedule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupSchedule>| r.into_body())
     }
 
     async fn get_backup_schedule(
@@ -556,6 +605,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupSchedule>| r.into_body())
     }
 
     async fn update_backup_schedule(
@@ -594,6 +644,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, Some(req.backup_schedule), options)
             .await
+            .map(|r: gax::response::Response<crate::model::BackupSchedule>| r.into_body())
     }
 
     async fn delete_backup_schedule(
@@ -613,7 +664,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_backup_schedules(
@@ -638,6 +689,11 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListBackupSchedulesResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_operations(
@@ -660,6 +716,11 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -679,6 +740,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -698,7 +760,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -718,7 +780,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -62,6 +62,11 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListInstanceConfigsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_instance_config(
@@ -81,6 +86,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InstanceConfig>| r.into_body())
     }
 
     async fn create_instance_config(
@@ -100,7 +106,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance_config(
@@ -126,7 +135,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance_config(
@@ -148,7 +160,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_instance_config_operations(
@@ -174,6 +186,11 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListInstanceConfigOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn list_instances(
@@ -209,6 +226,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListInstancesResponse>| r.into_body())
     }
 
     async fn list_instance_partitions(
@@ -243,6 +261,11 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<crate::model::ListInstancePartitionsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_instance(
@@ -272,6 +295,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::Instance>| r.into_body())
     }
 
     async fn create_instance(
@@ -291,7 +315,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn update_instance(
@@ -317,7 +344,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance(
@@ -337,7 +367,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn set_iam_policy(
@@ -357,7 +387,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn get_iam_policy(
@@ -377,7 +410,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<iam_v1::model::Policy>| r.into_body())
     }
 
     async fn test_iam_permissions(
@@ -397,7 +433,9 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner.execute(builder, Some(req), options).await.map(
+            |r: gax::response::Response<iam_v1::model::TestIamPermissionsResponse>| r.into_body(),
+        )
     }
 
     async fn get_instance_partition(
@@ -417,6 +455,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::InstancePartition>| r.into_body())
     }
 
     async fn create_instance_partition(
@@ -436,7 +475,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_instance_partition(
@@ -457,7 +499,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn update_instance_partition(
@@ -483,7 +525,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_instance_partition_operations(
@@ -519,6 +564,11 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<
+                    crate::model::ListInstancePartitionOperationsResponse,
+                >| r.into_body(),
+            )
     }
 
     async fn move_instance(
@@ -535,7 +585,10 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn list_operations(
@@ -558,6 +611,11 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -577,6 +635,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_operation(
@@ -596,7 +655,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn cancel_operation(
@@ -616,7 +675,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/generated/storagetransfer/v1/src/transport.rs
+++ b/src/generated/storagetransfer/v1/src/transport.rs
@@ -60,6 +60,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::GoogleServiceAccount>| r.into_body())
     }
 
     async fn create_transfer_job(
@@ -79,6 +80,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, Some(req.transfer_job), options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransferJob>| r.into_body())
     }
 
     async fn update_transfer_job(
@@ -95,7 +97,10 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<crate::model::TransferJob>| r.into_body())
     }
 
     async fn get_transfer_job(
@@ -116,6 +121,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::TransferJob>| r.into_body())
     }
 
     async fn list_transfer_jobs(
@@ -138,6 +144,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListTransferJobsResponse>| r.into_body())
     }
 
     async fn pause_transfer_operation(
@@ -157,7 +164,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn resume_transfer_operation(
@@ -177,7 +184,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn run_transfer_job(
@@ -194,7 +201,10 @@ impl super::stub::StorageTransferService for StorageTransferService {
                 "x-goog-api-client",
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
-        self.inner.execute(builder, Some(req), options).await
+        self.inner
+            .execute(builder, Some(req), options)
+            .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn delete_transfer_job(
@@ -215,7 +225,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn create_agent_pool(
@@ -239,6 +249,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, Some(req.agent_pool), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AgentPool>| r.into_body())
     }
 
     async fn update_agent_pool(
@@ -277,6 +288,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, Some(req.agent_pool), options)
             .await
+            .map(|r: gax::response::Response<crate::model::AgentPool>| r.into_body())
     }
 
     async fn get_agent_pool(
@@ -296,6 +308,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::AgentPool>| r.into_body())
     }
 
     async fn list_agent_pools(
@@ -321,6 +334,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<crate::model::ListAgentPoolsResponse>| r.into_body())
     }
 
     async fn delete_agent_pool(
@@ -340,7 +354,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     async fn list_operations(
@@ -363,6 +377,11 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(
+                |r: gax::response::Response<longrunning::model::ListOperationsResponse>| {
+                    r.into_body()
+                },
+            )
     }
 
     async fn get_operation(
@@ -382,6 +401,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, None::<gaxi::http::NoBody>, options)
             .await
+            .map(|r: gax::response::Response<longrunning::model::Operation>| r.into_body())
     }
 
     async fn cancel_operation(
@@ -401,7 +421,7 @@ impl super::stub::StorageTransferService for StorageTransferService {
         self.inner
             .execute(builder, Some(req), options)
             .await
-            .map(|_: wkt::Empty| ())
+            .map(|_: gax::response::Response<wkt::Empty>| ())
     }
 
     fn get_polling_error_policy(

--- a/src/lro/tests/fake/library/builders.rs
+++ b/src/lro/tests/fake/library/builders.rs
@@ -56,7 +56,7 @@ impl CreateResource {
                 gax::options::RequestOptions::default(),
             )
             .await?;
-        Ok(r)
+        Ok(r.into_body())
     }
 
     pub fn poller(
@@ -132,6 +132,6 @@ impl GetOperation {
                 gax::options::RequestOptions::default(),
             )
             .await?;
-        Ok(r)
+        Ok(r.into_body())
     }
 }


### PR DESCRIPTION
Include the metadata (currently just headers) with each response. Change
the generator to only use the body.

Part of the work for #1510
