### PR TITLE
feat(generator/dart): bump to the latest API versions

### DIFF
--- a/generator/dart/.sidekick.toml
+++ b/generator/dart/.sidekick.toml
@@ -17,8 +17,8 @@ language             = 'dart'
 specification-format = 'protobuf'
 
 [source]
-googleapis-root         = 'https://github.com/googleapis/googleapis/archive/c98457cd51f80e56daf7de102ed8d4c347ada663.tar.gz'
-googleapis-sha256       = '956029bbf637abff993619f6528b6c5e757fa630b36dc1679fede4c1d9f5ead2'
+googleapis-root         = 'https://github.com/googleapis/googleapis/archive/3da50fda505b4d483dd85579962421fc8bc7d2b1.tar.gz'
+googleapis-sha256       = 'a2bd4a29fda6f003636b4e9b3623c85c2915c357fde734bd03eb8988123b731b'
 protobuf-extracted-name = 'protobuf-29.3'
 protobuf-root           = 'https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protobuf-29.3.tar.gz'
 protobuf-sha256         = '008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2a310be0fbad987e'

--- a/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
+++ b/generator/dart/generated/google_cloud_rpc/lib/rpc.dart
@@ -248,15 +248,92 @@ class QuotaFailure_Violation extends ProtoMessage {
   /// exceeded".
   final String? description;
 
+  /// The API Service from which the `QuotaFailure.Violation` orginates. In
+  /// some cases, Quota issues originate from an API Service other than the one
+  /// that was called. In other words, a dependency of the called API Service
+  /// could be the cause of the `QuotaFailure`, and this field would have the
+  /// dependency API service name.
+  ///
+  /// For example, if the called API is Kubernetes Engine API
+  /// (container.googleapis.com), and a quota violation occurs in the
+  /// Kubernetes Engine API itself, this field would be
+  /// "container.googleapis.com". On the other hand, if the quota violation
+  /// occurs when the Kubernetes Engine API creates VMs in the Compute Engine
+  /// API (compute.googleapis.com), this field would be
+  /// "compute.googleapis.com".
+  final String? apiService;
+
+  /// The metric of the violated quota. A quota metric is a named counter to
+  /// measure usage, such as API requests or CPUs. When an activity occurs in a
+  /// service, such as Virtual Machine allocation, one or more quota metrics
+  /// may be affected.
+  ///
+  /// For example, "compute.googleapis.com/cpus_per_vm_family",
+  /// "storage.googleapis.com/internet_egress_bandwidth".
+  final String? quotaMetric;
+
+  /// The id of the violated quota. Also know as "limit name", this is the
+  /// unique identifier of a quota in the context of an API service.
+  ///
+  /// For example, "CPUS-PER-VM-FAMILY-per-project-region".
+  final String? quotaId;
+
+  /// The dimensions of the violated quota. Every non-global quota is enforced
+  /// on a set of dimensions. While quota metric defines what to count, the
+  /// dimensions specify for what aspects the counter should be increased.
+  ///
+  /// For example, the quota "CPUs per region per VM family" enforces a limit
+  /// on the metric "compute.googleapis.com/cpus_per_vm_family" on dimensions
+  /// "region" and "vm_family". And if the violation occurred in region
+  /// "us-central1" and for VM family "n1", the quota_dimensions would be,
+  ///
+  /// {
+  ///   "region": "us-central1",
+  ///   "vm_family": "n1",
+  /// }
+  ///
+  /// When a quota is enforced globally, the quota_dimensions would always be
+  /// empty.
+  final Map<String, String>? quotaDimensions;
+
+  /// The enforced quota value at the time of the `QuotaFailure`.
+  ///
+  /// For example, if the enforced quota value at the time of the
+  /// `QuotaFailure` on the number of CPUs is "10", then the value of this
+  /// field would reflect this quantity.
+  final int? quotaValue;
+
+  /// The new quota value being rolled out at the time of the violation. At the
+  /// completion of the rollout, this value will be enforced in place of
+  /// quota_value. If no rollout is in progress at the time of the violation,
+  /// this field is not set.
+  ///
+  /// For example, if at the time of the violation a rollout is in progress
+  /// changing the number of CPUs quota from 10 to 20, 20 would be the value of
+  /// this field.
+  final int? futureQuotaValue;
+
   QuotaFailure_Violation({
     this.subject,
     this.description,
+    this.apiService,
+    this.quotaMetric,
+    this.quotaId,
+    this.quotaDimensions,
+    this.quotaValue,
+    this.futureQuotaValue,
   }) : super(fullyQualifiedName);
 
   factory QuotaFailure_Violation.fromJson(Map<String, dynamic> json) {
     return QuotaFailure_Violation(
       subject: json['subject'],
       description: json['description'],
+      apiService: json['apiService'],
+      quotaMetric: json['quotaMetric'],
+      quotaId: json['quotaId'],
+      quotaDimensions: decodeMap(json['quotaDimensions']),
+      quotaValue: decodeInt64(json['quotaValue']),
+      futureQuotaValue: decodeInt64(json['futureQuotaValue']),
     );
   }
 
@@ -265,6 +342,13 @@ class QuotaFailure_Violation extends ProtoMessage {
     return {
       if (subject != null) 'subject': subject,
       if (description != null) 'description': description,
+      if (apiService != null) 'apiService': apiService,
+      if (quotaMetric != null) 'quotaMetric': quotaMetric,
+      if (quotaId != null) 'quotaId': quotaId,
+      if (quotaDimensions != null) 'quotaDimensions': quotaDimensions,
+      if (quotaValue != null) 'quotaValue': encodeInt64(quotaValue),
+      if (futureQuotaValue != null)
+        'futureQuotaValue': encodeInt64(futureQuotaValue),
     };
   }
 
@@ -273,6 +357,11 @@ class QuotaFailure_Violation extends ProtoMessage {
     final contents = [
       if (subject != null) 'subject=$subject',
       if (description != null) 'description=$description',
+      if (apiService != null) 'apiService=$apiService',
+      if (quotaMetric != null) 'quotaMetric=$quotaMetric',
+      if (quotaId != null) 'quotaId=$quotaId',
+      if (quotaValue != null) 'quotaValue=$quotaValue',
+      if (futureQuotaValue != null) 'futureQuotaValue=$futureQuotaValue',
     ].join(',');
     return 'Violation($contents)';
   }


### PR DESCRIPTION
- bump to the latest API SHA
- regenerate the existing APIs

Note that this captures added fields to a message in package:google_cloud_rpc. In the future, we may want some mechanism to help us know that this change requires a a semver minor version bump for `package:google_cloud_rpc`.
