### PR TITLE
cleanup: clippyfy all the tests

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -91,7 +91,7 @@ jobs:
             cargo "${sub}" --package google-cloud-wkt --no-default-features --features time
             cargo "${sub}" --package google-cloud-wkt --all-features
           done
-          cargo clippy --no-deps --package google-cloud-wkt --all-features -- --deny warnings
+          cargo clippy --no-deps --package google-cloud-wkt --all-features --profile=test -- --deny warnings
 
           cargo clean
           for sub in test doc; do
@@ -99,7 +99,7 @@ jobs:
             cargo "${sub}" --package google-cloud-gax --no-default-features --features unstable-sdk-client
             cargo "${sub}" --package google-cloud-gax --all-features
           done
-          cargo clippy --no-deps --package google-cloud-gax --all-features -- --deny warnings
+          cargo clippy --no-deps --package google-cloud-gax --all-features --profile=test -- --deny warnings
 
           cargo clean
           for sub in test doc; do
@@ -109,7 +109,7 @@ jobs:
             cargo "${sub}" --package google-cloud-gax-internal --no-default-features --features _internal_grpc_client
             cargo "${sub}" --package google-cloud-gax-internal --all-features
           done
-          cargo clippy --no-deps --package google-cloud-gax-internal --all-features -- --deny warnings
+          cargo clippy --no-deps --package google-cloud-gax-internal --all-features --profile=test -- --deny warnings
 
           cargo clean
           for sub in test doc; do
@@ -117,7 +117,7 @@ jobs:
             cargo "${sub}" --package google-cloud-lro --no-default-features --features unstable-stream
             cargo "${sub}" --package google-cloud-lro --all-features
           done
-          cargo clippy --no-deps --package google-cloud-lro --all-features -- --deny warnings
+          cargo clippy --no-deps --package google-cloud-lro --all-features --profile=test -- --deny warnings
   coverage:
     runs-on: ubuntu-24.04
     strategy:
@@ -225,7 +225,7 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustup show active-toolchain -v
-      - run: cargo clippy --workspace -- --deny warnings
+      - run: cargo clippy --workspace --profile=test -- --deny warnings
       - run: cargo fmt
       - run: git diff --exit-code
   regenerate:

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -57,7 +57,7 @@ cargo test
 ## Running lints and unit tests
 
 ```bash
-cargo fmt && cargo clippy -- --deny warnings && cargo test
+cargo fmt && cargo clippy --profile=test -- --deny warnings && cargo test
 git status # Shows any diffs created by `cargo fmt`
 ```
 

--- a/src/firestore/src/convert.rs
+++ b/src/firestore/src/convert.rs
@@ -87,7 +87,6 @@ mod test {
                 google::firestore::v1::structured_query::unary_filter::OperandType::Field(
                     google::firestore::v1::structured_query::FieldReference {
                         field_path: "a.b.c".into(),
-                        ..Default::default()
                     },
                 )
                 .into(),

--- a/src/firestore/src/status.rs
+++ b/src/firestore/src/status.rs
@@ -174,12 +174,10 @@ mod test {
                     description: "desc".into(),
                     ..Default::default()
                 }],
-                ..Default::default()
             }),
             Any::from_msg(&DebugInfo {
                 stack_entries: ["stack"].map(str::to_string).to_vec(),
                 detail: "detail".into(),
-                ..Default::default()
             }),
             Any::from_msg(&ErrorInfo {
                 reason: "reason".into(),
@@ -190,7 +188,6 @@ mod test {
                 links: vec![help::Link {
                     description: "desc".into(),
                     url: "url".into(),
-                    ..Default::default()
                 }],
             }),
             Any::from_msg(&LocalizedMessage {
@@ -202,9 +199,7 @@ mod test {
                     r#type: "type".into(),
                     subject: "subject".into(),
                     description: "desc".into(),
-                    ..Default::default()
                 }],
-                ..Default::default()
             }),
             Any::from_msg(&QuotaFailure {
                 violations: vec![quota_failure::Violation {

--- a/src/gax-internal/src/query_parameter.rs
+++ b/src/gax-internal/src/query_parameter.rs
@@ -63,7 +63,7 @@ mod tests {
             .query()
             .unwrap_or_default()
             .split("&")
-            .filter(|p| *p != "")
+            .filter(|p| !p.is_empty())
             .collect()
     }
 

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -850,13 +850,10 @@ mod test {
     #[test]
     fn code_try_from_string_error() {
         let err = Code::try_from("INVALID-NOT-A-CODE");
-        match err {
-            Err(s) => assert!(
-                s.contains("INVALID-NOT-A-CODE"),
-                "expected invalid string in error {s}"
-            ),
-            Ok(v) => assert!(false, "expected error in try_from, got {v:?}"),
-        };
+        assert!(
+            matches!(&err, Err(s) if s.contains("INVALID-NOT-A-CODE")),
+            "expected error in try_from, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -626,18 +626,22 @@ mod tests {
     }
 
     fn http_unavailable() -> Error {
-        let mut status = Status::default();
-        status.code = 503;
-        status.message = "SERVICE UNAVAILABLE".to_string();
-        status.status = Some("UNAVAILABLE".to_string());
+        let status = Status {
+            code: 503,
+            message: "SERVICE UNAVAILABLE".into(),
+            status: Some("UNAVAILABLE".into()),
+            ..Default::default()
+        };
         from_status(status)
     }
 
     fn http_permission_denied() -> Error {
-        let mut status = Status::default();
-        status.code = 403;
-        status.message = "PERMISSION DENIED".to_string();
-        status.status = Some("PERMISSION_DENIED".to_string());
+        let status = Status {
+            code: 403,
+            message: "PERMISSION DENIED".into(),
+            status: Some("PERMISSION_DENIED".into()),
+            ..Default::default()
+        };
         from_status(status)
     }
 

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -733,18 +733,22 @@ mod tests {
     }
 
     fn http_unavailable() -> Error {
-        let mut status = Status::default();
-        status.code = 503;
-        status.message = "SERVICE UNAVAILABLE".to_string();
-        status.status = Some("UNAVAILABLE".to_string());
+        let status = Status {
+            code: 503,
+            message: "SERVICE UNAVAILABLE".into(),
+            status: Some("UNAVAILABLE".into()),
+            ..Default::default()
+        };
         http_from_status(status)
     }
 
     fn http_permission_denied() -> Error {
-        let mut status = Status::default();
-        status.code = 403;
-        status.message = "PERMISSION DENIED".to_string();
-        status.status = Some("PERMISSION_DENIED".to_string());
+        let status = Status {
+            code: 403,
+            message: "PERMISSION DENIED".into(),
+            status: Some("PERMISSION_DENIED".into()),
+            ..Default::default()
+        };
         http_from_status(status)
     }
 
@@ -819,7 +823,7 @@ mod tests {
         let mut mock = MockPolicy::new();
         mock.expect_on_throttle()
             .times(1..)
-            .returning(|_, _| Some(Error::other(format!("err"))));
+            .returning(|_, _| Some(Error::other("err".to_string())));
 
         let now = std::time::Instant::now();
         let policy = LimitedElapsedTime::custom(mock, Duration::from_secs(60));
@@ -1008,7 +1012,7 @@ mod tests {
         let mut mock = MockPolicy::new();
         mock.expect_on_throttle()
             .times(1..)
-            .returning(|_, _| Some(Error::other(format!("err"))));
+            .returning(|_, _| Some(Error::other("err".to_string())));
 
         let now = std::time::Instant::now();
         let policy = LimitedAttemptCount::custom(mock, 3);

--- a/src/gax/src/retry_throttler.rs
+++ b/src/gax/src/retry_throttler.rs
@@ -407,7 +407,7 @@ mod tests {
         assert!(throttler.is_err());
 
         let throttler = AdaptiveThrottler::new(0.0);
-        assert!(!throttler.is_err());
+        assert!(throttler.is_ok());
     }
 
     fn test_error() -> Error {
@@ -459,7 +459,7 @@ mod tests {
         // This creates a throttler with reject probability == 0.
         let mut throttler = AdaptiveThrottler::new(100.0)?;
         throttler.on_success();
-        assert_eq!(false, throttler.throttle_retry_attempt(), "{throttler:?}");
+        assert!(!throttler.throttle_retry_attempt(), "{throttler:?}");
 
         Ok(())
     }
@@ -496,10 +496,10 @@ mod tests {
         // Permanent errors also open back the throttle.
         throttler.on_retry_failure(&LoopState::Continue(test_error()));
         for _ in 0..9 {
-            throttler.on_retry_failure(&&LoopState::Permanent(test_error()));
+            throttler.on_retry_failure(&LoopState::Permanent(test_error()));
             assert!(throttler.throttle_retry_attempt(), "{throttler:?}");
         }
-        throttler.on_retry_failure(&&LoopState::Permanent(test_error()));
+        throttler.on_retry_failure(&LoopState::Permanent(test_error()));
         assert!(!throttler.throttle_retry_attempt(), "{throttler:?}");
     }
 }

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -144,7 +144,7 @@ mod test {
             PollingResult::InProgress(m) => {
                 assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
             }
-            _ => assert!(false, "{poll:?}"),
+            _ => panic!("{poll:?}"),
         };
         Ok(())
     }
@@ -162,7 +162,7 @@ mod test {
                 let e = r.err().unwrap();
                 assert_eq!(e.kind(), gax::error::ErrorKind::Other, "{e}")
             }
-            _ => assert!(false, "{poll:?}"),
+            _ => panic!("{poll:?}"),
         };
     }
 
@@ -189,7 +189,7 @@ mod test {
             PollingResult::InProgress(m) => {
                 assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
             }
-            _ => assert!(false, "{poll:?}"),
+            _ => panic!("{poll:?}"),
         };
         Ok(())
     }
@@ -218,7 +218,7 @@ mod test {
                 let error = r.err().unwrap();
                 assert!(format!("{error}").contains("exhausted"), "{error}");
             }
-            _ => assert!(false, "{poll:?}"),
+            _ => panic!("{poll:?}"),
         };
         Ok(())
     }
@@ -241,7 +241,7 @@ mod test {
             PollingResult::PollingError(e) => {
                 assert_eq!(e.kind(), gax::error::ErrorKind::Other, "{e}")
             }
-            _ => assert!(false, "{poll:?}"),
+            _ => panic!("{poll:?}"),
         };
     }
 
@@ -265,7 +265,7 @@ mod test {
                 let e = r.err().unwrap();
                 assert_eq!(e.kind(), gax::error::ErrorKind::Other, "{e}")
             }
-            _ => assert!(false, "{poll:?}"),
+            _ => panic!("{poll:?}"),
         };
     }
 
@@ -290,7 +290,7 @@ mod test {
                 let response = r?;
                 assert_eq!(response, wkt::Duration::clamp(234, 0));
             }
-            _ => assert!(false, "{polling:?}"),
+            _ => panic!("{polling:?}"),
         };
         Ok(())
     }
@@ -311,7 +311,7 @@ mod test {
             PollingResult::InProgress(m) => {
                 assert_eq!(m, &Some(wkt::Timestamp::clamp(123, 0)));
             }
-            _ => assert!(false, "{polling:?}"),
+            _ => panic!("{polling:?}"),
         };
         Ok(())
     }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -341,9 +341,9 @@ mod test {
         let op = TestOperation::new(op);
         assert_eq!(op.name(), "test-only-name");
         assert!(!op.done());
-        assert!(matches!(op.metadata(), None));
-        assert!(matches!(op.response(), Some(_)));
-        assert!(matches!(op.error(), None));
+        assert!(op.metadata().is_none());
+        assert!(op.response().is_some());
+        assert!(op.error().is_none());
         let got = op
             .response()
             .unwrap()
@@ -412,7 +412,7 @@ mod test {
                 assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
             }
             r => {
-                assert!(false, "{r:?}");
+                panic!("{r:?}");
             }
         }
 
@@ -423,7 +423,7 @@ mod test {
                 assert_eq!(response, wkt::Duration::clamp(234, 0));
             }
             r => {
-                assert!(false, "{r:?}");
+                panic!("{r:?}");
             }
         }
 
@@ -470,7 +470,7 @@ mod test {
                 assert_eq!(m, Some(wkt::Timestamp::clamp(123, 0)));
             }
             r => {
-                assert!(false, "{r:?}");
+                panic!("{r:?}");
             }
         }
 
@@ -481,7 +481,7 @@ mod test {
                 assert_eq!(response, wkt::Duration::clamp(234, 0));
             }
             r => {
-                assert!(false, "{r:?}");
+                panic!("{r:?}");
             }
         }
 
@@ -594,7 +594,7 @@ mod test {
         };
 
         let query = move |_: String| async move {
-            return Err::<TestOperation, Error>(Error::other("unrecoverable (see policy below)"));
+            Err::<TestOperation, Error>(Error::other("unrecoverable (see policy below)"))
         };
 
         let poller = PollerImpl::new(

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -512,12 +512,10 @@ mod test {
         let got = Duration::try_from(input);
         assert!(got.is_err());
         let err = got.err().unwrap();
-        match err {
-            DurationError::Deserialize(_) => {
-                assert!(true)
-            }
-            _ => assert!(false, "unexpected error {err:?}"),
-        };
+        assert!(
+            matches!(err, DurationError::Deserialize(_)),
+            "unexpected error {err:?}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
`cargo clippy` does not lint the tests, `cargo clippy --profile=test` is
what we want to run.