### PR TITLE
cleanup(wkt): refactor `wkt::message::Message` trait

### DIFF
--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -168,6 +168,10 @@ impl crate::message::Message for Duration {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Duration"
     }
+}
+
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for Duration {
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
         crate::message::to_json_string(self)
     }

--- a/src/wkt/src/empty.rs
+++ b/src/wkt/src/empty.rs
@@ -31,6 +31,9 @@ impl crate::message::Message for Empty {
     }
 }
 
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for Empty {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -263,6 +263,9 @@ impl crate::message::Message for FieldMask {
     }
 }
 
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for FieldMask {}
+
 /// Implement [`serde`](::serde) serialization for [FieldMask]
 impl serde::ser::Serialize for FieldMask {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -44,12 +44,17 @@ impl crate::message::Message for Struct {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Struct"
     }
+}
+
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for Struct {
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
     where
         Self: serde::ser::Serialize + Sized,
     {
+        use crate::message::Message;
         let map: crate::message::Map = [
-            ("@type", Value::String(Self::typename().to_string())),
+            ("@type", Value::String(<Self as Message>::typename().to_string())),
             ("value", Value::Object(self.clone())),
         ]
         .into_iter()
@@ -72,12 +77,17 @@ impl crate::message::Message for Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Value"
     }
+}
+
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for Value {
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
     where
         Self: serde::ser::Serialize + Sized,
     {
+        use crate::message::Message;
         let map: crate::message::Map = [
-            ("@type", Value::String(Self::typename().to_string())),
+            ("@type", Value::String(<Self as Message>::typename().to_string())),
             ("value", self.clone()),
         ]
         .into_iter()
@@ -99,12 +109,17 @@ impl crate::message::Message for ListValue {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.ListValue"
     }
+}
+
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for ListValue {
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
     where
         Self: serde::ser::Serialize + Sized,
     {
+        use crate::message::Message;
         let map: crate::message::Map = [
-            ("@type", Value::String(Self::typename().to_string())),
+            ("@type", Value::String(<Self as Message>::typename().to_string())),
             ("value", Value::Array(self.clone())),
         ]
         .into_iter()

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -169,6 +169,10 @@ impl crate::message::Message for Timestamp {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Timestamp"
     }
+}
+
+#[doc(hidden)]
+impl crate::message::internal::SerializableMessage for Timestamp {
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
         crate::message::to_json_string(self)
     }

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -121,7 +121,7 @@ macro_rules! impl_message_traits {
             }
         }
 
-        impl crate::message::internal::MessageSerializer for $t {
+        impl crate::message::internal::SerializableMessage for $t {
             fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
             where
                 Self: serde::ser::Serialize + Sized,

--- a/src/wkt/tests/any.rs
+++ b/src/wkt/tests/any.rs
@@ -31,6 +31,8 @@ impl google_cloud_wkt::message::Message for TestOnly {
     }
 }
 
+impl google_cloud_wkt::message::testing::SerializableMessage for TestOnly { }
+
 #[test]
 fn roundtrip_generic() -> Result {
     let input = TestOnly {


### PR DESCRIPTION
This PR is part of the work for #1609 (please check the issue for more/better context).

Creates a new `SerializableMessage` trait inside an internal module (with `pub(crate)` visibility), that is hidden from docs.

**Note**: Some alternative names considered for the new trait were: `MessageSerializer` and `MapSerializable`. I'm open to considering a better name if suggested.

cc/ @coryan 