### PR TITLE
feat(generator/dart): generate LRO Operations with generic type parameters

### DIFF
--- a/.github/workflows/generator_dart.yaml
+++ b/.github/workflows/generator_dart.yaml
@@ -83,6 +83,9 @@ jobs:
       - name: "dart/tests"
         run: dart test
         working-directory: generator/dart/tests
+      - name: "test package:google_cloud_longrunning"
+        run: dart test
+        working-directory: generator/dart/generated/google_cloud_longrunning
       - name: "test package:google_cloud_protobuf"
         run: dart test
         working-directory: generator/dart/generated/google_cloud_protobuf

--- a/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -63,26 +63,56 @@ class FunctionService {
   /// Creates a new function. If a function with the given name already exists in
   /// the specified project, the long running operation will return
   /// `ALREADY_EXISTS` error.
-  Future<Operation> createFunction(CreateFunctionRequest request) async {
+  ///
+  /// Returns an [Operation] representing the status of the long-running
+  /// operation.
+  ///
+  /// When complete, [Operation.done] will be `true`. If successful,
+  /// [Operation.responseAsMessage] will contain the Operation's result.
+  Future<Operation<Function$, OperationMetadata>> createFunction(
+      CreateFunctionRequest request) async {
     final url = Uri.https(_host, '/v2/${request.parent}/functions');
     final response = await _client.post(url, body: request.function);
-    return Operation.fromJson(response);
+    return Operation.fromJson(
+      response,
+      OperationHelper(Function$.fromJson, OperationMetadata.fromJson),
+    );
   }
 
   /// Updates existing function.
-  Future<Operation> updateFunction(UpdateFunctionRequest request) async {
+  ///
+  /// Returns an [Operation] representing the status of the long-running
+  /// operation.
+  ///
+  /// When complete, [Operation.done] will be `true`. If successful,
+  /// [Operation.responseAsMessage] will contain the Operation's result.
+  Future<Operation<Function$, OperationMetadata>> updateFunction(
+      UpdateFunctionRequest request) async {
     final url = Uri.https(_host, '/v2/${request.function.name}');
     final response = await _client.patch(url, body: request.function);
-    return Operation.fromJson(response);
+    return Operation.fromJson(
+      response,
+      OperationHelper(Function$.fromJson, OperationMetadata.fromJson),
+    );
   }
 
   /// Deletes a function with the given name from the specified project. If the
   /// given function is used by some trigger, the trigger will be updated to
   /// remove this function.
-  Future<Operation> deleteFunction(DeleteFunctionRequest request) async {
+  ///
+  /// Returns an [Operation] representing the status of the long-running
+  /// operation.
+  ///
+  /// When complete, [Operation.done] will be `true`. If successful,
+  /// [Operation.responseAsMessage] will contain the Operation's result.
+  Future<Operation<Empty, OperationMetadata>> deleteFunction(
+      DeleteFunctionRequest request) async {
     final url = Uri.https(_host, '/v2/${request.name}');
     final response = await _client.delete(url);
-    return Operation.fromJson(response);
+    return Operation.fromJson(
+      response,
+      OperationHelper(Empty.fromJson, OperationMetadata.fromJson),
+    );
   }
 
   /// Returns a signed URL for uploading a function source code.
@@ -185,10 +215,14 @@ class FunctionService {
   }
 
   /// Provides the `Operations` service functionality in this service.
-  Future<Operation> getOperation(GetOperationRequest request) async {
+  ///
+  /// This method can be used to get the current status of a long-running
+  /// operation.
+  Future<Operation<T, S>> getOperation<T extends Message, S extends Message>(
+      Operation<T, S> request) async {
     final url = Uri.https(_host, '/v2/${request.name}');
     final response = await _client.get(url);
-    return Operation.fromJson(response);
+    return Operation.fromJson(response, request.operationHelper);
   }
 
   /// Closes the client and cleans up any resources associated with it.

--- a/generator/dart/generated/google_cloud_longrunning/.sidekick.toml
+++ b/generator/dart/generated/google_cloud_longrunning/.sidekick.toml
@@ -31,3 +31,5 @@ operations.
 
 [codec]
 copyright-year = '2025'
+dev-dependencies = "test"
+part-file = "src/longrunning.p.dart"

--- a/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -34,6 +34,8 @@ import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:http/http.dart' as http;
 
+part 'src/longrunning.p.dart';
+
 /// Manages long-running operations with an API service.
 ///
 /// When an API method normally takes long time to complete, it can be designed
@@ -98,79 +100,6 @@ class Operations {
   ///
   /// Once [close] is called, no other methods should be called.
   void close() => _client.close();
-}
-
-/// This resource represents a long-running operation that is the result of a
-/// network API call.
-class Operation extends Message {
-  static const String fullyQualifiedName = 'google.longrunning.Operation';
-
-  /// The server-assigned name, which is only unique within the same service that
-  /// originally returns it. If you use the default HTTP mapping, the
-  /// `name` should be a resource name ending with `operations/{unique_id}`.
-  final String? name;
-
-  /// Service-specific metadata associated with the operation.  It typically
-  /// contains progress information and common metadata such as create time.
-  /// Some services might not provide such metadata.  Any method that returns a
-  /// long-running operation should document the metadata type, if any.
-  final Any? metadata;
-
-  /// If the value is `false`, it means the operation is still in progress.
-  /// If `true`, the operation is completed, and either `error` or `response` is
-  /// available.
-  final bool? done;
-
-  /// The error result of the operation in case of failure or cancellation.
-  final Status? error;
-
-  /// The normal, successful response of the operation.  If the original
-  /// method returns no data on success, such as `Delete`, the response is
-  /// `google.protobuf.Empty`.  If the original method is standard
-  /// `Get`/`Create`/`Update`, the response should be the resource.  For other
-  /// methods, the response should have the type `XxxResponse`, where `Xxx`
-  /// is the original method name.  For example, if the original method name
-  /// is `TakeSnapshot()`, the inferred response type is
-  /// `TakeSnapshotResponse`.
-  final Any? response;
-
-  Operation({
-    this.name,
-    this.metadata,
-    this.done,
-    this.error,
-    this.response,
-  }) : super(fullyQualifiedName);
-
-  factory Operation.fromJson(Map<String, dynamic> json) {
-    return Operation(
-      name: json['name'],
-      metadata: decode(json['metadata'], Any.fromJson),
-      done: json['done'],
-      error: decode(json['error'], Status.fromJson),
-      response: decode(json['response'], Any.fromJson),
-    );
-  }
-
-  @override
-  Object toJson() {
-    return {
-      if (name != null) 'name': name,
-      if (metadata != null) 'metadata': metadata!.toJson(),
-      if (done != null) 'done': done,
-      if (error != null) 'error': error!.toJson(),
-      if (response != null) 'response': response!.toJson(),
-    };
-  }
-
-  @override
-  String toString() {
-    final contents = [
-      if (name != null) 'name=$name',
-      if (done != null) 'done=$done',
-    ].join(',');
-    return 'Operation($contents)';
-  }
 }
 
 /// The request message for

--- a/generator/dart/generated/google_cloud_longrunning/lib/src/longrunning.p.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/src/longrunning.p.dart
@@ -1,0 +1,130 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of '../longrunning.dart';
+
+/// This resource represents a long-running operation that is the result of a
+/// network API call.
+class Operation<T extends Message, S extends Message> extends Message {
+  static const String fullyQualifiedName = 'google.longrunning.Operation';
+
+  /// The server-assigned name, which is only unique within the same service that
+  /// originally returns it. If you use the default HTTP mapping, the
+  /// `name` should be a resource name ending with `operations/{unique_id}`.
+  final String? name;
+
+  /// Service-specific metadata associated with the operation. See also
+  /// [metadataAsMessage] for the typed version of this property.
+  ///
+  /// It typically
+  /// contains progress information and common metadata such as create time.
+  /// Some services might not provide such metadata.  Any method that returns a
+  /// long-running operation should document the metadata type, if any.
+  final Any? metadata;
+
+  /// If the value is `false`, it means the operation is still in progress.
+  /// If `true`, the operation is completed, and either `error` or `response` is
+  /// available.
+  final bool? done;
+
+  /// The error result of the operation in case of failure or cancellation.
+  final Status? error;
+
+  /// The normal, successful response of the operation. See also
+  /// [responseAsMessage] for the typed version of this property.
+  ///
+  /// If the original
+  /// method returns no data on success, such as `Delete`, the response is
+  /// `google.protobuf.Empty`.  If the original method is standard
+  /// `Get`/`Create`/`Update`, the response should be the resource.  For other
+  /// methods, the response should have the type `XxxResponse`, where `Xxx`
+  /// is the original method name.  For example, if the original method name
+  /// is `TakeSnapshot()`, the inferred response type is
+  /// `TakeSnapshotResponse`.
+  final Any? response;
+
+  /// Internal plumbing used to implement [responseAsMessage] and
+  /// [metadataAsMessage].
+  final OperationHelper<T, S>? operationHelper;
+
+  Operation({
+    this.name,
+    this.metadata,
+    this.done,
+    this.error,
+    this.response,
+    this.operationHelper,
+  }) : super(fullyQualifiedName);
+
+  factory Operation.fromJson(
+    Map<String, dynamic> json, [
+    OperationHelper<T, S>? helper,
+  ]) {
+    return Operation(
+      name: json['name'],
+      metadata: decode(json['metadata'], Any.fromJson),
+      done: json['done'],
+      error: decode(json['error'], Status.fromJson),
+      response: decode(json['response'], Any.fromJson),
+      operationHelper: helper,
+    );
+  }
+
+  /// The normal, successful response of the operation.
+  ///
+  /// See also [response] for the untyped version of this property.
+  T? get responseAsMessage {
+    if (operationHelper == null) return null;
+    return response?.unpackFrom(operationHelper!.responseDecoder);
+  }
+
+  /// Service-specific metadata associated with the operation.
+  ///
+  /// See also [metadata] for the untyped version of this property.
+  S? get metadataAsMessage {
+    if (operationHelper?.metadataDecoder == null) return null;
+    return metadata?.unpackFrom(operationHelper!.metadataDecoder!);
+  }
+
+  @override
+  Object toJson() {
+    return {
+      if (name != null) 'name': name,
+      if (metadata != null) 'metadata': metadata!.toJson(),
+      if (done != null) 'done': done,
+      if (error != null) 'error': error!.toJson(),
+      if (response != null) 'response': response!.toJson(),
+    };
+  }
+
+  @override
+  String toString() {
+    final contents = [
+      if (name != null) 'name=$name',
+      if (done != null) 'done=$done',
+    ].join(',');
+    return 'Operation($contents)';
+  }
+}
+
+/// This helper class is used to pull typed messages out of the
+/// [Operation.response] and [Operation.metadata] fields in order to populate
+/// the typed [Operation.responseAsMessage] and [Operation.metadataAsMessage]
+/// fields.
+final class OperationHelper<T extends Message, S extends Message> {
+  final T Function(Map<String, dynamic>) responseDecoder;
+  final S Function(Map<String, dynamic>)? metadataDecoder;
+
+  OperationHelper(this.responseDecoder, [this.metadataDecoder]);
+}

--- a/generator/dart/generated/google_cloud_longrunning/pubspec.yaml
+++ b/generator/dart/generated/google_cloud_longrunning/pubspec.yaml
@@ -30,4 +30,5 @@ dependencies:
   http: any
 
 dev_dependencies:
+  test: any
   lints: any

--- a/generator/dart/generated/google_cloud_longrunning/test/operation_test.dart
+++ b/generator/dart/generated/google_cloud_longrunning/test/operation_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:google_cloud_longrunning/longrunning.dart';
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:google_cloud_rpc/rpc.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('responseAsMessage', () {
+    final result = LocalizedMessage(locale: 'en-US', message: 'Lorem ipsum.');
+    final operation = Operation<LocalizedMessage, Any>(
+      name: 'temp-name',
+      done: true,
+      response: Any.from(result),
+      operationHelper: OperationHelper(LocalizedMessage.fromJson),
+    );
+
+    expect(operation.response, isNotNull);
+
+    final actual = operation.responseAsMessage!;
+    expect(actual, isA<LocalizedMessage>());
+    expect(actual.locale, 'en-US');
+    expect(actual.message, 'Lorem ipsum.');
+  });
+
+  test('metadataAsMessage', () {
+    final metadata = Status(code: 200, message: 'OK', details: []);
+    final operation = Operation<LocalizedMessage, Status>(
+      name: 'temp-name',
+      done: false,
+      metadata: Any.from(metadata),
+      operationHelper:
+          OperationHelper(LocalizedMessage.fromJson, Status.fromJson),
+    );
+
+    expect(operation.metadata, isNotNull);
+
+    final actual = operation.metadataAsMessage!;
+    expect(actual, isA<Status>());
+    expect(actual.code, 200);
+    expect(actual.message, 'OK');
+  });
+}

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -27,13 +27,13 @@ import (
 )
 
 var typedDataImport = "dart:typed_data"
-var httpImport = "package:http/http.dart"
+var httpImport = "package:http/http.dart as http"
 var commonImport = "package:google_cloud_gax/common.dart"
 var commonHelpersImport = "package:google_cloud_gax/src/json_helpers.dart"
 
 var needsCtorValidation = map[string]string{
-	".google.protobuf.Duration":  ".google.protobuf.Duration",
-	".google.protobuf.Timestamp": ".google.protobuf.Timestamp",
+	".google.protobuf.Duration":  "",
+	".google.protobuf.Timestamp": "",
 }
 
 // This list needs to be kept in sync with

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 }}
-{{^IsMap}}
+{{^Codec.OmitGeneration}}
 
 {{#Codec.DocLines}}
 {{{.}}}
@@ -78,4 +78,4 @@ class {{Codec.Name}} extends Message {
 {{#Enums}}
 {{> enum}}
 {{/Enums}}
-{{/IsMap}}
+{{/Codec.OmitGeneration}}

--- a/generator/internal/dart/templates/lib/method.mustache
+++ b/generator/internal/dart/templates/lib/method.mustache
@@ -17,10 +17,31 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-Future<{{Codec.ResponseType}}> {{Codec.Name}}({{Codec.RequestType}} request) async {
+{{#OperationInfo}}
+///
+/// Returns an [Operation] representing the status of the long-running
+/// operation.
+///
+/// When complete, [Operation.done] will be `true`. If successful,
+/// [Operation.responseAsMessage] will contain the Operation's result.
+{{/OperationInfo}}
+{{#Codec.IsLROGetOperation}}
+///
+/// This method can be used to get the current status of a long-running
+/// operation.
+Future<Operation<T, S>> getOperation<T extends Message, S extends Message>(Operation<T, S> request) async {
+{{/Codec.IsLROGetOperation}}
+{{^Codec.IsLROGetOperation}}
+Future<{{Codec.ResponseType}}{{#OperationInfo}}<{{Codec.ResponseType}}, {{Codec.MetadataType}}>{{/OperationInfo}}> {{Codec.Name}}({{Codec.RequestType}} request) async {
+{{/Codec.IsLROGetOperation}}
   final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}');
   {{#Codec.ReturnsValue}}final response = {{/Codec.ReturnsValue}}await _client.{{Codec.RequestMethod}}(url{{#Codec.HasBody}}, body: {{Codec.BodyMessageName}}{{/Codec.HasBody}});
-{{#Codec.ReturnsValue}}
-  return {{Codec.ResponseType}}.fromJson(response);
-{{/Codec.ReturnsValue}}
+{{#Codec.IsLROGetOperation}}
+  return Operation.fromJson(response, request.operationHelper);
+{{/Codec.IsLROGetOperation}}
+{{^Codec.IsLROGetOperation}}
+  {{#Codec.ReturnsValue}}
+    return {{Codec.ResponseType}}.fromJson(response{{#OperationInfo}}, OperationHelper({{Codec.ResponseType}}.fromJson, {{Codec.MetadataType}}.fromJson),{{/OperationInfo}});
+  {{/Codec.ReturnsValue}}
+{{/Codec.IsLROGetOperation}}
 }


### PR DESCRIPTION
- update the dart generator so that LRO methods use type parameters on their `Operation` result to indicate the expected result operation metadata
- hand-write an Operation class (based on the generated class) which provides `responseAsMessage` and `metadataAsMessage` getters to unpack the response and metadata typed objects from their respective Any instances
- the API delta for an API using LROs can be seen here: https://github.com/googleapis/google-cloud-rust/commit/d23837910cd80ef2f696c7fc67792401853848da

Note that this PR doesn't contain anything to help the user poll for the status of an LRO.

This keeps the existing `Any? response` and `Any? metadata` fields on Operation, and adds the typed `T? responseAsMessage` and `S? metadataAsMessage` getters. I don't know how important it is to preserve the API surface area from what comes over the wire. An alternative choice would be having a `T? response` getter and having the raw any available at `Any? responseRaw`. The choice probably depends on how closely we want to match generated code or patterns in other clients.

In order for the `responseAsMessage` and `metadataAsMessage` getters to work, the Operation instance needs to be created w/ a special ctor param that helps us unpack those fields (the generated APIs will call the ctors w/ the right info).
