### PR TITLE
feat(generator/dart): support passing http query params

### DIFF
--- a/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
+++ b/generator/dart/generated/google_cloud_functions_v2/lib/cloudfunctions.dart
@@ -45,7 +45,9 @@ class FunctionService {
 
   /// Returns a function with the given name from the requested project.
   Future<Function$> getFunction(GetFunctionRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.name}');
+    final url = Uri.https(_host, '/v2/${request.name}', {
+      if (request.revision != null) 'revision': request.revision!,
+    });
     final response = await _client.get(url);
     return Function$.fromJson(response);
   }
@@ -53,7 +55,12 @@ class FunctionService {
   /// Returns a list of functions that belong to the requested project.
   Future<ListFunctionsResponse> listFunctions(
       ListFunctionsRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.parent}/functions');
+    final url = Uri.https(_host, '/v2/${request.parent}/functions', {
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+      if (request.filter != null) 'filter': request.filter!,
+      if (request.orderBy != null) 'orderBy': request.orderBy!,
+    });
     final response = await _client.get(url);
     return ListFunctionsResponse.fromJson(response);
   }
@@ -69,7 +76,9 @@ class FunctionService {
   /// [Operation.responseAsMessage] will contain the operation's result.
   Future<Operation<Function$, OperationMetadata>> createFunction(
       CreateFunctionRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.parent}/functions');
+    final url = Uri.https(_host, '/v2/${request.parent}/functions', {
+      if (request.functionId != null) 'functionId': request.functionId!,
+    });
     final response = await _client.post(url, body: request.function);
     return Operation.fromJson(
       response,
@@ -86,7 +95,10 @@ class FunctionService {
   /// [Operation.responseAsMessage] will contain the operation's result.
   Future<Operation<Function$, OperationMetadata>> updateFunction(
       UpdateFunctionRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.function.name}');
+    final url = Uri.https(_host, '/v2/${request.function.name}', {
+      if (request.updateMask?.paths != null)
+        'updateMask.paths': request.updateMask?.paths!,
+    });
     final response = await _client.patch(url, body: request.function);
     return Operation.fromJson(
       response,
@@ -158,7 +170,9 @@ class FunctionService {
 
   /// Returns a list of runtimes that are supported for the requested project.
   Future<ListRuntimesResponse> listRuntimes(ListRuntimesRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.parent}/runtimes');
+    final url = Uri.https(_host, '/v2/${request.parent}/runtimes', {
+      if (request.filter != null) 'filter': request.filter!,
+    });
     final response = await _client.get(url);
     return ListRuntimesResponse.fromJson(response);
   }
@@ -166,7 +180,11 @@ class FunctionService {
   /// Lists information about the supported locations for this service.
   Future<ListLocationsResponse> listLocations(
       ListLocationsRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.name}/locations');
+    final url = Uri.https(_host, '/v2/${request.name}/locations', {
+      if (request.filter != null) 'filter': request.filter!,
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+    });
     final response = await _client.get(url);
     return ListLocationsResponse.fromJson(response);
   }
@@ -185,7 +203,11 @@ class FunctionService {
   /// Gets the access control policy for a resource. Returns an empty policy
   /// if the resource exists and does not have a policy set.
   Future<Policy> getIamPolicy(GetIamPolicyRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.resource}:getIamPolicy');
+    final url = Uri.https(_host, '/v2/${request.resource}:getIamPolicy', {
+      if (request.options?.requestedPolicyVersion != null)
+        'options.requestedPolicyVersion':
+            '${request.options?.requestedPolicyVersion}',
+    });
     final response = await _client.get(url);
     return Policy.fromJson(response);
   }
@@ -207,7 +229,11 @@ class FunctionService {
   /// Provides the `Operations` service functionality in this service.
   Future<ListOperationsResponse> listOperations(
       ListOperationsRequest request) async {
-    final url = Uri.https(_host, '/v2/${request.name}/operations');
+    final url = Uri.https(_host, '/v2/${request.name}/operations', {
+      if (request.filter != null) 'filter': request.filter!,
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+    });
     final response = await _client.get(url);
     return ListOperationsResponse.fromJson(response);
   }

--- a/generator/dart/generated/google_cloud_location/lib/location.dart
+++ b/generator/dart/generated/google_cloud_location/lib/location.dart
@@ -40,7 +40,11 @@ class Locations {
   /// Lists information about the supported locations for this service.
   Future<ListLocationsResponse> listLocations(
       ListLocationsRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.name}');
+    final url = Uri.https(_host, '/v1/${request.name}', {
+      if (request.filter != null) 'filter': request.filter!,
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+    });
     final response = await _client.get(url);
     return ListLocationsResponse.fromJson(response);
   }

--- a/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
+++ b/generator/dart/generated/google_cloud_longrunning/lib/longrunning.dart
@@ -57,7 +57,11 @@ class Operations {
   /// server doesn't support this method, it returns `UNIMPLEMENTED`.
   Future<ListOperationsResponse> listOperations(
       ListOperationsRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.name}');
+    final url = Uri.https(_host, '/v1/${request.name}', {
+      if (request.filter != null) 'filter': request.filter!,
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+    });
     final response = await _client.get(url);
     return ListOperationsResponse.fromJson(response);
   }

--- a/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
+++ b/generator/dart/generated/google_cloud_secretmanager_v1/lib/secretmanager.dart
@@ -44,7 +44,11 @@ class SecretManagerService {
 
   /// Lists `Secrets`.
   Future<ListSecretsResponse> listSecrets(ListSecretsRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.parent}/secrets');
+    final url = Uri.https(_host, '/v1/${request.parent}/secrets', {
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+      if (request.filter != null) 'filter': request.filter!,
+    });
     final response = await _client.get(url);
     return ListSecretsResponse.fromJson(response);
   }
@@ -52,7 +56,9 @@ class SecretManagerService {
   /// Creates a new `Secret` containing no
   /// `SecretVersions`.
   Future<Secret> createSecret(CreateSecretRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.parent}/secrets');
+    final url = Uri.https(_host, '/v1/${request.parent}/secrets', {
+      if (request.secretId != null) 'secretId': request.secretId!,
+    });
     final response = await _client.post(url, body: request.secret);
     return Secret.fromJson(response);
   }
@@ -77,14 +83,19 @@ class SecretManagerService {
   /// Updates metadata of an existing
   /// `Secret`.
   Future<Secret> updateSecret(UpdateSecretRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.secret.name}');
+    final url = Uri.https(_host, '/v1/${request.secret.name}', {
+      if (request.updateMask?.paths != null)
+        'updateMask.paths': request.updateMask?.paths!,
+    });
     final response = await _client.patch(url, body: request.secret);
     return Secret.fromJson(response);
   }
 
   /// Deletes a `Secret`.
   Future<void> deleteSecret(DeleteSecretRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.name}');
+    final url = Uri.https(_host, '/v1/${request.name}', {
+      if (request.etag != null) 'etag': request.etag!,
+    });
     await _client.delete(url);
   }
 
@@ -92,7 +103,11 @@ class SecretManagerService {
   /// call does not return secret data.
   Future<ListSecretVersionsResponse> listSecretVersions(
       ListSecretVersionsRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.parent}/versions');
+    final url = Uri.https(_host, '/v1/${request.parent}/versions', {
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+      if (request.filter != null) 'filter': request.filter!,
+    });
     final response = await _client.get(url);
     return ListSecretVersionsResponse.fromJson(response);
   }
@@ -174,7 +189,11 @@ class SecretManagerService {
   /// Gets the access control policy for a secret.
   /// Returns empty policy if the secret exists and does not have a policy set.
   Future<Policy> getIamPolicy(GetIamPolicyRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.resource}:getIamPolicy');
+    final url = Uri.https(_host, '/v1/${request.resource}:getIamPolicy', {
+      if (request.options?.requestedPolicyVersion != null)
+        'options.requestedPolicyVersion':
+            '${request.options?.requestedPolicyVersion}',
+    });
     final response = await _client.get(url);
     return Policy.fromJson(response);
   }
@@ -196,7 +215,11 @@ class SecretManagerService {
   /// Lists information about the supported locations for this service.
   Future<ListLocationsResponse> listLocations(
       ListLocationsRequest request) async {
-    final url = Uri.https(_host, '/v1/${request.name}/locations');
+    final url = Uri.https(_host, '/v1/${request.name}/locations', {
+      if (request.filter != null) 'filter': request.filter!,
+      if (request.pageSize != null) 'pageSize': '${request.pageSize}',
+      if (request.pageToken != null) 'pageToken': request.pageToken!,
+    });
     final response = await _client.get(url);
     return ListLocationsResponse.fromJson(response);
   }

--- a/generator/internal/dart/templates/lib/method.mustache
+++ b/generator/internal/dart/templates/lib/method.mustache
@@ -37,7 +37,14 @@ Future<Operation<T, S>> getOperation<T extends ProtoMessage, S extends ProtoMess
 /// [Operation.responseAsMessage] will contain the operation's result.
 {{/OperationInfo}}
 Future<{{Codec.ResponseType}}{{#OperationInfo}}<{{Codec.ResponseType}}, {{Codec.MetadataType}}>{{/OperationInfo}}> {{Codec.Name}}({{Codec.RequestType}} request) async {
-  final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}');
+  final url = Uri.https(_host, '{{PathInfo.Codec.PathFmt}}'
+    {{#Codec.HasQueryLines}}, {
+      {{#Codec.QueryLines}}
+        {{{.}}},
+      {{/Codec.QueryLines}}
+    }
+    {{/Codec.HasQueryLines}}
+  );
   {{#Codec.ReturnsValue}}final response = {{/Codec.ReturnsValue}}await _client.{{Codec.RequestMethod}}(url{{#Codec.HasBody}}, body: {{Codec.BodyMessageName}}{{/Codec.HasBody}});
   {{#Codec.ReturnsValue}}
     return {{Codec.ResponseType}}.fromJson(response{{#OperationInfo}}, OperationHelper({{Codec.ResponseType}}.fromJson, {{Codec.MetadataType}}.fromJson),{{/OperationInfo}});


### PR DESCRIPTION
- pass http query params when making calls
- fix https://github.com/googleapis/google-cloud-rust/issues/1577
- code re-generated in a 2nd commit

I verified this manually (at least w/ simple query params) using the gemini API. This handles the cases in the issue listed above (primitive types; repeated primitive types; messages, enums, and bytes). It doesn't handle repeated messages - which aren't part of the spec. It does handle repeated enums, which may or may not be part of the spec?
