### PR TITLE
refactor(gaxi): plumb `Extensions`, not `Method`

### DIFF
--- a/src/gax-internal/tests/grpc_auth.rs
+++ b/src/gax-internal/tests/grpc_auth.rs
@@ -157,13 +157,21 @@ mod test {
         client: grpc::Client,
         msg: &str,
     ) -> gax::Result<google::test::v1::EchoResponse> {
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Echo",
+            ));
+            e
+        };
         let request = google::test::v1::EchoRequest {
             message: msg.into(),
             ..Default::default()
         };
         client
             .execute(
-                tonic::GrpcMethod::new("google.test.v1.EchoServices", "Echo"),
+                extensions,
                 http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Echo"),
                 request,
                 RequestOptions::default(),

--- a/src/gax-internal/tests/grpc_retry_loop.rs
+++ b/src/gax-internal/tests/grpc_retry_loop.rs
@@ -120,15 +120,26 @@ mod test {
     }
 
     pub async fn send_request(client: grpc::Client, msg: &str) -> gax::Result<EchoResponse> {
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Echo",
+            ));
+            e
+        };
         let request = google::test::v1::EchoRequest {
             message: msg.into(),
             ..google::test::v1::EchoRequest::default()
         };
-        let mut request_options = RequestOptions::default();
-        request_options.set_idempotency(true);
+        let request_options = {
+            let mut o = RequestOptions::default();
+            o.set_idempotency(true);
+            o
+        };
         client
             .execute(
-                tonic::GrpcMethod::new("google.test.v1.EchoServices", "Echo"),
+                extensions,
                 http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Echo"),
                 request,
                 request_options,

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -102,17 +102,24 @@ mod test {
         client: grpc::Client,
         msg: &str,
     ) -> gax::Result<google::test::v1::EchoResponse> {
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Echo",
+            ));
+            e
+        };
         let request = google::test::v1::EchoRequest {
             message: msg.into(),
             ..google::test::v1::EchoRequest::default()
         };
-        let request_options = RequestOptions::default();
         client
             .execute(
-                tonic::GrpcMethod::new("google.test.v1.EchoServices", "Echo"),
+                extensions,
                 http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Echo"),
                 request,
-                request_options,
+                RequestOptions::default(),
                 "test-only-api-client/1.0",
                 "name=test-only",
             )

--- a/src/gax-internal/tests/grpc_timeout.rs
+++ b/src/gax-internal/tests/grpc_timeout.rs
@@ -223,14 +223,24 @@ mod test {
         msg: &str,
         delay: Option<Duration>,
     ) -> gax::Result<google::test::v1::EchoResponse> {
-        let delay_ms = delay.map(|d| u64::try_from(d.as_millis()).unwrap());
-        let request = google::test::v1::EchoRequest {
-            message: msg.into(),
-            delay_ms,
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Echo",
+            ));
+            e
+        };
+        let request = {
+            let delay_ms = delay.map(|d| u64::try_from(d.as_millis()).unwrap());
+            google::test::v1::EchoRequest {
+                message: msg.into(),
+                delay_ms,
+            }
         };
         client
             .execute(
-                tonic::GrpcMethod::new("google.test.v1.EchoServices", "Echo"),
+                extensions,
                 http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Echo"),
                 request,
                 request_options,


### PR DESCRIPTION
Part of the work for #1612 

Similar to #1833, these `GrpcMethod`s just hold two `&'static str`s. We will put it into an `Extensions` (which we need to do anyway). Note that `Extensions` box the values on insert. The `Extensions` is moved into the inner functor. It does not extend the lifetime of the functor.