### PR TITLE
impl(gaxi): convert tonic response to gax response

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -234,3 +234,16 @@ impl Client {
             .unwrap_or_else(|| self.retry_throttler.clone())
     }
 }
+
+/// Convert a `tonic::Response` wrapping a prost message into a
+/// `gax::response::Response` wrapping our equivalent message
+pub fn to_gax_response<T, G>(response: tonic::Response<T>) -> gax::response::Response<G>
+where
+    T: crate::prost::Convert<G>,
+{
+    let (metadata, body, _extensions) = response.into_parts();
+    gax::response::Response::from_parts(
+        gax::response::Parts::new().set_headers(metadata.into_headers()),
+        body.cnv(),
+    )
+}

--- a/src/gax-internal/tests/grpc_convert.rs
+++ b/src/gax-internal/tests/grpc_convert.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use google_cloud_gax_internal::grpc;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tonic::metadata::MetadataMap;
+
+    #[test]
+    fn test_to_gax_response() {
+        let tonic_body = prost_types::Duration {
+            seconds: 123,
+            nanos: 456,
+        };
+        let mut tonic_headers = MetadataMap::new();
+        tonic_headers.insert("key", "value".parse().unwrap());
+        let tonic_response = tonic::Response::from_parts(
+            tonic_headers.clone(),
+            tonic_body,
+            tonic::Extensions::new(),
+        );
+
+        let gax_response = grpc::to_gax_response(tonic_response);
+        assert_eq!(
+            gax_response.body().to_owned(),
+            wkt::Duration::clamp(123, 456)
+        );
+        assert_eq!(
+            gax_response.headers().to_owned(),
+            tonic_headers.into_headers()
+        );
+    }
+}


### PR DESCRIPTION
Part of the work for #1612

The `grpc::Client` interfaces are all in `prost`/`tonic` land, whereas our stub interfaces are all in `gax` land.

Every API in the gRPC transport will need this conversion function, so factor it out into one place instead of generating it N times.