### PR TITLE
docs: fix typos in user guide

### DIFF
--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -22,12 +22,12 @@ interact with Google Cloud Services.
 This guide is organized as a series of small tutorials showing how to perform
 specific actions with the client libraries. Most Google Cloud services follow a
 series of guidelines, collectively known as the [AIPs](https://google.aip.dev).
-This makes the client libraries more from one service to the next. The functions
+This makes the client libraries more consistent from one service to the next. The functions
 to delete or list resources almost always have the same interface.
 
 ## Audience
 
-This guide is intended for Rust developers that are familiar with the language
+This guide is intended for Rust developers who are familiar with the language
 and the Rust ecosystem. We will assume you know how to use Rust and its
 supporting toolchain.
 
@@ -38,13 +38,13 @@ initialize their projects and services.
 
 ## Service specific documentation
 
-These guides are not intended as tutorials for each services or as extended guides
+These guides are not intended as tutorials for each service or as extended guides
 on how to design Rust applications to work on Google Cloud. They are starting
 points to get you productive with the client libraries for Rust.
 
 We recommend you read the service documentation at <https://cloud.google.com> to
-learn more each service. If you need guidance on how to design your application
-for Google Cloud the [Cloud Architecture Center] may have what you are looking
+learn more about each service. If you need guidance on how to design your application
+for Google Cloud, the [Cloud Architecture Center] may have what you are looking
 for.
 
 ## Reporting bugs

--- a/guide/src/working_with_long_running_operations.md
+++ b/guide/src/working_with_long_running_operations.md
@@ -23,7 +23,7 @@ promise to the user and allow the user to check back in later.
 
 The Google Cloud Client Libraries for Rust provide helpers to work with these
 long-running operations (LROs). This guide will show you how to start LROs and
-wait for their complication.
+wait for their completion.
 
 ## Prerequisites
 
@@ -272,7 +272,7 @@ And then poll the operation to get its new status:
 ```
 
 For simplicity, we have chosen to ignore all errors. In your application you
-may chose to treat only a subset of the errors as non-recoverable, and may want
+may choose to treat only a subset of the errors as non-recoverable, and may want
 to limit the number of polling attempts if these fail.
 
 You can find the [full function](#manually-polling-a-long-running-operation-complete-code) below.


### PR DESCRIPTION
This PR fixes minor typos in two chapters of the User Guide:

1. Introduction
2. Working with long-running operations