### PR TITLE
fix(generator/dart): handle parsing NaN, Infinity, and -Infinity for doubles

### DIFF
--- a/generator/dart/generated/google_cloud_language_v2/lib/language.dart
+++ b/generator/dart/generated/google_cloud_language_v2/lib/language.dart
@@ -382,8 +382,8 @@ class Sentiment extends Message {
   @override
   Object toJson() {
     return {
-      if (magnitude != null) 'magnitude': magnitude,
-      if (score != null) 'score': score,
+      if (magnitude != null) 'magnitude': encodeDouble(magnitude),
+      if (score != null) 'score': encodeDouble(score),
     };
   }
 
@@ -443,7 +443,7 @@ class EntityMention extends Message {
       if (text != null) 'text': text!.toJson(),
       if (type != null) 'type': type!.toJson(),
       if (sentiment != null) 'sentiment': sentiment!.toJson(),
-      if (probability != null) 'probability': probability,
+      if (probability != null) 'probability': encodeDouble(probability),
     };
   }
 
@@ -554,8 +554,8 @@ class ClassificationCategory extends Message {
   Object toJson() {
     return {
       if (name != null) 'name': name,
-      if (confidence != null) 'confidence': confidence,
-      if (severity != null) 'severity': severity,
+      if (confidence != null) 'confidence': encodeDouble(confidence),
+      if (severity != null) 'severity': encodeDouble(severity),
     };
   }
 

--- a/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -373,50 +373,42 @@ class _TimestampHelper {
 }
 
 class _DoubleValueHelper {
-  static double encode(DoubleValue value) {
-    return value.value!;
+  static Object encode(DoubleValue value) {
+    return encodeDouble(value.value)!;
   }
 
   static DoubleValue decode(Object value) {
-    return DoubleValue(value: value as double);
+    return DoubleValue(value: decodeDouble(value)!);
   }
 }
 
 class _FloatValueHelper {
-  static double encode(FloatValue value) {
-    return value.value!;
+  static Object encode(FloatValue value) {
+    return encodeDouble(value.value)!;
   }
 
   static FloatValue decode(Object value) {
-    return FloatValue(value: value as double);
+    return FloatValue(value: decodeDouble(value)!);
   }
 }
 
 class _Int64ValueHelper {
   static String encode(Int64Value value) {
-    return '${value.value}';
+    return encodeInt64(value.value)!;
   }
 
   static Int64Value decode(Object value) {
-    if (value is String) {
-      return Int64Value(value: int.parse(value));
-    } else {
-      return Int64Value(value: value as int);
-    }
+    return Int64Value(value: decodeInt64(value)!);
   }
 }
 
 class _Uint64ValueHelper {
   static String encode(Uint64Value value) {
-    return '${value.value}';
+    return encodeInt64(value.value)!;
   }
 
   static Uint64Value decode(Object value) {
-    if (value is String) {
-      return Uint64Value(value: int.parse(value));
-    } else {
-      return Uint64Value(value: value as int);
-    }
+    return Uint64Value(value: decodeInt64(value)!);
   }
 }
 

--- a/generator/dart/generated/google_cloud_protobuf/test/wrappers_test.dart
+++ b/generator/dart/generated/google_cloud_protobuf/test/wrappers_test.dart
@@ -29,12 +29,44 @@ void main() {
     var expected = FloatValue(value: 0.5);
     var actual = FloatValue.fromJson(encodeDecode(expected.toJson()));
     expect(actual.value, expected.value);
+
+    expect(FloatValue.fromJson(1).value, 1.0);
   });
 
   test('DoubleValue', () {
     var expected = DoubleValue(value: 0.5);
     var actual = DoubleValue.fromJson(encodeDecode(expected.toJson()));
     expect(actual.value, expected.value);
+
+    expect(DoubleValue.fromJson(1).value, 1.0);
+  });
+
+  group('NaN and Infinity', () {
+    test('FloatValue', () {
+      expect(FloatValue.fromJson('NaN').value, isNaN);
+      expect(FloatValue.fromJson('Infinity').value, double.infinity);
+      expect(FloatValue.fromJson('-Infinity').value, double.negativeInfinity);
+
+      // don't allow arbitrary strings for floats
+      expect(() => FloatValue.fromJson('1.0').value, throwsFormatException);
+
+      expect(FloatValue(value: double.nan).toJson(), 'NaN');
+      expect(FloatValue(value: double.infinity).toJson(), 'Infinity');
+      expect(FloatValue(value: double.negativeInfinity).toJson(), '-Infinity');
+    });
+
+    test('DoubleValue', () {
+      expect(DoubleValue.fromJson('NaN').value, isNaN);
+      expect(DoubleValue.fromJson('Infinity').value, double.infinity);
+      expect(DoubleValue.fromJson('-Infinity').value, double.negativeInfinity);
+
+      // don't allow arbitrary strings for doubles
+      expect(() => DoubleValue.fromJson('1.0').value, throwsFormatException);
+
+      expect(DoubleValue(value: double.nan).toJson(), 'NaN');
+      expect(DoubleValue(value: double.infinity).toJson(), 'Infinity');
+      expect(DoubleValue(value: double.negativeInfinity).toJson(), '-Infinity');
+    });
   });
 
   test('Int64Value', () {

--- a/generator/dart/generated/google_cloud_type/lib/type.dart
+++ b/generator/dart/generated/google_cloud_type/lib/type.dart
@@ -191,9 +191,9 @@ class Color extends Message {
   @override
   Object toJson() {
     return {
-      if (red != null) 'red': red,
-      if (green != null) 'green': green,
-      if (blue != null) 'blue': blue,
+      if (red != null) 'red': encodeDouble(red),
+      if (green != null) 'green': encodeDouble(green),
+      if (blue != null) 'blue': encodeDouble(blue),
       if (alpha != null) 'alpha': alpha!.toJson(),
     };
   }
@@ -733,8 +733,8 @@ class LatLng extends Message {
   @override
   Object toJson() {
     return {
-      if (latitude != null) 'latitude': latitude,
-      if (longitude != null) 'longitude': longitude,
+      if (latitude != null) 'latitude': encodeDouble(latitude),
+      if (longitude != null) 'longitude': encodeDouble(longitude),
     };
   }
 
@@ -1257,10 +1257,10 @@ class Quaternion extends Message {
   @override
   Object toJson() {
     return {
-      if (x != null) 'x': x,
-      if (y != null) 'y': y,
-      if (z != null) 'z': z,
-      if (w != null) 'w': w,
+      if (x != null) 'x': encodeDouble(x),
+      if (y != null) 'y': encodeDouble(y),
+      if (z != null) 'z': encodeDouble(z),
+      if (w != null) 'w': encodeDouble(w),
     };
   }
 

--- a/generator/dart/packages/google_cloud_gax/lib/src/encoding.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/src/encoding.dart
@@ -30,7 +30,15 @@ int? decodeInt64(Object? value) {
 
 /// Decode a `double` value.
 double? decodeDouble(Object? value) {
-  return (value as num?)?.toDouble();
+  if (value is String) {
+    if (value == 'NaN' || value == 'Infinity' || value == '-Infinity') {
+      return double.parse(value);
+    } else {
+      throw FormatException('String value is not NaN, Infinity, or -Infinity');
+    }
+  } else {
+    return (value as num?)?.toDouble();
+  }
 }
 
 /// Decode a `bytes` value.
@@ -120,6 +128,15 @@ Map<K, V>? decodeMapMessageCustom<K, V extends Message>(
 
 /// Encode an `int64` value into JSON.
 String? encodeInt64(int? value) => value == null ? null : '$value';
+
+/// Encode 'float` and `double` values into JSON.
+Object? encodeDouble(double? value) {
+  if (value == null) {
+    return null;
+  }
+
+  return value.isNaN || value.isInfinite ? '$value' : value;
+}
 
 /// Encode a `bytes` value into JSON.
 String? encodeBytes(Uint8List? value) {

--- a/generator/dart/packages/google_cloud_gax/test/encoding_test.dart
+++ b/generator/dart/packages/google_cloud_gax/test/encoding_test.dart
@@ -27,6 +27,21 @@ void main() {
   test('double', () {
     expect(decodeDouble(1), 1);
     expect(decodeDouble(1.1), 1.1);
+    expect(decodeDouble(encodeDouble(1)), 1);
+    expect(decodeDouble(encodeDouble(1.1)), 1.1);
+  });
+
+  test('double NaN', () {
+    expect(decodeDouble('NaN'), isNaN);
+    expect(decodeDouble('Infinity'), double.infinity);
+    expect(decodeDouble('-Infinity'), double.negativeInfinity);
+
+    // don't allow arbitrary strings for doubles
+    expect(() => decodeDouble('1.0'), throwsFormatException);
+
+    expect(encodeDouble(double.nan), 'NaN');
+    expect(encodeDouble(double.infinity), 'Infinity');
+    expect(encodeDouble(double.negativeInfinity), '-Infinity');
   });
 
   test('enum', () {

--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -646,6 +646,8 @@ func createToJsonLine(field *api.Field, state *api.APIState, required bool) stri
 		return fmt.Sprintf("encodeBytes(%s)", name)
 	case field.Typez == api.INT64_TYPE || field.Typez == api.UINT64_TYPE:
 		return fmt.Sprintf("encodeInt64(%s)", name)
+	case field.Typez == api.FLOAT_TYPE || field.Typez == api.DOUBLE_TYPE:
+		return fmt.Sprintf("encodeDouble(%s)", name)
 	default:
 	}
 


### PR DESCRIPTION
- handle parsing NaN, Infinity, and -Infinity for doubles
- fix https://github.com/googleapis/google-cloud-rust/issues/1808

When decoding doubles, we now can decode a double, or the strings `'NaN'`, `'Infinity'`, and `'-Infinity'` (but don't parse arbitrary strings as doubles). We now encode doubles as either a double, or as one of the three strings above.
