### PR TITLE
refactor(generator): replace HasServices field with method for service

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -32,7 +32,6 @@ type modelAnnotations struct {
 	PackageNamespace string
 	RequiredPackages []string
 	ExternPackages   []string
-	HasServices      bool
 	HasLROs          bool
 	CopyrightYear    string
 	BoilerPlate      []string
@@ -54,6 +53,11 @@ type modelAnnotations struct {
 	DisabledRustdocWarnings []string
 	// Sets the default system parameters
 	DefaultSystemParameters []systemParameter
+}
+
+// HasServices returns true if there are any services in the model
+func (m *modelAnnotations) HasServices() bool {
+	return len(m.Services) > 0
 }
 
 type serviceAnnotations struct {
@@ -285,7 +289,6 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		ReleaseLevel:     codec.releaseLevel,
 		RequiredPackages: requiredPackages(codec.extraPackages),
 		ExternPackages:   externPackages(codec.extraPackages),
-		HasServices:      len(servicesSubset) > 0,
 		HasLROs:          hasLROs,
 		CopyrightYear:    codec.generationYear,
 		BoilerPlate: append(license.LicenseHeaderBulk(),

--- a/generator/internal/rust/generate.go
+++ b/generator/internal/rust/generate.go
@@ -32,7 +32,7 @@ func Generate(model *api.API, outdir string, cfg *config.Config) error {
 	}
 	annotations := annotateModel(model, codec)
 	provider := templatesProvider()
-	generatedFiles := codec.generatedFiles(annotations.HasServices)
+	generatedFiles := codec.generatedFiles(annotations.HasServices())
 	return language.GenerateFromModel(outdir, model, provider, generatedFiles)
 }
 


### PR DESCRIPTION
Part of the work for #1854

Remove duplicate HasServices field in modelAnnotations

Changes made:
1. Removed the HasServices boolean field from the modelAnnotations struct
2. Added a HasServices() method that returns true if there are any services in the Services slice
3. Updated the call in generate.go to use the new method instead of the field