### PR TITLE
cleanup: real error in mocking user guide

### DIFF
--- a/guide/samples/tests/mocking.rs
+++ b/guide/samples/tests/mocking.rs
@@ -92,7 +92,14 @@ mod test {
         // ANCHOR: error
         mock.expect_get_recognizer().return_once(|_, _| {
             // This time, return an error.
-            Err(gax::error::Error::other("fail"))
+            use gax::error::rpc::Status;
+            use gax::error::{Error, ServiceError};
+            let s = Status::default()
+                .set_code(404)
+                .set_message("Resource not found");
+            Err(Error::rpc(
+                ServiceError::from(s).with_http_status_code(404_u16),
+            ))
         });
         // ANCHOR_END: error
 


### PR DESCRIPTION
In response to: https://github.com/googleapis/google-cloud-rust/pull/1722#discussion_r2030186037

I think it is odd that we have to set the HTTP code twice. Perhaps the plan is for `Status.code` to represent a gRPC code.