### PR TITLE
cleanup(gaxi): switch from `built` to `rustc_version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,12 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
-
-[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,7 +2322,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "built",
  "bytes",
  "echo-server",
  "google-cloud-auth",
@@ -2342,6 +2335,7 @@ dependencies = [
  "prost",
  "prost-types",
  "reqwest",
+ "rustc_version",
  "scoped-env",
  "serde",
  "serde_json",

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -84,4 +84,4 @@ echo-server = { path = "echo-server" }
 grpc-server = { path = "grpc-server" }
 
 [build-dependencies]
-built = "0.7"
+rustc_version = "0.4"

--- a/src/gax-internal/build.rs
+++ b/src/gax-internal/build.rs
@@ -12,6 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
 fn main() {
-    built::write_built_file().expect("Failed to acquire build-time information");
+    let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR not specified");
+    let out_path = Path::new(&out_dir).to_owned();
+
+    let rust_version = rustc_version::version().expect("Could not retrieve rustc version");
+    let mut f =
+        File::create(out_path.join("build_env.rs")).expect("Could not create build environment");
+    f.write_all(
+        format!(
+            "pub(crate) const RUSTC_VERSION: &str = \"{}\";",
+            rust_version
+        )
+        .as_bytes(),
+    )
+    .expect("Unable to write rust version");
+    f.flush().expect("failed to flush");
 }

--- a/src/gax-internal/src/api_header.rs
+++ b/src/gax-internal/src/api_header.rs
@@ -27,9 +27,11 @@ pub struct XGoogApiClient {
 pub const GAPIC: &str = "gapic";
 pub const GCCL: &str = "gccl";
 
-mod built_info {
+mod build_info {
     // The file has been placed there by the build script.
-    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+    include!(concat!(env!("OUT_DIR"), "/build_env.rs"));
+
+    pub(crate) const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 }
 
 impl XGoogApiClient {
@@ -37,13 +39,13 @@ impl XGoogApiClient {
     pub fn header_value(&self) -> String {
         // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
         // found, leave RUSTC_VERSION unchanged.
-        let rustc_version = built_info::RUSTC_VERSION;
+        let rustc_version = build_info::RUSTC_VERSION;
         let rustc_version = rustc_version
             .strip_prefix("rustc ")
-            .unwrap_or(built_info::RUSTC_VERSION);
+            .unwrap_or(build_info::RUSTC_VERSION);
 
         // Capture the gax version too.
-        let gax_version = built_info::PKG_VERSION;
+        let gax_version = build_info::PKG_VERSION;
 
         format!(
             "gl-rust/{rustc_version} gax/{gax_version} {}/{}",
@@ -79,10 +81,10 @@ mod test {
         assert_eq!(got.as_deref(), Some("1.2.3"));
 
         let got = fields.get("gax").map(String::to_owned);
-        assert_eq!(got.as_deref(), Some(built_info::PKG_VERSION));
+        assert_eq!(got.as_deref(), Some(build_info::PKG_VERSION));
 
         let got = fields.get("gl-rust").map(String::to_owned);
-        let want = built_info::RUSTC_VERSION;
+        let want = build_info::RUSTC_VERSION;
         assert!(
             got.as_ref()
                 .map(|s| want.contains(s) && !s.is_empty())


### PR DESCRIPTION
Resolves https://github.com/googleapis/google-cloud-rust/issues/1872.

This change makes vendoring `google-cloud-rust` into a hermetic build system _substantially_ easier, as all environment variables needs to be enumerated. `built` reads a *lot* of environment variables, but `gaxi` is only interested in two values.