### PR TITLE
impl(generator/rust): compute service dependencies

### DIFF
--- a/generator/internal/api/service_dependencies.go
+++ b/generator/internal/api/service_dependencies.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"maps"
+	"slices"
+)
+
+type ServiceDependencies struct {
+	Messages []string
+	Enums    []string
+}
+
+// FindServiceDependencies returns the message and enum IDs that are required by
+// a given service.
+//
+// The function traverses `model` starting from the definition of `serviceID`.
+//   - Any message used by a method of the service is included in the results.
+//   - Any message used by LROs of the service is included in the results.
+//   - The results are recursively scanned searching for any fields of the
+//     messages included above.
+//   - If a nested message is included in the results, then the parent message
+//     is also included (recursively) in the results.
+func FindServiceDependencies(model *API, serviceID string) *ServiceDependencies {
+	service, ok := model.State.ServiceByID[serviceID]
+	if !ok {
+		return &ServiceDependencies{}
+	}
+	state := newFindServicesState(serviceID, model)
+	state.seed(service)
+	state.search()
+	return &ServiceDependencies{
+		Messages: slices.Sorted(maps.Keys(state.Messages)),
+		Enums:    slices.Sorted(maps.Keys(state.Enums)),
+	}
+}
+
+type findServiceState struct {
+	// The message IDs that have already been visited
+	Visited map[string]bool
+	// The enums already included in these results
+	Enums map[string]bool
+	// The messages already included in these results
+	Messages   map[string]bool
+	model      *API
+	candidates []*Message
+	serviceID  string
+}
+
+func newFindServicesState(serviceID string, model *API) *findServiceState {
+	return &findServiceState{
+		Visited:   map[string]bool{},
+		Enums:     map[string]bool{},
+		Messages:  map[string]bool{},
+		model:     model,
+		serviceID: serviceID,
+	}
+}
+
+func (state *findServiceState) seed(service *Service) {
+	for _, method := range service.Methods {
+		state.addCandidate(method.InputTypeID)
+		state.addCandidate(method.OutputTypeID)
+		if method.OperationInfo != nil {
+			state.addCandidate(method.OperationInfo.MetadataTypeID)
+			state.addCandidate(method.OperationInfo.ResponseTypeID)
+		}
+	}
+}
+
+func (state *findServiceState) search() {
+	for len(state.candidates) > 0 {
+		candidate := state.candidates[len(state.candidates)-1]
+		state.candidates = state.candidates[0 : len(state.candidates)-1]
+
+		if _, ok := state.Visited[candidate.ID]; ok {
+			continue
+		}
+		state.Messages[candidate.ID] = true
+		state.recurse(candidate)
+	}
+}
+
+func (state *findServiceState) recurse(msg *Message) {
+	state.Visited[msg.ID] = true
+	for _, field := range msg.Fields {
+		switch field.Typez {
+		case ENUM_TYPE:
+			state.addEnum(field.TypezID)
+		case MESSAGE_TYPE:
+			state.addMessage(field.TypezID)
+		default:
+		}
+	}
+}
+
+func (state *findServiceState) addEnum(id string) {
+	if e, ok := state.model.State.EnumByID[id]; ok {
+		if e.Parent != nil {
+			state.addCandidate(e.Parent.ID)
+		}
+		state.Enums[id] = true
+	}
+}
+
+func (state *findServiceState) addMessage(id string) {
+	state.addCandidate(id)
+	if m, ok := state.model.State.MessageByID[id]; ok {
+		if m.Parent != nil {
+			state.addCandidate(m.Parent.ID)
+		}
+		if !m.IsMap {
+			state.Messages[id] = true
+		}
+	}
+}
+
+func (state *findServiceState) addCandidate(id string) {
+	msg, ok := state.model.State.MessageByID[id]
+	if !ok {
+		return
+	}
+	if _, ok := state.Visited[msg.ID]; ok {
+		return
+	}
+	state.candidates = append(state.candidates, msg)
+}

--- a/generator/internal/api/service_dependencies_test.go
+++ b/generator/internal/api/service_dependencies_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestFindServiceDependencies(t *testing.T) {
+	enums := []*Enum{
+		{
+			Name: "SomeEnum",
+			ID:   ".test.SomeEnum",
+		},
+	}
+	messages := []*Message{
+		{
+			Name: "Message",
+			ID:   ".test.Message",
+			Fields: []*Field{
+				{
+					Name:  "a",
+					Typez: STRING_TYPE,
+				},
+				{
+					Name:    "b",
+					Typez:   ENUM_TYPE,
+					TypezID: ".test.SomeEnum",
+				},
+				{
+					Name:     "c",
+					Typez:    MESSAGE_TYPE,
+					TypezID:  ".test.Message",
+					Optional: true,
+				},
+			},
+		},
+		{
+			Name:   "Unused",
+			ID:     ".test.Unused",
+			Fields: []*Field{},
+		},
+		{
+			Name: "Request",
+			ID:   ".test.Request",
+			Fields: []*Field{
+				{
+					Name:    "body",
+					Typez:   MESSAGE_TYPE,
+					TypezID: ".test.Message",
+				},
+			},
+		},
+		{
+			Name:   "Response",
+			ID:     ".test.Response",
+			Fields: []*Field{},
+		},
+		{
+			Name:   "Empty",
+			ID:     ".test.Empty",
+			Fields: []*Field{},
+		},
+		{
+			Name:   "OpMetadata",
+			ID:     ".test.OpMetadata",
+			Fields: []*Field{},
+		},
+		{
+			Name:   "OpResponse",
+			ID:     ".test.OpResponse",
+			Fields: []*Field{},
+		},
+	}
+	services := []*Service{
+		{
+			Name: "Service1",
+			ID:   ".test.Service1",
+			Methods: []*Method{
+				{
+					Name:         "Method0",
+					ID:           ".test.Service1.Method0",
+					InputTypeID:  ".test.Request",
+					OutputTypeID: ".test.Response",
+				},
+			},
+		},
+		{
+			Name: "Service2",
+			ID:   ".test.Service2",
+			Methods: []*Method{
+				{
+					Name:         "Method0",
+					ID:           ".test.Service1.Method0",
+					InputTypeID:  ".test.Empty",
+					OutputTypeID: ".test.Empty",
+					OperationInfo: &OperationInfo{
+						MetadataTypeID: ".test.OpMetadata",
+						ResponseTypeID: ".test.OpResponse",
+					},
+				},
+			},
+		},
+	}
+	less := func(a, b string) bool { return a < b }
+	model := NewTestAPI(messages, enums, services)
+	got := FindServiceDependencies(model, ".test.NotFound")
+	want := &ServiceDependencies{}
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+	}
+
+	got = FindServiceDependencies(model, ".test.Service1")
+	want = &ServiceDependencies{
+		Messages: []string{".test.Request", ".test.Response", ".test.Message"},
+		Enums:    []string{".test.SomeEnum"},
+	}
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+	}
+
+	got = FindServiceDependencies(model, ".test.Service2")
+	want = &ServiceDependencies{
+		Messages: []string{".test.Empty", ".test.OpMetadata", ".test.OpResponse"},
+	}
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+		t.Errorf("dependencies mismatch (-want, +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Implement a function to compute the transitive closures of a service
dependencies, including all request messages, all response messages,
all LRO metadata and response messages, and the transitive deps of these
messages.

Part of the work for #1863