### PR TITLE
test(wkt): fix coverage gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ terraform.tfstate
 
 # Ignore code coverage output files.
 cobertura.xml
+
+# Ignore cargo-mutants directories.
+mutants.out/
+mutants.out.old/

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -364,6 +364,20 @@ mod null_value_tests {
     }
 
     #[test]
+    fn test_i32_from_null_value() {
+        let got = i32::from(NullValue);
+        assert_eq!(got, 0);
+    }
+
+    #[test]
+    fn test_serde_from_null_value() {
+        let got = serde_json::Value::from(NullValue);
+        assert_eq!(got, serde_json::Value::Null);
+        let got = serde_json::Value::from(&NullValue);
+        assert_eq!(got, serde_json::Value::Null);
+    }
+
+    #[test]
     fn test_null_value_serialize() -> Result {
         let input = NullValue;
         let got = serde_json::to_string(&input)?;

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -151,19 +151,19 @@ impl From<i32> for NullValue {
 // This is needed when `NullValue` is used in a Protobuf-generated message.
 impl From<NullValue> for i32 {
     fn from(_value: NullValue) -> Self {
-        i32::default()
+        Default::default()
     }
 }
 
 impl From<NullValue> for serde_json::Value {
     fn from(_value: NullValue) -> Self {
-        serde_json::Value::Null
+        Default::default()
     }
 }
 
 impl From<&NullValue> for serde_json::Value {
     fn from(_value: &NullValue) -> Self {
-        serde_json::Value::Null
+        Default::default()
     }
 }
 

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -346,7 +346,9 @@ mod test {
 
     #[test_case(0, 0, 0, 0; "zero")]
     #[test_case(0, 1_234_567_890, 1, 234_567_890; "nanos overflow")]
+    #[test_case(0, 2_100_000_123, 2, 100_000_123; "nanos overflow x2")]
     #[test_case(0, -1_400_000_000, -2, 600_000_000; "nanos underflow")]
+    #[test_case(0, -2_100_000_000, -3, 900_000_000; "nanos underflow x2")]
     #[test_case(self::get_max_seconds() + 1, 0, get_max_seconds(), 0; "seconds over range")]
     #[test_case(self::get_min_seconds() - 1, 0, get_min_seconds(), 0; "seconds below range")]
     #[test_case(self::get_max_seconds() - 1, 2_000_000_001, get_max_seconds(), 0; "nanos overflow range"


### PR DESCRIPTION
I used `cargo mutants` to find missing tests or cases where the code
could be simpler. With this, the generated code still has coverage
gaps, but we typically ignore those.