### PR TITLE
refactor(wkt): DRY for `impl Message`

### DIFF
--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -137,18 +137,10 @@ impl crate::message::Message for Any {
         "type.googleapis.com/google.protobuf.Any"
     }
     fn to_map(&self) -> Result<crate::message::Map, AnyError> {
-        use serde_json::Value;
-        let map = [
-            ("@type", Value::String(Self::typename().into())),
-            ("value", Value::Object(self.0.clone())),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect::<crate::message::Map>();
-        Ok(map)
+        crate::message::to_json_other(self)
     }
     fn from_map(map: &crate::message::Map) -> Result<Self, AnyError> {
-        crate::message::from_value(map)
+        crate::message::from_other(map)
     }
 }
 

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -165,10 +165,10 @@ impl crate::message::Message for Duration {
         "type.googleapis.com/google.protobuf.Duration"
     }
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_string(self)
+        crate::message::to_json_other(self)
     }
     fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
-        crate::message::from_value(map)
+        crate::message::from_other(map)
     }
 }
 

--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -45,11 +45,10 @@ pub trait Message {
 
 /// Write the serialization of `T` flatly into a map.
 ///
-/// This is used for types where the JSON serialization of `T` is an object.
+/// We use this for types that do not have special encodings, as defined in:
+/// https://protobuf.dev/programming-guides/json/
 ///
-/// `T` is a message with fields that cannot be named `@type`, so flattening the
-/// object saves some bytes over the wire (as compared with encoding the
-/// serialization into a `value` field).
+/// That typically means that `T` is an object.
 pub(crate) fn to_json_object<T>(message: &T) -> Result<Map, Error>
 where
     T: Message + serde::ser::Serialize,
@@ -71,11 +70,11 @@ where
 
 /// Write the serialization of `T` into the `value` field of a map.
 ///
-/// This is used for types where the JSON serialization of `T` is not an
-/// object (e.g. bool, number, string, etc.). The encoding is a map, and these
-/// values need a key.
+/// We use this for types that have special encodings, as defined in:
+/// https://protobuf.dev/programming-guides/json/
 ///
-/// It is also used for `Any`. Flatly serializing an `Any` would have
+/// Typically this means that the JSON serialization of `T` is not an object. It
+/// is also used for `Any`, as flatly serializing an `Any` would have
 /// conflicting `@type` fields.
 pub(crate) fn to_json_other<T>(message: &T) -> Result<Map, Error>
 where

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -44,27 +44,11 @@ impl crate::message::Message for Struct {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Struct"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
-        let map: crate::message::Map = [
-            ("@type", Value::String(Self::typename().to_string())),
-            ("value", Value::Object(self.clone())),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-        Ok(map)
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(self)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
-        map.get("value")
-            .and_then(|v| v.as_object())
-            .cloned()
-            .ok_or_else(crate::message::missing_value_field)
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+        crate::message::from_other(map)
     }
 }
 
@@ -72,26 +56,11 @@ impl crate::message::Message for Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Value"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
-        let map: crate::message::Map = [
-            ("@type", Value::String(Self::typename().to_string())),
-            ("value", self.clone()),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-        Ok(map)
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(self)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
-        map.get("value")
-            .cloned()
-            .ok_or_else(crate::message::missing_value_field)
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+        crate::message::from_other(map)
     }
 }
 
@@ -99,27 +68,11 @@ impl crate::message::Message for ListValue {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.ListValue"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
-        let map: crate::message::Map = [
-            ("@type", Value::String(Self::typename().to_string())),
-            ("value", Value::Array(self.clone())),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-        Ok(map)
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(self)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
-        map.get("value")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .ok_or_else(crate::message::missing_value_field)
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+        crate::message::from_other(map)
     }
 }
 

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -170,10 +170,10 @@ impl crate::message::Message for Timestamp {
         "type.googleapis.com/google.protobuf.Timestamp"
     }
     fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_string(self)
+        crate::message::to_json_other(self)
     }
     fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
-        crate::message::from_value(map)
+        crate::message::from_other(map)
     }
 }
 

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -119,27 +119,11 @@ macro_rules! impl_message {
             fn typename() -> &'static str {
                 concat!("type.googleapis.com/google.protobuf.", stringify!($t))
             }
-            fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-            where
-                Self: serde::ser::Serialize + Sized,
-            {
-                let map: crate::message::Map = [
-                    (
-                        "@type",
-                        serde_json::Value::String(Self::typename().to_string()),
-                    ),
-                    ("value", serde_json::json!(self)),
-                ]
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect();
-                Ok(map)
+            fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
+                crate::message::to_json_other(self)
             }
-            fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-            where
-                Self: serde::de::DeserializeOwned,
-            {
-                crate::message::from_value::<Self>(map)
+            fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+                crate::message::from_other(map)
             }
         }
     };
@@ -173,16 +157,10 @@ impl crate::message::Message for UInt64Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.UInt64Value"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
         encode_string::<Self>(self.to_string())
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
         map.get("value")
             .ok_or_else(crate::message::missing_value_field)?
             .as_str()
@@ -196,16 +174,10 @@ impl crate::message::Message for Int64Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Int64Value"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
         encode_string::<Self>(self.to_string())
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
         map.get("value")
             .ok_or_else(crate::message::missing_value_field)?
             .as_str()
@@ -219,16 +191,10 @@ impl crate::message::Message for BytesValue {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.BytesValue"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError>
-    where
-        Self: serde::ser::Serialize + Sized,
-    {
+    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
         encode_string::<Self>(STANDARD.encode(self))
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError>
-    where
-        Self: serde::de::DeserializeOwned,
-    {
+    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
         let s = map
             .get("value")
             .ok_or_else(crate::message::missing_value_field)?


### PR DESCRIPTION
Tangential to #1609, #1767 

There are only 2 cases for encoding, either we put the serialization of something into a `value` field, or we flatten it.

So use helper functions for the two cases and remove instances of logic.

While we're here, write up my understanding of why the `Any` business is the way it is.