### PR TITLE
fix(generator/dart): use json names for fields when encoding and decoding

### DIFF
--- a/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -1097,7 +1097,7 @@ class SecretPayload extends Message {
   factory SecretPayload.fromJson(Map<String, dynamic> json) {
     return SecretPayload(
       data: decodeBytes(json['data']),
-      dataCrc32C: decodeInt64(json['dataCrc32C']),
+      dataCrc32C: decodeInt64(json['dataCrc32c']),
     );
   }
 
@@ -1105,7 +1105,7 @@ class SecretPayload extends Message {
   Object toJson() {
     return {
       if (data != null) 'data': encodeBytes(data),
-      if (dataCrc32C != null) 'dataCrc32C': encodeInt64(dataCrc32C),
+      if (dataCrc32C != null) 'dataCrc32c': encodeInt64(dataCrc32C),
     };
   }
 
@@ -1113,7 +1113,7 @@ class SecretPayload extends Message {
   String toString() {
     final contents = [
       if (data != null) 'data=$data',
-      if (dataCrc32C != null) 'dataCrc32C=$dataCrc32C',
+      if (dataCrc32C != null) 'dataCrc32c=$dataCrc32C',
     ].join(',');
     return 'SecretPayload($contents)';
   }

--- a/generator/internal/dart/templates/lib/message.mustache
+++ b/generator/internal/dart/templates/lib/message.mustache
@@ -51,7 +51,7 @@ class {{Codec.Name}} extends Message {
   Object toJson() {
     return {
       {{#Fields}}
-      {{#Codec.Nullable}}if ({{{Codec.Name}}} != null) {{/Codec.Nullable}}'{{{Codec.Name}}}': {{{Codec.ToJson}}},
+      {{#Codec.Nullable}}if ({{{Codec.Name}}} != null) {{/Codec.Nullable}}'{{{JSONName}}}': {{{Codec.ToJson}}},
       {{/Fields}}
     };
   }


### PR DESCRIPTION
- use json names for fields when encoding and decoding

This switches from using the Dart field name (which is mostly the json name, but can occasionally be different) to using the json name when parsing from or converting to json. Found when generating google.cloud.aiplatform.v1, which has a field named `enum`, which we generate as `enum$`.
