### PR TITLE
fix: minimal reqwest features

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait    = "0.1"
 http           = "1"
-reqwest        = { version = "0.12", features = ["json"] }
+reqwest        = { version = "0.12", default-features=false, features = ["json"] }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait    = "0.1"
 http           = "1"
-reqwest        = { version = "0.12", default-features=false, features = ["json"] }
+reqwest        = { version = "0.12", default-features = false, features = ["json"] }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"
 thiserror      = "2"

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -57,7 +57,7 @@ http           = "1"
 http-body-util = "0.1"
 prost          = { workspace = true, optional = true }
 prost-types    = { workspace = true, optional = true }
-reqwest        = { version = "0.12", optional = true }
+reqwest        = { version = "0.12", default-features=false, optional = true }
 serde          = { version = "1", optional = true }
 serde_json     = { version = "1", optional = true }
 thiserror      = { version = "2", optional = true }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -57,7 +57,7 @@ http           = "1"
 http-body-util = "0.1"
 prost          = { workspace = true, optional = true }
 prost-types    = { workspace = true, optional = true }
-reqwest        = { version = "0.12", default-features=false, optional = true }
+reqwest        = { version = "0.12", default-features = false, optional = true }
 serde          = { version = "1", optional = true }
 serde_json     = { version = "1", optional = true }
 thiserror      = { version = "2", optional = true }


### PR DESCRIPTION
Use the minimal feature set for `reqwest` so downstream crates do not have to pull in extra deps.

Thanks to @lerouxrgd for the original PR: #1806

This is a good change, and we want it to be included in our release (which we want to do today).