### PR TITLE
impl(gax-internal): improve routing info matchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
  "http",
  "http-body-util",
  "mockall",
+ "percent-encoding",
  "prost",
  "prost-types",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,22 +271,23 @@ inherits    = "dev"
 incremental = false
 
 [workspace.dependencies]
-async-trait = { version = "0.1" }
-bytes       = { version = "1", default-features = false, features = ["serde"] }
-http        = { version = "1", default-features = false }
-lazy_static = { version = "1", default-features = false }
-prost       = { version = "0.13", default-features = false }
-prost-build = { version = "0.13", default-features = false }
-prost-types = { version = "0.13", default-features = false }
-reqwest     = { version = "0.12", default-features = false, features = ["json"] }
-serde       = { version = "1", default-features = false, features = ["serde_derive"] }
-serde_json  = { version = "1", default-features = false }
-serde_with  = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-tokio       = { version = "1", default-features = false }
-tokio-test  = { version = "0.4", default-features = false }
-tonic       = { version = "0.13", default-features = false, features = ["prost", "tls-native-roots", "tls-ring"] }
-tonic-build = { version = "0.13", default-features = false }
-tracing     = { version = "0.1" }
+async-trait      = { version = "0.1" }
+bytes            = { version = "1", default-features = false, features = ["serde"] }
+http             = { version = "1", default-features = false }
+lazy_static      = { version = "1", default-features = false }
+percent-encoding = { version = "2", default-features = false }
+prost            = { version = "0.13", default-features = false }
+prost-build      = { version = "0.13", default-features = false }
+prost-types      = { version = "0.13", default-features = false }
+reqwest          = { version = "0.12", default-features = false, features = ["json"] }
+serde            = { version = "1", default-features = false, features = ["serde_derive"] }
+serde_json       = { version = "1", default-features = false }
+serde_with       = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
+tokio            = { version = "1", default-features = false }
+tokio-test       = { version = "0.4", default-features = false }
+tonic            = { version = "0.13", default-features = false, features = ["prost", "tls-native-roots", "tls-ring"] }
+tonic-build      = { version = "0.13", default-features = false }
+tracing          = { version = "0.1" }
 # Local packages used as dependencies
 auth                          = { version = "0.20", path = "src/auth", package = "google-cloud-auth" }
 gax                           = { version = "0.22", path = "src/gax", package = "google-cloud-gax" }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -49,20 +49,21 @@ _internal_grpc_client = [
   "dep:tonic",
   "dep:wkt",
 ]
-_internal_common = ["dep:auth", "dep:gax", "dep:thiserror"]
+_internal_common = ["dep:auth", "dep:gax", "dep:percent-encoding", "dep:thiserror"]
 
 [dependencies]
-bytes          = { version = "1", features = ["serde"] }
-http           = "1"
-http-body-util = "0.1"
-prost          = { workspace = true, optional = true }
-prost-types    = { workspace = true, optional = true }
-reqwest        = { version = "0.12", optional = true }
-serde          = { version = "1", optional = true }
-serde_json     = { version = "1", optional = true }
-thiserror      = { version = "2", optional = true }
-tokio          = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
-tonic          = { workspace = true, optional = true }
+bytes            = { version = "1", features = ["serde"] }
+http             = "1"
+http-body-util   = "0.1"
+percent-encoding = { workspace = true, optional = true }
+prost            = { workspace = true, optional = true }
+prost-types      = { workspace = true, optional = true }
+reqwest          = { version = "0.12", optional = true }
+serde            = { version = "1", optional = true }
+serde_json       = { version = "1", optional = true }
+thiserror        = { version = "2", optional = true }
+tokio            = { version = "1", features = ["macros", "rt-multi-thread"], optional = true }
+tonic            = { workspace = true, optional = true }
 # Local crates
 auth = { workspace = true, optional = true }
 gax  = { workspace = true, features = ["unstable-sdk-client"], optional = true }

--- a/src/gax-internal/src/routing_parameter.rs
+++ b/src/gax-internal/src/routing_parameter.rs
@@ -16,7 +16,7 @@
 
 use percent_encoding::NON_ALPHANUMERIC;
 
-/// Find a routing parameter value in `haytack` using the (decomposed) template.
+/// Find a routing parameter value in `haystack` using the (decomposed) template.
 ///
 /// # Example
 /// ```
@@ -70,7 +70,7 @@ pub fn value<'h>(
     Some(&haystack[start..end])
 }
 
-/// Format a list of routing parameter key value pair.
+/// Format a list of routing parameter key value pairs.
 ///
 /// ```
 /// # use google_cloud_gax_internal::routing_parameter::*;
@@ -239,7 +239,7 @@ mod test {
     #[test_case("", "profiles/q", "routing_id=q"; "match #3 wins")]
     #[test_case("", "thingy/q/child/c", "routing_id=thingy%2Fq%2Fchild%2Fc"; "match #2 wins")]
     #[test_case("projects/p/instances/i", "", "routing_id=projects%2Fp"; "match #1 wins")]
-    #[test_case("projects/p/instances/i/tables/t", "", "table_location=instances%2Fi&routing_id=projects%2Fp"; "one field matches 2 vables wins")]
+    #[test_case("projects/p/instances/i/tables/t", "", "table_location=instances%2Fi&routing_id=projects%2Fp"; "one field matches 2 variables")]
     #[test_case("projects/p/instances/i/tables/t", "profiles/q", "table_location=instances%2Fi&routing_id=q"; "multiple variables")]
     #[test_case("projects/p/instances/i/tables/t", "thingy/q/child/c", "table_location=instances%2Fi&routing_id=thingy%2Fq%2Fchild%2Fc"; "multiple variables skipping one template")]
     fn simulated_request(table_name: &str, app_profile_id: &str, want: &str) {

--- a/src/gax-internal/src/routing_parameter.rs
+++ b/src/gax-internal/src/routing_parameter.rs
@@ -314,20 +314,20 @@ mod test {
 
     #[test]
     fn example1() {
-        let matched = value(Some(&APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
+        let matched = value(Some(APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
         assert_eq!(matched, Some("profiles/prof_qux"));
     }
 
     #[test]
     fn example2() {
-        let matched = value(Some(&APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
+        let matched = value(Some(APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
         assert_eq!(matched, Some("profiles/prof_qux"));
     }
 
     #[test]
     fn example3a() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[
                 Literal("projects"),
@@ -350,7 +350,7 @@ mod test {
     #[test]
     fn example3b() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[
                 Literal("regions"),
@@ -369,7 +369,7 @@ mod test {
     #[test]
     fn example3c() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[
                 Literal("regions"),
@@ -384,7 +384,7 @@ mod test {
         );
         assert_eq!(matched, None);
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[
                 Literal("projects"),
@@ -407,7 +407,7 @@ mod test {
     #[test]
     fn example4() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
@@ -418,14 +418,14 @@ mod test {
     #[test]
     fn example5() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
         );
         assert_eq!(matched, Some("projects/proj_foo"));
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[
                 Literal("projects"),
@@ -444,7 +444,7 @@ mod test {
     #[test]
     fn example6a() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[
@@ -457,7 +457,7 @@ mod test {
         );
         assert_eq!(matched, Some("projects/proj_foo"));
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[
                 Literal("projects"),
                 Literal("/"),
@@ -473,14 +473,14 @@ mod test {
     #[test]
     fn example6b() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
         );
         assert_eq!(matched, Some("projects/proj_foo"));
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[
                 Literal("projects"),
                 Literal("/"),
@@ -496,40 +496,40 @@ mod test {
     #[test]
     fn example7() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
         );
         assert_eq!(matched, Some("projects/proj_foo"));
-        let matched = value(Some(&APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
+        let matched = value(Some(APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
         assert_eq!(matched, Some("profiles/prof_qux"));
     }
 
     #[test]
     fn example8() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
         );
         assert_eq!(matched, Some("projects/proj_foo"));
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("regions"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
         );
         assert_eq!(matched, None);
-        let matched = value(Some(&APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
+        let matched = value(Some(APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
         assert_eq!(matched, Some("profiles/prof_qux"));
     }
 
     #[test]
     fn example9() {
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[
                 Literal("projects"),
                 Literal("/"),
@@ -541,7 +541,7 @@ mod test {
         );
         assert_eq!(matched, Some("instances/instance_bar"));
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[
                 Literal("regions"),
@@ -556,16 +556,16 @@ mod test {
         );
         assert_eq!(matched, None);
         let matched = value(
-            Some(&TABLE_NAME),
+            Some(TABLE_NAME),
             &[],
             &[Literal("projects"), Literal("/"), SingleWildcard],
             &[TrailingMultiWildcard],
         );
         assert_eq!(matched, Some("projects/proj_foo"));
-        let matched = value(Some(&APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
+        let matched = value(Some(APP_PROFILE_ID), &[], &[MultiWildcard], &[]);
         assert_eq!(matched, Some("profiles/prof_qux"));
         let matched = value(
-            Some(&APP_PROFILE_ID),
+            Some(APP_PROFILE_ID),
             &[Literal("profiles"), Literal("/")],
             &[SingleWildcard],
             &[],

--- a/src/gax-internal/src/routing_parameter.rs
+++ b/src/gax-internal/src/routing_parameter.rs
@@ -85,7 +85,7 @@ pub fn value<'h>(
 ///     "bucket=projects%2F_%2Fbuckets%2Fd&source_bucket=projects%2F_%2Fbuckets%2Fs");
 /// ```
 pub fn format(matches: &[Option<(&str, &str)>]) -> String {
-    let matches: Vec<_> = matches.into_iter().flatten().collect();
+    let matches: Vec<_> = matches.iter().flatten().collect();
     if matches.is_empty() {
         return String::new();
     }


### PR DESCRIPTION
Use a Rust enum to avoid `if x == "**"`, the generator can convert the
wildcards into branches of the enum ahead of time. Also, the generator
can use a special branch for "trailing" multi-segment wildcards. Those
have slightly different matching rules.

Part of the work for #1846
