### PR TITLE
cleanup(auth): comment out invalid closing brace

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -353,7 +353,7 @@ impl Builder {
     /// let credentials = Builder::default()
     ///     .with_quota_project_id("my-project")
     ///     .build();
-    /// });
+    /// # });
     /// ```
     ///
     /// [quota project]: https://cloud.google.com/docs/quotas/quota-project


### PR DESCRIPTION
Updated documentation to comment out invalid closing brace.