### PR TITLE
impl(gax-internal): fix tonic endpoints

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -175,7 +175,7 @@ impl Client {
     }
 
     async fn make_inner(endpoint: Option<String>, default_endpoint: &str) -> Result<InnerClient> {
-        let endpoint = tonic::transport::Endpoint::from_shared(
+        let endpoint = tonic::transport::Endpoint::new(
             endpoint.unwrap_or_else(|| default_endpoint.to_string()),
         )
         .map_err(Error::other)?;

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -175,10 +175,12 @@ impl Client {
     }
 
     async fn make_inner(endpoint: Option<String>, default_endpoint: &str) -> Result<InnerClient> {
-        let endpoint = tonic::transport::Endpoint::new(
-            endpoint.unwrap_or_else(|| default_endpoint.to_string()),
-        )
-        .map_err(Error::other)?;
+        use tonic::transport::{ClientTlsConfig, Endpoint};
+        let endpoint =
+            Endpoint::from_shared(endpoint.unwrap_or_else(|| default_endpoint.to_string()))
+                .map_err(Error::other)?
+                .tls_config(ClientTlsConfig::new().with_enabled_roots())
+                .map_err(Error::other)?;
         let conn = endpoint.connect().await.map_err(Error::io)?;
         Ok(tonic::client::Grpc::new(conn))
     }


### PR DESCRIPTION
Part of the work for #1612 

`endpoint.connect()` would fail when trying to connect to `https://firestore.googleapis.com`. This was noticed when running the integration tests with a firestore client implemented by the `grpc::Client`.

Apparently we need to configure TLS on the endpoint. Note that:

(1) Our current firestore client (which passes the integration tests) uses `tonic::Endpoint::new()` (which @coryan notices is not part of `tonic`'s public API)

https://github.com/googleapis/google-cloud-rust/blob/cf54b210da52fd216042b57fb235e0edbb9cec47/src/firestore/src/generated/gapic/transport.rs#L74

(2) We are enabling the `_tls-any` feature via `tonic:tls-ring`, which gates the `tonic::transport::ClientTlsConfig` API.