### PR TITLE
feat(generator/rust): per-service feature option

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -53,6 +53,8 @@ type modelAnnotations struct {
 	DisabledRustdocWarnings []string
 	// Sets the default system parameters
 	DefaultSystemParameters []systemParameter
+	// Enables per-service features
+	PerServiceFeatures bool
 }
 
 // HasServices returns true if there are any services in the model
@@ -301,6 +303,7 @@ func annotateModel(model *api.API, codec *codec) *modelAnnotations {
 		NotForPublication:       codec.doNotPublish,
 		IsWktCrate:              model.PackageName == "google.protobuf",
 		DisabledRustdocWarnings: codec.disabledRustdocWarnings,
+		PerServiceFeatures:      codec.perServiceFeatures && len(servicesSubset) > 0,
 	}
 
 	model.Codec = ann

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -28,14 +28,28 @@ func TestPackageNames(t *testing.T) {
 		[]*api.Service{{Name: "Workflows", Package: "google.cloud.workflows.v1"}})
 	// Override the default name for test APIs ("Test").
 	model.Name = "workflows-v1"
-	codec, err := newCodec(true, map[string]string{})
+	codec, err := newCodec(true, map[string]string{
+		"per-service-features": "true",
+		"copyright-year":       "2035",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	got := annotateModel(model, codec)
-	want := "google_cloud_workflows_v1"
-	if got.PackageNamespace != want {
-		t.Errorf("mismatched package namespace, want=%s, got=%s", want, got.PackageNamespace)
+	want := &modelAnnotations{
+		PackageName:        "google-cloud-workflows-v1",
+		PackageNamespace:   "google_cloud_workflows_v1",
+		PackageVersion:     "0.0.0",
+		ReleaseLevel:       "preview",
+		RequiredPackages:   []string{},
+		ExternPackages:     []string{},
+		CopyrightYear:      "2035",
+		Services:           []*api.Service{},
+		NameToLower:        "workflows-v1",
+		PerServiceFeatures: false,
+	}
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(modelAnnotations{}, "BoilerPlate")); diff != "" {
+		t.Errorf("mismatch in modelAnnotations list (-want, +got)\n:%s", diff)
 	}
 }
 

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -111,6 +111,12 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 				return nil, fmt.Errorf("cannot convert `include-grpc-only-methods` value %q to boolean: %w", definition, err)
 			}
 			codec.includeGrpcOnlyMethods = value
+		case key == "per-service-features":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `per-service-features` value %q to boolean: %w", definition, err)
+			}
+			codec.perServiceFeatures = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -213,6 +219,8 @@ type codec struct {
 	// If true, this includes gRPC-only methods, such as methods without HTTP
 	// annotations.
 	includeGrpcOnlyMethods bool
+	// If true, the generator will produce per-client features
+	perServiceFeatures bool
 }
 
 type systemParameter struct {

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -53,6 +53,7 @@ func TestParseOptionsProtobuf(t *testing.T) {
 		"package:gax":               "package=gax,path=src/gax,feature=unstable-sdk-client",
 		"package:serde_with":        "package=serde_with,version=2.3.4,default-features=false",
 		"include-grpc-only-methods": "true",
+		"per-service-features":      "true",
 	}
 	got, err := newCodec(true, options)
 	if err != nil {
@@ -96,6 +97,7 @@ func TestParseOptionsProtobuf(t *testing.T) {
 			{Name: "$alt", Value: "json;enum-encoding=int"},
 		},
 		includeGrpcOnlyMethods: true,
+		perServiceFeatures:     true,
 	}
 	sort.Slice(want.extraPackages, func(i, j int) bool {
 		return want.extraPackages[i].name < want.extraPackages[j].name

--- a/generator/internal/rust/templates/common/Cargo.toml.mustache
+++ b/generator/internal/rust/templates/common/Cargo.toml.mustache
@@ -32,6 +32,18 @@ rust-version.workspace = true
 {{#Codec.NotForPublication}}
 publish                = false
 {{/Codec.NotForPublication}}
+{{#Codec.PerServiceFeatures}}
+
+[features]
+default = [
+    {{#Codec.Services}}
+    "{{Codec.ModuleName}}",
+    {{/Codec.Services}}
+]
+{{#Codec.Services}}
+{{Codec.ModuleName}} = []
+{{/Codec.Services}}
+{{/Codec.PerServiceFeatures}}
 
 [dependencies]
 {{#Codec.RequiredPackages}}

--- a/src/generated/cloud/aiplatform/v1/.sidekick.toml
+++ b/src/generated/cloud/aiplatform/v1/.sidekick.toml
@@ -20,3 +20,4 @@ service-config = 'google/cloud/aiplatform/v1/aiplatform_v1.yaml'
 copyright-year = '2025'
 # TODO(#893) - handle the bad HTML tags in this library.
 disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links,invalid_html_tags"
+per-service-features = 'true'

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -26,6 +26,74 @@ keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
 
+[features]
+default = [
+    "dataset_service",
+    "deployment_resource_pool_service",
+    "endpoint_service",
+    "evaluation_service",
+    "feature_online_store_admin_service",
+    "feature_online_store_service",
+    "feature_registry_service",
+    "featurestore_online_serving_service",
+    "featurestore_service",
+    "gen_ai_cache_service",
+    "gen_ai_tuning_service",
+    "index_endpoint_service",
+    "index_service",
+    "job_service",
+    "llm_utility_service",
+    "match_service",
+    "metadata_service",
+    "migration_service",
+    "model_garden_service",
+    "model_service",
+    "notebook_service",
+    "persistent_resource_service",
+    "pipeline_service",
+    "prediction_service",
+    "reasoning_engine_execution_service",
+    "reasoning_engine_service",
+    "schedule_service",
+    "specialist_pool_service",
+    "tensorboard_service",
+    "vertex_rag_data_service",
+    "vertex_rag_service",
+    "vizier_service",
+]
+dataset_service = []
+deployment_resource_pool_service = []
+endpoint_service = []
+evaluation_service = []
+feature_online_store_admin_service = []
+feature_online_store_service = []
+feature_registry_service = []
+featurestore_online_serving_service = []
+featurestore_service = []
+gen_ai_cache_service = []
+gen_ai_tuning_service = []
+index_endpoint_service = []
+index_service = []
+job_service = []
+llm_utility_service = []
+match_service = []
+metadata_service = []
+migration_service = []
+model_garden_service = []
+model_service = []
+notebook_service = []
+persistent_resource_service = []
+pipeline_service = []
+prediction_service = []
+reasoning_engine_execution_service = []
+reasoning_engine_service = []
+schedule_service = []
+specialist_pool_service = []
+tensorboard_service = []
+vertex_rag_data_service = []
+vertex_rag_service = []
+vizier_service = []
+
 [dependencies]
 api.workspace        = true
 async-trait.workspace = true


### PR DESCRIPTION
Introduce an option to generate per-service features. Use this option
in the `Cargo.toml.mustache` template to introduce the features and
the default feature.

Part of the work for #1863
