### PR TITLE
refactor(gaxi): make fixed headers outside of loop

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -136,6 +136,7 @@ impl Client {
     }
 
     /// Makes a single request attempt.
+    #[allow(clippy::too_many_arguments)]
     async fn request_attempt<Request, Response>(
         inner: &mut InnerClient,
         credentials: &Credentials,


### PR DESCRIPTION
Part of the work for #1612 

Move header creation outside of the retry loop.

The strings referenced by a `HeaderValue` (such as our `api_client_header`) are copied into a `HeaderMap` when a `HeaderMap` is made. The lifetime of the `HeaderMap` is easier for the compiler to reason about. (We do not want the inner call in the retry loop to have a `'static` lifetime, which I think is what was happening when we tried to hold `&'static str`s in it.)

Cleanups:
- This brings us to <= 7 parameters, so we can remove the clippy allows.
- Restrict visibility on implementation details. `execute()` is the only API we need to expose for our tests / client crates.