### PR TITLE
feat(generator/dart): generate and implement the struct.proto well known types

### DIFF
--- a/generator/dart/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generator/dart/generated/google_cloud_protobuf/.sidekick.toml
@@ -20,7 +20,7 @@ name-override = 'protobuf'
 title-override = 'Core Protobuf Types'
 description-override = 'Core Protobuf types used by most services.'
 # Don't generate 'any.proto'; use the hand-written version in protobuf.p.dart.
-include-list = "duration.proto,empty.proto,field_mask.proto,timestamp.proto,wrappers.proto"
+include-list = "duration.proto,empty.proto,field_mask.proto,struct.proto,timestamp.proto,wrappers.proto"
 
 [codec]
 copyright-year = '2025'

--- a/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -107,10 +107,10 @@ class Duration extends Message {
     _validate();
   }
 
-  factory Duration.fromJson(Object json) => DurationHelper.decode(json);
+  factory Duration.fromJson(Object json) => _DurationHelper.decode(json);
 
   @override
-  Object toJson() => DurationHelper.encode(this);
+  Object toJson() => _DurationHelper.encode(this);
 
   @override
   String toString() {
@@ -356,13 +356,62 @@ class FieldMask extends Message {
     this.paths,
   }) : super(fullyQualifiedName);
 
-  factory FieldMask.fromJson(Object json) => FieldMaskHelper.decode(json);
+  factory FieldMask.fromJson(Object json) => _FieldMaskHelper.decode(json);
 
   @override
-  Object toJson() => FieldMaskHelper.encode(this);
+  Object toJson() => _FieldMaskHelper.encode(this);
 
   @override
   String toString() => 'FieldMask()';
+}
+
+/// `Struct` represents a structured data value, consisting of fields
+/// which map to dynamically typed values. In some languages, `Struct`
+/// might be supported by a native representation. For example, in
+/// scripting languages like JS a struct is represented as an
+/// object. The details of that representation are described together
+/// with the proto support for the language.
+///
+/// The JSON representation for `Struct` is JSON object.
+class Struct extends Message {
+  static const String fullyQualifiedName = 'google.protobuf.Struct';
+
+  /// Unordered map of dynamically typed values.
+  final Map<String, Value>? fields;
+
+  Struct({
+    this.fields,
+  }) : super(fullyQualifiedName);
+
+  factory Struct.fromJson(Object json) => _StructHelper.decode(json);
+
+  @override
+  Object toJson() => _StructHelper.encode(this);
+
+  @override
+  String toString() => 'Struct()';
+}
+
+/// `ListValue` is a wrapper around a repeated field of values.
+///
+/// The JSON representation for `ListValue` is JSON array.
+class ListValue extends Message {
+  static const String fullyQualifiedName = 'google.protobuf.ListValue';
+
+  /// Repeated field of dynamically typed values.
+  final List<Value>? values;
+
+  ListValue({
+    this.values,
+  }) : super(fullyQualifiedName);
+
+  factory ListValue.fromJson(Object json) => _ListValueHelper.decode(json);
+
+  @override
+  Object toJson() => _ListValueHelper.encode(this);
+
+  @override
+  String toString() => 'ListValue()';
 }
 
 /// A Timestamp represents a point in time independent of any time zone or local
@@ -475,10 +524,10 @@ class Timestamp extends Message {
     _validate();
   }
 
-  factory Timestamp.fromJson(Object json) => TimestampHelper.decode(json);
+  factory Timestamp.fromJson(Object json) => _TimestampHelper.decode(json);
 
   @override
-  Object toJson() => TimestampHelper.encode(this);
+  Object toJson() => _TimestampHelper.encode(this);
 
   @override
   String toString() {
@@ -503,10 +552,10 @@ class DoubleValue extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory DoubleValue.fromJson(Object json) => DoubleValueHelper.decode(json);
+  factory DoubleValue.fromJson(Object json) => _DoubleValueHelper.decode(json);
 
   @override
-  Object toJson() => DoubleValueHelper.encode(this);
+  Object toJson() => _DoubleValueHelper.encode(this);
 
   @override
   String toString() {
@@ -530,10 +579,10 @@ class FloatValue extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory FloatValue.fromJson(Object json) => FloatValueHelper.decode(json);
+  factory FloatValue.fromJson(Object json) => _FloatValueHelper.decode(json);
 
   @override
-  Object toJson() => FloatValueHelper.encode(this);
+  Object toJson() => _FloatValueHelper.encode(this);
 
   @override
   String toString() {
@@ -557,10 +606,10 @@ class Int64Value extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory Int64Value.fromJson(Object json) => Int64ValueHelper.decode(json);
+  factory Int64Value.fromJson(Object json) => _Int64ValueHelper.decode(json);
 
   @override
-  Object toJson() => Int64ValueHelper.encode(this);
+  Object toJson() => _Int64ValueHelper.encode(this);
 
   @override
   String toString() {
@@ -584,10 +633,10 @@ class Uint64Value extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory Uint64Value.fromJson(Object json) => Uint64ValueHelper.decode(json);
+  factory Uint64Value.fromJson(Object json) => _Uint64ValueHelper.decode(json);
 
   @override
-  Object toJson() => Uint64ValueHelper.encode(this);
+  Object toJson() => _Uint64ValueHelper.encode(this);
 
   @override
   String toString() {
@@ -611,10 +660,10 @@ class Int32Value extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory Int32Value.fromJson(Object json) => Int32ValueHelper.decode(json);
+  factory Int32Value.fromJson(Object json) => _Int32ValueHelper.decode(json);
 
   @override
-  Object toJson() => Int32ValueHelper.encode(this);
+  Object toJson() => _Int32ValueHelper.encode(this);
 
   @override
   String toString() {
@@ -638,10 +687,10 @@ class Uint32Value extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory Uint32Value.fromJson(Object json) => Uint32ValueHelper.decode(json);
+  factory Uint32Value.fromJson(Object json) => _Uint32ValueHelper.decode(json);
 
   @override
-  Object toJson() => Uint32ValueHelper.encode(this);
+  Object toJson() => _Uint32ValueHelper.encode(this);
 
   @override
   String toString() {
@@ -665,10 +714,10 @@ class BoolValue extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory BoolValue.fromJson(Object json) => BoolValueHelper.decode(json);
+  factory BoolValue.fromJson(Object json) => _BoolValueHelper.decode(json);
 
   @override
-  Object toJson() => BoolValueHelper.encode(this);
+  Object toJson() => _BoolValueHelper.encode(this);
 
   @override
   String toString() {
@@ -692,10 +741,10 @@ class StringValue extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory StringValue.fromJson(Object json) => StringValueHelper.decode(json);
+  factory StringValue.fromJson(Object json) => _StringValueHelper.decode(json);
 
   @override
-  Object toJson() => StringValueHelper.encode(this);
+  Object toJson() => _StringValueHelper.encode(this);
 
   @override
   String toString() {
@@ -719,10 +768,10 @@ class BytesValue extends Message {
     this.value,
   }) : super(fullyQualifiedName);
 
-  factory BytesValue.fromJson(Object json) => BytesValueHelper.decode(json);
+  factory BytesValue.fromJson(Object json) => _BytesValueHelper.decode(json);
 
   @override
-  Object toJson() => BytesValueHelper.encode(this);
+  Object toJson() => _BytesValueHelper.encode(this);
 
   @override
   String toString() {
@@ -731,4 +780,20 @@ class BytesValue extends Message {
     ].join(',');
     return 'BytesValue($contents)';
   }
+}
+
+/// `NullValue` is a singleton enumeration to represent the null value for the
+/// `Value` type union.
+///
+/// The JSON representation for `NullValue` is JSON `null`.
+class NullValue extends Enum {
+  /// Null value.
+  static const nullValue = NullValue('NULL_VALUE');
+
+  const NullValue(super.value);
+
+  factory NullValue.fromJson(String json) => NullValue(json);
+
+  @override
+  String toString() => 'NullValue.$value';
 }

--- a/generator/dart/generated/google_cloud_protobuf/test/struct_test.dart
+++ b/generator/dart/generated/google_cloud_protobuf/test/struct_test.dart
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:google_cloud_protobuf/protobuf.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Struct', () {
+    const data = '''{
+  "indexes_entries_scanned": "1000",
+  "documents_scanned": "20",
+  "billing_details" : {
+    "documents_billable": "20",
+    "index_entries_billable": "1000",
+    "min_query_cost": "0"
+  }
+}
+''';
+
+    final struct = Struct.fromJson(jsonDecode(data));
+    expect(struct.fields, hasLength(3));
+    expect(struct.fields!['billing_details'], isA<Value>());
+    final billingDetails = struct.fields!['billing_details']!;
+    expect(billingDetails.structValue, isNotNull);
+
+    expect(struct.toJson(), isA<Map>());
+  });
+
+  test('ListValue', () {
+    const data = '''[
+  {"query_scope": "Collection", "properties": "(foo ASC, __name__ ASC)"},
+  {"query_scope": "Collection", "properties": "(bar ASC, __name__ ASC)"}
+]
+''';
+
+    final list = ListValue.fromJson(jsonDecode(data));
+    expect(list.values, hasLength(2));
+    expect(list.values![0].structValue, isNotNull);
+    expect(list.values![1].structValue, isNotNull);
+    final childStruct = list.values![0].structValue!;
+    expect(childStruct.fields, hasLength(2));
+
+    expect(list.toJson(), isA<List>());
+  });
+
+  test('NullValue', () {
+    expect(Value.fromJson(null).nullValue, isNotNull);
+    expect(Value.fromJson('foo').nullValue, isNull);
+
+    expect(Value(nullValue: NullValue.nullValue).toJson(), isNull);
+  });
+
+  group('Value', () {
+    test('numberValue', () {
+      expect(Value.fromJson(3).numberValue, 3);
+      expect(Value.fromJson(3.14).numberValue, 3.14);
+
+      expect(Value(numberValue: 3).toJson(), 3);
+      expect(Value(numberValue: 3.14).toJson(), 3.14);
+    });
+
+    test('stringValue', () {
+      expect(Value.fromJson('foo bar').stringValue, 'foo bar');
+      expect(Value(stringValue: 'foo bar').toJson(), 'foo bar');
+    });
+
+    test('boolValue', () {
+      expect(Value.fromJson(true).boolValue, true);
+      expect(Value(boolValue: true).toJson(), true);
+    });
+
+    test('structValue', () {
+      const data = '{"foo": "one", "bar": 3.14, "baz": null}';
+
+      final struct = Value.fromJson(jsonDecode(data)).structValue;
+      expect(struct, isNotNull);
+      expect(struct!.fields, hasLength(3));
+
+      final actual = struct.toJson();
+      expect(actual, isA<Map>());
+      expect(actual, hasLength(3));
+      expect((actual as Map)['foo'], 'one');
+      expect(actual['bar'], 3.14);
+      expect(actual['baz'], isNull);
+    });
+
+    test('listValue', () {
+      const data = '["foo", 3, false, true, 3.14, null]';
+
+      final list = Value.fromJson(jsonDecode(data)).listValue;
+      expect(list, isNotNull);
+      expect(list!.values, hasLength(6));
+
+      final actual = list.toJson();
+      expect(actual, isA<List>());
+      expect(actual, hasLength(6));
+      expect((actual as List).join(','), 'foo,3.0,false,true,3.14,null');
+    });
+  });
+}

--- a/generator/dart/generated/google_cloud_protobuf/test/timestamp_test.dart
+++ b/generator/dart/generated/google_cloud_protobuf/test/timestamp_test.dart
@@ -29,13 +29,13 @@ void main() {
   });
 
   test('min seconds', () {
-    final timestamp = TimestampHelper.decode('0001-01-01T00:00:00Z');
+    final timestamp = Timestamp.fromJson('0001-01-01T00:00:00Z');
     expect(timestamp.seconds, TimestampExtension.minSeconds);
     expect(timestamp.nanos, 0);
   });
 
   test('max seconds', () {
-    final timestamp = TimestampHelper.decode('9999-12-31T23:59:59Z');
+    final timestamp = Timestamp.fromJson('9999-12-31T23:59:59Z');
     expect(timestamp.seconds, TimestampExtension.maxSeconds);
     expect(timestamp.nanos, 0);
   });

--- a/generator/dart/packages/google_cloud_gax/lib/common.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/common.dart
@@ -24,7 +24,7 @@ const String _clientName = 'dart-test-client';
 /// Classes that implement [JsonEncodable] will often have a `fromJson()`
 /// constructor.
 abstract class JsonEncodable {
-  Object toJson();
+  Object? toJson();
 }
 
 /// The abstract common superclass of all messages.

--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -30,6 +30,7 @@ import (
 
 var omitGeneration = map[string]string{
 	".google.longrunning.Operation": "",
+	".google.protobuf.Value":        "",
 }
 
 type modelAnnotations struct {

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -47,10 +47,13 @@ var usesCustomEncoding = map[string]string{
 	".google.protobuf.FloatValue":  "",
 	".google.protobuf.Int32Value":  "",
 	".google.protobuf.Int64Value":  "",
+	".google.protobuf.ListValue":   "",
 	".google.protobuf.StringValue": "",
+	".google.protobuf.Struct":      "",
 	".google.protobuf.Timestamp":   "",
 	".google.protobuf.UInt32Value": "",
 	".google.protobuf.UInt64Value": "",
+	".google.protobuf.Value":       "",
 }
 
 // Used to concatenate a message and a child message.

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -31,7 +31,7 @@ class {{Codec.Name}} extends Message {
   }{{/Codec.HasFields}}) : super(fullyQualifiedName){{Codec.ConstructorBody}}
 
   {{#Codec.HasCustomEncoding}}
-  factory {{Codec.Name}}.fromJson(Object json) => {{Codec.Name}}Helper.decode(json);
+  factory {{Codec.Name}}.fromJson(Object json) => _{{Codec.Name}}Helper.decode(json);
   {{/Codec.HasCustomEncoding}}
   {{^Codec.HasCustomEncoding}}
   factory {{Codec.Name}}.fromJson(Map<String, dynamic> json) {
@@ -45,7 +45,7 @@ class {{Codec.Name}} extends Message {
 
   @override
   {{#Codec.HasCustomEncoding}}
-  Object toJson() => {{Codec.Name}}Helper.encode(this);
+  Object toJson() => _{{Codec.Name}}Helper.encode(this);
   {{/Codec.HasCustomEncoding}}
   {{^Codec.HasCustomEncoding}}
   Object toJson() {


### PR DESCRIPTION
- generate and implement the `struct.proto` well known types
- make the various `FooHelper` classses library private (these are used to implement custom json encodings; they don't need to be visible outside the library)
- closes https://github.com/googleapis/google-cloud-rust/issues/1574

This allows generation of `google_cloud_firestore_v1` - it uses `Struct` and `NullValue`; we're able to make some calls with that library now.

Generating NullValue meant we had to adjust the types for toJson() a bit - we hadn't expected `null` values to be produced.

This _should_ complete all the messages that have custom encodings.

The `Value` class needed enough customization post-generation (mostly to deal with null values in and out) that I decided to generate and modify it rather than parameterize the mustache templates for a single use case. We're also doing this (using hand-written versions) for `Any` and `Operation`. We _could_ generate unmodified versions of these to markdown files, check those in, and use the diffs to be aware of any upstream changes. I understand changes to these types to be extremely rare, but it might be useful to known about doc changes and such.
