### PR TITLE
refactor: use `grpc::Client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,6 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
- "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-rpc",
@@ -4000,7 +3999,6 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
- "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-iam-v1",

--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -23,7 +23,7 @@ use crate::Result;
 {{! Disable warnings about unused imports: sometimes there are no RPCs with query parameters and this goes unused }}
 #[allow(unused_imports)]
 use gax::error::Error;
-use std::sync::Arc;
+use gaxi::prost::Convert;
 
 const DEFAULT_HOST: &str = "https://{{Codec.DefaultHost}}";
 
@@ -47,11 +47,7 @@ mod info {
 /// Implements [{{Codec.Name}}](super::stub::{{Codec.Name}}) using a Tonic-generated client.
 #[derive(Clone)]
 pub struct {{Codec.Name}} {
-    inner: tonic::client::Grpc<tonic::transport::Channel>,
-    cred: auth::credentials::Credentials,
-    retry_policy: Option<Arc<dyn gax::retry_policy::RetryPolicy>>,
-    backoff_policy: Option<Arc<dyn gax::backoff_policy::BackoffPolicy>>,
-    retry_throttler: gax::retry_throttler::SharedRetryThrottler,
+    inner: gaxi::grpc::Client,
 }
 
 impl std::fmt::Debug for {{Codec.Name}} {
@@ -64,210 +60,8 @@ impl std::fmt::Debug for {{Codec.Name}} {
 
 impl {{Codec.Name}} {
     pub async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
-        let cred = Self::make_credentials(&config).await?;
-        let inner = Self::make_inner(config.endpoint).await?;
-        Ok(Self {
-            inner,
-            cred,
-            retry_policy: config.retry_policy,
-            backoff_policy: config.backoff_policy,
-            retry_throttler: config.retry_throttler,
-        })
-    }
-
-    async fn make_inner(endpoint: Option<String>) -> Result<tonic::client::Grpc<tonic::transport::Channel>> {
-        let endpoint = tonic::transport::Endpoint::new(
-            endpoint.unwrap_or_else(|| DEFAULT_HOST.to_string())
-        ).map_err(Error::other)?;
-        let conn = endpoint.connect().await.map_err(Error::other)?;
-        Ok(tonic::client::Grpc::new(conn))
-    }
-
-    async fn make_credentials(config: &gaxi::options::ClientConfig) -> Result<auth::credentials::Credentials> {
-        if let Some(c) = config.cred.clone() {
-            return Ok(c);
-        }
-        auth::credentials::create_access_token_credentials()
-                .await
-                .map_err(Error::authentication)
-    }
-
-    async fn make_headers(
-        &self,
-        options: &gax::options::RequestOptions,
-        request_params: &str,
-    ) -> Result<http::header::HeaderMap> {
-        let mut headers = self
-            .cred
-            .headers()
-            .await
-            .map_err(Error::authentication)?;
-        headers.push((
-            http::header::HeaderName::from_static("x-goog-api-client"),
-            http::header::HeaderValue::from_static(&info::X_GOOG_API_CLIENT_HEADER),
-        ));
-        headers.push((
-            http::header::HeaderName::from_static("x-goog-request-params"),
-            http::header::HeaderValue::from_str(request_params).map_err(Error::other)?,
-        ));
-        if let Some(user_agent) = options.user_agent() {
-            headers.push((
-                http::header::USER_AGENT,
-                http::header::HeaderValue::from_str(user_agent).map_err(Error::other)?,
-            ));
-        }
-        Ok(http::header::HeaderMap::from_iter(headers))
-    }
-
-    async fn execute<Request, Response, F, RF>(
-        &self,
-        call: F,
-        req: Request,
-        options: &gax::options::RequestOptions,
-        request_params: String,
-    ) -> Result<Response>
-    where
-        F: Fn(Request, http::header::HeaderMap) -> RF + Send + Sync,
-        RF: std::future::Future<Output = Result<Response>>,
-        Request: std::clone::Clone,
-    {
-        match self.get_retry_policy(options) {
-            None => {
-                let headers = self.make_headers(options, &request_params).await?;
-                call(req, headers).await
-            },
-            Some(policy) => {
-                self.retry_loop(call, req, options, request_params, policy).await
-            },
-        }
-    }
-
-    async fn retry_loop<Request, Response, F, RF>(&self, call: F,
-         req: Request,
-         options: &gax::options::RequestOptions,
-         request_params: String,
-         retry_policy: Arc<dyn gax::retry_policy::RetryPolicy>,
-    ) -> Result<Response>
-    where
-        F: Fn(Request, http::header::HeaderMap) -> RF + Send + Sync,
-        RF: std::future::Future<Output = Result<Response>>,
-        Request: std::clone::Clone,
-    {
-        let loop_start = std::time::Instant::now();
-        let throttler = self.get_retry_throttler(options);
-        let backoff = self.get_backoff_policy(options);
-        let mut attempt_count = 0;
-        loop {
-            let request = req.clone();
-            let remaining_time = retry_policy.remaining_time(loop_start, attempt_count);
-            let throttle = if attempt_count == 0 {
-                false
-            } else {
-                let t = throttler.lock().expect("retry throttler lock is poisoned");
-                t.throttle_retry_attempt()
-            };
-            if throttle {
-                // This counts as an error for the purposes of the retry policy.
-                if let Some(error) = retry_policy.on_throttle(loop_start, attempt_count) {
-                    return Err(error);
-                }
-                let delay = backoff.on_failure(loop_start, attempt_count);
-                tokio::time::sleep(delay).await;
-                continue;
-            }
-            attempt_count += 1;
-            match self.request_attempt(&call, request, options, &request_params, remaining_time).await {
-                Ok(r) => {
-                    throttler
-                        .lock()
-                        .expect("retry throttler lock is poisoned")
-                        .on_success();
-                    return Ok(r);
-                }
-                Err(e) => {
-                    let flow = retry_policy.on_error(
-                        loop_start,
-                        attempt_count,
-                        options.idempotent().unwrap_or(false),
-                        e,
-                    );
-                    let delay = backoff.on_failure(loop_start, attempt_count);
-                    {
-                        throttler
-                            .lock()
-                            .expect("retry throttler lock is poisoned")
-                            .on_retry_failure(&flow);
-                    };
-                    self.on_error(flow, delay).await?;
-                }
-            };
-        }
-    }
-
-    async fn request_attempt<Request, Response, F, RF>(
-        &self,
-        call: &F,
-        req: Request,
-        options: &gax::options::RequestOptions,
-        request_params: &str,
-        _remaining_time: Option<std::time::Duration>,
-    ) -> Result<Response>
-    where
-        F: Fn(Request, http::header::HeaderMap) -> RF + Send + Sync,
-        RF: std::future::Future<Output = Result<Response>>,
-        Request: std::clone::Clone,
-    {
-        {{! TODO(#1384) - we need to add the timeout handling }}
-        let headers = self.make_headers(options, request_params).await?;
-        call(req, headers).await
-    }
-
-    async fn on_error(
-        &self,
-        retry_flow: gax::loop_state::LoopState,
-        backoff_delay: std::time::Duration,
-    ) -> Result<()> {
-        use gax::loop_state::LoopState;
-        match retry_flow {
-            LoopState::Permanent(e) | LoopState::Exhausted(e) => {
-                return Err(e);
-            }
-            LoopState::Continue(_e) => {
-                tokio::time::sleep(backoff_delay).await;
-            }
-        }
-        Ok(())
-    }
-
-    fn get_retry_policy(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> Option<Arc<dyn gax::retry_policy::RetryPolicy>> {
-        options
-            .retry_policy()
-            .clone()
-            .or_else(|| self.retry_policy.clone())
-    }
-
-    fn get_backoff_policy(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> Arc<dyn gax::backoff_policy::BackoffPolicy> {
-        options
-            .backoff_policy()
-            .clone()
-            .or_else(|| self.backoff_policy.clone())
-            .unwrap_or_else(|| Arc::new(gax::exponential_backoff::ExponentialBackoff::default()))
-    }
-
-    fn get_retry_throttler(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> gax::retry_throttler::SharedRetryThrottler {
-        options
-            .retry_throttler()
-            .clone()
-            .unwrap_or_else(|| self.retry_throttler.clone())
+        let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
+        Ok(Self { inner })
     }
 }
 
@@ -278,43 +72,14 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         req: {{InputType.Codec.QualifiedName}},
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<{{Codec.ReturnType}}>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: {{InputType.Codec.QualifiedName}}, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new("{{Service.Package}}.{{Service.Name}}", "{{Name}}"));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/{{Service.Package}}.{{Service.Name}}/{{Name}}"
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            {{#ReturnsEmpty}}
-            let response : tonic::Response<()> =
-                inner.unary(request, path, codec).await.map_err(Error::rpc)?;
-            let (metadata, _body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new()
-                    .set_headers(metadata.into_headers()),
-                (),
-            ))
-            {{/ReturnsEmpty}}
-            {{^ReturnsEmpty}}
-            let response : tonic::Response<crate::{{Service.Codec.PackageModuleName}}::{{OutputType.Codec.RelativeName}}> =
-                inner.unary(request, path, codec).await.map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new()
-                    .set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
-            {{/ReturnsEmpty}}
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new("{{Service.Package}}.{{Service.Name}}", "{{Name}}"));
+            e
         };
+        let path = http::uri::PathAndQuery::from_static(
+            "/{{Service.Package}}.{{Service.Name}}/{{Name}}"
+        );
         let x_goog_request_params = [
             {{#PathInfo.Codec.PathArgs}}
             format!("{{Name}}={}", req{{{Accessor}}}),
@@ -324,9 +89,24 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             {{/PathInfo.Codec.PathArgs}}
         ].into_iter().fold(String::new(), |b, p| b + "&" + &p);
 
-        {{! TODO(#1384) - we should do something with the metadata }}
-        self.execute(call, req, &options, x_goog_request_params)
-            .await
+        self.inner
+          .execute(
+              extensions,
+              path,
+              req.cnv(),
+              options,
+              &info::X_GOOG_API_CLIENT_HEADER,
+              &x_goog_request_params,
+          )
+          .await
+          .map(gaxi::grpc::to_gax_response::<
+          {{#ReturnsEmpty}}
+          (),
+          {{/ReturnsEmpty}}
+          {{^ReturnsEmpty}}
+          crate::{{Service.Codec.PackageModuleName}}::{{OutputType.Codec.RelativeName}},
+          {{/ReturnsEmpty}}
+          {{Codec.ReturnType}}>)
     }
 
     {{/Codec.Methods}}

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -40,7 +40,6 @@ tonic.workspace       = true
 tokio                 = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing               = "0.1"
 # Local crates
-auth.workspace  = true
 gax             = { workspace = true, features = ["unstable-sdk-client"] }
 gaxi            = { workspace = true, features = ["_internal_common", "_internal_grpc_client"] }
 gtype.workspace = true

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -17,7 +17,7 @@
 use crate::Result;
 #[allow(unused_imports)]
 use gax::error::Error;
-use std::sync::Arc;
+use gaxi::prost::Convert;
 
 const DEFAULT_HOST: &str = "https://firestore.googleapis.com";
 
@@ -39,11 +39,7 @@ mod info {
 /// Implements [Firestore](super::stub::Firestore) using a Tonic-generated client.
 #[derive(Clone)]
 pub struct Firestore {
-    inner: tonic::client::Grpc<tonic::transport::Channel>,
-    cred: auth::credentials::Credentials,
-    retry_policy: Option<Arc<dyn gax::retry_policy::RetryPolicy>>,
-    backoff_policy: Option<Arc<dyn gax::backoff_policy::BackoffPolicy>>,
-    retry_throttler: gax::retry_throttler::SharedRetryThrottler,
+    inner: gaxi::grpc::Client,
 }
 
 impl std::fmt::Debug for Firestore {
@@ -56,215 +52,8 @@ impl std::fmt::Debug for Firestore {
 
 impl Firestore {
     pub async fn new(config: gaxi::options::ClientConfig) -> Result<Self> {
-        let cred = Self::make_credentials(&config).await?;
-        let inner = Self::make_inner(config.endpoint).await?;
-        Ok(Self {
-            inner,
-            cred,
-            retry_policy: config.retry_policy,
-            backoff_policy: config.backoff_policy,
-            retry_throttler: config.retry_throttler,
-        })
-    }
-
-    async fn make_inner(
-        endpoint: Option<String>,
-    ) -> Result<tonic::client::Grpc<tonic::transport::Channel>> {
-        let endpoint =
-            tonic::transport::Endpoint::new(endpoint.unwrap_or_else(|| DEFAULT_HOST.to_string()))
-                .map_err(Error::other)?;
-        let conn = endpoint.connect().await.map_err(Error::other)?;
-        Ok(tonic::client::Grpc::new(conn))
-    }
-
-    async fn make_credentials(
-        config: &gaxi::options::ClientConfig,
-    ) -> Result<auth::credentials::Credentials> {
-        if let Some(c) = config.cred.clone() {
-            return Ok(c);
-        }
-        auth::credentials::create_access_token_credentials()
-            .await
-            .map_err(Error::authentication)
-    }
-
-    async fn make_headers(
-        &self,
-        options: &gax::options::RequestOptions,
-        request_params: &str,
-    ) -> Result<http::header::HeaderMap> {
-        let mut headers = self.cred.headers().await.map_err(Error::authentication)?;
-        headers.push((
-            http::header::HeaderName::from_static("x-goog-api-client"),
-            http::header::HeaderValue::from_static(&info::X_GOOG_API_CLIENT_HEADER),
-        ));
-        headers.push((
-            http::header::HeaderName::from_static("x-goog-request-params"),
-            http::header::HeaderValue::from_str(request_params).map_err(Error::other)?,
-        ));
-        if let Some(user_agent) = options.user_agent() {
-            headers.push((
-                http::header::USER_AGENT,
-                http::header::HeaderValue::from_str(user_agent).map_err(Error::other)?,
-            ));
-        }
-        Ok(http::header::HeaderMap::from_iter(headers))
-    }
-
-    async fn execute<Request, Response, F, RF>(
-        &self,
-        call: F,
-        req: Request,
-        options: &gax::options::RequestOptions,
-        request_params: String,
-    ) -> Result<Response>
-    where
-        F: Fn(Request, http::header::HeaderMap) -> RF + Send + Sync,
-        RF: std::future::Future<Output = Result<Response>>,
-        Request: std::clone::Clone,
-    {
-        match self.get_retry_policy(options) {
-            None => {
-                let headers = self.make_headers(options, &request_params).await?;
-                call(req, headers).await
-            }
-            Some(policy) => {
-                self.retry_loop(call, req, options, request_params, policy)
-                    .await
-            }
-        }
-    }
-
-    async fn retry_loop<Request, Response, F, RF>(
-        &self,
-        call: F,
-        req: Request,
-        options: &gax::options::RequestOptions,
-        request_params: String,
-        retry_policy: Arc<dyn gax::retry_policy::RetryPolicy>,
-    ) -> Result<Response>
-    where
-        F: Fn(Request, http::header::HeaderMap) -> RF + Send + Sync,
-        RF: std::future::Future<Output = Result<Response>>,
-        Request: std::clone::Clone,
-    {
-        let loop_start = std::time::Instant::now();
-        let throttler = self.get_retry_throttler(options);
-        let backoff = self.get_backoff_policy(options);
-        let mut attempt_count = 0;
-        loop {
-            let request = req.clone();
-            let remaining_time = retry_policy.remaining_time(loop_start, attempt_count);
-            let throttle = if attempt_count == 0 {
-                false
-            } else {
-                let t = throttler.lock().expect("retry throttler lock is poisoned");
-                t.throttle_retry_attempt()
-            };
-            if throttle {
-                // This counts as an error for the purposes of the retry policy.
-                if let Some(error) = retry_policy.on_throttle(loop_start, attempt_count) {
-                    return Err(error);
-                }
-                let delay = backoff.on_failure(loop_start, attempt_count);
-                tokio::time::sleep(delay).await;
-                continue;
-            }
-            attempt_count += 1;
-            match self
-                .request_attempt(&call, request, options, &request_params, remaining_time)
-                .await
-            {
-                Ok(r) => {
-                    throttler
-                        .lock()
-                        .expect("retry throttler lock is poisoned")
-                        .on_success();
-                    return Ok(r);
-                }
-                Err(e) => {
-                    let flow = retry_policy.on_error(
-                        loop_start,
-                        attempt_count,
-                        options.idempotent().unwrap_or(false),
-                        e,
-                    );
-                    let delay = backoff.on_failure(loop_start, attempt_count);
-                    {
-                        throttler
-                            .lock()
-                            .expect("retry throttler lock is poisoned")
-                            .on_retry_failure(&flow);
-                    };
-                    self.on_error(flow, delay).await?;
-                }
-            };
-        }
-    }
-
-    async fn request_attempt<Request, Response, F, RF>(
-        &self,
-        call: &F,
-        req: Request,
-        options: &gax::options::RequestOptions,
-        request_params: &str,
-        _remaining_time: Option<std::time::Duration>,
-    ) -> Result<Response>
-    where
-        F: Fn(Request, http::header::HeaderMap) -> RF + Send + Sync,
-        RF: std::future::Future<Output = Result<Response>>,
-        Request: std::clone::Clone,
-    {
-        let headers = self.make_headers(options, request_params).await?;
-        call(req, headers).await
-    }
-
-    async fn on_error(
-        &self,
-        retry_flow: gax::loop_state::LoopState,
-        backoff_delay: std::time::Duration,
-    ) -> Result<()> {
-        use gax::loop_state::LoopState;
-        match retry_flow {
-            LoopState::Permanent(e) | LoopState::Exhausted(e) => {
-                return Err(e);
-            }
-            LoopState::Continue(_e) => {
-                tokio::time::sleep(backoff_delay).await;
-            }
-        }
-        Ok(())
-    }
-
-    fn get_retry_policy(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> Option<Arc<dyn gax::retry_policy::RetryPolicy>> {
-        options
-            .retry_policy()
-            .clone()
-            .or_else(|| self.retry_policy.clone())
-    }
-
-    fn get_backoff_policy(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> Arc<dyn gax::backoff_policy::BackoffPolicy> {
-        options
-            .backoff_policy()
-            .clone()
-            .or_else(|| self.backoff_policy.clone())
-            .unwrap_or_else(|| Arc::new(gax::exponential_backoff::ExponentialBackoff::default()))
-    }
-
-    fn get_retry_throttler(
-        &self,
-        options: &gax::options::RequestOptions,
-    ) -> gax::retry_throttler::SharedRetryThrottler {
-        options
-            .retry_throttler()
-            .clone()
-            .unwrap_or_else(|| self.retry_throttler.clone())
+        let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
+        Ok(Self { inner })
     }
 }
 
@@ -274,40 +63,36 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::GetDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::GetDocumentRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "GetDocument",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/GetDocument");
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::Document> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "GetDocument",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/GetDocument");
         let x_goog_request_params = [format!("name={}", req.name)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::Document,
+                    crate::model::Document,
+                >,
+            )
     }
 
     async fn list_documents(
@@ -315,36 +100,16 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::ListDocumentsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDocumentsResponse>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::ListDocumentsRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "ListDocuments",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/ListDocuments",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::ListDocumentsResponse> =
-                inner
-                    .unary(request, path, codec)
-                    .await
-                    .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "ListDocuments",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/ListDocuments");
         let x_goog_request_params = [
             format!("parent={}", req.parent),
             format!("collection_id={}", req.collection_id),
@@ -352,8 +117,22 @@ impl super::stub::Firestore for Firestore {
         .into_iter()
         .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::ListDocumentsResponse,
+                    crate::model::ListDocumentsResponse,
+                >,
+            )
     }
 
     async fn update_document(
@@ -361,35 +140,16 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::UpdateDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::UpdateDocumentRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "UpdateDocument",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/UpdateDocument",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::Document> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "UpdateDocument",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/UpdateDocument");
         let x_goog_request_params = [format!(
             "document.name={}",
             req.document
@@ -400,8 +160,22 @@ impl super::stub::Firestore for Firestore {
         .into_iter()
         .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::Document,
+                    crate::model::Document,
+                >,
+            )
     }
 
     async fn delete_document(
@@ -409,41 +183,31 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::DeleteDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::DeleteDocumentRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "DeleteDocument",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/DeleteDocument",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<()> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, _body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                (),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "DeleteDocument",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/DeleteDocument");
         let x_goog_request_params = [format!("name={}", req.name)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(gaxi::grpc::to_gax_response::<(), ()>)
     }
 
     async fn begin_transaction(
@@ -451,42 +215,36 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::BeginTransactionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BeginTransactionResponse>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::BeginTransactionRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "BeginTransaction",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/BeginTransaction",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::BeginTransactionResponse> =
-                inner
-                    .unary(request, path, codec)
-                    .await
-                    .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "BeginTransaction",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/BeginTransaction");
         let x_goog_request_params = [format!("database={}", req.database)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::BeginTransactionResponse,
+                    crate::model::BeginTransactionResponse,
+                >,
+            )
     }
 
     async fn commit(
@@ -494,40 +252,35 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::CommitRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CommitResponse>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::CommitRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "Commit",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/Commit");
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::CommitResponse> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "Commit",
+            ));
+            e
         };
+        let path = http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/Commit");
         let x_goog_request_params = [format!("database={}", req.database)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::CommitResponse,
+                    crate::model::CommitResponse,
+                >,
+            )
     }
 
     async fn rollback(
@@ -535,40 +288,30 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::RollbackRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::RollbackRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "Rollback",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/Rollback");
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<()> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, _body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                (),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "Rollback",
+            ));
+            e
         };
+        let path = http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/Rollback");
         let x_goog_request_params = [format!("database={}", req.database)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(gaxi::grpc::to_gax_response::<(), ()>)
     }
 
     async fn partition_query(
@@ -576,42 +319,36 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::PartitionQueryRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PartitionQueryResponse>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::PartitionQueryRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "PartitionQuery",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/PartitionQuery",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::PartitionQueryResponse> =
-                inner
-                    .unary(request, path, codec)
-                    .await
-                    .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "PartitionQuery",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/PartitionQuery");
         let x_goog_request_params = [format!("parent={}", req.parent)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::PartitionQueryResponse,
+                    crate::model::PartitionQueryResponse,
+                >,
+            )
     }
 
     async fn list_collection_ids(
@@ -619,42 +356,37 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::ListCollectionIdsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCollectionIdsResponse>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::ListCollectionIdsRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "ListCollectionIds",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/ListCollectionIds",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::ListCollectionIdsResponse> =
-                inner
-                    .unary(request, path, codec)
-                    .await
-                    .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "ListCollectionIds",
+            ));
+            e
         };
+        let path = http::uri::PathAndQuery::from_static(
+            "/google.firestore.v1.Firestore/ListCollectionIds",
+        );
         let x_goog_request_params = [format!("parent={}", req.parent)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::ListCollectionIdsResponse,
+                    crate::model::ListCollectionIdsResponse,
+                >,
+            )
     }
 
     async fn batch_write(
@@ -662,40 +394,36 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::BatchWriteRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchWriteResponse>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::BatchWriteRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "BatchWrite",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/BatchWrite");
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::BatchWriteResponse> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "BatchWrite",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/BatchWrite");
         let x_goog_request_params = [format!("database={}", req.database)]
             .into_iter()
             .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::BatchWriteResponse,
+                    crate::model::BatchWriteResponse,
+                >,
+            )
     }
 
     async fn create_document(
@@ -703,35 +431,16 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::CreateDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
-        use gaxi::prost::Convert;
-        let inner = self.inner.clone();
-        let call = |r: crate::model::CreateDocumentRequest, h: http::header::HeaderMap| async {
-            let extensions = {
-                let mut e = tonic::Extensions::new();
-                e.insert(tonic::GrpcMethod::new(
-                    "google.firestore.v1.Firestore",
-                    "CreateDocument",
-                ));
-                e
-            };
-            let metadata = tonic::metadata::MetadataMap::from_headers(h);
-            let request = tonic::Request::from_parts(metadata, extensions, r.cnv());
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/google.firestore.v1.Firestore/CreateDocument",
-            );
-            let mut inner = inner.clone();
-            inner.ready().await.map_err(Error::rpc)?;
-            let response: tonic::Response<crate::google::firestore::v1::Document> = inner
-                .unary(request, path, codec)
-                .await
-                .map_err(Error::rpc)?;
-            let (metadata, body, _extensions) = response.into_parts();
-            Ok(gax::response::Response::from_parts(
-                gax::response::Parts::new().set_headers(metadata.into_headers()),
-                body.cnv(),
-            ))
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.firestore.v1.Firestore",
+                "CreateDocument",
+            ));
+            e
         };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.firestore.v1.Firestore/CreateDocument");
         let x_goog_request_params = [
             format!("parent={}", req.parent),
             format!("collection_id={}", req.collection_id),
@@ -739,7 +448,21 @@ impl super::stub::Firestore for Firestore {
         .into_iter()
         .fold(String::new(), |b, p| b + "&" + &p);
 
-        self.execute(call, req, &options, x_goog_request_params)
+        self.inner
+            .execute(
+                extensions,
+                path,
+                req.cnv(),
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
             .await
+            .map(
+                gaxi::grpc::to_gax_response::<
+                    crate::google::firestore::v1::Document,
+                    crate::model::Document,
+                >,
+            )
     }
 }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -62,7 +62,7 @@ impl Client {
         request: Request,
         options: gax::options::RequestOptions,
         api_client_header: &'static str,
-        request_params: &'static str,
+        request_params: &str,
     ) -> Result<tonic::Response<Response>>
     where
         Request: prost::Message + 'static + Clone,

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -40,7 +40,6 @@ tonic.workspace       = true
 tokio                 = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace     = true
 # Local crates
-auth.workspace   = true
 gax              = { workspace = true, features = ["unstable-sdk-client"] }
 gaxi             = { workspace = true, features = ["_internal_common", "_internal_grpc_client"] }
 gtype.workspace  = true


### PR DESCRIPTION
Most of the work for #1612

Implement our gRPC-based client crates using the `gaxi::grpc::Client`.

I think it is slightly more than a pure refactor as these clients now support timeouts.

We rely on the firestore integration tests to ensure correctness of the code.