### PR TITLE
impl(generator/rust): default idempotency

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -554,3 +554,11 @@ func (c *codec) annotateEnumValue(ev *api.EnumValue, e *api.Enum, state *api.API
 		EnumType: enumName(e),
 	}
 }
+
+// Returns "true" if the method is idempotent by default, and "false", if not.
+func (p *pathInfoAnnotation) IsIdempotent() string {
+	if p.Method == "GET" || p.Method == "PUT" || p.Method == "DELETE" {
+		return "true"
+	}
+	return "false"
+}

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -915,3 +915,63 @@ func TestEnumFieldAnnotations(t *testing.T) {
 		t.Errorf("mismatch in field annotations (-want, +got)\n:%s", diff)
 	}
 }
+
+func TestPathInfoAnnotations(t *testing.T) {
+	type TestCase struct {
+		Verb               string
+		DefaultIdempotency string
+	}
+	testCases := []TestCase{
+		{"GET", "true"},
+		{"PUT", "true"},
+		{"DELETE", "true"},
+		{"POST", "false"},
+		{"PATCH", "false"},
+	}
+	for _, testCase := range testCases {
+		request := &api.Message{
+			Name:    "Request",
+			Package: "test.v1",
+			ID:      ".test.v1.Request",
+		}
+		response := &api.Message{
+			Name:    "Response",
+			Package: "test.v1",
+			ID:      ".test.v1.Response",
+		}
+		method := &api.Method{
+			Name:         "GetResource",
+			ID:           ".test.v1.Service.GetResource",
+			InputTypeID:  ".test.v1.Request",
+			OutputTypeID: ".test.v1.Response",
+			PathInfo: &api.PathInfo{
+				Verb: testCase.Verb,
+				PathTemplate: []api.PathSegment{
+					api.NewLiteralPathSegment("/v1/resource"),
+				},
+			},
+		}
+		service := &api.Service{
+			Name:    "ResourceService",
+			ID:      ".test.v1.ResourceService",
+			Package: "test.v1",
+			Methods: []*api.Method{method},
+		}
+
+		model := api.NewTestAPI(
+			[]*api.Message{request, response},
+			[]*api.Enum{},
+			[]*api.Service{service})
+		api.CrossReference(model)
+		codec, err := newCodec(true, map[string]string{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		annotateModel(model, codec)
+
+		pathInfoAnn := method.PathInfo.Codec.(*pathInfoAnnotation)
+		if pathInfoAnn.IsIdempotent() != testCase.DefaultIdempotency {
+			t.Errorf("fail")
+		}
+	}
+}


### PR DESCRIPTION
Part of the work for #1612

In the HTTP transport, we defer to `reqwest::Method::is_idempotent()` to tell us whether a request is idempotent. We cannot use that dep for gRPC transport.

So add a helper function to return the default idempotency, given the `pathInfoAnnotation`.

In a follow up, I will modify the template to call this function, and `set_default_idempotency(...)` using the output.

Please eviscerate my golang code, this is all new to me.