### PR TITLE
refactor(generator/dart): rename base message and enum types to avoid name conflicts

### DIFF
--- a/generator/dart/generated/google_cloud_common/lib/common.dart
+++ b/generator/dart/generated/google_cloud_common/lib/common.dart
@@ -19,12 +19,12 @@
 /// Additional metadata for operations.
 library;
 
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
 /// Represents the metadata of the long-running operation.
-class OperationMetadata extends Message {
+class OperationMetadata extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.common.OperationMetadata';
 

--- a/generator/dart/generated/google_cloud_common/lib/common.dart
+++ b/generator/dart/generated/google_cloud_common/lib/common.dart
@@ -24,7 +24,7 @@ import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
 /// Represents the metadata of the long-running operation.
-class OperationMetadata extends GMessage {
+class OperationMetadata extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.common.OperationMetadata';
 

--- a/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -19,9 +19,7 @@
 /// Manages lightweight user-provided functions executed in response to events.
 library;
 
-import 'dart:typed_data';
-
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_iam_v1/iam.dart';
 import 'package:google_cloud_location/location.dart';
@@ -218,7 +216,7 @@ class FunctionService {
   ///
   /// This method can be used to get the current status of a long-running
   /// operation.
-  Future<Operation<T, S>> getOperation<T extends Message, S extends Message>(
+  Future<Operation<T, S>> getOperation<T extends GMessage, S extends GMessage>(
       Operation<T, S> request) async {
     final url = Uri.https(_host, '/v2/${request.name}');
     final response = await _client.get(url);
@@ -233,7 +231,7 @@ class FunctionService {
 
 /// Describes a Cloud Function that contains user computation executed in
 /// response to an event. It encapsulates function and trigger configurations.
-class Function$ extends Message {
+class Function$ extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.functions.v2.Function';
 
   /// A user-defined name of the function. Function names must be unique
@@ -360,7 +358,7 @@ class Function$ extends Message {
 }
 
 /// Describes the current state of the function.
-class Function$_State extends Enum {
+class Function$_State extends GEnum {
   /// Not specified. Invalid state.
   static const stateUnspecified = Function$_State('STATE_UNSPECIFIED');
 
@@ -389,7 +387,7 @@ class Function$_State extends Enum {
 }
 
 /// Informational messages about the state of the Cloud Function or Operation.
-class StateMessage extends Message {
+class StateMessage extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.StateMessage';
 
@@ -437,7 +435,7 @@ class StateMessage extends Message {
 }
 
 /// Severity of the state message.
-class StateMessage_Severity extends Enum {
+class StateMessage_Severity extends GEnum {
   /// Not specified. Invalid severity.
   static const severityUnspecified =
       StateMessage_Severity('SEVERITY_UNSPECIFIED');
@@ -461,7 +459,7 @@ class StateMessage_Severity extends Enum {
 }
 
 /// Location of the source in an archive file in Google Cloud Storage.
-class StorageSource extends Message {
+class StorageSource extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.StorageSource';
 
@@ -524,7 +522,7 @@ class StorageSource extends Message {
 }
 
 /// Location of the source in a Google Cloud Source Repository.
-class RepoSource extends Message {
+class RepoSource extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.RepoSource';
 
@@ -612,7 +610,7 @@ class RepoSource extends Message {
 }
 
 /// The location of the function source code.
-class Source extends Message {
+class Source extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.functions.v2.Source';
 
   /// If provided, get the source from this location in Google Cloud Storage.
@@ -661,7 +659,7 @@ class Source extends Message {
 
 /// Provenance of the source. Ways to find the original source, or verify that
 /// some source was used for this build.
-class SourceProvenance extends Message {
+class SourceProvenance extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SourceProvenance';
 
@@ -715,7 +713,7 @@ class SourceProvenance extends Message {
 
 /// Describes the Build step of the function that builds a container from the
 /// given source.
-class BuildConfig extends Message {
+class BuildConfig extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.BuildConfig';
 
@@ -867,7 +865,7 @@ class BuildConfig extends Message {
 }
 
 /// Docker Registry to use for storing function Docker images.
-class BuildConfig_DockerRegistry extends Enum {
+class BuildConfig_DockerRegistry extends GEnum {
   /// Unspecified.
   static const dockerRegistryUnspecified =
       BuildConfig_DockerRegistry('DOCKER_REGISTRY_UNSPECIFIED');
@@ -896,7 +894,7 @@ class BuildConfig_DockerRegistry extends Enum {
 
 /// Describes the Service being deployed.
 /// Currently Supported : Cloud Run (fully managed).
-class ServiceConfig extends Message {
+class ServiceConfig extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ServiceConfig';
 
@@ -1118,7 +1116,7 @@ class ServiceConfig extends Message {
 ///
 /// This controls what traffic is diverted through the VPC Access Connector
 /// resource. By default PRIVATE_RANGES_ONLY will be used.
-class ServiceConfig_VpcConnectorEgressSettings extends Enum {
+class ServiceConfig_VpcConnectorEgressSettings extends GEnum {
   /// Unspecified.
   static const vpcConnectorEgressSettingsUnspecified =
       ServiceConfig_VpcConnectorEgressSettings(
@@ -1147,7 +1145,7 @@ class ServiceConfig_VpcConnectorEgressSettings extends Enum {
 /// This controls what traffic can reach the function.
 ///
 /// If unspecified, ALLOW_ALL will be used.
-class ServiceConfig_IngressSettings extends Enum {
+class ServiceConfig_IngressSettings extends GEnum {
   /// Unspecified.
   static const ingressSettingsUnspecified =
       ServiceConfig_IngressSettings('INGRESS_SETTINGS_UNSPECIFIED');
@@ -1178,7 +1176,7 @@ class ServiceConfig_IngressSettings extends Enum {
 ///
 /// Security level is only configurable for 1st Gen functions, If unspecified,
 /// SECURE_OPTIONAL will be used. 2nd Gen functions are SECURE_ALWAYS ONLY.
-class ServiceConfig_SecurityLevel extends Enum {
+class ServiceConfig_SecurityLevel extends GEnum {
   /// Unspecified.
   static const securityLevelUnspecified =
       ServiceConfig_SecurityLevel('SECURITY_LEVEL_UNSPECIFIED');
@@ -1205,7 +1203,7 @@ class ServiceConfig_SecurityLevel extends Enum {
 /// Configuration for a secret environment variable. It has the information
 /// necessary to fetch the secret value from secret manager and expose it as an
 /// environment variable.
-class SecretEnvVar extends Message {
+class SecretEnvVar extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SecretEnvVar';
 
@@ -1267,7 +1265,7 @@ class SecretEnvVar extends Message {
 /// Configuration for a secret volume. It has the information necessary to fetch
 /// the secret value from secret manager and make it available as files mounted
 /// at the requested paths within the application container.
-class SecretVolume extends Message {
+class SecretVolume extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SecretVolume';
 
@@ -1330,7 +1328,7 @@ class SecretVolume extends Message {
 }
 
 /// Configuration for a single version.
-class SecretVolume_SecretVersion extends Message {
+class SecretVolume_SecretVersion extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SecretVolume.SecretVersion';
 
@@ -1377,7 +1375,7 @@ class SecretVolume_SecretVersion extends Message {
 
 /// Describes EventTrigger, used to request events to be sent from another
 /// service.
-class EventTrigger extends Message {
+class EventTrigger extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.EventTrigger';
 
@@ -1497,7 +1495,7 @@ class EventTrigger extends Message {
 
 /// Describes the retry policy in case of function's execution failure.
 /// Retried execution is charged as any other execution.
-class EventTrigger_RetryPolicy extends Enum {
+class EventTrigger_RetryPolicy extends GEnum {
   /// Not specified.
   static const retryPolicyUnspecified =
       EventTrigger_RetryPolicy('RETRY_POLICY_UNSPECIFIED');
@@ -1521,7 +1519,7 @@ class EventTrigger_RetryPolicy extends Enum {
 }
 
 /// Filters events based on exact matches on the CloudEvents attributes.
-class EventFilter extends Message {
+class EventFilter extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.EventFilter';
 
@@ -1572,7 +1570,7 @@ class EventFilter extends Message {
 }
 
 /// Request for the `GetFunction` method.
-class GetFunctionRequest extends Message {
+class GetFunctionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GetFunctionRequest';
 
@@ -1618,7 +1616,7 @@ class GetFunctionRequest extends Message {
 }
 
 /// Request for the `ListFunctions` method.
-class ListFunctionsRequest extends Message {
+class ListFunctionsRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListFunctionsRequest';
 
@@ -1694,7 +1692,7 @@ class ListFunctionsRequest extends Message {
 }
 
 /// Response for the `ListFunctions` method.
-class ListFunctionsResponse extends Message {
+class ListFunctionsResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListFunctionsResponse';
 
@@ -1742,7 +1740,7 @@ class ListFunctionsResponse extends Message {
 }
 
 /// Request for the `CreateFunction` method.
-class CreateFunctionRequest extends Message {
+class CreateFunctionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.CreateFunctionRequest';
 
@@ -1794,7 +1792,7 @@ class CreateFunctionRequest extends Message {
 }
 
 /// Request for the `UpdateFunction` method.
-class UpdateFunctionRequest extends Message {
+class UpdateFunctionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.UpdateFunctionRequest';
 
@@ -1830,7 +1828,7 @@ class UpdateFunctionRequest extends Message {
 }
 
 /// Request for the `DeleteFunction` method.
-class DeleteFunctionRequest extends Message {
+class DeleteFunctionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.DeleteFunctionRequest';
 
@@ -1864,7 +1862,7 @@ class DeleteFunctionRequest extends Message {
 }
 
 /// Request of `GenerateSourceUploadUrl` method.
-class GenerateUploadUrlRequest extends Message {
+class GenerateUploadUrlRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateUploadUrlRequest';
 
@@ -1930,7 +1928,7 @@ class GenerateUploadUrlRequest extends Message {
 }
 
 /// Response of `GenerateSourceUploadUrl` method.
-class GenerateUploadUrlResponse extends Message {
+class GenerateUploadUrlResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateUploadUrlResponse';
 
@@ -1979,7 +1977,7 @@ class GenerateUploadUrlResponse extends Message {
 }
 
 /// Request of `GenerateDownloadUrl` method.
-class GenerateDownloadUrlRequest extends Message {
+class GenerateDownloadUrlRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateDownloadUrlRequest';
 
@@ -2014,7 +2012,7 @@ class GenerateDownloadUrlRequest extends Message {
 }
 
 /// Response of `GenerateDownloadUrl` method.
-class GenerateDownloadUrlResponse extends Message {
+class GenerateDownloadUrlResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateDownloadUrlResponse';
 
@@ -2049,7 +2047,7 @@ class GenerateDownloadUrlResponse extends Message {
 }
 
 /// Request for the `ListRuntimes` method.
-class ListRuntimesRequest extends Message {
+class ListRuntimesRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListRuntimesRequest';
 
@@ -2092,7 +2090,7 @@ class ListRuntimesRequest extends Message {
 }
 
 /// Response for the `ListRuntimes` method.
-class ListRuntimesResponse extends Message {
+class ListRuntimesResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListRuntimesResponse';
 
@@ -2123,7 +2121,7 @@ class ListRuntimesResponse extends Message {
 
 /// Describes a runtime and any special information (e.g., deprecation status)
 /// related to it.
-class ListRuntimesResponse_Runtime extends Message {
+class ListRuntimesResponse_Runtime extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListRuntimesResponse.Runtime';
 
@@ -2198,7 +2196,7 @@ class ListRuntimesResponse_Runtime extends Message {
 }
 
 /// The various stages that a runtime can be in.
-class ListRuntimesResponse_RuntimeStage extends Enum {
+class ListRuntimesResponse_RuntimeStage extends GEnum {
   /// Not specified.
   static const runtimeStageUnspecified =
       ListRuntimesResponse_RuntimeStage('RUNTIME_STAGE_UNSPECIFIED');
@@ -2233,7 +2231,7 @@ class ListRuntimesResponse_RuntimeStage extends Enum {
 
 /// Security patches are applied automatically to the runtime without requiring
 /// the function to be redeployed.
-class AutomaticUpdatePolicy extends Message {
+class AutomaticUpdatePolicy extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.AutomaticUpdatePolicy';
 
@@ -2253,7 +2251,7 @@ class AutomaticUpdatePolicy extends Message {
 }
 
 /// Security patches are only applied when a function is redeployed.
-class OnDeployUpdatePolicy extends Message {
+class OnDeployUpdatePolicy extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.OnDeployUpdatePolicy';
 
@@ -2288,7 +2286,7 @@ class OnDeployUpdatePolicy extends Message {
 }
 
 /// Represents the metadata of the long-running operation.
-class OperationMetadata extends Message {
+class OperationMetadata extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.OperationMetadata';
 
@@ -2401,7 +2399,7 @@ class OperationMetadata extends Message {
 }
 
 /// Extra GCF specific location information.
-class LocationMetadata extends Message {
+class LocationMetadata extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.LocationMetadata';
 
@@ -2430,7 +2428,7 @@ class LocationMetadata extends Message {
 }
 
 /// Each Stage of the deployment process
-class Stage extends Message {
+class Stage extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.functions.v2.Stage';
 
   /// Name of the Stage. This will be unique for each Stage.
@@ -2498,7 +2496,7 @@ class Stage extends Message {
 }
 
 /// Possible names for a Stage
-class Stage_Name extends Enum {
+class Stage_Name extends GEnum {
   /// Not specified. Invalid name.
   static const nameUnspecified = Stage_Name('NAME_UNSPECIFIED');
 
@@ -2529,7 +2527,7 @@ class Stage_Name extends Enum {
 }
 
 /// Possible states for a Stage
-class Stage_State extends Enum {
+class Stage_State extends GEnum {
   /// Not specified. Invalid state.
   static const stateUnspecified = Stage_State('STATE_UNSPECIFIED');
 
@@ -2551,7 +2549,7 @@ class Stage_State extends Enum {
 }
 
 /// The type of the long running operation.
-class OperationType extends Enum {
+class OperationType extends GEnum {
   /// Unspecified
   static const operationtypeUnspecified =
       OperationType('OPERATIONTYPE_UNSPECIFIED');
@@ -2574,7 +2572,7 @@ class OperationType extends Enum {
 }
 
 /// The environment the function is hosted on.
-class Environment extends Enum {
+class Environment extends GEnum {
   /// Unspecified
   static const environmentUnspecified = Environment('ENVIRONMENT_UNSPECIFIED');
 

--- a/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -216,8 +216,9 @@ class FunctionService {
   ///
   /// This method can be used to get the current status of a long-running
   /// operation.
-  Future<Operation<T, S>> getOperation<T extends GMessage, S extends GMessage>(
-      Operation<T, S> request) async {
+  Future<Operation<T, S>>
+      getOperation<T extends ProtoMessage, S extends ProtoMessage>(
+          Operation<T, S> request) async {
     final url = Uri.https(_host, '/v2/${request.name}');
     final response = await _client.get(url);
     return Operation.fromJson(response, request.operationHelper);
@@ -231,7 +232,7 @@ class FunctionService {
 
 /// Describes a Cloud Function that contains user computation executed in
 /// response to an event. It encapsulates function and trigger configurations.
-class Function$ extends GMessage {
+class Function$ extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.functions.v2.Function';
 
   /// A user-defined name of the function. Function names must be unique
@@ -358,7 +359,7 @@ class Function$ extends GMessage {
 }
 
 /// Describes the current state of the function.
-class Function$_State extends GEnum {
+class Function$_State extends ProtoEnum {
   /// Not specified. Invalid state.
   static const stateUnspecified = Function$_State('STATE_UNSPECIFIED');
 
@@ -387,7 +388,7 @@ class Function$_State extends GEnum {
 }
 
 /// Informational messages about the state of the Cloud Function or Operation.
-class StateMessage extends GMessage {
+class StateMessage extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.StateMessage';
 
@@ -435,7 +436,7 @@ class StateMessage extends GMessage {
 }
 
 /// Severity of the state message.
-class StateMessage_Severity extends GEnum {
+class StateMessage_Severity extends ProtoEnum {
   /// Not specified. Invalid severity.
   static const severityUnspecified =
       StateMessage_Severity('SEVERITY_UNSPECIFIED');
@@ -459,7 +460,7 @@ class StateMessage_Severity extends GEnum {
 }
 
 /// Location of the source in an archive file in Google Cloud Storage.
-class StorageSource extends GMessage {
+class StorageSource extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.StorageSource';
 
@@ -522,7 +523,7 @@ class StorageSource extends GMessage {
 }
 
 /// Location of the source in a Google Cloud Source Repository.
-class RepoSource extends GMessage {
+class RepoSource extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.RepoSource';
 
@@ -610,7 +611,7 @@ class RepoSource extends GMessage {
 }
 
 /// The location of the function source code.
-class Source extends GMessage {
+class Source extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.functions.v2.Source';
 
   /// If provided, get the source from this location in Google Cloud Storage.
@@ -659,7 +660,7 @@ class Source extends GMessage {
 
 /// Provenance of the source. Ways to find the original source, or verify that
 /// some source was used for this build.
-class SourceProvenance extends GMessage {
+class SourceProvenance extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SourceProvenance';
 
@@ -713,7 +714,7 @@ class SourceProvenance extends GMessage {
 
 /// Describes the Build step of the function that builds a container from the
 /// given source.
-class BuildConfig extends GMessage {
+class BuildConfig extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.BuildConfig';
 
@@ -865,7 +866,7 @@ class BuildConfig extends GMessage {
 }
 
 /// Docker Registry to use for storing function Docker images.
-class BuildConfig_DockerRegistry extends GEnum {
+class BuildConfig_DockerRegistry extends ProtoEnum {
   /// Unspecified.
   static const dockerRegistryUnspecified =
       BuildConfig_DockerRegistry('DOCKER_REGISTRY_UNSPECIFIED');
@@ -894,7 +895,7 @@ class BuildConfig_DockerRegistry extends GEnum {
 
 /// Describes the Service being deployed.
 /// Currently Supported : Cloud Run (fully managed).
-class ServiceConfig extends GMessage {
+class ServiceConfig extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ServiceConfig';
 
@@ -1116,7 +1117,7 @@ class ServiceConfig extends GMessage {
 ///
 /// This controls what traffic is diverted through the VPC Access Connector
 /// resource. By default PRIVATE_RANGES_ONLY will be used.
-class ServiceConfig_VpcConnectorEgressSettings extends GEnum {
+class ServiceConfig_VpcConnectorEgressSettings extends ProtoEnum {
   /// Unspecified.
   static const vpcConnectorEgressSettingsUnspecified =
       ServiceConfig_VpcConnectorEgressSettings(
@@ -1145,7 +1146,7 @@ class ServiceConfig_VpcConnectorEgressSettings extends GEnum {
 /// This controls what traffic can reach the function.
 ///
 /// If unspecified, ALLOW_ALL will be used.
-class ServiceConfig_IngressSettings extends GEnum {
+class ServiceConfig_IngressSettings extends ProtoEnum {
   /// Unspecified.
   static const ingressSettingsUnspecified =
       ServiceConfig_IngressSettings('INGRESS_SETTINGS_UNSPECIFIED');
@@ -1176,7 +1177,7 @@ class ServiceConfig_IngressSettings extends GEnum {
 ///
 /// Security level is only configurable for 1st Gen functions, If unspecified,
 /// SECURE_OPTIONAL will be used. 2nd Gen functions are SECURE_ALWAYS ONLY.
-class ServiceConfig_SecurityLevel extends GEnum {
+class ServiceConfig_SecurityLevel extends ProtoEnum {
   /// Unspecified.
   static const securityLevelUnspecified =
       ServiceConfig_SecurityLevel('SECURITY_LEVEL_UNSPECIFIED');
@@ -1203,7 +1204,7 @@ class ServiceConfig_SecurityLevel extends GEnum {
 /// Configuration for a secret environment variable. It has the information
 /// necessary to fetch the secret value from secret manager and expose it as an
 /// environment variable.
-class SecretEnvVar extends GMessage {
+class SecretEnvVar extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SecretEnvVar';
 
@@ -1265,7 +1266,7 @@ class SecretEnvVar extends GMessage {
 /// Configuration for a secret volume. It has the information necessary to fetch
 /// the secret value from secret manager and make it available as files mounted
 /// at the requested paths within the application container.
-class SecretVolume extends GMessage {
+class SecretVolume extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SecretVolume';
 
@@ -1328,7 +1329,7 @@ class SecretVolume extends GMessage {
 }
 
 /// Configuration for a single version.
-class SecretVolume_SecretVersion extends GMessage {
+class SecretVolume_SecretVersion extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.SecretVolume.SecretVersion';
 
@@ -1375,7 +1376,7 @@ class SecretVolume_SecretVersion extends GMessage {
 
 /// Describes EventTrigger, used to request events to be sent from another
 /// service.
-class EventTrigger extends GMessage {
+class EventTrigger extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.EventTrigger';
 
@@ -1495,7 +1496,7 @@ class EventTrigger extends GMessage {
 
 /// Describes the retry policy in case of function's execution failure.
 /// Retried execution is charged as any other execution.
-class EventTrigger_RetryPolicy extends GEnum {
+class EventTrigger_RetryPolicy extends ProtoEnum {
   /// Not specified.
   static const retryPolicyUnspecified =
       EventTrigger_RetryPolicy('RETRY_POLICY_UNSPECIFIED');
@@ -1519,7 +1520,7 @@ class EventTrigger_RetryPolicy extends GEnum {
 }
 
 /// Filters events based on exact matches on the CloudEvents attributes.
-class EventFilter extends GMessage {
+class EventFilter extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.EventFilter';
 
@@ -1570,7 +1571,7 @@ class EventFilter extends GMessage {
 }
 
 /// Request for the `GetFunction` method.
-class GetFunctionRequest extends GMessage {
+class GetFunctionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GetFunctionRequest';
 
@@ -1616,7 +1617,7 @@ class GetFunctionRequest extends GMessage {
 }
 
 /// Request for the `ListFunctions` method.
-class ListFunctionsRequest extends GMessage {
+class ListFunctionsRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListFunctionsRequest';
 
@@ -1692,7 +1693,7 @@ class ListFunctionsRequest extends GMessage {
 }
 
 /// Response for the `ListFunctions` method.
-class ListFunctionsResponse extends GMessage {
+class ListFunctionsResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListFunctionsResponse';
 
@@ -1740,7 +1741,7 @@ class ListFunctionsResponse extends GMessage {
 }
 
 /// Request for the `CreateFunction` method.
-class CreateFunctionRequest extends GMessage {
+class CreateFunctionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.CreateFunctionRequest';
 
@@ -1792,7 +1793,7 @@ class CreateFunctionRequest extends GMessage {
 }
 
 /// Request for the `UpdateFunction` method.
-class UpdateFunctionRequest extends GMessage {
+class UpdateFunctionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.UpdateFunctionRequest';
 
@@ -1828,7 +1829,7 @@ class UpdateFunctionRequest extends GMessage {
 }
 
 /// Request for the `DeleteFunction` method.
-class DeleteFunctionRequest extends GMessage {
+class DeleteFunctionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.DeleteFunctionRequest';
 
@@ -1862,7 +1863,7 @@ class DeleteFunctionRequest extends GMessage {
 }
 
 /// Request of `GenerateSourceUploadUrl` method.
-class GenerateUploadUrlRequest extends GMessage {
+class GenerateUploadUrlRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateUploadUrlRequest';
 
@@ -1928,7 +1929,7 @@ class GenerateUploadUrlRequest extends GMessage {
 }
 
 /// Response of `GenerateSourceUploadUrl` method.
-class GenerateUploadUrlResponse extends GMessage {
+class GenerateUploadUrlResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateUploadUrlResponse';
 
@@ -1977,7 +1978,7 @@ class GenerateUploadUrlResponse extends GMessage {
 }
 
 /// Request of `GenerateDownloadUrl` method.
-class GenerateDownloadUrlRequest extends GMessage {
+class GenerateDownloadUrlRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateDownloadUrlRequest';
 
@@ -2012,7 +2013,7 @@ class GenerateDownloadUrlRequest extends GMessage {
 }
 
 /// Response of `GenerateDownloadUrl` method.
-class GenerateDownloadUrlResponse extends GMessage {
+class GenerateDownloadUrlResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.GenerateDownloadUrlResponse';
 
@@ -2047,7 +2048,7 @@ class GenerateDownloadUrlResponse extends GMessage {
 }
 
 /// Request for the `ListRuntimes` method.
-class ListRuntimesRequest extends GMessage {
+class ListRuntimesRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListRuntimesRequest';
 
@@ -2090,7 +2091,7 @@ class ListRuntimesRequest extends GMessage {
 }
 
 /// Response for the `ListRuntimes` method.
-class ListRuntimesResponse extends GMessage {
+class ListRuntimesResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListRuntimesResponse';
 
@@ -2121,7 +2122,7 @@ class ListRuntimesResponse extends GMessage {
 
 /// Describes a runtime and any special information (e.g., deprecation status)
 /// related to it.
-class ListRuntimesResponse_Runtime extends GMessage {
+class ListRuntimesResponse_Runtime extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.ListRuntimesResponse.Runtime';
 
@@ -2196,7 +2197,7 @@ class ListRuntimesResponse_Runtime extends GMessage {
 }
 
 /// The various stages that a runtime can be in.
-class ListRuntimesResponse_RuntimeStage extends GEnum {
+class ListRuntimesResponse_RuntimeStage extends ProtoEnum {
   /// Not specified.
   static const runtimeStageUnspecified =
       ListRuntimesResponse_RuntimeStage('RUNTIME_STAGE_UNSPECIFIED');
@@ -2231,7 +2232,7 @@ class ListRuntimesResponse_RuntimeStage extends GEnum {
 
 /// Security patches are applied automatically to the runtime without requiring
 /// the function to be redeployed.
-class AutomaticUpdatePolicy extends GMessage {
+class AutomaticUpdatePolicy extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.AutomaticUpdatePolicy';
 
@@ -2251,7 +2252,7 @@ class AutomaticUpdatePolicy extends GMessage {
 }
 
 /// Security patches are only applied when a function is redeployed.
-class OnDeployUpdatePolicy extends GMessage {
+class OnDeployUpdatePolicy extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.OnDeployUpdatePolicy';
 
@@ -2286,7 +2287,7 @@ class OnDeployUpdatePolicy extends GMessage {
 }
 
 /// Represents the metadata of the long-running operation.
-class OperationMetadata extends GMessage {
+class OperationMetadata extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.OperationMetadata';
 
@@ -2399,7 +2400,7 @@ class OperationMetadata extends GMessage {
 }
 
 /// Extra GCF specific location information.
-class LocationMetadata extends GMessage {
+class LocationMetadata extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.functions.v2.LocationMetadata';
 
@@ -2428,7 +2429,7 @@ class LocationMetadata extends GMessage {
 }
 
 /// Each Stage of the deployment process
-class Stage extends GMessage {
+class Stage extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.functions.v2.Stage';
 
   /// Name of the Stage. This will be unique for each Stage.
@@ -2496,7 +2497,7 @@ class Stage extends GMessage {
 }
 
 /// Possible names for a Stage
-class Stage_Name extends GEnum {
+class Stage_Name extends ProtoEnum {
   /// Not specified. Invalid name.
   static const nameUnspecified = Stage_Name('NAME_UNSPECIFIED');
 
@@ -2527,7 +2528,7 @@ class Stage_Name extends GEnum {
 }
 
 /// Possible states for a Stage
-class Stage_State extends GEnum {
+class Stage_State extends ProtoEnum {
   /// Not specified. Invalid state.
   static const stateUnspecified = Stage_State('STATE_UNSPECIFIED');
 
@@ -2549,7 +2550,7 @@ class Stage_State extends GEnum {
 }
 
 /// The type of the long running operation.
-class OperationType extends GEnum {
+class OperationType extends ProtoEnum {
   /// Unspecified
   static const operationtypeUnspecified =
       OperationType('OPERATIONTYPE_UNSPECIFIED');
@@ -2572,7 +2573,7 @@ class OperationType extends GEnum {
 }
 
 /// The environment the function is hosted on.
-class Environment extends GEnum {
+class Environment extends ProtoEnum {
   /// Unspecified
   static const environmentUnspecified = Environment('ENVIRONMENT_UNSPECIFIED');
 

--- a/generator/dart/generated/google_cloud_iam_v1/lib/iam.dart
+++ b/generator/dart/generated/google_cloud_iam_v1/lib/iam.dart
@@ -98,7 +98,7 @@ class IAMPolicy {
 }
 
 /// Request message for `SetIamPolicy` method.
-class SetIamPolicyRequest extends GMessage {
+class SetIamPolicyRequest extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.SetIamPolicyRequest';
 
   /// REQUIRED: The resource for which the policy is being specified.
@@ -151,7 +151,7 @@ class SetIamPolicyRequest extends GMessage {
 }
 
 /// Request message for `GetIamPolicy` method.
-class GetIamPolicyRequest extends GMessage {
+class GetIamPolicyRequest extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.GetIamPolicyRequest';
 
   /// REQUIRED: The resource for which the policy is being requested.
@@ -192,7 +192,7 @@ class GetIamPolicyRequest extends GMessage {
 }
 
 /// Request message for `TestIamPermissions` method.
-class TestIamPermissionsRequest extends GMessage {
+class TestIamPermissionsRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.iam.v1.TestIamPermissionsRequest';
 
@@ -236,7 +236,7 @@ class TestIamPermissionsRequest extends GMessage {
 }
 
 /// Response message for `TestIamPermissions` method.
-class TestIamPermissionsResponse extends GMessage {
+class TestIamPermissionsResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.iam.v1.TestIamPermissionsResponse';
 
@@ -266,7 +266,7 @@ class TestIamPermissionsResponse extends GMessage {
 }
 
 /// Encapsulates settings provided to GetIamPolicy.
-class GetPolicyOptions extends GMessage {
+class GetPolicyOptions extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.GetPolicyOptions';
 
   /// Optional. The maximum policy version that will be used to format the
@@ -390,7 +390,7 @@ class GetPolicyOptions extends GMessage {
 ///
 /// For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
-class Policy extends GMessage {
+class Policy extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.Policy';
 
   /// Specifies the format of the policy.
@@ -487,7 +487,7 @@ class Policy extends GMessage {
 }
 
 /// Associates `members`, or principals, with a `role`.
-class Binding extends GMessage {
+class Binding extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.Binding';
 
   /// Role that is assigned to the list of `members`, or principals.
@@ -635,7 +635,7 @@ class Binding extends GMessage {
 /// For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ
 /// logging. It also exempts `jose@example.com` from DATA_READ logging, and
 /// `aliya@example.com` from DATA_WRITE logging.
-class AuditConfig extends GMessage {
+class AuditConfig extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.AuditConfig';
 
   /// Specifies a service that will be enabled for audit logging.
@@ -696,7 +696,7 @@ class AuditConfig extends GMessage {
 ///
 /// This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting
 /// jose@example.com from DATA_READ logging.
-class AuditLogConfig extends GMessage {
+class AuditLogConfig extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.AuditLogConfig';
 
   /// The log type that this config enables.
@@ -739,7 +739,7 @@ class AuditLogConfig extends GMessage {
 
 /// The list of valid permission types for which logging can be configured.
 /// Admin writes are always logged, and are not configurable.
-class AuditLogConfig_LogType extends GEnum {
+class AuditLogConfig_LogType extends ProtoEnum {
   /// Default case. Should never be this.
   static const logTypeUnspecified =
       AuditLogConfig_LogType('LOG_TYPE_UNSPECIFIED');
@@ -763,7 +763,7 @@ class AuditLogConfig_LogType extends GEnum {
 }
 
 /// The difference delta between two policies.
-class PolicyDelta extends GMessage {
+class PolicyDelta extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.PolicyDelta';
 
   /// The delta for Bindings between two policies.
@@ -801,7 +801,7 @@ class PolicyDelta extends GMessage {
 
 /// One delta entry for Binding. Each individual change (only one member in each
 /// entry) to a binding will be a separate entry.
-class BindingDelta extends GMessage {
+class BindingDelta extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.BindingDelta';
 
   /// The action that was performed on a Binding.
@@ -859,7 +859,7 @@ class BindingDelta extends GMessage {
 }
 
 /// The type of action performed on a Binding in a policy.
-class BindingDelta_Action extends GEnum {
+class BindingDelta_Action extends ProtoEnum {
   /// Unspecified.
   static const actionUnspecified = BindingDelta_Action('ACTION_UNSPECIFIED');
 
@@ -880,7 +880,7 @@ class BindingDelta_Action extends GEnum {
 
 /// One delta entry for AuditConfig. Each individual change (only one
 /// exempted_member in each entry) to a AuditConfig will be a separate entry.
-class AuditConfigDelta extends GMessage {
+class AuditConfigDelta extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.AuditConfigDelta';
 
   /// The action that was performed on an audit configuration in a policy.
@@ -942,7 +942,7 @@ class AuditConfigDelta extends GMessage {
 }
 
 /// The type of action performed on an audit configuration in a policy.
-class AuditConfigDelta_Action extends GEnum {
+class AuditConfigDelta_Action extends ProtoEnum {
   /// Unspecified.
   static const actionUnspecified =
       AuditConfigDelta_Action('ACTION_UNSPECIFIED');
@@ -964,7 +964,7 @@ class AuditConfigDelta_Action extends GEnum {
 
 /// Output-only policy member strings of a Google Cloud resource's built-in
 /// identity.
-class ResourcePolicyMember extends GMessage {
+class ResourcePolicyMember extends ProtoMessage {
   static const String fullyQualifiedName = 'google.iam.v1.ResourcePolicyMember';
 
   /// IAM policy binding member referring to a Google Cloud resource by

--- a/generator/dart/generated/google_cloud_iam_v1/lib/iam.dart
+++ b/generator/dart/generated/google_cloud_iam_v1/lib/iam.dart
@@ -19,9 +19,7 @@
 /// Manages access control for Google Cloud Platform resources.
 library;
 
-import 'dart:typed_data';
-
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_type/type.dart';
@@ -100,7 +98,7 @@ class IAMPolicy {
 }
 
 /// Request message for `SetIamPolicy` method.
-class SetIamPolicyRequest extends Message {
+class SetIamPolicyRequest extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.SetIamPolicyRequest';
 
   /// REQUIRED: The resource for which the policy is being specified.
@@ -153,7 +151,7 @@ class SetIamPolicyRequest extends Message {
 }
 
 /// Request message for `GetIamPolicy` method.
-class GetIamPolicyRequest extends Message {
+class GetIamPolicyRequest extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.GetIamPolicyRequest';
 
   /// REQUIRED: The resource for which the policy is being requested.
@@ -194,7 +192,7 @@ class GetIamPolicyRequest extends Message {
 }
 
 /// Request message for `TestIamPermissions` method.
-class TestIamPermissionsRequest extends Message {
+class TestIamPermissionsRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.iam.v1.TestIamPermissionsRequest';
 
@@ -238,7 +236,7 @@ class TestIamPermissionsRequest extends Message {
 }
 
 /// Response message for `TestIamPermissions` method.
-class TestIamPermissionsResponse extends Message {
+class TestIamPermissionsResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.iam.v1.TestIamPermissionsResponse';
 
@@ -268,7 +266,7 @@ class TestIamPermissionsResponse extends Message {
 }
 
 /// Encapsulates settings provided to GetIamPolicy.
-class GetPolicyOptions extends Message {
+class GetPolicyOptions extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.GetPolicyOptions';
 
   /// Optional. The maximum policy version that will be used to format the
@@ -392,7 +390,7 @@ class GetPolicyOptions extends Message {
 ///
 /// For a description of IAM and its features, see the
 /// [IAM documentation](https://cloud.google.com/iam/docs/).
-class Policy extends Message {
+class Policy extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.Policy';
 
   /// Specifies the format of the policy.
@@ -489,7 +487,7 @@ class Policy extends Message {
 }
 
 /// Associates `members`, or principals, with a `role`.
-class Binding extends Message {
+class Binding extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.Binding';
 
   /// Role that is assigned to the list of `members`, or principals.
@@ -637,7 +635,7 @@ class Binding extends Message {
 /// For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ
 /// logging. It also exempts `jose@example.com` from DATA_READ logging, and
 /// `aliya@example.com` from DATA_WRITE logging.
-class AuditConfig extends Message {
+class AuditConfig extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.AuditConfig';
 
   /// Specifies a service that will be enabled for audit logging.
@@ -698,7 +696,7 @@ class AuditConfig extends Message {
 ///
 /// This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting
 /// jose@example.com from DATA_READ logging.
-class AuditLogConfig extends Message {
+class AuditLogConfig extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.AuditLogConfig';
 
   /// The log type that this config enables.
@@ -741,7 +739,7 @@ class AuditLogConfig extends Message {
 
 /// The list of valid permission types for which logging can be configured.
 /// Admin writes are always logged, and are not configurable.
-class AuditLogConfig_LogType extends Enum {
+class AuditLogConfig_LogType extends GEnum {
   /// Default case. Should never be this.
   static const logTypeUnspecified =
       AuditLogConfig_LogType('LOG_TYPE_UNSPECIFIED');
@@ -765,7 +763,7 @@ class AuditLogConfig_LogType extends Enum {
 }
 
 /// The difference delta between two policies.
-class PolicyDelta extends Message {
+class PolicyDelta extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.PolicyDelta';
 
   /// The delta for Bindings between two policies.
@@ -803,7 +801,7 @@ class PolicyDelta extends Message {
 
 /// One delta entry for Binding. Each individual change (only one member in each
 /// entry) to a binding will be a separate entry.
-class BindingDelta extends Message {
+class BindingDelta extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.BindingDelta';
 
   /// The action that was performed on a Binding.
@@ -861,7 +859,7 @@ class BindingDelta extends Message {
 }
 
 /// The type of action performed on a Binding in a policy.
-class BindingDelta_Action extends Enum {
+class BindingDelta_Action extends GEnum {
   /// Unspecified.
   static const actionUnspecified = BindingDelta_Action('ACTION_UNSPECIFIED');
 
@@ -882,7 +880,7 @@ class BindingDelta_Action extends Enum {
 
 /// One delta entry for AuditConfig. Each individual change (only one
 /// exempted_member in each entry) to a AuditConfig will be a separate entry.
-class AuditConfigDelta extends Message {
+class AuditConfigDelta extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.AuditConfigDelta';
 
   /// The action that was performed on an audit configuration in a policy.
@@ -944,7 +942,7 @@ class AuditConfigDelta extends Message {
 }
 
 /// The type of action performed on an audit configuration in a policy.
-class AuditConfigDelta_Action extends Enum {
+class AuditConfigDelta_Action extends GEnum {
   /// Unspecified.
   static const actionUnspecified =
       AuditConfigDelta_Action('ACTION_UNSPECIFIED');
@@ -966,7 +964,7 @@ class AuditConfigDelta_Action extends Enum {
 
 /// Output-only policy member strings of a Google Cloud resource's built-in
 /// identity.
-class ResourcePolicyMember extends Message {
+class ResourcePolicyMember extends GMessage {
   static const String fullyQualifiedName = 'google.iam.v1.ResourcePolicyMember';
 
   /// IAM policy binding member referring to a Google Cloud resource by

--- a/generator/dart/generated/google_cloud_language_v2/lib/language.dart
+++ b/generator/dart/generated/google_cloud_language_v2/lib/language.dart
@@ -21,7 +21,7 @@
 /// annotations, to developers.
 library;
 
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:http/http.dart' as http;
 
@@ -81,7 +81,7 @@ class LanguageService {
 }
 
 /// Represents the input to API methods.
-class Document extends Message {
+class Document extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Document';
 
   /// Required. If the type is not set or is `TYPE_UNSPECIFIED`,
@@ -147,7 +147,7 @@ class Document extends Message {
 }
 
 /// The document types enum.
-class Document_Type extends Enum {
+class Document_Type extends GEnum {
   /// The content type is not specified.
   static const typeUnspecified = Document_Type('TYPE_UNSPECIFIED');
 
@@ -166,7 +166,7 @@ class Document_Type extends Enum {
 }
 
 /// Represents a sentence in the input document.
-class Sentence extends Message {
+class Sentence extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Sentence';
 
   /// The sentence text.
@@ -204,7 +204,7 @@ class Sentence extends Message {
 /// Represents a phrase in the text that is a known entity, such as
 /// a person, an organization, or location. The API associates information, such
 /// as probability and mentions, with entities.
-class Entity extends Message {
+class Entity extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Entity';
 
   /// The representative name for the entity.
@@ -271,7 +271,7 @@ class Entity extends Message {
 /// The type of the entity. The table
 /// below lists the associated fields for entities that have different
 /// metadata.
-class Entity_Type extends Enum {
+class Entity_Type extends GEnum {
   /// Unknown
   static const unknown = Entity_Type('UNKNOWN');
 
@@ -355,7 +355,7 @@ class Entity_Type extends Enum {
 
 /// Represents the feeling associated with the entire text or entities in
 /// the text.
-class Sentiment extends Message {
+class Sentiment extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Sentiment';
 
   /// A non-negative number in the [0, +inf) range, which represents
@@ -399,7 +399,7 @@ class Sentiment extends Message {
 
 /// Represents a mention for an entity in the text. Currently, proper noun
 /// mentions are supported.
-class EntityMention extends Message {
+class EntityMention extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.EntityMention';
 
@@ -458,7 +458,7 @@ class EntityMention extends Message {
 }
 
 /// The supported types of mentions.
-class EntityMention_Type extends Enum {
+class EntityMention_Type extends GEnum {
   /// Unknown
   static const typeUnknown = EntityMention_Type('TYPE_UNKNOWN');
 
@@ -477,7 +477,7 @@ class EntityMention_Type extends Enum {
 }
 
 /// Represents a text span in the input document.
-class TextSpan extends Message {
+class TextSpan extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.TextSpan';
 
   /// The content of the text span, which is a substring of the document.
@@ -520,7 +520,7 @@ class TextSpan extends Message {
 }
 
 /// Represents a category returned from the text classifier.
-class ClassificationCategory extends Message {
+class ClassificationCategory extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ClassificationCategory';
 
@@ -571,7 +571,7 @@ class ClassificationCategory extends Message {
 }
 
 /// The sentiment analysis request message.
-class AnalyzeSentimentRequest extends Message {
+class AnalyzeSentimentRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeSentimentRequest';
 
@@ -611,7 +611,7 @@ class AnalyzeSentimentRequest extends Message {
 }
 
 /// The sentiment analysis response message.
-class AnalyzeSentimentResponse extends Message {
+class AnalyzeSentimentResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeSentimentResponse';
 
@@ -669,7 +669,7 @@ class AnalyzeSentimentResponse extends Message {
 }
 
 /// The entity analysis request message.
-class AnalyzeEntitiesRequest extends Message {
+class AnalyzeEntitiesRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeEntitiesRequest';
 
@@ -709,7 +709,7 @@ class AnalyzeEntitiesRequest extends Message {
 }
 
 /// The entity analysis response message.
-class AnalyzeEntitiesResponse extends Message {
+class AnalyzeEntitiesResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeEntitiesResponse';
 
@@ -760,7 +760,7 @@ class AnalyzeEntitiesResponse extends Message {
 }
 
 /// The document classification request message.
-class ClassifyTextRequest extends Message {
+class ClassifyTextRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ClassifyTextRequest';
 
@@ -789,7 +789,7 @@ class ClassifyTextRequest extends Message {
 }
 
 /// The document classification response message.
-class ClassifyTextResponse extends Message {
+class ClassifyTextResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ClassifyTextResponse';
 
@@ -841,7 +841,7 @@ class ClassifyTextResponse extends Message {
 }
 
 /// The document moderation request message.
-class ModerateTextRequest extends Message {
+class ModerateTextRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ModerateTextRequest';
 
@@ -882,7 +882,7 @@ class ModerateTextRequest extends Message {
 }
 
 /// The model version to use for ModerateText.
-class ModerateTextRequest_ModelVersion extends Enum {
+class ModerateTextRequest_ModelVersion extends GEnum {
   /// The default model version.
   static const modelVersionUnspecified =
       ModerateTextRequest_ModelVersion('MODEL_VERSION_UNSPECIFIED');
@@ -909,7 +909,7 @@ class ModerateTextRequest_ModelVersion extends Enum {
 }
 
 /// The document moderation response message.
-class ModerateTextResponse extends Message {
+class ModerateTextResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ModerateTextResponse';
 
@@ -963,7 +963,7 @@ class ModerateTextResponse extends Message {
 
 /// The request message for the text annotation API, which can perform multiple
 /// analysis types in one call.
-class AnnotateTextRequest extends Message {
+class AnnotateTextRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnnotateTextRequest';
 
@@ -1010,7 +1010,7 @@ class AnnotateTextRequest extends Message {
 
 /// All available features.
 /// Setting each one to true will enable that specific analysis for the input.
-class AnnotateTextRequest_Features extends Message {
+class AnnotateTextRequest_Features extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnnotateTextRequest.Features';
 
@@ -1067,7 +1067,7 @@ class AnnotateTextRequest_Features extends Message {
 }
 
 /// The text annotations response message.
-class AnnotateTextResponse extends Message {
+class AnnotateTextResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnnotateTextResponse';
 
@@ -1156,7 +1156,7 @@ class AnnotateTextResponse extends Message {
 /// beginning offsets for various outputs, such as tokens and mentions, and
 /// languages that natively use different text encodings may access offsets
 /// differently.
-class EncodingType extends Enum {
+class EncodingType extends GEnum {
   /// If `EncodingType` is not specified, encoding-dependent information (such as
   /// `begin_offset`) will be set at `-1`.
   static const none = EncodingType('NONE');

--- a/generator/dart/generated/google_cloud_language_v2/lib/language.dart
+++ b/generator/dart/generated/google_cloud_language_v2/lib/language.dart
@@ -81,7 +81,7 @@ class LanguageService {
 }
 
 /// Represents the input to API methods.
-class Document extends GMessage {
+class Document extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Document';
 
   /// Required. If the type is not set or is `TYPE_UNSPECIFIED`,
@@ -147,7 +147,7 @@ class Document extends GMessage {
 }
 
 /// The document types enum.
-class Document_Type extends GEnum {
+class Document_Type extends ProtoEnum {
   /// The content type is not specified.
   static const typeUnspecified = Document_Type('TYPE_UNSPECIFIED');
 
@@ -166,7 +166,7 @@ class Document_Type extends GEnum {
 }
 
 /// Represents a sentence in the input document.
-class Sentence extends GMessage {
+class Sentence extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Sentence';
 
   /// The sentence text.
@@ -204,7 +204,7 @@ class Sentence extends GMessage {
 /// Represents a phrase in the text that is a known entity, such as
 /// a person, an organization, or location. The API associates information, such
 /// as probability and mentions, with entities.
-class Entity extends GMessage {
+class Entity extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Entity';
 
   /// The representative name for the entity.
@@ -271,7 +271,7 @@ class Entity extends GMessage {
 /// The type of the entity. The table
 /// below lists the associated fields for entities that have different
 /// metadata.
-class Entity_Type extends GEnum {
+class Entity_Type extends ProtoEnum {
   /// Unknown
   static const unknown = Entity_Type('UNKNOWN');
 
@@ -355,7 +355,7 @@ class Entity_Type extends GEnum {
 
 /// Represents the feeling associated with the entire text or entities in
 /// the text.
-class Sentiment extends GMessage {
+class Sentiment extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.Sentiment';
 
   /// A non-negative number in the [0, +inf) range, which represents
@@ -399,7 +399,7 @@ class Sentiment extends GMessage {
 
 /// Represents a mention for an entity in the text. Currently, proper noun
 /// mentions are supported.
-class EntityMention extends GMessage {
+class EntityMention extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.EntityMention';
 
@@ -458,7 +458,7 @@ class EntityMention extends GMessage {
 }
 
 /// The supported types of mentions.
-class EntityMention_Type extends GEnum {
+class EntityMention_Type extends ProtoEnum {
   /// Unknown
   static const typeUnknown = EntityMention_Type('TYPE_UNKNOWN');
 
@@ -477,7 +477,7 @@ class EntityMention_Type extends GEnum {
 }
 
 /// Represents a text span in the input document.
-class TextSpan extends GMessage {
+class TextSpan extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.language.v2.TextSpan';
 
   /// The content of the text span, which is a substring of the document.
@@ -520,7 +520,7 @@ class TextSpan extends GMessage {
 }
 
 /// Represents a category returned from the text classifier.
-class ClassificationCategory extends GMessage {
+class ClassificationCategory extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ClassificationCategory';
 
@@ -571,7 +571,7 @@ class ClassificationCategory extends GMessage {
 }
 
 /// The sentiment analysis request message.
-class AnalyzeSentimentRequest extends GMessage {
+class AnalyzeSentimentRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeSentimentRequest';
 
@@ -611,7 +611,7 @@ class AnalyzeSentimentRequest extends GMessage {
 }
 
 /// The sentiment analysis response message.
-class AnalyzeSentimentResponse extends GMessage {
+class AnalyzeSentimentResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeSentimentResponse';
 
@@ -669,7 +669,7 @@ class AnalyzeSentimentResponse extends GMessage {
 }
 
 /// The entity analysis request message.
-class AnalyzeEntitiesRequest extends GMessage {
+class AnalyzeEntitiesRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeEntitiesRequest';
 
@@ -709,7 +709,7 @@ class AnalyzeEntitiesRequest extends GMessage {
 }
 
 /// The entity analysis response message.
-class AnalyzeEntitiesResponse extends GMessage {
+class AnalyzeEntitiesResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnalyzeEntitiesResponse';
 
@@ -760,7 +760,7 @@ class AnalyzeEntitiesResponse extends GMessage {
 }
 
 /// The document classification request message.
-class ClassifyTextRequest extends GMessage {
+class ClassifyTextRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ClassifyTextRequest';
 
@@ -789,7 +789,7 @@ class ClassifyTextRequest extends GMessage {
 }
 
 /// The document classification response message.
-class ClassifyTextResponse extends GMessage {
+class ClassifyTextResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ClassifyTextResponse';
 
@@ -841,7 +841,7 @@ class ClassifyTextResponse extends GMessage {
 }
 
 /// The document moderation request message.
-class ModerateTextRequest extends GMessage {
+class ModerateTextRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ModerateTextRequest';
 
@@ -882,7 +882,7 @@ class ModerateTextRequest extends GMessage {
 }
 
 /// The model version to use for ModerateText.
-class ModerateTextRequest_ModelVersion extends GEnum {
+class ModerateTextRequest_ModelVersion extends ProtoEnum {
   /// The default model version.
   static const modelVersionUnspecified =
       ModerateTextRequest_ModelVersion('MODEL_VERSION_UNSPECIFIED');
@@ -909,7 +909,7 @@ class ModerateTextRequest_ModelVersion extends GEnum {
 }
 
 /// The document moderation response message.
-class ModerateTextResponse extends GMessage {
+class ModerateTextResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.ModerateTextResponse';
 
@@ -963,7 +963,7 @@ class ModerateTextResponse extends GMessage {
 
 /// The request message for the text annotation API, which can perform multiple
 /// analysis types in one call.
-class AnnotateTextRequest extends GMessage {
+class AnnotateTextRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnnotateTextRequest';
 
@@ -1010,7 +1010,7 @@ class AnnotateTextRequest extends GMessage {
 
 /// All available features.
 /// Setting each one to true will enable that specific analysis for the input.
-class AnnotateTextRequest_Features extends GMessage {
+class AnnotateTextRequest_Features extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnnotateTextRequest.Features';
 
@@ -1067,7 +1067,7 @@ class AnnotateTextRequest_Features extends GMessage {
 }
 
 /// The text annotations response message.
-class AnnotateTextResponse extends GMessage {
+class AnnotateTextResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.language.v2.AnnotateTextResponse';
 
@@ -1156,7 +1156,7 @@ class AnnotateTextResponse extends GMessage {
 /// beginning offsets for various outputs, such as tokens and mentions, and
 /// languages that natively use different text encodings may access offsets
 /// differently.
-class EncodingType extends GEnum {
+class EncodingType extends ProtoEnum {
   /// If `EncodingType` is not specified, encoding-dependent information (such as
   /// `begin_offset`) will be set at `-1`.
   static const none = EncodingType('NONE');

--- a/generator/dart/generated/google_cloud_location/lib/location.dart
+++ b/generator/dart/generated/google_cloud_location/lib/location.dart
@@ -21,7 +21,7 @@
 /// zones, regions, and countries.
 library;
 
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:http/http.dart' as http;
@@ -59,7 +59,7 @@ class Locations {
 }
 
 /// The request message for `Locations.ListLocations`.
-class ListLocationsRequest extends Message {
+class ListLocationsRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.location.ListLocationsRequest';
 
@@ -114,7 +114,7 @@ class ListLocationsRequest extends Message {
 }
 
 /// The response message for `Locations.ListLocations`.
-class ListLocationsResponse extends Message {
+class ListLocationsResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.location.ListLocationsResponse';
 
@@ -154,7 +154,7 @@ class ListLocationsResponse extends Message {
 }
 
 /// The request message for `Locations.GetLocation`.
-class GetLocationRequest extends Message {
+class GetLocationRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.location.GetLocationRequest';
 
@@ -188,7 +188,7 @@ class GetLocationRequest extends Message {
 }
 
 /// A resource that represents Google Cloud Platform location.
-class Location extends Message {
+class Location extends GMessage {
   static const String fullyQualifiedName = 'google.cloud.location.Location';
 
   /// Resource name for the location, which may vary between implementations.

--- a/generator/dart/generated/google_cloud_location/lib/location.dart
+++ b/generator/dart/generated/google_cloud_location/lib/location.dart
@@ -59,7 +59,7 @@ class Locations {
 }
 
 /// The request message for `Locations.ListLocations`.
-class ListLocationsRequest extends GMessage {
+class ListLocationsRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.location.ListLocationsRequest';
 
@@ -114,7 +114,7 @@ class ListLocationsRequest extends GMessage {
 }
 
 /// The response message for `Locations.ListLocations`.
-class ListLocationsResponse extends GMessage {
+class ListLocationsResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.location.ListLocationsResponse';
 
@@ -154,7 +154,7 @@ class ListLocationsResponse extends GMessage {
 }
 
 /// The request message for `Locations.GetLocation`.
-class GetLocationRequest extends GMessage {
+class GetLocationRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.location.GetLocationRequest';
 
@@ -188,7 +188,7 @@ class GetLocationRequest extends GMessage {
 }
 
 /// A resource that represents Google Cloud Platform location.
-class Location extends GMessage {
+class Location extends ProtoMessage {
   static const String fullyQualifiedName = 'google.cloud.location.Location';
 
   /// Resource name for the location, which may vary between implementations.

--- a/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -28,7 +28,7 @@
 /// [Long-running operations]: https://google.aip.dev/151
 library;
 
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 import 'package:google_cloud_rpc/rpc.dart';
@@ -104,7 +104,7 @@ class Operations {
 
 /// The request message for
 /// `Operations.GetOperation`.
-class GetOperationRequest extends Message {
+class GetOperationRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.longrunning.GetOperationRequest';
 
@@ -139,7 +139,7 @@ class GetOperationRequest extends Message {
 
 /// The request message for
 /// `Operations.ListOperations`.
-class ListOperationsRequest extends Message {
+class ListOperationsRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.longrunning.ListOperationsRequest';
 
@@ -195,7 +195,7 @@ class ListOperationsRequest extends Message {
 
 /// The response message for
 /// `Operations.ListOperations`.
-class ListOperationsResponse extends Message {
+class ListOperationsResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.longrunning.ListOperationsResponse';
 
@@ -236,7 +236,7 @@ class ListOperationsResponse extends Message {
 
 /// The request message for
 /// `Operations.CancelOperation`.
-class CancelOperationRequest extends Message {
+class CancelOperationRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.longrunning.CancelOperationRequest';
 
@@ -271,7 +271,7 @@ class CancelOperationRequest extends Message {
 
 /// The request message for
 /// `Operations.DeleteOperation`.
-class DeleteOperationRequest extends Message {
+class DeleteOperationRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.longrunning.DeleteOperationRequest';
 
@@ -306,7 +306,7 @@ class DeleteOperationRequest extends Message {
 
 /// The request message for
 /// `Operations.WaitOperation`.
-class WaitOperationRequest extends Message {
+class WaitOperationRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.longrunning.WaitOperationRequest';
 
@@ -357,7 +357,7 @@ class WaitOperationRequest extends Message {
 ///         metadata_type: "ExportMetadata"
 ///       };
 ///     }
-class OperationInfo extends Message {
+class OperationInfo extends GMessage {
   static const String fullyQualifiedName = 'google.longrunning.OperationInfo';
 
   /// Required. The message name of the primary return type for this

--- a/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -104,7 +104,7 @@ class Operations {
 
 /// The request message for
 /// `Operations.GetOperation`.
-class GetOperationRequest extends GMessage {
+class GetOperationRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.longrunning.GetOperationRequest';
 
@@ -139,7 +139,7 @@ class GetOperationRequest extends GMessage {
 
 /// The request message for
 /// `Operations.ListOperations`.
-class ListOperationsRequest extends GMessage {
+class ListOperationsRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.longrunning.ListOperationsRequest';
 
@@ -195,7 +195,7 @@ class ListOperationsRequest extends GMessage {
 
 /// The response message for
 /// `Operations.ListOperations`.
-class ListOperationsResponse extends GMessage {
+class ListOperationsResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.longrunning.ListOperationsResponse';
 
@@ -236,7 +236,7 @@ class ListOperationsResponse extends GMessage {
 
 /// The request message for
 /// `Operations.CancelOperation`.
-class CancelOperationRequest extends GMessage {
+class CancelOperationRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.longrunning.CancelOperationRequest';
 
@@ -271,7 +271,7 @@ class CancelOperationRequest extends GMessage {
 
 /// The request message for
 /// `Operations.DeleteOperation`.
-class DeleteOperationRequest extends GMessage {
+class DeleteOperationRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.longrunning.DeleteOperationRequest';
 
@@ -306,7 +306,7 @@ class DeleteOperationRequest extends GMessage {
 
 /// The request message for
 /// `Operations.WaitOperation`.
-class WaitOperationRequest extends GMessage {
+class WaitOperationRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.longrunning.WaitOperationRequest';
 
@@ -357,7 +357,7 @@ class WaitOperationRequest extends GMessage {
 ///         metadata_type: "ExportMetadata"
 ///       };
 ///     }
-class OperationInfo extends GMessage {
+class OperationInfo extends ProtoMessage {
   static const String fullyQualifiedName = 'google.longrunning.OperationInfo';
 
   /// Required. The message name of the primary return type for this

--- a/generator/dart/generated/google_cloud_longrunning/lib/src/longrunning.p.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/src/longrunning.p.dart
@@ -16,7 +16,8 @@ part of '../longrunning.dart';
 
 /// This resource represents a long-running operation that is the result of a
 /// network API call.
-class Operation<T extends GMessage, S extends GMessage> extends GMessage {
+class Operation<T extends ProtoMessage, S extends ProtoMessage>
+    extends ProtoMessage {
   static const String fullyQualifiedName = 'google.longrunning.Operation';
 
   /// The server-assigned name, which is only unique within the same service that
@@ -122,7 +123,7 @@ class Operation<T extends GMessage, S extends GMessage> extends GMessage {
 /// [Operation.response] and [Operation.metadata] fields in order to populate
 /// the typed [Operation.responseAsMessage] and [Operation.metadataAsMessage]
 /// fields.
-final class OperationHelper<T extends GMessage, S extends GMessage> {
+final class OperationHelper<T extends ProtoMessage, S extends ProtoMessage> {
   final T Function(Map<String, dynamic>) responseDecoder;
   final S Function(Map<String, dynamic>)? metadataDecoder;
 

--- a/generator/dart/generated/google_cloud_longrunning/lib/src/longrunning.p.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/src/longrunning.p.dart
@@ -16,7 +16,7 @@ part of '../longrunning.dart';
 
 /// This resource represents a long-running operation that is the result of a
 /// network API call.
-class Operation<T extends Message, S extends Message> extends Message {
+class Operation<T extends GMessage, S extends GMessage> extends GMessage {
   static const String fullyQualifiedName = 'google.longrunning.Operation';
 
   /// The server-assigned name, which is only unique within the same service that
@@ -122,7 +122,7 @@ class Operation<T extends Message, S extends Message> extends Message {
 /// [Operation.response] and [Operation.metadata] fields in order to populate
 /// the typed [Operation.responseAsMessage] and [Operation.metadataAsMessage]
 /// fields.
-final class OperationHelper<T extends Message, S extends Message> {
+final class OperationHelper<T extends GMessage, S extends GMessage> {
   final T Function(Map<String, dynamic>) responseDecoder;
   final S Function(Map<String, dynamic>)? metadataDecoder;
 

--- a/generator/dart/generated/google_cloud_protobuf/.sidekick.toml
+++ b/generator/dart/generated/google_cloud_protobuf/.sidekick.toml
@@ -33,4 +33,3 @@ include-list = """\
 copyright-year = '2025'
 part-file = "src/protobuf.p.dart"
 dev-dependencies = "test"
-extra-imports = "dart:typed_data"

--- a/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -19,9 +19,7 @@
 /// Core Protobuf types used by most services.
 library;
 
-import 'dart:typed_data';
-
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 
 part 'src/protobuf.p.dart';
@@ -84,7 +82,7 @@ part 'src/protobuf.p.dart';
 /// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
-class Duration extends Message {
+class Duration extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Duration';
 
   /// Signed seconds of the span of time. Must be from -315,576,000,000
@@ -129,7 +127,7 @@ class Duration extends Message {
 ///     service Foo {
 ///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 ///     }
-class Empty extends Message {
+class Empty extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Empty';
 
   Empty() : super(fullyQualifiedName);
@@ -346,7 +344,7 @@ class Empty extends Message {
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is unmappable.
-class FieldMask extends Message {
+class FieldMask extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.FieldMask';
 
   /// The set of field mask paths.
@@ -373,7 +371,7 @@ class FieldMask extends Message {
 /// with the proto support for the language.
 ///
 /// The JSON representation for `Struct` is JSON object.
-class Struct extends Message {
+class Struct extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Struct';
 
   /// Unordered map of dynamically typed values.
@@ -395,7 +393,7 @@ class Struct extends Message {
 /// `ListValue` is a wrapper around a repeated field of values.
 ///
 /// The JSON representation for `ListValue` is JSON array.
-class ListValue extends Message {
+class ListValue extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.ListValue';
 
   /// Repeated field of dynamically typed values.
@@ -503,7 +501,7 @@ class ListValue extends Message {
 /// the Joda Time's [`ISODateTimeFormat.dateTime()`](
 /// http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
 /// ) to obtain a formatter capable of generating timestamps in this format.
-class Timestamp extends Message {
+class Timestamp extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Timestamp';
 
   /// Represents seconds of UTC time since Unix epoch
@@ -542,7 +540,7 @@ class Timestamp extends Message {
 /// Wrapper message for `double`.
 ///
 /// The JSON representation for `DoubleValue` is JSON number.
-class DoubleValue extends Message {
+class DoubleValue extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.DoubleValue';
 
   /// The double value.
@@ -569,7 +567,7 @@ class DoubleValue extends Message {
 /// Wrapper message for `float`.
 ///
 /// The JSON representation for `FloatValue` is JSON number.
-class FloatValue extends Message {
+class FloatValue extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.FloatValue';
 
   /// The float value.
@@ -596,7 +594,7 @@ class FloatValue extends Message {
 /// Wrapper message for `int64`.
 ///
 /// The JSON representation for `Int64Value` is JSON string.
-class Int64Value extends Message {
+class Int64Value extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Int64Value';
 
   /// The int64 value.
@@ -623,7 +621,7 @@ class Int64Value extends Message {
 /// Wrapper message for `uint64`.
 ///
 /// The JSON representation for `UInt64Value` is JSON string.
-class Uint64Value extends Message {
+class Uint64Value extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.UInt64Value';
 
   /// The uint64 value.
@@ -650,7 +648,7 @@ class Uint64Value extends Message {
 /// Wrapper message for `int32`.
 ///
 /// The JSON representation for `Int32Value` is JSON number.
-class Int32Value extends Message {
+class Int32Value extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Int32Value';
 
   /// The int32 value.
@@ -677,7 +675,7 @@ class Int32Value extends Message {
 /// Wrapper message for `uint32`.
 ///
 /// The JSON representation for `UInt32Value` is JSON number.
-class Uint32Value extends Message {
+class Uint32Value extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.UInt32Value';
 
   /// The uint32 value.
@@ -704,7 +702,7 @@ class Uint32Value extends Message {
 /// Wrapper message for `bool`.
 ///
 /// The JSON representation for `BoolValue` is JSON `true` and `false`.
-class BoolValue extends Message {
+class BoolValue extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.BoolValue';
 
   /// The bool value.
@@ -731,7 +729,7 @@ class BoolValue extends Message {
 /// Wrapper message for `string`.
 ///
 /// The JSON representation for `StringValue` is JSON string.
-class StringValue extends Message {
+class StringValue extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.StringValue';
 
   /// The string value.
@@ -758,7 +756,7 @@ class StringValue extends Message {
 /// Wrapper message for `bytes`.
 ///
 /// The JSON representation for `BytesValue` is JSON string.
-class BytesValue extends Message {
+class BytesValue extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.BytesValue';
 
   /// The bytes value.
@@ -786,7 +784,7 @@ class BytesValue extends Message {
 /// `Value` type union.
 ///
 /// The JSON representation for `NullValue` is JSON `null`.
-class NullValue extends Enum {
+class NullValue extends GEnum {
   /// Null value.
   static const nullValue = NullValue('NULL_VALUE');
 

--- a/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/protobuf.dart
@@ -82,7 +82,7 @@ part 'src/protobuf.p.dart';
 /// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
-class Duration extends GMessage {
+class Duration extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Duration';
 
   /// Signed seconds of the span of time. Must be from -315,576,000,000
@@ -127,7 +127,7 @@ class Duration extends GMessage {
 ///     service Foo {
 ///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 ///     }
-class Empty extends GMessage {
+class Empty extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Empty';
 
   Empty() : super(fullyQualifiedName);
@@ -344,7 +344,7 @@ class Empty extends GMessage {
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is unmappable.
-class FieldMask extends GMessage {
+class FieldMask extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.FieldMask';
 
   /// The set of field mask paths.
@@ -371,7 +371,7 @@ class FieldMask extends GMessage {
 /// with the proto support for the language.
 ///
 /// The JSON representation for `Struct` is JSON object.
-class Struct extends GMessage {
+class Struct extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Struct';
 
   /// Unordered map of dynamically typed values.
@@ -393,7 +393,7 @@ class Struct extends GMessage {
 /// `ListValue` is a wrapper around a repeated field of values.
 ///
 /// The JSON representation for `ListValue` is JSON array.
-class ListValue extends GMessage {
+class ListValue extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.ListValue';
 
   /// Repeated field of dynamically typed values.
@@ -501,7 +501,7 @@ class ListValue extends GMessage {
 /// the Joda Time's [`ISODateTimeFormat.dateTime()`](
 /// http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
 /// ) to obtain a formatter capable of generating timestamps in this format.
-class Timestamp extends GMessage {
+class Timestamp extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Timestamp';
 
   /// Represents seconds of UTC time since Unix epoch
@@ -540,7 +540,7 @@ class Timestamp extends GMessage {
 /// Wrapper message for `double`.
 ///
 /// The JSON representation for `DoubleValue` is JSON number.
-class DoubleValue extends GMessage {
+class DoubleValue extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.DoubleValue';
 
   /// The double value.
@@ -567,7 +567,7 @@ class DoubleValue extends GMessage {
 /// Wrapper message for `float`.
 ///
 /// The JSON representation for `FloatValue` is JSON number.
-class FloatValue extends GMessage {
+class FloatValue extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.FloatValue';
 
   /// The float value.
@@ -594,7 +594,7 @@ class FloatValue extends GMessage {
 /// Wrapper message for `int64`.
 ///
 /// The JSON representation for `Int64Value` is JSON string.
-class Int64Value extends GMessage {
+class Int64Value extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Int64Value';
 
   /// The int64 value.
@@ -621,7 +621,7 @@ class Int64Value extends GMessage {
 /// Wrapper message for `uint64`.
 ///
 /// The JSON representation for `UInt64Value` is JSON string.
-class Uint64Value extends GMessage {
+class Uint64Value extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.UInt64Value';
 
   /// The uint64 value.
@@ -648,7 +648,7 @@ class Uint64Value extends GMessage {
 /// Wrapper message for `int32`.
 ///
 /// The JSON representation for `Int32Value` is JSON number.
-class Int32Value extends GMessage {
+class Int32Value extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Int32Value';
 
   /// The int32 value.
@@ -675,7 +675,7 @@ class Int32Value extends GMessage {
 /// Wrapper message for `uint32`.
 ///
 /// The JSON representation for `UInt32Value` is JSON number.
-class Uint32Value extends GMessage {
+class Uint32Value extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.UInt32Value';
 
   /// The uint32 value.
@@ -702,7 +702,7 @@ class Uint32Value extends GMessage {
 /// Wrapper message for `bool`.
 ///
 /// The JSON representation for `BoolValue` is JSON `true` and `false`.
-class BoolValue extends GMessage {
+class BoolValue extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.BoolValue';
 
   /// The bool value.
@@ -729,7 +729,7 @@ class BoolValue extends GMessage {
 /// Wrapper message for `string`.
 ///
 /// The JSON representation for `StringValue` is JSON string.
-class StringValue extends GMessage {
+class StringValue extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.StringValue';
 
   /// The string value.
@@ -756,7 +756,7 @@ class StringValue extends GMessage {
 /// Wrapper message for `bytes`.
 ///
 /// The JSON representation for `BytesValue` is JSON string.
-class BytesValue extends GMessage {
+class BytesValue extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.BytesValue';
 
   /// The bytes value.
@@ -784,7 +784,7 @@ class BytesValue extends GMessage {
 /// `Value` type union.
 ///
 /// The JSON representation for `NullValue` is JSON `null`.
-class NullValue extends GEnum {
+class NullValue extends ProtoEnum {
   /// Null value.
   static const nullValue = NullValue('NULL_VALUE');
 

--- a/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -16,7 +16,7 @@ part of '../protobuf.dart';
 
 /// `Any` contains an arbitrary serialized message along with a URL that
 /// describes the type of the serialized message.
-class Any extends GMessage {
+class Any extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Any';
 
   // This list needs to be kept in sync with generator/internal/dart/dart.go.
@@ -46,7 +46,7 @@ class Any extends GMessage {
         super(fullyQualifiedName);
 
   /// Create an [Any] from an existing [message].
-  Any.from(GMessage message)
+  Any.from(ProtoMessage message)
       : json = {},
         super(fullyQualifiedName) {
     packInto(message);
@@ -94,7 +94,7 @@ class Any extends GMessage {
   ///   ...
   /// }
   /// ```
-  T unpackFrom<T extends GMessage, S>(T Function(S) decoder) {
+  T unpackFrom<T extends ProtoMessage, S>(T Function(S) decoder) {
     final name = typeName;
 
     if (_customEncodedTypes.contains(name)) {
@@ -107,7 +107,7 @@ class Any extends GMessage {
   }
 
   /// Serialize the given message into this `Any` instance.
-  void packInto(GMessage message) {
+  void packInto(ProtoMessage message) {
     final qualifiedName = message.qualifiedName;
 
     // @type
@@ -137,7 +137,7 @@ class Any extends GMessage {
 /// variants. Absence of any variant indicates an error.
 ///
 /// The JSON representation for `Value` is JSON value.
-class Value extends GMessage {
+class Value extends ProtoMessage {
   static const String fullyQualifiedName = 'google.protobuf.Value';
 
   /// Represents a null value.

--- a/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
+++ b/generator/dart/generated/google_cloud_protobuf/lib/src/protobuf.p.dart
@@ -16,7 +16,7 @@ part of '../protobuf.dart';
 
 /// `Any` contains an arbitrary serialized message along with a URL that
 /// describes the type of the serialized message.
-class Any extends Message {
+class Any extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Any';
 
   // This list needs to be kept in sync with generator/internal/dart/dart.go.
@@ -46,7 +46,7 @@ class Any extends Message {
         super(fullyQualifiedName);
 
   /// Create an [Any] from an existing [message].
-  Any.from(Message message)
+  Any.from(GMessage message)
       : json = {},
         super(fullyQualifiedName) {
     packInto(message);
@@ -94,7 +94,7 @@ class Any extends Message {
   ///   ...
   /// }
   /// ```
-  T unpackFrom<T extends Message, S>(T Function(S) decoder) {
+  T unpackFrom<T extends GMessage, S>(T Function(S) decoder) {
     final name = typeName;
 
     if (_customEncodedTypes.contains(name)) {
@@ -107,7 +107,7 @@ class Any extends Message {
   }
 
   /// Serialize the given message into this `Any` instance.
-  void packInto(Message message) {
+  void packInto(GMessage message) {
     final qualifiedName = message.qualifiedName;
 
     // @type
@@ -137,7 +137,7 @@ class Any extends Message {
 /// variants. Absence of any variant indicates an error.
 ///
 /// The JSON representation for `Value` is JSON value.
-class Value extends Message {
+class Value extends GMessage {
   static const String fullyQualifiedName = 'google.protobuf.Value';
 
   /// Represents a null value.

--- a/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
@@ -19,9 +19,7 @@
 /// Defines RPC types.
 library;
 
-import 'dart:typed_data';
-
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
@@ -51,7 +49,7 @@ part 'src/rpc.p.dart';
 ///         "availableRegions": "us-central1,us-east2"
 ///       }
 ///     }
-class ErrorInfo extends Message {
+class ErrorInfo extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.ErrorInfo';
 
   /// The reason of the error. This is a constant value that identifies the
@@ -126,7 +124,7 @@ class ErrorInfo extends Message {
 /// the delay between retries based on `retry_delay`, until either a maximum
 /// number of retries have been reached or a maximum retry delay cap has been
 /// reached.
-class RetryInfo extends Message {
+class RetryInfo extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.RetryInfo';
 
   /// Clients should wait at least this long between retrying the same request.
@@ -154,7 +152,7 @@ class RetryInfo extends Message {
 }
 
 /// Describes additional debugging info.
-class DebugInfo extends Message {
+class DebugInfo extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.DebugInfo';
 
   /// The stack trace entries indicating where the error occurred.
@@ -203,7 +201,7 @@ class DebugInfo extends Message {
 ///
 /// Also see RetryInfo and Help types for other details about handling a
 /// quota failure.
-class QuotaFailure extends Message {
+class QuotaFailure extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.QuotaFailure';
 
   /// Describes all quota violations.
@@ -233,7 +231,7 @@ class QuotaFailure extends Message {
 
 /// A message type used to describe a single quota violation.  For example, a
 /// daily quota or a custom quota that was exceeded.
-class QuotaFailure_Violation extends Message {
+class QuotaFailure_Violation extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.QuotaFailure.Violation';
 
   /// The subject on which the quota check failed.
@@ -285,7 +283,7 @@ class QuotaFailure_Violation extends Message {
 /// For example, if an RPC failed because it required the Terms of Service to be
 /// acknowledged, it could list the terms of service violation in the
 /// PreconditionFailure message.
-class PreconditionFailure extends Message {
+class PreconditionFailure extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.PreconditionFailure';
 
   /// Describes all precondition violations.
@@ -314,7 +312,7 @@ class PreconditionFailure extends Message {
 }
 
 /// A message type used to describe a single precondition failure.
-class PreconditionFailure_Violation extends Message {
+class PreconditionFailure_Violation extends GMessage {
   static const String fullyQualifiedName =
       'google.rpc.PreconditionFailure.Violation';
 
@@ -370,7 +368,7 @@ class PreconditionFailure_Violation extends Message {
 
 /// Describes violations in a client request. This error type focuses on the
 /// syntactic aspects of the request.
-class BadRequest extends Message {
+class BadRequest extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.BadRequest';
 
   /// Describes all violations in a client request.
@@ -400,7 +398,7 @@ class BadRequest extends Message {
 }
 
 /// A message type used to describe a single bad request field.
-class BadRequest_FieldViolation extends Message {
+class BadRequest_FieldViolation extends GMessage {
   static const String fullyQualifiedName =
       'google.rpc.BadRequest.FieldViolation';
 
@@ -499,7 +497,7 @@ class BadRequest_FieldViolation extends Message {
 
 /// Contains metadata about the request that clients can attach when filing a bug
 /// or providing other forms of feedback.
-class RequestInfo extends Message {
+class RequestInfo extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.RequestInfo';
 
   /// An opaque string that should only be interpreted by the service generating
@@ -541,7 +539,7 @@ class RequestInfo extends Message {
 }
 
 /// Describes the resource that is being accessed.
-class ResourceInfo extends Message {
+class ResourceInfo extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.ResourceInfo';
 
   /// A name for the type of resource being accessed, e.g. "sql table",
@@ -608,7 +606,7 @@ class ResourceInfo extends Message {
 /// For example, if a quota check failed with an error indicating the calling
 /// project hasn't enabled the accessed service, this can contain a URL pointing
 /// directly to the right place in the developer console to flip the bit.
-class Help extends Message {
+class Help extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.Help';
 
   /// URL(s) pointing to additional information on handling the current error.
@@ -636,7 +634,7 @@ class Help extends Message {
 }
 
 /// Describes a URL link.
-class Help_Link extends Message {
+class Help_Link extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.Help.Link';
 
   /// Describes what the link offers.
@@ -677,7 +675,7 @@ class Help_Link extends Message {
 
 /// Provides a localized error message that is safe to return to the user
 /// which can be attached to an RPC error.
-class LocalizedMessage extends Message {
+class LocalizedMessage extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.LocalizedMessage';
 
   /// The locale used following the specification defined at
@@ -719,7 +717,7 @@ class LocalizedMessage extends Message {
 }
 
 /// Represents an HTTP request.
-class HttpRequest extends Message {
+class HttpRequest extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.HttpRequest';
 
   /// The HTTP request method.
@@ -773,7 +771,7 @@ class HttpRequest extends Message {
 }
 
 /// Represents an HTTP response.
-class HttpResponse extends Message {
+class HttpResponse extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.HttpResponse';
 
   /// The HTTP status code, such as 200 or 404.
@@ -827,7 +825,7 @@ class HttpResponse extends Message {
 }
 
 /// Represents an HTTP header.
-class HttpHeader extends Message {
+class HttpHeader extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.HttpHeader';
 
   /// The HTTP header key. It is case insensitive.
@@ -873,7 +871,7 @@ class HttpHeader extends Message {
 ///
 /// You can find out more about this error model and how to work with it in the
 /// [API Design Guide](https://cloud.google.com/apis/design/errors).
-class Status extends Message {
+class Status extends GMessage {
   static const String fullyQualifiedName = 'google.rpc.Status';
 
   /// The status code, which should be an enum value of
@@ -930,7 +928,7 @@ class Status extends Message {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-class Code extends Enum {
+class Code extends GEnum {
   /// Not an error; returned on success.
   ///
   /// HTTP Mapping: 200 OK

--- a/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
@@ -49,7 +49,7 @@ part 'src/rpc.p.dart';
 ///         "availableRegions": "us-central1,us-east2"
 ///       }
 ///     }
-class ErrorInfo extends GMessage {
+class ErrorInfo extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.ErrorInfo';
 
   /// The reason of the error. This is a constant value that identifies the
@@ -124,7 +124,7 @@ class ErrorInfo extends GMessage {
 /// the delay between retries based on `retry_delay`, until either a maximum
 /// number of retries have been reached or a maximum retry delay cap has been
 /// reached.
-class RetryInfo extends GMessage {
+class RetryInfo extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.RetryInfo';
 
   /// Clients should wait at least this long between retrying the same request.
@@ -152,7 +152,7 @@ class RetryInfo extends GMessage {
 }
 
 /// Describes additional debugging info.
-class DebugInfo extends GMessage {
+class DebugInfo extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.DebugInfo';
 
   /// The stack trace entries indicating where the error occurred.
@@ -201,7 +201,7 @@ class DebugInfo extends GMessage {
 ///
 /// Also see RetryInfo and Help types for other details about handling a
 /// quota failure.
-class QuotaFailure extends GMessage {
+class QuotaFailure extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.QuotaFailure';
 
   /// Describes all quota violations.
@@ -231,7 +231,7 @@ class QuotaFailure extends GMessage {
 
 /// A message type used to describe a single quota violation.  For example, a
 /// daily quota or a custom quota that was exceeded.
-class QuotaFailure_Violation extends GMessage {
+class QuotaFailure_Violation extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.QuotaFailure.Violation';
 
   /// The subject on which the quota check failed.
@@ -283,7 +283,7 @@ class QuotaFailure_Violation extends GMessage {
 /// For example, if an RPC failed because it required the Terms of Service to be
 /// acknowledged, it could list the terms of service violation in the
 /// PreconditionFailure message.
-class PreconditionFailure extends GMessage {
+class PreconditionFailure extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.PreconditionFailure';
 
   /// Describes all precondition violations.
@@ -312,7 +312,7 @@ class PreconditionFailure extends GMessage {
 }
 
 /// A message type used to describe a single precondition failure.
-class PreconditionFailure_Violation extends GMessage {
+class PreconditionFailure_Violation extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.rpc.PreconditionFailure.Violation';
 
@@ -368,7 +368,7 @@ class PreconditionFailure_Violation extends GMessage {
 
 /// Describes violations in a client request. This error type focuses on the
 /// syntactic aspects of the request.
-class BadRequest extends GMessage {
+class BadRequest extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.BadRequest';
 
   /// Describes all violations in a client request.
@@ -398,7 +398,7 @@ class BadRequest extends GMessage {
 }
 
 /// A message type used to describe a single bad request field.
-class BadRequest_FieldViolation extends GMessage {
+class BadRequest_FieldViolation extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.rpc.BadRequest.FieldViolation';
 
@@ -497,7 +497,7 @@ class BadRequest_FieldViolation extends GMessage {
 
 /// Contains metadata about the request that clients can attach when filing a bug
 /// or providing other forms of feedback.
-class RequestInfo extends GMessage {
+class RequestInfo extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.RequestInfo';
 
   /// An opaque string that should only be interpreted by the service generating
@@ -539,7 +539,7 @@ class RequestInfo extends GMessage {
 }
 
 /// Describes the resource that is being accessed.
-class ResourceInfo extends GMessage {
+class ResourceInfo extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.ResourceInfo';
 
   /// A name for the type of resource being accessed, e.g. "sql table",
@@ -606,7 +606,7 @@ class ResourceInfo extends GMessage {
 /// For example, if a quota check failed with an error indicating the calling
 /// project hasn't enabled the accessed service, this can contain a URL pointing
 /// directly to the right place in the developer console to flip the bit.
-class Help extends GMessage {
+class Help extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.Help';
 
   /// URL(s) pointing to additional information on handling the current error.
@@ -634,7 +634,7 @@ class Help extends GMessage {
 }
 
 /// Describes a URL link.
-class Help_Link extends GMessage {
+class Help_Link extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.Help.Link';
 
   /// Describes what the link offers.
@@ -675,7 +675,7 @@ class Help_Link extends GMessage {
 
 /// Provides a localized error message that is safe to return to the user
 /// which can be attached to an RPC error.
-class LocalizedMessage extends GMessage {
+class LocalizedMessage extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.LocalizedMessage';
 
   /// The locale used following the specification defined at
@@ -717,7 +717,7 @@ class LocalizedMessage extends GMessage {
 }
 
 /// Represents an HTTP request.
-class HttpRequest extends GMessage {
+class HttpRequest extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.HttpRequest';
 
   /// The HTTP request method.
@@ -771,7 +771,7 @@ class HttpRequest extends GMessage {
 }
 
 /// Represents an HTTP response.
-class HttpResponse extends GMessage {
+class HttpResponse extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.HttpResponse';
 
   /// The HTTP status code, such as 200 or 404.
@@ -825,7 +825,7 @@ class HttpResponse extends GMessage {
 }
 
 /// Represents an HTTP header.
-class HttpHeader extends GMessage {
+class HttpHeader extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.HttpHeader';
 
   /// The HTTP header key. It is case insensitive.
@@ -871,7 +871,7 @@ class HttpHeader extends GMessage {
 ///
 /// You can find out more about this error model and how to work with it in the
 /// [API Design Guide](https://cloud.google.com/apis/design/errors).
-class Status extends GMessage {
+class Status extends ProtoMessage {
   static const String fullyQualifiedName = 'google.rpc.Status';
 
   /// The status code, which should be an enum value of
@@ -928,7 +928,7 @@ class Status extends GMessage {
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-class Code extends GEnum {
+class Code extends ProtoEnum {
   /// Not an error; returned on success.
   ///
   /// HTTP Mapping: 200 OK

--- a/generator/dart/generated/google_cloud_rpc/lib/src/rpc.p.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/src/rpc.p.dart
@@ -14,7 +14,7 @@
 
 part of '../rpc.dart';
 
-typedef _MessageDecoder = GMessage Function(Map<String, dynamic> json);
+typedef _MessageDecoder = ProtoMessage Function(Map<String, dynamic> json);
 
 // A map from message IDs to decoder functions.
 const Map<String, _MessageDecoder> _decoders = {
@@ -63,7 +63,7 @@ extension StatusExtension on Status {
   }
 
   /// Return the list of [details] with the list elements converted to
-  /// [GMessage] instances.
+  /// [ProtoMessage] instances.
   ///
   /// If an element isn't a known error detail type then [Any] is returned for
   /// that element.
@@ -83,7 +83,7 @@ extension StatusExtension on Status {
   ///
   /// For more information see https://google.aip.dev/193 and
   /// https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto.
-  List<GMessage> get detailsAsMessages {
+  List<ProtoMessage> get detailsAsMessages {
     return (details ?? []).map((any) {
       final decoder = _decoders[any.typeName];
       return decoder == null ? any : any.unpackFrom(decoder);

--- a/generator/dart/generated/google_cloud_rpc/lib/src/rpc.p.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/src/rpc.p.dart
@@ -14,7 +14,7 @@
 
 part of '../rpc.dart';
 
-typedef _MessageDecoder = Message Function(Map<String, dynamic> json);
+typedef _MessageDecoder = GMessage Function(Map<String, dynamic> json);
 
 // A map from message IDs to decoder functions.
 const Map<String, _MessageDecoder> _decoders = {
@@ -62,8 +62,8 @@ extension StatusExtension on Status {
     return null;
   }
 
-  /// Return the list of [details] with the list elements converted to [Message]
-  /// instances.
+  /// Return the list of [details] with the list elements converted to
+  /// [GMessage] instances.
   ///
   /// If an element isn't a known error detail type then [Any] is returned for
   /// that element.
@@ -83,7 +83,7 @@ extension StatusExtension on Status {
   ///
   /// For more information see https://google.aip.dev/193 and
   /// https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto.
-  List<Message> get detailsAsMessages {
+  List<GMessage> get detailsAsMessages {
     return (details ?? []).map((any) {
       final decoder = _decoders[any.typeName];
       return decoder == null ? any : any.unpackFrom(decoder);

--- a/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -220,7 +220,7 @@ class SecretManagerService {
 /// A `Secret` is made up of zero or more
 /// `SecretVersions` that represent
 /// the secret data.
-class Secret extends GMessage {
+class Secret extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Secret';
 
@@ -388,7 +388,7 @@ class Secret extends GMessage {
 }
 
 /// A secret version resource in the Secret Manager API.
-class SecretVersion extends GMessage {
+class SecretVersion extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.SecretVersion';
 
@@ -509,7 +509,7 @@ class SecretVersion extends GMessage {
 /// The state of a
 /// `SecretVersion`, indicating if
 /// it can be accessed.
-class SecretVersion_State extends GEnum {
+class SecretVersion_State extends ProtoEnum {
   /// Not specified. This value is unused and invalid.
   static const stateUnspecified = SecretVersion_State('STATE_UNSPECIFIED');
 
@@ -539,7 +539,7 @@ class SecretVersion_State extends GEnum {
 }
 
 /// A policy that defines the replication and encryption configuration of data.
-class Replication extends GMessage {
+class Replication extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication';
 
@@ -579,7 +579,7 @@ class Replication extends GMessage {
 /// A replication policy that replicates the
 /// `Secret` payload without any
 /// restrictions.
-class Replication_Automatic extends GMessage {
+class Replication_Automatic extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication.Automatic';
 
@@ -621,7 +621,7 @@ class Replication_Automatic extends GMessage {
 /// `Secret` payload into the locations
 /// specified in
 /// `Replication.UserManaged.replicas`
-class Replication_UserManaged extends GMessage {
+class Replication_UserManaged extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication.UserManaged';
 
@@ -655,7 +655,7 @@ class Replication_UserManaged extends GMessage {
 
 /// Represents a Replica for this
 /// `Secret`.
-class Replication_UserManaged_Replica extends GMessage {
+class Replication_UserManaged_Replica extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication.UserManaged.Replica';
 
@@ -707,7 +707,7 @@ class Replication_UserManaged_Replica extends GMessage {
 
 /// Configuration for encrypting secret payloads using customer-managed
 /// encryption keys (CMEK).
-class CustomerManagedEncryption extends GMessage {
+class CustomerManagedEncryption extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.CustomerManagedEncryption';
 
@@ -754,7 +754,7 @@ class CustomerManagedEncryption extends GMessage {
 
 /// The replication status of a
 /// `SecretVersion`.
-class ReplicationStatus extends GMessage {
+class ReplicationStatus extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus';
 
@@ -808,7 +808,7 @@ class ReplicationStatus extends GMessage {
 ///
 /// Only populated if the parent `Secret`
 /// has an automatic replication policy.
-class ReplicationStatus_AutomaticStatus extends GMessage {
+class ReplicationStatus_AutomaticStatus extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus.AutomaticStatus';
 
@@ -847,7 +847,7 @@ class ReplicationStatus_AutomaticStatus extends GMessage {
 ///
 /// Only populated if the parent `Secret`
 /// has a user-managed replication policy.
-class ReplicationStatus_UserManagedStatus extends GMessage {
+class ReplicationStatus_UserManagedStatus extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus.UserManagedStatus';
 
@@ -880,7 +880,7 @@ class ReplicationStatus_UserManagedStatus extends GMessage {
 
 /// Describes the status of a user-managed replica for the
 /// `SecretVersion`.
-class ReplicationStatus_UserManagedStatus_ReplicaStatus extends GMessage {
+class ReplicationStatus_UserManagedStatus_ReplicaStatus extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus.UserManagedStatus.ReplicaStatus';
 
@@ -926,7 +926,7 @@ class ReplicationStatus_UserManagedStatus_ReplicaStatus extends GMessage {
 }
 
 /// Describes the status of customer-managed encryption.
-class CustomerManagedEncryptionStatus extends GMessage {
+class CustomerManagedEncryptionStatus extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.CustomerManagedEncryptionStatus';
 
@@ -963,7 +963,7 @@ class CustomerManagedEncryptionStatus extends GMessage {
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
 /// events occur on this secret.
-class Topic extends GMessage {
+class Topic extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Topic';
 
@@ -1005,7 +1005,7 @@ class Topic extends GMessage {
 /// Manager will send a Pub/Sub notification to the topics configured on the
 /// Secret. `Secret.topics` must be
 /// set to configure rotation.
-class Rotation extends GMessage {
+class Rotation extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Rotation';
 
@@ -1062,7 +1062,7 @@ class Rotation extends GMessage {
 /// A secret payload resource in the Secret Manager API. This contains the
 /// sensitive secret payload that is associated with a
 /// `SecretVersion`.
-class SecretPayload extends GMessage {
+class SecretPayload extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.SecretPayload';
 
@@ -1119,7 +1119,7 @@ class SecretPayload extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.ListSecrets`.
-class ListSecretsRequest extends GMessage {
+class ListSecretsRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretsRequest';
 
@@ -1184,7 +1184,7 @@ class ListSecretsRequest extends GMessage {
 
 /// Response message for
 /// `SecretManagerService.ListSecrets`.
-class ListSecretsResponse extends GMessage {
+class ListSecretsResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretsResponse';
 
@@ -1238,7 +1238,7 @@ class ListSecretsResponse extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.CreateSecret`.
-class CreateSecretRequest extends GMessage {
+class CreateSecretRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.CreateSecretRequest';
 
@@ -1293,7 +1293,7 @@ class CreateSecretRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.AddSecretVersion`.
-class AddSecretVersionRequest extends GMessage {
+class AddSecretVersionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.AddSecretVersionRequest';
 
@@ -1338,7 +1338,7 @@ class AddSecretVersionRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.GetSecret`.
-class GetSecretRequest extends GMessage {
+class GetSecretRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.GetSecretRequest';
 
@@ -1375,7 +1375,7 @@ class GetSecretRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.ListSecretVersions`.
-class ListSecretVersionsRequest extends GMessage {
+class ListSecretVersionsRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretVersionsRequest';
 
@@ -1441,7 +1441,7 @@ class ListSecretVersionsRequest extends GMessage {
 
 /// Response message for
 /// `SecretManagerService.ListSecretVersions`.
-class ListSecretVersionsResponse extends GMessage {
+class ListSecretVersionsResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretVersionsResponse';
 
@@ -1496,7 +1496,7 @@ class ListSecretVersionsResponse extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.GetSecretVersion`.
-class GetSecretVersionRequest extends GMessage {
+class GetSecretVersionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.GetSecretVersionRequest';
 
@@ -1539,7 +1539,7 @@ class GetSecretVersionRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.UpdateSecret`.
-class UpdateSecretRequest extends GMessage {
+class UpdateSecretRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.UpdateSecretRequest';
 
@@ -1576,7 +1576,7 @@ class UpdateSecretRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.AccessSecretVersion`.
-class AccessSecretVersionRequest extends GMessage {
+class AccessSecretVersionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.AccessSecretVersionRequest';
 
@@ -1619,7 +1619,7 @@ class AccessSecretVersionRequest extends GMessage {
 
 /// Response message for
 /// `SecretManagerService.AccessSecretVersion`.
-class AccessSecretVersionResponse extends GMessage {
+class AccessSecretVersionResponse extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.AccessSecretVersionResponse';
 
@@ -1663,7 +1663,7 @@ class AccessSecretVersionResponse extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.DeleteSecret`.
-class DeleteSecretRequest extends GMessage {
+class DeleteSecretRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.DeleteSecretRequest';
 
@@ -1709,7 +1709,7 @@ class DeleteSecretRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.DisableSecretVersion`.
-class DisableSecretVersionRequest extends GMessage {
+class DisableSecretVersionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.DisableSecretVersionRequest';
 
@@ -1757,7 +1757,7 @@ class DisableSecretVersionRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.EnableSecretVersion`.
-class EnableSecretVersionRequest extends GMessage {
+class EnableSecretVersionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.EnableSecretVersionRequest';
 
@@ -1805,7 +1805,7 @@ class EnableSecretVersionRequest extends GMessage {
 
 /// Request message for
 /// `SecretManagerService.DestroySecretVersion`.
-class DestroySecretVersionRequest extends GMessage {
+class DestroySecretVersionRequest extends ProtoMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.DestroySecretVersionRequest';
 

--- a/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -20,9 +20,7 @@
 /// Provides convenience while improving security.
 library;
 
-import 'dart:typed_data';
-
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_iam_v1/iam.dart';
 import 'package:google_cloud_location/location.dart';
@@ -222,7 +220,7 @@ class SecretManagerService {
 /// A `Secret` is made up of zero or more
 /// `SecretVersions` that represent
 /// the secret data.
-class Secret extends Message {
+class Secret extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Secret';
 
@@ -390,7 +388,7 @@ class Secret extends Message {
 }
 
 /// A secret version resource in the Secret Manager API.
-class SecretVersion extends Message {
+class SecretVersion extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.SecretVersion';
 
@@ -511,7 +509,7 @@ class SecretVersion extends Message {
 /// The state of a
 /// `SecretVersion`, indicating if
 /// it can be accessed.
-class SecretVersion_State extends Enum {
+class SecretVersion_State extends GEnum {
   /// Not specified. This value is unused and invalid.
   static const stateUnspecified = SecretVersion_State('STATE_UNSPECIFIED');
 
@@ -541,7 +539,7 @@ class SecretVersion_State extends Enum {
 }
 
 /// A policy that defines the replication and encryption configuration of data.
-class Replication extends Message {
+class Replication extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication';
 
@@ -581,7 +579,7 @@ class Replication extends Message {
 /// A replication policy that replicates the
 /// `Secret` payload without any
 /// restrictions.
-class Replication_Automatic extends Message {
+class Replication_Automatic extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication.Automatic';
 
@@ -623,7 +621,7 @@ class Replication_Automatic extends Message {
 /// `Secret` payload into the locations
 /// specified in
 /// `Replication.UserManaged.replicas`
-class Replication_UserManaged extends Message {
+class Replication_UserManaged extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication.UserManaged';
 
@@ -657,7 +655,7 @@ class Replication_UserManaged extends Message {
 
 /// Represents a Replica for this
 /// `Secret`.
-class Replication_UserManaged_Replica extends Message {
+class Replication_UserManaged_Replica extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Replication.UserManaged.Replica';
 
@@ -709,7 +707,7 @@ class Replication_UserManaged_Replica extends Message {
 
 /// Configuration for encrypting secret payloads using customer-managed
 /// encryption keys (CMEK).
-class CustomerManagedEncryption extends Message {
+class CustomerManagedEncryption extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.CustomerManagedEncryption';
 
@@ -756,7 +754,7 @@ class CustomerManagedEncryption extends Message {
 
 /// The replication status of a
 /// `SecretVersion`.
-class ReplicationStatus extends Message {
+class ReplicationStatus extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus';
 
@@ -810,7 +808,7 @@ class ReplicationStatus extends Message {
 ///
 /// Only populated if the parent `Secret`
 /// has an automatic replication policy.
-class ReplicationStatus_AutomaticStatus extends Message {
+class ReplicationStatus_AutomaticStatus extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus.AutomaticStatus';
 
@@ -849,7 +847,7 @@ class ReplicationStatus_AutomaticStatus extends Message {
 ///
 /// Only populated if the parent `Secret`
 /// has a user-managed replication policy.
-class ReplicationStatus_UserManagedStatus extends Message {
+class ReplicationStatus_UserManagedStatus extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus.UserManagedStatus';
 
@@ -882,7 +880,7 @@ class ReplicationStatus_UserManagedStatus extends Message {
 
 /// Describes the status of a user-managed replica for the
 /// `SecretVersion`.
-class ReplicationStatus_UserManagedStatus_ReplicaStatus extends Message {
+class ReplicationStatus_UserManagedStatus_ReplicaStatus extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ReplicationStatus.UserManagedStatus.ReplicaStatus';
 
@@ -928,7 +926,7 @@ class ReplicationStatus_UserManagedStatus_ReplicaStatus extends Message {
 }
 
 /// Describes the status of customer-managed encryption.
-class CustomerManagedEncryptionStatus extends Message {
+class CustomerManagedEncryptionStatus extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.CustomerManagedEncryptionStatus';
 
@@ -965,7 +963,7 @@ class CustomerManagedEncryptionStatus extends Message {
 
 /// A Pub/Sub topic which Secret Manager will publish to when control plane
 /// events occur on this secret.
-class Topic extends Message {
+class Topic extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Topic';
 
@@ -1007,7 +1005,7 @@ class Topic extends Message {
 /// Manager will send a Pub/Sub notification to the topics configured on the
 /// Secret. `Secret.topics` must be
 /// set to configure rotation.
-class Rotation extends Message {
+class Rotation extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.Rotation';
 
@@ -1064,7 +1062,7 @@ class Rotation extends Message {
 /// A secret payload resource in the Secret Manager API. This contains the
 /// sensitive secret payload that is associated with a
 /// `SecretVersion`.
-class SecretPayload extends Message {
+class SecretPayload extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.SecretPayload';
 
@@ -1121,7 +1119,7 @@ class SecretPayload extends Message {
 
 /// Request message for
 /// `SecretManagerService.ListSecrets`.
-class ListSecretsRequest extends Message {
+class ListSecretsRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretsRequest';
 
@@ -1186,7 +1184,7 @@ class ListSecretsRequest extends Message {
 
 /// Response message for
 /// `SecretManagerService.ListSecrets`.
-class ListSecretsResponse extends Message {
+class ListSecretsResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretsResponse';
 
@@ -1240,7 +1238,7 @@ class ListSecretsResponse extends Message {
 
 /// Request message for
 /// `SecretManagerService.CreateSecret`.
-class CreateSecretRequest extends Message {
+class CreateSecretRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.CreateSecretRequest';
 
@@ -1295,7 +1293,7 @@ class CreateSecretRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.AddSecretVersion`.
-class AddSecretVersionRequest extends Message {
+class AddSecretVersionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.AddSecretVersionRequest';
 
@@ -1340,7 +1338,7 @@ class AddSecretVersionRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.GetSecret`.
-class GetSecretRequest extends Message {
+class GetSecretRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.GetSecretRequest';
 
@@ -1377,7 +1375,7 @@ class GetSecretRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.ListSecretVersions`.
-class ListSecretVersionsRequest extends Message {
+class ListSecretVersionsRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretVersionsRequest';
 
@@ -1443,7 +1441,7 @@ class ListSecretVersionsRequest extends Message {
 
 /// Response message for
 /// `SecretManagerService.ListSecretVersions`.
-class ListSecretVersionsResponse extends Message {
+class ListSecretVersionsResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.ListSecretVersionsResponse';
 
@@ -1498,7 +1496,7 @@ class ListSecretVersionsResponse extends Message {
 
 /// Request message for
 /// `SecretManagerService.GetSecretVersion`.
-class GetSecretVersionRequest extends Message {
+class GetSecretVersionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.GetSecretVersionRequest';
 
@@ -1541,7 +1539,7 @@ class GetSecretVersionRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.UpdateSecret`.
-class UpdateSecretRequest extends Message {
+class UpdateSecretRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.UpdateSecretRequest';
 
@@ -1578,7 +1576,7 @@ class UpdateSecretRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.AccessSecretVersion`.
-class AccessSecretVersionRequest extends Message {
+class AccessSecretVersionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.AccessSecretVersionRequest';
 
@@ -1621,7 +1619,7 @@ class AccessSecretVersionRequest extends Message {
 
 /// Response message for
 /// `SecretManagerService.AccessSecretVersion`.
-class AccessSecretVersionResponse extends Message {
+class AccessSecretVersionResponse extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.AccessSecretVersionResponse';
 
@@ -1665,7 +1663,7 @@ class AccessSecretVersionResponse extends Message {
 
 /// Request message for
 /// `SecretManagerService.DeleteSecret`.
-class DeleteSecretRequest extends Message {
+class DeleteSecretRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.DeleteSecretRequest';
 
@@ -1711,7 +1709,7 @@ class DeleteSecretRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.DisableSecretVersion`.
-class DisableSecretVersionRequest extends Message {
+class DisableSecretVersionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.DisableSecretVersionRequest';
 
@@ -1759,7 +1757,7 @@ class DisableSecretVersionRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.EnableSecretVersion`.
-class EnableSecretVersionRequest extends Message {
+class EnableSecretVersionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.EnableSecretVersionRequest';
 
@@ -1807,7 +1805,7 @@ class EnableSecretVersionRequest extends Message {
 
 /// Request message for
 /// `SecretManagerService.DestroySecretVersion`.
-class DestroySecretVersionRequest extends Message {
+class DestroySecretVersionRequest extends GMessage {
   static const String fullyQualifiedName =
       'google.cloud.secretmanager.v1.DestroySecretVersionRequest';
 

--- a/generator/dart/generated/google_cloud_type/lib/type.dart
+++ b/generator/dart/generated/google_cloud_type/lib/type.dart
@@ -19,7 +19,7 @@
 /// Defines common types for Google APIs.
 library;
 
-import 'package:google_cloud_gax/common.dart';
+import 'package:google_cloud_gax/gax.dart';
 import 'package:google_cloud_gax/src/encoding.dart';
 import 'package:google_cloud_protobuf/protobuf.dart';
 
@@ -147,7 +147,7 @@ import 'package:google_cloud_protobuf/protobuf.dart';
 ///     };
 ///
 ///     // ...
-class Color extends Message {
+class Color extends GMessage {
   static const String fullyQualifiedName = 'google.type.Color';
 
   /// The amount of red in the color as a value in the interval [0, 1].
@@ -222,7 +222,7 @@ class Color extends Message {
 ///
 /// Related types are `google.type.TimeOfDay` and
 /// `google.protobuf.Timestamp`.
-class Date extends Message {
+class Date extends GMessage {
   static const String fullyQualifiedName = 'google.type.Date';
 
   /// Year of the date. Must be from 1 to 9999, or 0 to specify a date without
@@ -296,7 +296,7 @@ class Date extends Message {
 ///
 /// This type is more flexible than some applications may want. Make sure to
 /// document and validate your application's limitations.
-class DateTime extends Message {
+class DateTime extends GMessage {
   static const String fullyQualifiedName = 'google.type.DateTime';
 
   /// Optional. Year of date. Must be from 1 to 9999, or 0 if specifying a
@@ -392,7 +392,7 @@ class DateTime extends Message {
 
 /// Represents a time zone from the
 /// [IANA Time Zone Database](https://www.iana.org/time-zones).
-class TimeZone extends Message {
+class TimeZone extends GMessage {
   static const String fullyQualifiedName = 'google.type.TimeZone';
 
   /// IANA Time Zone Database time zone, e.g. "America/New_York".
@@ -438,7 +438,7 @@ class TimeZone extends Message {
 /// [BigDecimal]:
 /// https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/BigDecimal.html
 /// [decimal.Decimal]: https://docs.python.org/3/library/decimal.html
-class Decimal extends Message {
+class Decimal extends GMessage {
   static const String fullyQualifiedName = 'google.type.Decimal';
 
   /// The decimal value, as a string.
@@ -560,7 +560,7 @@ class Decimal extends Message {
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
 /// documentation for additional information.
-class Expr extends Message {
+class Expr extends GMessage {
   static const String fullyQualifiedName = 'google.type.Expr';
 
   /// Textual representation of an expression in Common Expression Language
@@ -619,7 +619,7 @@ class Expr extends Message {
 }
 
 /// Represents a fraction in terms of a numerator divided by a denominator.
-class Fraction extends Message {
+class Fraction extends GMessage {
   static const String fullyQualifiedName = 'google.type.Fraction';
 
   /// The numerator in the fraction, e.g. 2 in 2/3.
@@ -665,7 +665,7 @@ class Fraction extends Message {
 /// The start must be less than or equal to the end.
 /// When the start equals the end, the interval is empty (matches no time).
 /// When both start and end are unspecified, the interval matches any time.
-class Interval extends Message {
+class Interval extends GMessage {
   static const String fullyQualifiedName = 'google.type.Interval';
 
   /// Optional. Inclusive start of the interval.
@@ -709,7 +709,7 @@ class Interval extends Message {
 /// specified otherwise, this must conform to the
 /// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
 /// standard</a>. Values must be within normalized ranges.
-class LatLng extends Message {
+class LatLng extends GMessage {
   static const String fullyQualifiedName = 'google.type.LatLng';
 
   /// The latitude in degrees. It must be in the range [-90.0, +90.0].
@@ -749,7 +749,7 @@ class LatLng extends Message {
 }
 
 /// Localized variant of a text in a particular language.
-class LocalizedText extends Message {
+class LocalizedText extends GMessage {
   static const String fullyQualifiedName = 'google.type.LocalizedText';
 
   /// Localized string in the language corresponding to `language_code' below.
@@ -792,7 +792,7 @@ class LocalizedText extends Message {
 }
 
 /// Represents an amount of money with its currency type.
-class Money extends Message {
+class Money extends GMessage {
   static const String fullyQualifiedName = 'google.type.Money';
 
   /// The three-letter currency code defined in ISO 4217.
@@ -870,7 +870,7 @@ class Money extends Message {
 ///
 ///  Reference(s):
 ///   - https://github.com/google/libphonenumber
-class PhoneNumber extends Message {
+class PhoneNumber extends GMessage {
   static const String fullyQualifiedName = 'google.type.PhoneNumber';
 
   /// The phone number, represented as a leading plus sign ('+'), followed by a
@@ -949,7 +949,7 @@ class PhoneNumber extends Message {
 /// dialable, which means the same short code can exist in different regions,
 /// with different usage and pricing, even if those regions share the same
 /// country calling code (e.g. US and CA).
-class PhoneNumber_ShortCode extends Message {
+class PhoneNumber_ShortCode extends GMessage {
   static const String fullyQualifiedName = 'google.type.PhoneNumber.ShortCode';
 
   /// Required. The BCP-47 region code of the location where calls to this
@@ -1010,7 +1010,7 @@ class PhoneNumber_ShortCode extends Message {
 ///
 /// For more guidance on how to use this schema, please see:
 /// https://support.google.com/business/answer/6397478
-class PostalAddress extends Message {
+class PostalAddress extends GMessage {
   static const String fullyQualifiedName = 'google.type.PostalAddress';
 
   /// The schema revision of the `PostalAddress`. This must be set to 0, which is
@@ -1223,7 +1223,7 @@ class PostalAddress extends Message {
 /// it would produce a unique representation. It is thus recommended that `w` be
 /// kept positive, which can be achieved by changing all the signs when `w` is
 /// negative.
-class Quaternion extends Message {
+class Quaternion extends GMessage {
   static const String fullyQualifiedName = 'google.type.Quaternion';
 
   /// The x component.
@@ -1280,7 +1280,7 @@ class Quaternion extends Message {
 /// or are specified elsewhere. An API may choose to allow leap seconds. Related
 /// types are `google.type.Date` and
 /// `google.protobuf.Timestamp`.
-class TimeOfDay extends Message {
+class TimeOfDay extends GMessage {
   static const String fullyQualifiedName = 'google.type.TimeOfDay';
 
   /// Hours of day in 24 hour format. Should be from 0 to 23. An API may choose
@@ -1338,7 +1338,7 @@ class TimeOfDay extends Message {
 /// A `CalendarPeriod` represents the abstract concept of a time period that has
 /// a canonical start. Grammatically, "the start of the current
 /// `CalendarPeriod`." All calendar times begin at midnight UTC.
-class CalendarPeriod extends Enum {
+class CalendarPeriod extends GEnum {
   /// Undefined period, raises an error.
   static const calendarPeriodUnspecified =
       CalendarPeriod('CALENDAR_PERIOD_UNSPECIFIED');
@@ -1377,7 +1377,7 @@ class CalendarPeriod extends Enum {
 }
 
 /// Represents a day of the week.
-class DayOfWeek extends Enum {
+class DayOfWeek extends GEnum {
   /// The day of the week is unspecified.
   static const dayOfWeekUnspecified = DayOfWeek('DAY_OF_WEEK_UNSPECIFIED');
 
@@ -1411,7 +1411,7 @@ class DayOfWeek extends Enum {
 }
 
 /// Represents a month in the Gregorian calendar.
-class Month extends Enum {
+class Month extends GEnum {
   /// The unspecified month.
   static const monthUnspecified = Month('MONTH_UNSPECIFIED');
 

--- a/generator/dart/generated/google_cloud_type/lib/type.dart
+++ b/generator/dart/generated/google_cloud_type/lib/type.dart
@@ -147,7 +147,7 @@ import 'package:google_cloud_protobuf/protobuf.dart';
 ///     };
 ///
 ///     // ...
-class Color extends GMessage {
+class Color extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Color';
 
   /// The amount of red in the color as a value in the interval [0, 1].
@@ -222,7 +222,7 @@ class Color extends GMessage {
 ///
 /// Related types are `google.type.TimeOfDay` and
 /// `google.protobuf.Timestamp`.
-class Date extends GMessage {
+class Date extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Date';
 
   /// Year of the date. Must be from 1 to 9999, or 0 to specify a date without
@@ -296,7 +296,7 @@ class Date extends GMessage {
 ///
 /// This type is more flexible than some applications may want. Make sure to
 /// document and validate your application's limitations.
-class DateTime extends GMessage {
+class DateTime extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.DateTime';
 
   /// Optional. Year of date. Must be from 1 to 9999, or 0 if specifying a
@@ -392,7 +392,7 @@ class DateTime extends GMessage {
 
 /// Represents a time zone from the
 /// [IANA Time Zone Database](https://www.iana.org/time-zones).
-class TimeZone extends GMessage {
+class TimeZone extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.TimeZone';
 
   /// IANA Time Zone Database time zone, e.g. "America/New_York".
@@ -438,7 +438,7 @@ class TimeZone extends GMessage {
 /// [BigDecimal]:
 /// https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/BigDecimal.html
 /// [decimal.Decimal]: https://docs.python.org/3/library/decimal.html
-class Decimal extends GMessage {
+class Decimal extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Decimal';
 
   /// The decimal value, as a string.
@@ -560,7 +560,7 @@ class Decimal extends GMessage {
 /// The exact variables and functions that may be referenced within an expression
 /// are determined by the service that evaluates it. See the service
 /// documentation for additional information.
-class Expr extends GMessage {
+class Expr extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Expr';
 
   /// Textual representation of an expression in Common Expression Language
@@ -619,7 +619,7 @@ class Expr extends GMessage {
 }
 
 /// Represents a fraction in terms of a numerator divided by a denominator.
-class Fraction extends GMessage {
+class Fraction extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Fraction';
 
   /// The numerator in the fraction, e.g. 2 in 2/3.
@@ -665,7 +665,7 @@ class Fraction extends GMessage {
 /// The start must be less than or equal to the end.
 /// When the start equals the end, the interval is empty (matches no time).
 /// When both start and end are unspecified, the interval matches any time.
-class Interval extends GMessage {
+class Interval extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Interval';
 
   /// Optional. Inclusive start of the interval.
@@ -709,7 +709,7 @@ class Interval extends GMessage {
 /// specified otherwise, this must conform to the
 /// <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
 /// standard</a>. Values must be within normalized ranges.
-class LatLng extends GMessage {
+class LatLng extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.LatLng';
 
   /// The latitude in degrees. It must be in the range [-90.0, +90.0].
@@ -749,7 +749,7 @@ class LatLng extends GMessage {
 }
 
 /// Localized variant of a text in a particular language.
-class LocalizedText extends GMessage {
+class LocalizedText extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.LocalizedText';
 
   /// Localized string in the language corresponding to `language_code' below.
@@ -792,7 +792,7 @@ class LocalizedText extends GMessage {
 }
 
 /// Represents an amount of money with its currency type.
-class Money extends GMessage {
+class Money extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Money';
 
   /// The three-letter currency code defined in ISO 4217.
@@ -870,7 +870,7 @@ class Money extends GMessage {
 ///
 ///  Reference(s):
 ///   - https://github.com/google/libphonenumber
-class PhoneNumber extends GMessage {
+class PhoneNumber extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.PhoneNumber';
 
   /// The phone number, represented as a leading plus sign ('+'), followed by a
@@ -949,7 +949,7 @@ class PhoneNumber extends GMessage {
 /// dialable, which means the same short code can exist in different regions,
 /// with different usage and pricing, even if those regions share the same
 /// country calling code (e.g. US and CA).
-class PhoneNumber_ShortCode extends GMessage {
+class PhoneNumber_ShortCode extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.PhoneNumber.ShortCode';
 
   /// Required. The BCP-47 region code of the location where calls to this
@@ -1010,7 +1010,7 @@ class PhoneNumber_ShortCode extends GMessage {
 ///
 /// For more guidance on how to use this schema, please see:
 /// https://support.google.com/business/answer/6397478
-class PostalAddress extends GMessage {
+class PostalAddress extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.PostalAddress';
 
   /// The schema revision of the `PostalAddress`. This must be set to 0, which is
@@ -1223,7 +1223,7 @@ class PostalAddress extends GMessage {
 /// it would produce a unique representation. It is thus recommended that `w` be
 /// kept positive, which can be achieved by changing all the signs when `w` is
 /// negative.
-class Quaternion extends GMessage {
+class Quaternion extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.Quaternion';
 
   /// The x component.
@@ -1280,7 +1280,7 @@ class Quaternion extends GMessage {
 /// or are specified elsewhere. An API may choose to allow leap seconds. Related
 /// types are `google.type.Date` and
 /// `google.protobuf.Timestamp`.
-class TimeOfDay extends GMessage {
+class TimeOfDay extends ProtoMessage {
   static const String fullyQualifiedName = 'google.type.TimeOfDay';
 
   /// Hours of day in 24 hour format. Should be from 0 to 23. An API may choose
@@ -1338,7 +1338,7 @@ class TimeOfDay extends GMessage {
 /// A `CalendarPeriod` represents the abstract concept of a time period that has
 /// a canonical start. Grammatically, "the start of the current
 /// `CalendarPeriod`." All calendar times begin at midnight UTC.
-class CalendarPeriod extends GEnum {
+class CalendarPeriod extends ProtoEnum {
   /// Undefined period, raises an error.
   static const calendarPeriodUnspecified =
       CalendarPeriod('CALENDAR_PERIOD_UNSPECIFIED');
@@ -1377,7 +1377,7 @@ class CalendarPeriod extends GEnum {
 }
 
 /// Represents a day of the week.
-class DayOfWeek extends GEnum {
+class DayOfWeek extends ProtoEnum {
   /// The day of the week is unspecified.
   static const dayOfWeekUnspecified = DayOfWeek('DAY_OF_WEEK_UNSPECIFIED');
 
@@ -1411,7 +1411,7 @@ class DayOfWeek extends GEnum {
 }
 
 /// Represents a month in the Gregorian calendar.
-class Month extends GEnum {
+class Month extends ProtoEnum {
   /// The unspecified month.
   static const monthUnspecified = Month('MONTH_UNSPECIFIED');
 

--- a/generator/dart/packages/google_cloud_gax/lib/gax.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/gax.dart
@@ -17,6 +17,8 @@ import 'dart:convert';
 import 'package:google_cloud_rpc/rpc.dart';
 import 'package:http/http.dart' as http;
 
+export 'dart:typed_data' show Uint8List;
+
 const String _clientName = 'dart-test-client';
 
 /// An abstract class that can return a JSON encodable representation of itself.
@@ -28,26 +30,26 @@ abstract class JsonEncodable {
 }
 
 /// The abstract common superclass of all messages.
-abstract class Message implements JsonEncodable {
+abstract class GMessage implements JsonEncodable {
   /// The fully qualified name of this message, i.e., `google.protobuf.Duration`
   /// or `google.rpc.ErrorInfo`
   final String qualifiedName;
 
-  Message(this.qualifiedName);
+  GMessage(this.qualifiedName);
 }
 
 /// The abstract common superclass of all enum values.
-abstract class Enum implements JsonEncodable {
+abstract class GEnum implements JsonEncodable {
   final String value;
 
-  const Enum(this.value);
+  const GEnum(this.value);
 
   @override
   String toJson() => value;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == runtimeType && value == (other as Enum).value;
+    return other.runtimeType == runtimeType && value == (other as GEnum).value;
   }
 
   @override

--- a/generator/dart/packages/google_cloud_gax/lib/gax.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/gax.dart
@@ -30,26 +30,27 @@ abstract class JsonEncodable {
 }
 
 /// The abstract common superclass of all messages.
-abstract class GMessage implements JsonEncodable {
+abstract class ProtoMessage implements JsonEncodable {
   /// The fully qualified name of this message, i.e., `google.protobuf.Duration`
   /// or `google.rpc.ErrorInfo`
   final String qualifiedName;
 
-  GMessage(this.qualifiedName);
+  ProtoMessage(this.qualifiedName);
 }
 
 /// The abstract common superclass of all enum values.
-abstract class GEnum implements JsonEncodable {
+abstract class ProtoEnum implements JsonEncodable {
   final String value;
 
-  const GEnum(this.value);
+  const ProtoEnum(this.value);
 
   @override
   String toJson() => value;
 
   @override
   bool operator ==(Object other) {
-    return other.runtimeType == runtimeType && value == (other as GEnum).value;
+    return other.runtimeType == runtimeType &&
+        value == (other as ProtoEnum).value;
   }
 
   @override

--- a/generator/dart/packages/google_cloud_gax/lib/src/encoding.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/src/encoding.dart
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Utility methods for JSON encoding and decoding from [Message] objects.
+/// Utility methods for JSON encoding and decoding from [GMessage] objects.
 ///
 /// See https://protobuf.dev/programming-guides/json/ for docs on the JSON
 /// encoding of many of these types.
 library;
 
 import 'dart:convert';
-import 'dart:typed_data';
 
-import '../common.dart';
+import '../gax.dart';
 
 /// Decode an `int64` value.
 int? decodeInt64(Object? value) {
@@ -46,19 +45,19 @@ Uint8List? decodeBytes(String? value) {
   return value == null ? null : base64Decode(value);
 }
 
-/// Decode an [Enum].
-T? decodeEnum<T extends Enum>(String? value, T Function(String) decoder) {
+/// Decode an [GEnum].
+T? decodeEnum<T extends GEnum>(String? value, T Function(String) decoder) {
   return value == null ? null : decoder(value);
 }
 
-/// Decode a [Message].
-T? decode<T extends Message>(
+/// Decode a [GMessage].
+T? decode<T extends GMessage>(
     Map<String, dynamic>? value, T Function(Map<String, dynamic>) decoder) {
   return value != null ? decoder(value) : null;
 }
 
-/// Decode a [Message] which uses a custom JSON encoding.
-T? decodeCustom<T extends Message>(Object? value, T Function(Object) decoder) {
+/// Decode a [GMessage] which uses a custom JSON encoding.
+T? decodeCustom<T extends GMessage>(Object? value, T Function(Object) decoder) {
   return value == null ? null : decoder(value);
 }
 
@@ -72,20 +71,20 @@ List<Uint8List>? decodeListBytes(Object? value) {
   return (value as List?)?.map((item) => base64Decode(item)).toList().cast();
 }
 
-/// Decode a list of [Enum]s.
-List<T>? decodeListEnum<T extends Enum>(
+/// Decode a list of [GEnum]s.
+List<T>? decodeListEnum<T extends GEnum>(
     Object? value, T Function(String) decoder) {
   return (value as List?)?.map((item) => decoder(item)).toList().cast();
 }
 
 /// Decode a list of [Messages]s.
-List<T>? decodeListMessage<T extends Message>(
+List<T>? decodeListMessage<T extends GMessage>(
     Object? value, T Function(Map<String, dynamic>) decoder) {
   return (value as List?)?.map((item) => decoder(item)).toList().cast();
 }
 
 /// Decode a list of [Messages]s which use custom JSON encodings.
-List<T>? decodeListMessageCustom<T extends Message>(
+List<T>? decodeListMessageCustom<T extends GMessage>(
     Object? value, T Function(Object) decoder) {
   return (value as List?)?.map((item) => decoder(item)).toList().cast();
 }
@@ -95,8 +94,8 @@ Map<K, V>? decodeMap<K, V>(Object? value) {
   return (value as Map?)?.cast();
 }
 
-/// Decode a map of [Enum]s.
-Map<K, V>? decodeMapEnum<K, V extends Enum>(
+/// Decode a map of [GEnum]s.
+Map<K, V>? decodeMapEnum<K, V extends GEnum>(
     Object? value, V Function(String) decoder) {
   return (value as Map?)
       ?.map((key, value) => MapEntry(key, decoder(value)))
@@ -110,16 +109,16 @@ Map<K, Uint8List>? decodeMapBytes<K>(Object? value) {
       .cast();
 }
 
-/// Decode a map of [Message]s.
-Map<K, V>? decodeMapMessage<K, V extends Message>(
+/// Decode a map of [GMessage]s.
+Map<K, V>? decodeMapMessage<K, V extends GMessage>(
     Object? value, V Function(Map<String, dynamic>) decoder) {
   return (value as Map?)
       ?.map((key, value) => MapEntry(key, decoder(value)))
       .cast();
 }
 
-/// Decode a map of [Message]s which use custom JSON encodings.
-Map<K, V>? decodeMapMessageCustom<K, V extends Message>(
+/// Decode a map of [GMessage]s which use custom JSON encodings.
+Map<K, V>? decodeMapMessageCustom<K, V extends GMessage>(
     Object? value, V Function(Object) decoder) {
   return (value as Map?)
       ?.map((key, value) => MapEntry(key, decoder(value)))

--- a/generator/dart/packages/google_cloud_gax/lib/src/encoding.dart
+++ b/generator/dart/packages/google_cloud_gax/lib/src/encoding.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Utility methods for JSON encoding and decoding from [GMessage] objects.
+/// Utility methods for JSON encoding and decoding from [ProtoMessage] objects.
 ///
 /// See https://protobuf.dev/programming-guides/json/ for docs on the JSON
 /// encoding of many of these types.
@@ -45,19 +45,20 @@ Uint8List? decodeBytes(String? value) {
   return value == null ? null : base64Decode(value);
 }
 
-/// Decode an [GEnum].
-T? decodeEnum<T extends GEnum>(String? value, T Function(String) decoder) {
+/// Decode an [ProtoEnum].
+T? decodeEnum<T extends ProtoEnum>(String? value, T Function(String) decoder) {
   return value == null ? null : decoder(value);
 }
 
-/// Decode a [GMessage].
-T? decode<T extends GMessage>(
+/// Decode a [ProtoMessage].
+T? decode<T extends ProtoMessage>(
     Map<String, dynamic>? value, T Function(Map<String, dynamic>) decoder) {
   return value != null ? decoder(value) : null;
 }
 
-/// Decode a [GMessage] which uses a custom JSON encoding.
-T? decodeCustom<T extends GMessage>(Object? value, T Function(Object) decoder) {
+/// Decode a [ProtoMessage] which uses a custom JSON encoding.
+T? decodeCustom<T extends ProtoMessage>(
+    Object? value, T Function(Object) decoder) {
   return value == null ? null : decoder(value);
 }
 
@@ -71,20 +72,20 @@ List<Uint8List>? decodeListBytes(Object? value) {
   return (value as List?)?.map((item) => base64Decode(item)).toList().cast();
 }
 
-/// Decode a list of [GEnum]s.
-List<T>? decodeListEnum<T extends GEnum>(
+/// Decode a list of [ProtoEnum]s.
+List<T>? decodeListEnum<T extends ProtoEnum>(
     Object? value, T Function(String) decoder) {
   return (value as List?)?.map((item) => decoder(item)).toList().cast();
 }
 
 /// Decode a list of [Messages]s.
-List<T>? decodeListMessage<T extends GMessage>(
+List<T>? decodeListMessage<T extends ProtoMessage>(
     Object? value, T Function(Map<String, dynamic>) decoder) {
   return (value as List?)?.map((item) => decoder(item)).toList().cast();
 }
 
 /// Decode a list of [Messages]s which use custom JSON encodings.
-List<T>? decodeListMessageCustom<T extends GMessage>(
+List<T>? decodeListMessageCustom<T extends ProtoMessage>(
     Object? value, T Function(Object) decoder) {
   return (value as List?)?.map((item) => decoder(item)).toList().cast();
 }
@@ -94,8 +95,8 @@ Map<K, V>? decodeMap<K, V>(Object? value) {
   return (value as Map?)?.cast();
 }
 
-/// Decode a map of [GEnum]s.
-Map<K, V>? decodeMapEnum<K, V extends GEnum>(
+/// Decode a map of [ProtoEnum]s.
+Map<K, V>? decodeMapEnum<K, V extends ProtoEnum>(
     Object? value, V Function(String) decoder) {
   return (value as Map?)
       ?.map((key, value) => MapEntry(key, decoder(value)))
@@ -109,16 +110,16 @@ Map<K, Uint8List>? decodeMapBytes<K>(Object? value) {
       .cast();
 }
 
-/// Decode a map of [GMessage]s.
-Map<K, V>? decodeMapMessage<K, V extends GMessage>(
+/// Decode a map of [ProtoMessage]s.
+Map<K, V>? decodeMapMessage<K, V extends ProtoMessage>(
     Object? value, V Function(Map<String, dynamic>) decoder) {
   return (value as Map?)
       ?.map((key, value) => MapEntry(key, decoder(value)))
       .cast();
 }
 
-/// Decode a map of [GMessage]s which use custom JSON encodings.
-Map<K, V>? decodeMapMessageCustom<K, V extends GMessage>(
+/// Decode a map of [ProtoMessage]s which use custom JSON encodings.
+Map<K, V>? decodeMapMessageCustom<K, V extends ProtoMessage>(
     Object? value, V Function(Object) decoder) {
   return (value as Map?)
       ?.map((key, value) => MapEntry(key, decoder(value)))

--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -693,7 +693,6 @@ func (annotate *annotateModel) fieldType(f *api.Field) string {
 	case api.STRING_TYPE:
 		out = "String"
 	case api.BYTES_TYPE:
-		annotate.imports[typedDataImport] = typedDataImport
 		out = "Uint8List"
 	case api.MESSAGE_TYPE:
 		message, ok := annotate.state.MessageByID[f.TypezID]

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -28,7 +28,7 @@ import (
 
 var typedDataImport = "dart:typed_data"
 var httpImport = "package:http/http.dart as http"
-var commonImport = "package:google_cloud_gax/common.dart"
+var commonImport = "package:google_cloud_gax/gax.dart"
 var commonHelpersImport = "package:google_cloud_gax/src/encoding.dart"
 
 var needsCtorValidation = map[string]string{

--- a/generator/internal/dart/dart_test.go
+++ b/generator/internal/dart/dart_test.go
@@ -386,25 +386,12 @@ func TestFieldType_Bytes(t *testing.T) {
 	annotate := newAnnotateModel(model)
 	annotate.annotateModel(map[string]string{})
 	annotate.imports = map[string]string{}
-	annotate.packageMapping[typedDataImport] = typedDataImport
 
 	{
 		got := annotate.fieldType(field)
 		want := "Uint8List"
 		if got != want {
 			t.Errorf("unexpected type name, got: %s want: %s", got, want)
-		}
-	}
-
-	// verify the  dart:typed_data import
-	if !(len(annotate.imports) > 0) {
-		t.Errorf("unexpected: no  dart:typed_data import added")
-	}
-
-	for _, got := range annotate.imports {
-		want := typedDataImport
-		if got != want {
-			t.Errorf("unexpected import, got: %s want: %s", got, want)
 		}
 	}
 }

--- a/generator/internal/dart/templates/lib/enum.mustache
+++ b/generator/internal/dart/templates/lib/enum.mustache
@@ -17,7 +17,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} extends GEnum {
+class {{Codec.Name}} extends ProtoEnum {
   {{#Values}}
   {{#Codec.DocLines}}
   {{{.}}}

--- a/generator/internal/dart/templates/lib/enum.mustache
+++ b/generator/internal/dart/templates/lib/enum.mustache
@@ -17,7 +17,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} extends Enum {
+class {{Codec.Name}} extends GEnum {
   {{#Values}}
   {{#Codec.DocLines}}
   {{{.}}}

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -18,7 +18,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} extends Message {
+class {{Codec.Name}} extends GMessage {
   static const String fullyQualifiedName = '{{Codec.QualifiedName}}';
 
   {{#Fields}}

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -18,7 +18,7 @@ limitations under the License.
 {{#Codec.DocLines}}
 {{{.}}}
 {{/Codec.DocLines}}
-class {{Codec.Name}} extends GMessage {
+class {{Codec.Name}} extends ProtoMessage {
   static const String fullyQualifiedName = '{{Codec.QualifiedName}}';
 
   {{#Fields}}

--- a/generator/internal/dart/templates/lib/method.mustache
+++ b/generator/internal/dart/templates/lib/method.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 ///
 /// This method can be used to get the current status of a long-running
 /// operation.
-Future<Operation<T, S>> getOperation<T extends Message, S extends Message>(Operation<T, S> request) async {
+Future<Operation<T, S>> getOperation<T extends GMessage, S extends GMessage>(Operation<T, S> request) async {
   final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}');
   {{#Codec.ReturnsValue}}final response = {{/Codec.ReturnsValue}}await _client.{{Codec.RequestMethod}}(url{{#Codec.HasBody}}, body: {{Codec.BodyMessageName}}{{/Codec.HasBody}});
   return Operation.fromJson(response, request.operationHelper);

--- a/generator/internal/dart/templates/lib/method.mustache
+++ b/generator/internal/dart/templates/lib/method.mustache
@@ -21,7 +21,7 @@ limitations under the License.
 ///
 /// This method can be used to get the current status of a long-running
 /// operation.
-Future<Operation<T, S>> getOperation<T extends GMessage, S extends GMessage>(Operation<T, S> request) async {
+Future<Operation<T, S>> getOperation<T extends ProtoMessage, S extends ProtoMessage>(Operation<T, S> request) async {
   final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}');
   {{#Codec.ReturnsValue}}final response = {{/Codec.ReturnsValue}}await _client.{{Codec.RequestMethod}}(url{{#Codec.HasBody}}, body: {{Codec.BodyMessageName}}{{/Codec.HasBody}});
   return Operation.fromJson(response, request.operationHelper);


### PR DESCRIPTION
- rename base message and enum types to avoid name conflicts; `Message` => `GMessage` and `Enum` => `GEnum`
- rename the `package:google_cloud_gax/common.dart` library to `package:google_cloud_gax/gax.dart`
- remove the need to explicitly import `dart:typed_data` (we just export the Uint8List type to people importing the gax base library)

`Enum` was going to conflict with a type of the same name from google.protobuf (it was also shadowing the `Enum` type from dart:core). `Message` was going to conflict with a type from firebase cloud messaging. We will need to figure out name prefixing in the future (google.cloud.aiplatform also has a message named 'Type', but needs to be able to refer the one from protobuf as well), but I think we should rename away from Enum and Message since the names are so common.

I don't have a strong opinion re: the name; `GMessage`? `GaxMessage`? `BaseMessage`? `ProtoMessage`?

I've uploaded the PR using `GMessage`; I _may_ switch that to `ProtoMessage`. I don't know if there's any prior art from other languages -
