### PR TITLE
Disable reqwest default-features in google-cloud-auth

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait    = "0.1"
 http           = "1"
-reqwest        = { version = "0.12", features = ["json"] }
+reqwest        = { version = "0.12", default-features = false, features = ["json"] }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"


### PR DESCRIPTION
This prevents downstream crates to pull openssl as a dependency.