### PR TITLE
feat: retry more requests in firestore, storage

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -72,6 +72,10 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         req: {{InputType.Codec.QualifiedName}},
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<{{Codec.ReturnType}}>> {
+        let options = gax::options::internal::set_default_idempotency(
+            options,
+            {{PathInfo.Codec.IsIdempotent}},
+        );
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new("{{Service.Package}}.{{Service.Name}}", "{{Name}}"));

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -63,6 +63,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::GetDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -100,6 +101,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::ListDocumentsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListDocumentsResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -140,6 +142,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::UpdateDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -183,6 +186,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::DeleteDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
+        let options = gax::options::internal::set_default_idempotency(options, true);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -215,6 +219,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::BeginTransactionRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BeginTransactionResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -252,6 +257,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::CommitRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CommitResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -288,6 +294,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::RollbackRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -319,6 +326,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::PartitionQueryRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::PartitionQueryResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -356,6 +364,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::ListCollectionIdsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListCollectionIdsResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -394,6 +403,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::BatchWriteRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::BatchWriteResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -431,6 +441,7 @@ impl super::stub::Firestore for Firestore {
         req: crate::model::CreateDocumentRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Document>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(

--- a/src/storage/src/generated/gapic/transport.rs
+++ b/src/storage/src/generated/gapic/transport.rs
@@ -63,6 +63,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::DeleteBucketRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -92,6 +93,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::GetBucketRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Bucket>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -126,6 +128,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::CreateBucketRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Bucket>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -160,6 +163,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::ListBucketsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListBucketsResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -194,6 +198,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::LockBucketRetentionPolicyRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Bucket>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -230,6 +235,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::UpdateBucketRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Bucket>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -264,6 +270,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::ComposeObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Object>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -298,6 +305,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::DeleteObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<()>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -327,6 +335,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::RestoreObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Object>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -361,6 +370,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::CancelResumableWriteRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::CancelResumableWriteResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -396,6 +406,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::GetObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Object>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -430,6 +441,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::UpdateObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Object>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -464,6 +476,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::ListObjectsRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::ListObjectsResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -498,6 +511,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::RewriteObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::RewriteResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -532,6 +546,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::StartResumableWriteRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::StartResumableWriteResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -567,6 +582,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::QueryWriteStatusRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::QueryWriteStatusResponse>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -602,6 +618,7 @@ impl super::stub::Storage for Storage {
         req: crate::model::MoveObjectRequest,
         options: gax::options::RequestOptions,
     ) -> Result<gax::response::Response<crate::model::Object>> {
+        let options = gax::options::internal::set_default_idempotency(options, false);
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(


### PR DESCRIPTION
Part of the work for #1612

Set the default idempotency in `firestore` and `storage`, thus retrying more requests by default.

See: #1883 for the equivalent changes over HTTP.

On testing... I will defer: #1884