### PR TITLE
fix(auth): remove trailing slash from Metadata root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-test",
+ "url",
 ]
 
 [[package]]

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -53,3 +53,4 @@ tempfile    = "3"
 test-case   = "3"
 tokio       = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 tokio-test  = "0.4"
+url = "2"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -53,4 +53,4 @@ tempfile    = "3"
 test-case   = "3"
 tokio       = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 tokio-test  = "0.4"
-url = "2"
+url         = "2"

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -313,7 +313,7 @@ mod test {
     }
 
     #[test]
-    fn validate_token_url() {
+    fn validate_default_endpoint_urls() {
         let default_endpoint_address = Url::parse(&format!("{}{}", METADATA_ROOT, MDS_DEFAULT_URI));
         assert!(default_endpoint_address.is_ok());
 

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -102,7 +102,18 @@ pub struct Builder {
 impl Builder {
     /// Sets the endpoint for this credentials.
     ///
-    /// If not set, the credentials use `http://metadata.google.internal/`.
+    /// A trailing slash is significant, so specify the base URL without a trailing  
+    /// slash. If not set, the credentials use `http://metadata.google.internal`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_auth::credentials::mds::Builder;
+    /// # tokio_test::block_on(async {
+    /// let credentials = Builder::default()
+    ///     .with_endpoint("https://metadata.google.foobar")
+    ///     .build();
+    /// # });
+    /// ```
     pub fn with_endpoint<S: Into<String>>(mut self, endpoint: S) -> Self {
         self.endpoint = Some(endpoint.into());
         self


### PR DESCRIPTION
This PR removes the trailing slash from the default Metadata endpoint (`METADATA_ROOT `).

**Reason:**

* The trailing slash caused multiple calls to MDS, see: https://github.com/googleapis/google-cloud-rust/issues/1835

**Implementation Details:**

* Updated the `METADATA_ROOT` to remove trailing slash
* Added `url` crate to `dev-dependencies`.
* Added a unit test using the `url` crate to validate the format of the default URL(s): for fetching token and service account.