### PR TITLE
feat(generator): group RoutingInfo variants

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -208,6 +208,16 @@ type RoutingInfo struct {
 	// The name in `x-goog-request-params`.
 	Name string
 	// Group the possible variants for the given name.
+	//
+	// The variants are parsed into the reverse order of definition. AIP-4222
+	// declares:
+	//
+	//   In cases when multiple routing parameters have the same resource ID
+	//   path segment name, thus referencing the same header key, the
+	//   "last one wins" rule is used to determine which value to send.
+	//
+	// Reversing the order allows us to implement "the first match wins". That
+	// is easier and more efficient in most languages.
 	Variants []*RoutingInfoVariant
 }
 

--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -188,46 +188,54 @@ type OperationInfo struct {
 	Codec any
 }
 
-// Normalize routing info
+// Normalize routing info.
 //
 // The routing information format is documented in:
 //
-//	https://github.com/googleapis/googleapis/blob/113746270b58d12303e1e4f5eb01bc822aa7d68d/google/api/routing.proto#L406
+// https://google.aip.dev/client-libraries/4222
 //
 // At a high level, it consists of a field name (from the request) that is used
 // to match a certain path template. If the value of the field matches the
 // template, the matching portion is added to `x-goog-request-params`.
 //
-// Of interest to us is the general format of the template. The documentation
-// does not provide a grammar or other specification of the template, just a
-// series of examples, which we won't duplicate here. From these examples we
-// glean that the template must match this grammar:
+// An empty `Name` field is used as the special marker to cover this case in
+// AIP-4222:
 //
-// template := [ path_spec "/" ] "{" name "=" path_spec "}" [ "/" patch_spec ]
-// segment := "*" | "**" | literal
-// path_spec := segment ( "/" segment )...
-// literal is a string matching `[a-z][a-z_]*`
-// name is a string matching `[a-z][a-z_]*`
+//	An empty google.api.routing annotation is acceptable. It means that no
+//	routing headers should be generated for the RPC, when they otherwise
+//	would be e.g. implicitly from the google.api.http annotation.
 type RoutingInfo struct {
-	// The name of the field containing the routing information
+	// The name in `x-goog-request-params`.
+	Name string
+	// Group the possible variants for the given name.
+	Variants []*RoutingInfoVariant
+}
+
+// The routing information stripped of its name.
+type RoutingInfoVariant struct {
+	// The sequence of field names accessed to get the routing information.
 	FieldPath []string
-	// The name in `x-goog-request-params`
-	Name     string
-	Matching RoutingPathSpec
-	// The prefix and suffix (maybe empty)
+	// A path template that must match the beginning of the field value.
 	Prefix RoutingPathSpec
+	// A path template that, if matching, is used in the `x-goog-request-params`.
+	Matching RoutingPathSpec
+	// A path template that must match the end of the field value.
 	Suffix RoutingPathSpec
 }
 
 type RoutingPathSpec struct {
+	// A sequence of matching segments.
+	//
+	// A template like `projects/*/location/*/**` maps to
+	// `["projects", "*", "locations", "*", "**"]`.
 	Segments []string
 }
 
 const (
 	// A special routing path segment which indicates "match anything that does not include a `/`"
-	RoutingSegmentSingle = "*"
+	RoutingSingleSegmentWildcard = "*"
 	// A special routing path segment which indicates "match anything including `/`"
-	RoutingSegmentMulti = "**"
+	RoutingMultiSegmentWildcard = "**"
 )
 
 // A path segment is either a string literal (such as "projects") or a field

--- a/generator/internal/parser/routing_info.go
+++ b/generator/internal/parser/routing_info.go
@@ -47,7 +47,7 @@ func parseRoutingAnnotations(methodID string, m *descriptorpb.MethodDescriptorPr
 			collect[new.Name] = new
 			continue
 		}
-		current.Variants = append(current.Variants, new.Variants...)
+		current.Variants = append(new.Variants, current.Variants...)
 	}
 	if len(errs) != 0 {
 		return nil, errors.Join(errs...)
@@ -74,14 +74,12 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 		// AIP-4222: empty routing infos mean something special.
 		info := &api.RoutingInfo{
 			Name: fieldName,
-			Variants: []*api.RoutingInfoVariant{
-				{
-					FieldPath: []string{},
-					Matching: api.RoutingPathSpec{
-						Segments: []string{},
-					},
+			Variants: []*api.RoutingInfoVariant{{
+				FieldPath: []string{},
+				Matching: api.RoutingPathSpec{
+					Segments: []string{},
 				},
-			},
+			}},
 		}
 		return info, nil
 	}
@@ -89,14 +87,12 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 	if pathTemplate == "" {
 		info := &api.RoutingInfo{
 			Name: fieldName,
-			Variants: []*api.RoutingInfoVariant{
-				{
-					FieldPath: fieldPath,
-					Matching: api.RoutingPathSpec{
-						Segments: []string{api.RoutingMultiSegmentWildcard},
-					},
+			Variants: []*api.RoutingInfoVariant{{
+				FieldPath: fieldPath,
+				Matching: api.RoutingPathSpec{
+					Segments: []string{api.RoutingMultiSegmentWildcard},
 				},
-			},
+			}},
 		}
 		return info, nil
 	}
@@ -142,14 +138,12 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 	}
 	info := &api.RoutingInfo{
 		Name: name,
-		Variants: []*api.RoutingInfoVariant{
-			{
-				FieldPath: fieldPath,
-				Prefix:    prefix,
-				Matching:  match,
-				Suffix:    suffix,
-			},
-		},
+		Variants: []*api.RoutingInfoVariant{{
+			FieldPath: fieldPath,
+			Prefix:    prefix,
+			Matching:  match,
+			Suffix:    suffix,
+		}},
 	}
 	return info, nil
 }

--- a/generator/internal/parser/routing_info.go
+++ b/generator/internal/parser/routing_info.go
@@ -17,6 +17,8 @@ package parser
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/googleapis/google-cloud-rust/generator/internal/api"
@@ -26,24 +28,33 @@ import (
 )
 
 func parseRoutingAnnotations(methodID string, m *descriptorpb.MethodDescriptorProto) ([]*api.RoutingInfo, error) {
-	var info []*api.RoutingInfo
 	extensionId := annotations.E_Routing
 	if !proto.HasExtension(m.GetOptions(), extensionId) {
-		return info, nil
+		return nil, nil
 	}
 
 	rule := proto.GetExtension(m.GetOptions(), extensionId).(*annotations.RoutingRule)
 	var errs []error
+	collect := map[string]*api.RoutingInfo{}
 	for _, routing := range rule.GetRoutingParameters() {
 		new, err := parseRoutingInfo(methodID, routing)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		info = append(info, new)
+		current, ok := collect[new.Name]
+		if !ok {
+			collect[new.Name] = new
+			continue
+		}
+		current.Variants = append(current.Variants, new.Variants...)
 	}
 	if len(errs) != 0 {
 		return nil, errors.Join(errs...)
+	}
+	var info []*api.RoutingInfo
+	for _, k := range slices.Sorted(maps.Keys(collect)) {
+		info = append(info, collect[k])
 	}
 	return info, nil
 }
@@ -59,18 +70,37 @@ func parseRoutingInfo(methodID string, routing *annotations.RoutingParameter) (*
 }
 
 func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo, error) {
-	fieldPath := strings.Split(fieldName, ".")
-	if pathTemplate == "" {
+	if fieldName == "" && pathTemplate == "" {
+		// AIP-4222: empty routing infos mean something special.
 		info := &api.RoutingInfo{
-			FieldPath: fieldPath,
-			Name:      fieldName,
-			Matching: api.RoutingPathSpec{
-				Segments: []string{api.RoutingSegmentMulti},
+			Name: fieldName,
+			Variants: []*api.RoutingInfoVariant{
+				{
+					FieldPath: []string{},
+					Matching: api.RoutingPathSpec{
+						Segments: []string{},
+					},
+				},
 			},
 		}
 		return info, nil
 	}
-	if strings.Count(pathTemplate, api.RoutingSegmentMulti) > 1 {
+	fieldPath := strings.Split(fieldName, ".")
+	if pathTemplate == "" {
+		info := &api.RoutingInfo{
+			Name: fieldName,
+			Variants: []*api.RoutingInfoVariant{
+				{
+					FieldPath: fieldPath,
+					Matching: api.RoutingPathSpec{
+						Segments: []string{api.RoutingMultiSegmentWildcard},
+					},
+				},
+			},
+		}
+		return info, nil
+	}
+	if strings.Count(pathTemplate, api.RoutingMultiSegmentWildcard) > 1 {
 		return nil, fmt.Errorf("too many `**` matchers in pathTemplate=%q", pathTemplate)
 	}
 
@@ -96,15 +126,30 @@ func parseRoutingPathTemplate(fieldName, pathTemplate string) (*api.RoutingInfo,
 		suffix, width = parseRoutingSuffix(pathTemplate[pos:])
 		pos += width
 	}
+	index := slices.Index(prefix.Segments, api.RoutingMultiSegmentWildcard)
+	if index != -1 {
+		return nil, fmt.Errorf("multi segment wildcards may not appear in the prefix portion of a path template, template=%s", pathTemplate)
+	}
+	for _, spec := range []*api.RoutingPathSpec{&match, &suffix} {
+		index := slices.Index(spec.Segments, api.RoutingMultiSegmentWildcard)
+		if index == -1 || index == len(spec.Segments)-1 {
+			continue
+		}
+		return nil, fmt.Errorf("multi segment wildcards may only appear at the end of a path template, template=%s", pathTemplate)
+	}
 	if pathTemplate[pos:] != "" {
 		return nil, fmt.Errorf("unexpected trailer in pathTemplate trailer=%s", pathTemplate[pos:])
 	}
 	info := &api.RoutingInfo{
-		FieldPath: fieldPath,
-		Name:      name,
-		Prefix:    prefix,
-		Matching:  match,
-		Suffix:    suffix,
+		Name: name,
+		Variants: []*api.RoutingInfoVariant{
+			{
+				FieldPath: fieldPath,
+				Prefix:    prefix,
+				Matching:  match,
+				Suffix:    suffix,
+			},
+		},
 	}
 	return info, nil
 }
@@ -113,17 +158,26 @@ func parseRoutingPrefix(pathTemplate string) (api.RoutingPathSpec, int) {
 	return parseRoutingPathSpec(pathTemplate)
 }
 
+func isRoutingWilcard(segment string) bool {
+	return segment == api.RoutingSingleSegmentWildcard || segment == api.RoutingMultiSegmentWildcard
+}
+
 func parseRoutingVariable(defaultName, pathTemplate string) (string, api.RoutingPathSpec, int, error) {
 	spec, width := parseRoutingPathSpec(pathTemplate)
 	if strings.HasPrefix(pathTemplate[width:], "=") {
 		pos := width + 1
 		// The initial spec must be a simple name.
-		if len(spec.Segments) != 1 || spec.Segments[0] == api.RoutingSegmentMulti || spec.Segments[0] == api.RoutingSegmentSingle {
+		if len(spec.Segments) != 1 || isRoutingWilcard(spec.Segments[0]) {
 			return "", api.RoutingPathSpec{}, 0, fmt.Errorf("expected name=pathspec, but the name format is invalid name=%v", spec.Segments)
 		}
 		name := spec.Segments[0]
 		spec, width := parseRoutingPathSpec(pathTemplate[pos:])
 		return name, spec, pos + width, nil
+	}
+	if len(spec.Segments) == 1 && !isRoutingWilcard(spec.Segments[0]) {
+		// AIP-4222: It is acceptable to omit the pattern in the resource ID
+		// segment, `{parent}` for example, is equivalent to `{parent=*}`.
+		return spec.Segments[0], api.RoutingPathSpec{Segments: []string{"*"}}, width, nil
 	}
 	return defaultName, spec, width, nil
 }
@@ -147,11 +201,11 @@ func parseRoutingPathSpec(pathTemplate string) (api.RoutingPathSpec, int) {
 }
 
 func parseRoutingSegment(pathTemplate string) (string, int) {
-	if strings.HasPrefix(pathTemplate, api.RoutingSegmentMulti) {
-		return api.RoutingSegmentMulti, len(api.RoutingSegmentMulti)
+	if strings.HasPrefix(pathTemplate, api.RoutingMultiSegmentWildcard) {
+		return api.RoutingMultiSegmentWildcard, len(api.RoutingMultiSegmentWildcard)
 	}
-	if strings.HasPrefix(pathTemplate, api.RoutingSegmentSingle) {
-		return api.RoutingSegmentSingle, len(api.RoutingSegmentSingle)
+	if strings.HasPrefix(pathTemplate, api.RoutingSingleSegmentWildcard) {
+		return api.RoutingSingleSegmentWildcard, len(api.RoutingSingleSegmentWildcard)
 	}
 	index := strings.IndexAny(pathTemplate, "=/{}")
 	if index == -1 {

--- a/generator/internal/parser/routing_info.go
+++ b/generator/internal/parser/routing_info.go
@@ -158,7 +158,7 @@ func parseRoutingPrefix(pathTemplate string) (api.RoutingPathSpec, int) {
 	return parseRoutingPathSpec(pathTemplate)
 }
 
-func isRoutingWilcard(segment string) bool {
+func isRoutingWildcard(segment string) bool {
 	return segment == api.RoutingSingleSegmentWildcard || segment == api.RoutingMultiSegmentWildcard
 }
 
@@ -167,14 +167,14 @@ func parseRoutingVariable(defaultName, pathTemplate string) (string, api.Routing
 	if strings.HasPrefix(pathTemplate[width:], "=") {
 		pos := width + 1
 		// The initial spec must be a simple name.
-		if len(spec.Segments) != 1 || isRoutingWilcard(spec.Segments[0]) {
+		if len(spec.Segments) != 1 || isRoutingWildcard(spec.Segments[0]) {
 			return "", api.RoutingPathSpec{}, 0, fmt.Errorf("expected name=pathspec, but the name format is invalid name=%v", spec.Segments)
 		}
 		name := spec.Segments[0]
 		spec, width := parseRoutingPathSpec(pathTemplate[pos:])
 		return name, spec, pos + width, nil
 	}
-	if len(spec.Segments) == 1 && !isRoutingWilcard(spec.Segments[0]) {
+	if len(spec.Segments) == 1 && !isRoutingWildcard(spec.Segments[0]) {
 		// AIP-4222: It is acceptable to omit the pattern in the resource ID
 		// segment, `{parent}` for example, is equivalent to `{parent=*}`.
 		return spec.Segments[0], api.RoutingPathSpec{Segments: []string{"*"}}, width, nil

--- a/generator/internal/parser/routing_info_test.go
+++ b/generator/internal/parser/routing_info_test.go
@@ -29,136 +29,108 @@ func TestExamples(t *testing.T) {
 	}{
 		{
 			".test.TestService.Example1",
-			[]*api.RoutingInfo{
-				{
-					Name: "app_profile_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"app_profile_id"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
-				},
-			},
+			[]*api.RoutingInfo{{
+				Name: "app_profile_id",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"app_profile_id"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				}},
+			}},
 		},
 		{
 			".test.TestService.Example2",
-			[]*api.RoutingInfo{
-				{
-					Name: "routing_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"app_profile_id"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
-				},
-			},
+			[]*api.RoutingInfo{{
+				Name: "routing_id",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"app_profile_id"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				}},
+			}},
 		},
 		{
 			".test.TestService.Example3a",
-			[]*api.RoutingInfo{
-				{
-					Name: "table_name",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
-						},
-					},
-				},
-			},
+			[]*api.RoutingInfo{{
+				Name: "table_name",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"table_name"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+				}},
+			}},
 		},
 		{
 			".test.TestService.Example3b",
-			[]*api.RoutingInfo{
-				{
-					Name: "table_name",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
-						},
-					},
-				},
-			},
+			[]*api.RoutingInfo{{
+				Name: "table_name",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"table_name"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
+				}},
+			}},
 		},
 		{
 			".test.TestService.Example3c",
-			[]*api.RoutingInfo{
-				{
-					Name: "table_name",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
-						},
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
-						},
+			[]*api.RoutingInfo{{
+				Name: "table_name",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+					},
+					{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
 					},
 				},
-			},
+			}},
 		},
 		{
 			".test.TestService.Example4",
-			[]*api.RoutingInfo{
-				{
-					Name: "routing_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
-				},
-			},
+			[]*api.RoutingInfo{{
+				Name: "routing_id",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"table_name"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+				}},
+			}},
 		},
 		{
 			".test.TestService.Example5",
-			[]*api.RoutingInfo{
-				{
-					Name: "routing_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
+			[]*api.RoutingInfo{{
+				Name: "routing_id",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					},
+					{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 					},
 				},
-			},
+			}},
 		},
 		{
 			".test.TestService.Example6a",
 			[]*api.RoutingInfo{
 				{
 					Name: "instance_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
+					Variants: []*api.RoutingInfoVariant{{
+						FieldPath: []string{"table_name"},
+						Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+						Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					}},
 				},
 				{
 					Name: "project_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"instances", "*", "**"}},
-						},
-					},
+					Variants: []*api.RoutingInfoVariant{{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"instances", "*", "**"}},
+					}},
 				},
 			},
 		},
@@ -167,24 +139,20 @@ func TestExamples(t *testing.T) {
 			[]*api.RoutingInfo{
 				{
 					Name: "instance_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
+					Variants: []*api.RoutingInfoVariant{{
+						FieldPath: []string{"table_name"},
+						Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+						Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					}},
 				},
 				{
 					Name: "project_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
+					Variants: []*api.RoutingInfoVariant{{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					}},
 				},
 			},
 		},
@@ -193,22 +161,18 @@ func TestExamples(t *testing.T) {
 			[]*api.RoutingInfo{
 				{
 					Name: "project_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
+					Variants: []*api.RoutingInfoVariant{{
+						FieldPath: []string{"table_name"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					}},
 				},
 				{
 					Name: "routing_id",
-					Variants: []*api.RoutingInfoVariant{
-						{
-							FieldPath: []string{"app_profile_id"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
-						},
-					},
+					Variants: []*api.RoutingInfoVariant{{
+						FieldPath: []string{"app_profile_id"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					}},
 				},
 			},
 		},
@@ -219,9 +183,8 @@ func TestExamples(t *testing.T) {
 					Name: "routing_id",
 					Variants: []*api.RoutingInfoVariant{
 						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+							FieldPath: []string{"app_profile_id"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 						},
 						{
 							FieldPath: []string{"table_name"},
@@ -229,8 +192,9 @@ func TestExamples(t *testing.T) {
 							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 						},
 						{
-							FieldPath: []string{"app_profile_id"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 						},
 					},
 				},
@@ -243,18 +207,18 @@ func TestExamples(t *testing.T) {
 					Name: "routing_id",
 					Variants: []*api.RoutingInfoVariant{
 						{
-							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+							FieldPath: []string{"app_profile_id"},
+							Prefix:    api.RoutingPathSpec{Segments: []string{"profiles"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
 						},
 						{
 							FieldPath: []string{"app_profile_id"},
 							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
 						},
 						{
-							FieldPath: []string{"app_profile_id"},
-							Prefix:    api.RoutingPathSpec{Segments: []string{"profiles"}},
-							Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
 						},
 					},
 				},
@@ -263,13 +227,13 @@ func TestExamples(t *testing.T) {
 					Variants: []*api.RoutingInfoVariant{
 						{
 							FieldPath: []string{"table_name"},
-							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*"}},
 							Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
 						},
 						{
 							FieldPath: []string{"table_name"},
-							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*"}},
+							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
 							Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
 						},
 					},

--- a/generator/internal/parser/routing_info_test.go
+++ b/generator/internal/parser/routing_info_test.go
@@ -15,6 +15,7 @@
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,9 +31,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example1",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"app_profile_id"},
-					Name:      "app_profile_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "app_profile_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"app_profile_id"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -40,9 +45,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example2",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"app_profile_id"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"app_profile_id"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -50,9 +59,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example3a",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "table_name",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+					Name: "table_name",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+						},
+					},
 				},
 			},
 		},
@@ -60,9 +73,13 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example3b",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "table_name",
-					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
+					Name: "table_name",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
+						},
+					},
 				},
 			},
 		},
@@ -70,14 +87,17 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example3c",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "table_name",
-					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
-				},
-				{
-					FieldPath: []string{"table_name"},
-					Name:      "table_name",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+					Name: "table_name",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*", "**"}},
+						},
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*", "**"}},
+						},
+					},
 				},
 			},
 		},
@@ -85,10 +105,14 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example4",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -96,16 +120,19 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example5",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-				},
-				{
-					FieldPath: []string{"table_name"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*", "instances", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -113,17 +140,25 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example6a",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "project_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"instances", "*", "**"}},
+					Name: "instance_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "instance_id",
-					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "project_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"instances", "*", "**"}},
+						},
+					},
 				},
 			},
 		},
@@ -131,17 +166,25 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example6b",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "project_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "instance_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "instance_id",
-					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "project_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -149,15 +192,23 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example7",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "project_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "project_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 				{
-					FieldPath: []string{"app_profile_id"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"app_profile_id"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -165,21 +216,23 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example8",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-				},
-				{
-					FieldPath: []string{"table_name"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-				},
-				{
-					FieldPath: []string{"app_profile_id"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+						{
+							FieldPath: []string{"app_profile_id"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+					},
 				},
 			},
 		},
@@ -187,34 +240,39 @@ func TestExamples(t *testing.T) {
 			".test.TestService.Example9",
 			[]*api.RoutingInfo{
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "table_location",
-					Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
+					Name: "routing_id",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+						{
+							FieldPath: []string{"app_profile_id"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+						},
+						{
+							FieldPath: []string{"app_profile_id"},
+							Prefix:    api.RoutingPathSpec{Segments: []string{"profiles"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
+						},
+					},
 				},
 				{
-					FieldPath: []string{"table_name"},
-					Name:      "table_location",
-					Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
-				},
-				{
-					FieldPath: []string{"table_name"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"projects", "*"}},
-					Suffix:    api.RoutingPathSpec{Segments: []string{"**"}},
-				},
-				{
-					FieldPath: []string{"app_profile_id"},
-					Name:      "routing_id",
-					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
-				},
-				{
-					FieldPath: []string{"app_profile_id"},
-					Name:      "routing_id",
-					Prefix:    api.RoutingPathSpec{Segments: []string{"profiles"}},
-					Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
+					Name: "table_location",
+					Variants: []*api.RoutingInfoVariant{
+						{
+							FieldPath: []string{"table_name"},
+							Prefix:    api.RoutingPathSpec{Segments: []string{"projects", "*"}},
+							Matching:  api.RoutingPathSpec{Segments: []string{"instances", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
+						},
+						{
+							FieldPath: []string{"table_name"},
+							Matching:  api.RoutingPathSpec{Segments: []string{"regions", "*", "zones", "*"}},
+							Suffix:    api.RoutingPathSpec{Segments: []string{"tables", "*"}},
+						},
+					},
 				},
 			},
 		},
@@ -244,83 +302,169 @@ func TestParsePathTemplateSuccess(t *testing.T) {
 			"default",
 			"",
 			api.RoutingInfo{
-				FieldPath: []string{"default"},
-				Name:      "default",
-				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				Name: "default",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"default"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				}},
+			},
+		},
+		{
+			// AIP-4222: An empty google.api.routing annotation is acceptable.
+			// It means that no routing headers should be generated for the RPC,
+			// when they otherwise would be e.g. implicitly from the
+			// google.api.http annotation.
+			"",
+			"",
+			api.RoutingInfo{
+				Name: "",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{},
+					Matching:  api.RoutingPathSpec{Segments: []string{}},
+				}},
+			},
+		},
+		{
+			// AIP-4222: It is acceptable to omit the pattern in the resource ID
+			// segment, `{parent}` for example, is equivalent to `{parent=*}`.
+			"parent",
+			"projects/{parent}",
+			api.RoutingInfo{
+				Name: "parent",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"parent"},
+					Prefix:    api.RoutingPathSpec{Segments: []string{"projects"}},
+					Matching:  api.RoutingPathSpec{Segments: []string{"*"}},
+				}},
+			},
+		},
+		{
+			// AIP-4222: It is acceptable to omit the path_template field
+			// altogether. An omitted path_template is equivalent to a
+			// path_template with the same resource ID name as the field and
+			// the pattern `**`.
+			"parent",
+			"",
+			api.RoutingInfo{
+				Name: "parent",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"parent"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				}},
 			},
 		},
 		{
 			"field.child",
 			"",
 			api.RoutingInfo{
-				FieldPath: []string{"field", "child"},
-				Name:      "field.child",
-				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				Name: "field.child",
+				Variants: []*api.RoutingInfoVariant{{
+					FieldPath: []string{"field", "child"},
+					Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				}},
 			},
 		},
 		{
 			"default",
 			"{**}",
 			api.RoutingInfo{
-				FieldPath: []string{"default"},
-				Name:      "default",
-				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				Name: "default",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"default"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					},
+				},
 			},
 		},
 		{
 			"default",
 			"{routing=**}",
 			api.RoutingInfo{
-				FieldPath: []string{"default"},
-				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+				Name: "routing",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"default"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"**"}},
+					},
+				},
 			},
 		},
 		{
 			"default",
 			"{routing=a/*/b/**}",
 			api.RoutingInfo{
-				FieldPath: []string{"default"},
-				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+				Name: "routing",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"default"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+					},
+				},
 			},
 		},
 		{
 			"default",
 			"p/*/q/*/{routing=a/*/b/**}",
 			api.RoutingInfo{
-				FieldPath: []string{"default"},
-				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
-				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+				Name: "routing",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"default"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+						Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+					},
+				},
 			},
 		},
 		{
 			"default",
 			"p/*/q/*/{routing=a/*/b/*}/s/*/u/*/v/**",
 			api.RoutingInfo{
-				FieldPath: []string{"default"},
-				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "*"}},
-				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
-				Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
+				Name: "routing",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"default"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "*"}},
+						Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
+					},
+				},
+			},
+		},
+		{
+			"default",
+			"p/*/q/*/{routing=a/*/b/**}/s/*/u/*/v/*",
+			api.RoutingInfo{
+				Name: "routing",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"default"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "**"}},
+						Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "*"}},
+					},
+				},
 			},
 		},
 		{
 			"field.sub_field.child",
 			"p/*/q/*/{routing=a/*/b/*}/s/*/u/*/v/**",
 			api.RoutingInfo{
-				FieldPath: []string{"field", "sub_field", "child"},
-				Name:      "routing",
-				Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "*"}},
-				Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
-				Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
+				Name: "routing",
+				Variants: []*api.RoutingInfoVariant{
+					{
+						FieldPath: []string{"field", "sub_field", "child"},
+						Matching:  api.RoutingPathSpec{Segments: []string{"a", "*", "b", "*"}},
+						Prefix:    api.RoutingPathSpec{Segments: []string{"p", "*", "q", "*"}},
+						Suffix:    api.RoutingPathSpec{Segments: []string{"s", "*", "u", "*", "v", "**"}},
+					}},
 			},
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.path, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s:%s", tc.fieldPath, tc.path), func(t *testing.T) {
 			got, err := parseRoutingPathTemplate(tc.fieldPath, tc.path)
 			if err != nil {
 				t.Fatal(err)
@@ -342,6 +486,15 @@ func TestParsePathTemplateFailures(t *testing.T) {
 		"projects/*/{{",
 		"projects/*/{a/b/c=**}",
 		"projects/*/{routing_id=**}foo",
+		// AIP-4222: A multi-segment wildcard must only appear as the final
+		// segment or make up the entire path_template.
+		"projects/**/{a}",
+		"projects/**/b/{a}",
+		"projects/*/{**/a}",
+		"projects/*/{a/**/b}",
+		"projects/*/{a/**/b/*}",
+		"projects/*/{a}/**/b",
+		"projects/*/{a}/*/b/**/c",
 	}
 
 	for _, path := range tests {


### PR DESCRIPTION
It is easier to generate code for the RoutingInfo if the path template
variants are grouped by name.

Fixes #1819 for realsies.
