### PR TITLE
impl(generator/rust): parse routing extensions

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -135,6 +135,8 @@ type Method struct {
 	ServerSideStreaming bool
 	// For methods returning long-running operations
 	OperationInfo *OperationInfo
+	// The routing annotations, if any
+	Routing []*RoutingInfo
 	// The model this method belongs to, mustache templates use this field to
 	// navigate the data structure.
 	Model *API
@@ -185,6 +187,48 @@ type OperationInfo struct {
 	// Language specific annotations
 	Codec any
 }
+
+// Normalize routing info
+//
+// The routing information format is documented in:
+//
+//	https://github.com/googleapis/googleapis/blob/113746270b58d12303e1e4f5eb01bc822aa7d68d/google/api/routing.proto#L406
+//
+// At a high level, it consists of a field name (from the request) that is used
+// to match a certain path template. If the value of the field matches the
+// template, the matching portion is added to `x-goog-request-params`.
+//
+// Of interest to us is the general format of the template. The documentation
+// does not provide a grammar or other specification of the template, just a
+// series of examples, which we won't duplicate here. From these examples we
+// glean that the template must match this grammar:
+//
+// template := [ path_spec "/" ] "{" name "=" path_spec "}" [ "/" patch_spec ]
+// segment := "*" | "**" | literal
+// path_spec := segment ( "/" segment )...
+// literal is a string matching `[a-z][a-z_]*`
+// name is a string matching `[a-z][a-z_]*`
+type RoutingInfo struct {
+	// The name of the field containing the routing information
+	FieldName string
+	// The name in `x-goog-request-params`
+	Name     string
+	Matching RoutingPathSpec
+	// The prefix and suffix (maybe empty)
+	Prefix RoutingPathSpec
+	Suffix RoutingPathSpec
+}
+
+type RoutingPathSpec struct {
+	Segments []string
+}
+
+const (
+	// A special routing path segment which indicates "match anything that does not include a `/`"
+	RoutingSegmentSingle = "*"
+	// A special routing path segment which indicates "match anything including `/`"
+	RoutingSegmentMulti = "**"
+)
 
 // A path segment is either a string literal (such as "projects") or a field
 // path (such as "options.version").

--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -210,7 +210,7 @@ type OperationInfo struct {
 // name is a string matching `[a-z][a-z_]*`
 type RoutingInfo struct {
 	// The name of the field containing the routing information
-	FieldName string
+	FieldPath []string
 	// The name in `x-goog-request-params`
 	Name     string
 	Matching RoutingPathSpec

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -440,6 +440,11 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		slog.Error("unsupported http method", "method", m)
 		return nil
 	}
+	routing, err := parseRoutingAnnotations(mFQN, m)
+	if err != nil {
+		slog.Error("cannot parse routing annotations", "method", m, "err", err)
+		return nil
+	}
 	outputTypeID := m.GetOutputType()
 	method := &api.Method{
 		ID:                  mFQN,
@@ -450,6 +455,7 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		ClientSideStreaming: m.GetClientStreaming(),
 		ServerSideStreaming: m.GetServerStreaming(),
 		OperationInfo:       parseOperationInfo(packagez, m),
+		Routing:             routing,
 		ReturnsEmpty:        outputTypeID == ".google.protobuf.Empty",
 	}
 	state.MethodByID[mFQN] = method

--- a/generator/internal/parser/routing_info.go
+++ b/generator/internal/parser/routing_info.go
@@ -61,9 +61,6 @@ func parseRoutingInfo(methodID string, routing *annotations.RoutingParameter) (*
 func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo, error) {
 	fieldPath := strings.Split(fieldName, ".")
 	if pathTemplate == "" {
-		if len(fieldPath) != 1 {
-			return nil, fmt.Errorf("fieldName (%q) cannot have '.' when path_template is empty", fieldName)
-		}
 		info := &api.RoutingInfo{
 			FieldPath: fieldPath,
 			Name:      fieldName,
@@ -73,6 +70,10 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 		}
 		return info, nil
 	}
+	if strings.Count(pathTemplate, api.RoutingSegmentMulti) > 1 {
+		return nil, fmt.Errorf("too many `**` matchers in pathTemplate=%q", pathTemplate)
+	}
+
 	pos := 0
 	prefix, width := parseRoutingPrefix(pathTemplate[pos:])
 	pos += width

--- a/generator/internal/parser/routing_info.go
+++ b/generator/internal/parser/routing_info.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func parseRoutingAnnotations(methodID string, m *descriptorpb.MethodDescriptorProto) ([]*api.RoutingInfo, error) {
+	var info []*api.RoutingInfo
+	extensionId := annotations.E_Routing
+	if !proto.HasExtension(m.GetOptions(), extensionId) {
+		return info, nil
+	}
+
+	rule := proto.GetExtension(m.GetOptions(), extensionId).(*annotations.RoutingRule)
+	var errs []error
+	for _, routing := range rule.GetRoutingParameters() {
+		new, err := parseRoutingInfo(methodID, routing)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		info = append(info, new)
+	}
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
+	}
+	return info, nil
+}
+
+func parseRoutingInfo(methodID string, routing *annotations.RoutingParameter) (*api.RoutingInfo, error) {
+	pathTemplate := routing.GetPathTemplate()
+	fieldName := routing.GetField()
+	if pathTemplate == "" {
+		info := &api.RoutingInfo{
+			FieldName: fieldName,
+			Name:      fieldName,
+			Matching: api.RoutingPathSpec{
+				Segments: []string{api.RoutingSegmentMulti},
+			},
+		}
+		return info, nil
+	}
+	info, err := parseRoutingPathTemplate(fieldName, pathTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("%w, method=%s", err, methodID)
+	}
+	info.FieldName = routing.GetField()
+	return info, nil
+}
+
+func parseRoutingPathTemplate(defaultName, pathTemplate string) (*api.RoutingInfo, error) {
+	pos := 0
+	prefix, width := parseRoutingPrefix(pathTemplate[pos:])
+	pos += width
+	if !strings.HasPrefix(pathTemplate[pos:], "{") {
+		return nil, fmt.Errorf("expected '{', found=%s", pathTemplate[pos:])
+	}
+	pos += 1
+	name, match, width, err := parseRoutingVariable(defaultName, pathTemplate[pos:])
+	if err != nil {
+		return nil, err
+	}
+	pos += width
+	if !strings.HasPrefix(pathTemplate[pos:], "}") {
+		return nil, fmt.Errorf("expected '}', found=%s", pathTemplate[pos:])
+	}
+	pos += 1
+	suffix := api.RoutingPathSpec{}
+	if strings.HasPrefix(pathTemplate[pos:], "/") {
+		pos += 1
+		suffix, width = parseRoutingSuffix(pathTemplate[pos:])
+		pos += width
+	}
+	if pathTemplate[pos:] != "" {
+		return nil, fmt.Errorf("unexpected trailer in pathTemplate trailer=%s", pathTemplate[pos:])
+	}
+	info := &api.RoutingInfo{
+		FieldName: name,
+		Name:      name,
+		Prefix:    prefix,
+		Matching:  match,
+		Suffix:    suffix,
+	}
+	return info, nil
+}
+
+func parseRoutingPrefix(pathTemplate string) (api.RoutingPathSpec, int) {
+	return parseRoutingPathSpec(pathTemplate)
+}
+
+func parseRoutingVariable(defaultName, pathTemplate string) (string, api.RoutingPathSpec, int, error) {
+	spec, width := parseRoutingPathSpec(pathTemplate)
+	if strings.HasPrefix(pathTemplate[width:], "=") {
+		pos := width + 1
+		// The initial spec must be a simple name.
+		if len(spec.Segments) != 1 || spec.Segments[0] == api.RoutingSegmentMulti || spec.Segments[0] == api.RoutingSegmentSingle {
+			return "", api.RoutingPathSpec{}, 0, fmt.Errorf("expected name=pathspec, but the name format is invalid name=%v", spec.Segments)
+		}
+		name := spec.Segments[0]
+		spec, width := parseRoutingPathSpec(pathTemplate[pos:])
+		return name, spec, pos + width, nil
+	}
+	return defaultName, spec, width, nil
+}
+
+func parseRoutingSuffix(pathTemplate string) (api.RoutingPathSpec, int) {
+	return parseRoutingPathSpec(pathTemplate)
+}
+
+func parseRoutingPathSpec(pathTemplate string) (api.RoutingPathSpec, int) {
+	segment, width := parseRoutingSegment(pathTemplate)
+	if segment == "" {
+		return api.RoutingPathSpec{}, width
+	}
+	if !strings.HasPrefix(pathTemplate[width:], "/") {
+		return api.RoutingPathSpec{Segments: []string{segment}}, width
+	}
+	pos := width + 1
+	spec, width := parseRoutingPathSpec(pathTemplate[pos:])
+	spec.Segments = append([]string{segment}, spec.Segments...)
+	return spec, width + pos
+}
+
+func parseRoutingSegment(pathTemplate string) (string, int) {
+	if strings.HasPrefix(pathTemplate, api.RoutingSegmentMulti) {
+		return api.RoutingSegmentMulti, len(api.RoutingSegmentMulti)
+	}
+	if strings.HasPrefix(pathTemplate, api.RoutingSegmentSingle) {
+		return api.RoutingSegmentSingle, len(api.RoutingSegmentSingle)
+	}
+	index := strings.IndexAny(pathTemplate, "=/{}")
+	if index == -1 {
+		return pathTemplate, len(pathTemplate)
+	}
+	return pathTemplate[:index], index
+}

--- a/generator/internal/parser/routing_info_test.go
+++ b/generator/internal/parser/routing_info_test.go
@@ -1,0 +1,393 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/google-cloud-rust/generator/internal/api"
+)
+
+func TestExamples(t *testing.T) {
+	tests := []struct {
+		methodID string
+		want     []*api.RoutingInfo
+	}{
+		{
+			".test.TestService.Example1",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "app_profile_id",
+					Name:      "app_profile_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example2",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "app_profile_id",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example3a",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "table_name",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example3b",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "table_name",
+					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example3c",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "table_name",
+					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "table_name",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example4",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example5",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example6a",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "project_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"instances", "*", "**"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "instance_id",
+					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example6b",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "project_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "instance_id",
+					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example7",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "project_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "app_profile_id",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example8",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "app_profile_id",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+			},
+		},
+		{
+			".test.TestService.Example9",
+			[]*api.RoutingInfo{
+				{
+					FieldName: "table_name",
+					Name:      "table_location",
+					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "table_location",
+					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
+				},
+				{
+					FieldName: "table_name",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "app_profile_id",
+					Name:      "routing_id",
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				},
+				{
+					FieldName: "app_profile_id",
+					Name:      "routing_id",
+					Prefix:    api.RoutingPathSpec{Segments: []string{"profiles"}},
+					Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
+				},
+			},
+		},
+	}
+
+	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "routing_info.proto"))
+	for _, tc := range tests {
+		t.Run(tc.methodID, func(t *testing.T) {
+			got, ok := test.State.MethodByID[tc.methodID]
+			if !ok {
+				t.Fatalf("Cannot find method %s in API State", tc.methodID)
+			}
+			if diff := cmp.Diff(got.Routing, tc.want); diff != "" {
+				t.Errorf("routing mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParsePathTemplateSuccess(t *testing.T) {
+	tests := []struct {
+		path string
+		want api.RoutingInfo
+	}{
+		{
+			"{**}",
+			api.RoutingInfo{
+				FieldName: "default",
+				Name:      "default",
+				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+			},
+		},
+		{
+			"{routing=**}",
+			api.RoutingInfo{
+				FieldName: "routing",
+				Name:      "routing",
+				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+			},
+		},
+		{
+			"{routing=a/*/b/**}",
+			api.RoutingInfo{
+				FieldName: "routing",
+				Name:      "routing",
+				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+			},
+		},
+		{
+			"p/*/q/*/{routing=a/*/b/**}",
+			api.RoutingInfo{
+				FieldName: "routing",
+				Name:      "routing",
+				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+			},
+		},
+		{
+			"p/*/q/*/{routing=a/*/b/**}/s/*/u/*/v/**",
+			api.RoutingInfo{
+				FieldName: "routing",
+				Name:      "routing",
+				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+				Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			got, err := parseRoutingPathTemplate("default", tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(got, &tc.want); diff != "" {
+				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestParsePathTemplateFailures(t *testing.T) {
+	tests := []string{
+		"",
+		"projects/*",
+		"projects/*}",
+		"projects/*/}",
+		"projects/*/{",
+		"projects/*/{{",
+		"projects/*/{a/b/c=**}",
+		"projects/*/{routing_id=**}foo",
+	}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			got, err := parseRoutingPathTemplate("default", path)
+			if err == nil {
+				t.Errorf("expected error for %q, got=%v", path, got)
+			}
+		})
+	}
+}
+
+func TestParseVariableSuccess(t *testing.T) {
+	tests := []struct {
+		path        string
+		wantName    string
+		wantSpec    api.RoutingPathSpec
+		wantTrailer string
+	}{
+		{"**", "default", api.RoutingPathSpec{Segments: []string{"**"}}, ""},
+		{"routing=**", "routing", api.RoutingPathSpec{Segments: []string{"**"}}, ""},
+		{"routing=a/*/b/**", "routing", api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}}, ""},
+		{"routing=a/*/b/**}", "routing", api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}}, "}"},
+		{"routing=a/*/b/**}/c/*", "routing", api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}}, "}/c/*"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			gotName, gotSpec, width, err := parseRoutingVariable("default", tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotName != tc.wantName {
+				t.Errorf("mistmatched variable names, want=%s, got=%s", tc.wantName, gotName)
+			}
+			if diff := cmp.Diff(gotSpec, tc.wantSpec); diff != "" {
+				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
+			}
+			if tc.path[width:] != tc.wantTrailer {
+				t.Errorf("trailer segment mismatch, want=%s, got=%s", tc.wantTrailer, tc.path[width:])
+			}
+		})
+	}
+}
+
+func TestParseRoutingVariableError(t *testing.T) {
+	tests := []string{"=**", "a/b=**"}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			gotName, gotSpec, _, err := parseRoutingVariable("default", path)
+			if err == nil {
+				t.Errorf("expected error for %q, gotName=%s, gotSpec=%v", path, gotName, gotSpec)
+			}
+		})
+	}
+}
+
+func TestParseRoutingPathSpecSuccess(t *testing.T) {
+	tests := []struct {
+		path         string
+		wantTrailer  string
+		wantSegments []string
+	}{
+		{"**", "", []string{"**"}},
+		{"a/b/c", "", []string{"a", "b", "c"}},
+		{"a/*/b/*/c/**", "", []string{"a", "*", "b", "*", "c", "**"}},
+		{"a/*/b/*}/c/**", "}/c/**", []string{"a", "*", "b", "*"}},
+		{"a=b/*/c/*", "=b/*/c/*", []string{"a"}},
+		{"a/b=b/*/c/*", "=b/*/c/*", []string{"a", "b"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			got, width := parseRoutingPathSpec(tc.path)
+			if diff := cmp.Diff(got.Segments, tc.wantSegments); diff != "" {
+				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)
+			}
+			if tc.path[width:] != tc.wantTrailer {
+				t.Errorf("trailer segment mismatch, want=%s, got=%s", tc.wantTrailer, tc.path[width:])
+			}
+		})
+	}
+}

--- a/generator/internal/parser/routing_info_test.go
+++ b/generator/internal/parser/routing_info_test.go
@@ -30,7 +30,7 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example1",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "app_profile_id",
+					FieldPath: []string{"app_profile_id"},
 					Name:      "app_profile_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 				},
@@ -40,7 +40,7 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example2",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "app_profile_id",
+					FieldPath: []string{"app_profile_id"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 				},
@@ -50,7 +50,7 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example3a",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "table_name",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
 				},
@@ -60,7 +60,7 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example3b",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "table_name",
 					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
 				},
@@ -70,12 +70,12 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example3c",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "table_name",
 					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "table_name",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
 				},
@@ -85,7 +85,7 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example4",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
@@ -96,13 +96,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example5",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
@@ -113,13 +113,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example6a",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "project_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"instances", "*", "**"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "instance_id",
 					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
@@ -131,13 +131,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example6b",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "project_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "instance_id",
 					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
@@ -149,13 +149,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example7",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "project_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "app_profile_id",
+					FieldPath: []string{"app_profile_id"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 				},
@@ -165,19 +165,19 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example8",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "app_profile_id",
+					FieldPath: []string{"app_profile_id"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 				},
@@ -187,31 +187,31 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example9",
 			[]*api.RoutingInfo{
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "table_location",
 					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "table_location",
 					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
 				},
 				{
-					FieldName: "table_name",
+					FieldPath: []string{"table_name"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
 					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "app_profile_id",
+					FieldPath: []string{"app_profile_id"},
 					Name:      "routing_id",
 					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 				},
 				{
-					FieldName: "app_profile_id",
+					FieldPath: []string{"app_profile_id"},
 					Name:      "routing_id",
 					Prefix:    api.RoutingPathSpec{Segments: []string{"profiles"}},
 					Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
@@ -236,46 +236,72 @@ func TestExamples(t *testing.T) {
 
 func TestParsePathTemplateSuccess(t *testing.T) {
 	tests := []struct {
-		path string
-		want api.RoutingInfo
+		fieldPath string
+		path      string
+		want      api.RoutingInfo
 	}{
 		{
-			"{**}",
+			"default",
+			"",
 			api.RoutingInfo{
-				FieldName: "default",
+				FieldPath: []string{"default"},
 				Name:      "default",
 				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 			},
 		},
 		{
+			"default",
+			"{**}",
+			api.RoutingInfo{
+				FieldPath: []string{"default"},
+				Name:      "default",
+				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+			},
+		},
+		{
+			"default",
 			"{routing=**}",
 			api.RoutingInfo{
-				FieldName: "routing",
+				FieldPath: []string{"default"},
 				Name:      "routing",
 				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 			},
 		},
 		{
+			"default",
 			"{routing=a/*/b/**}",
 			api.RoutingInfo{
-				FieldName: "routing",
+				FieldPath: []string{"default"},
 				Name:      "routing",
 				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
 			},
 		},
 		{
+			"default",
 			"p/*/q/*/{routing=a/*/b/**}",
 			api.RoutingInfo{
-				FieldName: "routing",
+				FieldPath: []string{"default"},
 				Name:      "routing",
 				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
 				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
 			},
 		},
 		{
+			"default",
 			"p/*/q/*/{routing=a/*/b/**}/s/*/u/*/v/**",
 			api.RoutingInfo{
-				FieldName: "routing",
+				FieldPath: []string{"default"},
+				Name:      "routing",
+				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+				Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
+			},
+		},
+		{
+			"field.sub_field.child",
+			"p/*/q/*/{routing=a/*/b/**}/s/*/u/*/v/**",
+			api.RoutingInfo{
+				FieldPath: []string{"field", "sub_field", "child"},
 				Name:      "routing",
 				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
 				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
@@ -286,7 +312,7 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {
-			got, err := parseRoutingPathTemplate("default", tc.path)
+			got, err := parseRoutingPathTemplate(tc.fieldPath, tc.path)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -299,7 +325,6 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 
 func TestParsePathTemplateFailures(t *testing.T) {
 	tests := []string{
-		"",
 		"projects/*",
 		"projects/*}",
 		"projects/*/}",
@@ -316,6 +341,13 @@ func TestParsePathTemplateFailures(t *testing.T) {
 				t.Errorf("expected error for %q, got=%v", path, got)
 			}
 		})
+	}
+}
+
+func TestParsePathTemplateBadFieldPath(t *testing.T) {
+	got, err := parseRoutingPathTemplate("field.child", "")
+	if err == nil {
+		t.Errorf("expected error got=%v", got)
 	}
 }
 

--- a/generator/internal/parser/routing_info_test.go
+++ b/generator/internal/parser/routing_info_test.go
@@ -250,6 +250,15 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 			},
 		},
 		{
+			"field.child",
+			"",
+			api.RoutingInfo{
+				FieldPath: []string{"field", "child"},
+				Name:      "field.child",
+				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+			},
+		},
+		{
 			"default",
 			"{**}",
 			api.RoutingInfo{
@@ -288,22 +297,22 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 		},
 		{
 			"default",
-			"p/*/q/*/{routing=a/*/b/**}/s/*/u/*/v/**",
+			"p/*/q/*/{routing=a/*/b/*}/s/*/u/*/v/**",
 			api.RoutingInfo{
 				FieldPath: []string{"default"},
 				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "*"}},
 				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
 				Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
 			},
 		},
 		{
 			"field.sub_field.child",
-			"p/*/q/*/{routing=a/*/b/**}/s/*/u/*/v/**",
+			"p/*/q/*/{routing=a/*/b/*}/s/*/u/*/v/**",
 			api.RoutingInfo{
 				FieldPath: []string{"field", "sub_field", "child"},
 				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "*"}},
 				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
 				Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
 			},
@@ -326,6 +335,7 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 func TestParsePathTemplateFailures(t *testing.T) {
 	tests := []string{
 		"projects/*",
+		"projects/*/{routing_id=**}/**",
 		"projects/*}",
 		"projects/*/}",
 		"projects/*/{",
@@ -341,13 +351,6 @@ func TestParsePathTemplateFailures(t *testing.T) {
 				t.Errorf("expected error for %q, got=%v", path, got)
 			}
 		})
-	}
-}
-
-func TestParsePathTemplateBadFieldPath(t *testing.T) {
-	got, err := parseRoutingPathTemplate("field.child", "")
-	if err == nil {
-		t.Errorf("expected error got=%v", got)
 	}
 }
 

--- a/generator/internal/parser/routing_info_test.go
+++ b/generator/internal/parser/routing_info_test.go
@@ -340,7 +340,7 @@ func TestParseVariableSuccess(t *testing.T) {
 				t.Fatal(err)
 			}
 			if gotName != tc.wantName {
-				t.Errorf("mistmatched variable names, want=%s, got=%s", tc.wantName, gotName)
+				t.Errorf("mismatched variable names, want=%s, got=%s", tc.wantName, gotName)
 			}
 			if diff := cmp.Diff(gotSpec, tc.wantSpec); diff != "" {
 				t.Errorf("segments mismatch (-want, +got):\n%s\n", diff)

--- a/generator/internal/parser/testdata/routing_info.proto
+++ b/generator/internal/parser/testdata/routing_info.proto
@@ -1,0 +1,187 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/routing.proto";
+import "google/api/resource.proto";
+
+service TestService {
+  option (google.api.default_host) = "test.googleapis.com";
+  option (google.api.oauth_scopes) =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  rpc Example1(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters { field: "app_profile_id" }
+    };
+  }
+
+  rpc Example2(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "app_profile_id",
+        path_template: "{routing_id=**}"
+      }
+    };
+  }
+
+  rpc Example3a(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{table_name=projects/*/instances/*/**}"
+      }
+    };
+  }
+
+  rpc Example3b(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{table_name=regions/*/zones/*/**}"
+      }
+    };
+  }
+
+  rpc Example3c(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{table_name=regions/*/zones/*/**}"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{table_name=projects/*/instances/*/**}"
+      }
+    };
+  }
+
+  rpc Example4(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=projects/*}/**"
+      }
+    };
+  }
+
+  rpc Example5(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=projects/*}/**"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=projects/*/instances/*}/**"
+      }
+    };
+  }
+
+  rpc Example6a(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{project_id=projects/*}/instances/*/**"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "projects/*/{instance_id=instances/*}/**"
+      }
+    };
+  }
+
+  rpc Example6b(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{project_id=projects/*}/**"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "projects/*/{instance_id=instances/*}/**"
+      }
+    };
+  }
+
+  rpc Example7(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{project_id=projects/*}/**"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "{routing_id=**}"
+      }
+    };
+  }
+
+  rpc Example8(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=projects/*}/**"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=regions/*}/**"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "{routing_id=**}"
+      }
+    };
+  }
+
+  rpc Example9(Request) returns (Response) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "projects/*/{table_location=instances/*}/tables/*"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{table_location=regions/*/zones/*}/tables/*"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=projects/*}/**"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "{routing_id=**}"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "profiles/{routing_id=*}"
+      }
+    };
+  }
+}
+
+message Request {
+  string table_name = 1;
+  string app_profile_id = 2;
+}
+
+message Response {
+  string table_name = 1;
+  string app_profile_id = 2;
+}

--- a/generator/testdata/googleapis/google/api/routing.proto
+++ b/generator/testdata/googleapis/google/api/routing.proto
@@ -1,0 +1,461 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "RoutingProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See RoutingRule.
+  google.api.RoutingRule routing = 72295729;
+}
+
+// Specifies the routing information that should be sent along with the request
+// in the form of routing header.
+// **NOTE:** All service configuration rules follow the "last one wins" order.
+//
+// The examples below will apply to an RPC which has the following request type:
+//
+// Message Definition:
+//
+//     message Request {
+//       // The name of the Table
+//       // Values can be of the following formats:
+//       // - `projects/<project>/tables/<table>`
+//       // - `projects/<project>/instances/<instance>/tables/<table>`
+//       // - `region/<region>/zones/<zone>/tables/<table>`
+//       string table_name = 1;
+//
+//       // This value specifies routing for replication.
+//       // It can be in the following formats:
+//       // - `profiles/<profile_id>`
+//       // - a legacy `profile_id` that can be any string
+//       string app_profile_id = 2;
+//     }
+//
+// Example message:
+//
+//     {
+//       table_name: projects/proj_foo/instances/instance_bar/table/table_baz,
+//       app_profile_id: profiles/prof_qux
+//     }
+//
+// The routing header consists of one or multiple key-value pairs. Every key
+// and value must be percent-encoded, and joined together in the format of
+// `key1=value1&key2=value2`.
+// The examples below skip the percent-encoding for readability.
+//
+// Example 1
+//
+// Extracting a field from the request to put into the routing header
+// unchanged, with the key equal to the field name.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `app_profile_id`.
+//       routing_parameters {
+//         field: "app_profile_id"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: app_profile_id=profiles/prof_qux
+//
+// Example 2
+//
+// Extracting a field from the request to put into the routing header
+// unchanged, with the key different from the field name.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `app_profile_id`, but name it `routing_id` in the header.
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: routing_id=profiles/prof_qux
+//
+// Example 3
+//
+// Extracting a field from the request to put into the routing
+// header, while matching a path template syntax on the field's value.
+//
+// NB: it is more useful to send nothing than to send garbage for the purpose
+// of dynamic routing, since garbage pollutes cache. Thus the matching.
+//
+// Sub-example 3a
+//
+// The field matches the template.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `table_name`, if it's well-formed (with project-based
+//       // syntax).
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=projects/*/instances/*/**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+//
+// Sub-example 3b
+//
+// The field does not match the template.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `table_name`, if it's well-formed (with region-based
+//       // syntax).
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=regions/*/zones/*/**}"
+//       }
+//     };
+//
+// result:
+//
+//     <no routing header will be sent>
+//
+// Sub-example 3c
+//
+// Multiple alternative conflictingly named path templates are
+// specified. The one that matches is used to construct the header.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take the `table_name`, if it's well-formed, whether
+//       // using the region- or projects-based syntax.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=regions/*/zones/*/**}"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_name=projects/*/instances/*/**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     table_name=projects/proj_foo/instances/instance_bar/table/table_baz
+//
+// Example 4
+//
+// Extracting a single routing header key-value pair by matching a
+// template syntax on (a part of) a single request field.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // Take just the project id from the `table_name` field.
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: routing_id=projects/proj_foo
+//
+// Example 5
+//
+// Extracting a single routing header key-value pair by matching
+// several conflictingly named path templates on (parts of) a single request
+// field. The last template to match "wins" the conflict.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // If the `table_name` does not have instances information,
+//       // take just the project id for routing.
+//       // Otherwise take project + instance.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*/instances/*}/**"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     routing_id=projects/proj_foo/instances/instance_bar
+//
+// Example 6
+//
+// Extracting multiple routing header key-value pairs by matching
+// several non-conflicting path templates on (parts of) a single request field.
+//
+// Sub-example 6a
+//
+// Make the templates strict, so that if the `table_name` does not
+// have an instance information, nothing is sent.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The routing code needs two keys instead of one composite
+//       // but works only for the tables with the "project-instance" name
+//       // syntax.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{project_id=projects/*}/instances/*/**"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "projects/*/{instance_id=instances/*}/**"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     project_id=projects/proj_foo&instance_id=instances/instance_bar
+//
+// Sub-example 6b
+//
+// Make the templates loose, so that if the `table_name` does not
+// have an instance information, just the project id part is sent.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The routing code wants two keys instead of one composite
+//       // but will work with just the `project_id` for tables without
+//       // an instance in the `table_name`.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{project_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "projects/*/{instance_id=instances/*}/**"
+//       }
+//     };
+//
+// result (is the same as 6a for our example message because it has the instance
+// information):
+//
+//     x-goog-request-params:
+//     project_id=projects/proj_foo&instance_id=instances/instance_bar
+//
+// Example 7
+//
+// Extracting multiple routing header key-value pairs by matching
+// several path templates on multiple request fields.
+//
+// NB: note that here there is no way to specify sending nothing if one of the
+// fields does not match its template. E.g. if the `table_name` is in the wrong
+// format, the `project_id` will not be sent, but the `routing_id` will be.
+// The backend routing code has to be aware of that and be prepared to not
+// receive a full complement of keys if it expects multiple.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The routing needs both `project_id` and `routing_id`
+//       // (from the `app_profile_id` field) for routing.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{project_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     project_id=projects/proj_foo&routing_id=profiles/prof_qux
+//
+// Example 8
+//
+// Extracting a single routing header key-value pair by matching
+// several conflictingly named path templates on several request fields. The
+// last template to match "wins" the conflict.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // The `routing_id` can be a project id or a region id depending on
+//       // the table name format, but only if the `app_profile_id` is not set.
+//       // If `app_profile_id` is set it should be used instead.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//          field: "table_name"
+//          path_template: "{routing_id=regions/*}/**"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params: routing_id=profiles/prof_qux
+//
+// Example 9
+//
+// Bringing it all together.
+//
+// annotation:
+//
+//     option (google.api.routing) = {
+//       // For routing both `table_location` and a `routing_id` are needed.
+//       //
+//       // table_location can be either an instance id or a region+zone id.
+//       //
+//       // For `routing_id`, take the value of `app_profile_id`
+//       // - If it's in the format `profiles/<profile_id>`, send
+//       // just the `<profile_id>` part.
+//       // - If it's any other literal, send it as is.
+//       // If the `app_profile_id` is empty, and the `table_name` starts with
+//       // the project_id, send that instead.
+//
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "projects/*/{table_location=instances/*}/tables/*"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{table_location=regions/*/zones/*}/tables/*"
+//       }
+//       routing_parameters {
+//         field: "table_name"
+//         path_template: "{routing_id=projects/*}/**"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "{routing_id=**}"
+//       }
+//       routing_parameters {
+//         field: "app_profile_id"
+//         path_template: "profiles/{routing_id=*}"
+//       }
+//     };
+//
+// result:
+//
+//     x-goog-request-params:
+//     table_location=instances/instance_bar&routing_id=prof_qux
+message RoutingRule {
+  // A collection of Routing Parameter specifications.
+  // **NOTE:** If multiple Routing Parameters describe the same key
+  // (via the `path_template` field or via the `field` field when
+  // `path_template` is not provided), "last one wins" rule
+  // determines which Parameter gets used.
+  // See the examples for more details.
+  repeated RoutingParameter routing_parameters = 2;
+}
+
+// A projection from an input message to the GRPC or REST header.
+message RoutingParameter {
+  // A request field to extract the header key-value pair from.
+  string field = 1;
+
+  // A pattern matching the key-value field. Optional.
+  // If not specified, the whole field specified in the `field` field will be
+  // taken as value, and its name used as key. If specified, it MUST contain
+  // exactly one named segment (along with any number of unnamed segments) The
+  // pattern will be matched over the field specified in the `field` field, then
+  // if the match is successful:
+  // - the name of the single named segment will be used as a header name,
+  // - the match value of the segment will be used as a header value;
+  // if the match is NOT successful, nothing will be sent.
+  //
+  // Example:
+  //
+  //               -- This is a field in the request message
+  //              |   that the header value will be extracted from.
+  //              |
+  //              |                     -- This is the key name in the
+  //              |                    |   routing header.
+  //              V                    |
+  //     field: "table_name"           v
+  //     path_template: "projects/*/{table_location=instances/*}/tables/*"
+  //                                                ^            ^
+  //                                                |            |
+  //       In the {} brackets is the pattern that --             |
+  //       specifies what to extract from the                    |
+  //       field as a value to be sent.                          |
+  //                                                             |
+  //      The string in the field must match the whole pattern --
+  //      before brackets, inside brackets, after brackets.
+  //
+  // When looking at this specific example, we can see that:
+  // - A key-value pair with the key `table_location`
+  //   and the value matching `instances/*` should be added
+  //   to the x-goog-request-params routing header.
+  // - The value is extracted from the request message's `table_name` field
+  //   if it matches the full pattern specified:
+  //   `projects/*/instances/*/tables/*`.
+  //
+  // **NB:** If the `path_template` field is not provided, the key name is
+  // equal to the field name, and the whole field should be sent as a value.
+  // This makes the pattern for the field and the value functionally equivalent
+  // to `**`, and the configuration
+  //
+  //     {
+  //       field: "table_name"
+  //     }
+  //
+  // is a functionally equivalent shorthand to:
+  //
+  //     {
+  //       field: "table_name"
+  //       path_template: "{table_name=**}"
+  //     }
+  //
+  // See Example 1 for more details.
+  string path_template = 2;
+}


### PR DESCRIPTION
Parse the method routing extensions (if any) and save them in the model.
In a future PR we will use these extensions to generate Rust code.

Fixes #1819
