### PR TITLE
chore: bump g-c-longrunning version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-longrunning"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ gax                           = { version = "0.21", path = "src/gax", package = 
 gaxi                          = { version = "0.1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.2", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 location                      = { version = "0.2", path = "src/generated/cloud/location", package = "google-cloud-location" }
-longrunning                   = { version = "0.22", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
+longrunning                   = { version = "0.23", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
 lro                           = { version = "0.1", path = "src/lro", package = "google-cloud-lro" }
 wkt                           = { version = "0.3", path = "src/wkt", package = "google-cloud-wkt" }
 api                           = { version = "0.2", path = "src/generated/api/types", package = "google-cloud-api" }

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -31,7 +31,7 @@ name = "getting_started"
 crc32c = "0.6"
 tokio  = { version = "1", features = ["full", "macros"] }
 # ANCHOR: longrunning
-google-cloud-longrunning = { version = "0.22", path = "../../src/generated/longrunning" }
+google-cloud-longrunning = { version = "0.23", path = "../../src/generated/longrunning" }
 # ANCHOR_END: longrunning
 # ANCHOR: gax
 google-cloud-gax = { version = "0.21", path = "../../src/gax" }

--- a/src/generated/longrunning/.sidekick.toml
+++ b/src/generated/longrunning/.sidekick.toml
@@ -14,7 +14,7 @@
 
 [general]
 specification-source = 'google/longrunning'
-service-config = 'google/longrunning/longrunning.yaml'
+service-config       = 'google/longrunning/longrunning.yaml'
 
 [source]
 description-override = """Defines types and an abstract service to handle long-running operations.
@@ -34,6 +34,8 @@ operations.
 [gcloud-longrunning]: https://crates.io/crates/gcloud-longrunning"""
 
 [codec]
-version = "0.22.0" # Match existing version
-copyright-year = '2024'
+# We override the default version for generated crates. We want the latest
+# version of `google-cloud-longrunning` to be this crate.
+version               = "0.23.0"
+copyright-year        = '2024'
 'package:longrunning' = 'ignore=true'

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-longrunning"
-version                = "0.22.0"
+version                = "0.23.0"
 description            = "Google Cloud Client Libraries for Rust - Long Running Operations API"
 edition.workspace      = true
 authors.workspace      = true


### PR DESCRIPTION
This is a generated crate, but we manually keep track of its version (because a `google-cloud-longrunning` already existed).

This crate has changes since the last release: https://github.com/googleapis/google-cloud-rust/commits/main/src/generated/longrunning

In preparation for our next release