### PR TITLE
refactor(auth)!: rename CredentialsTrait to CredentialsProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ tonic       = { version = "0.13", default-features = false, features = ["prost",
 tonic-build = { version = "0.13", default-features = false }
 tracing     = { version = "0.1" }
 # Local packages used as dependencies
-auth                          = { version = "0.20", path = "src/auth", package = "google-cloud-auth" }
+auth                          = { version = "0.21", path = "src/auth", package = "google-cloud-auth" }
 gax                           = { version = "0.22", path = "src/gax", package = "google-cloud-gax" }
 gaxi                          = { version = "0.1", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.3", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-auth"
-version     = "0.20.0"
+version     = "0.21.0"
 description = "Google Cloud Client Libraries for Rust - Authentication"
 # Inherit other attributes from the workspace.
 authors.workspace      = true

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 pub(crate) const QUOTA_PROJECT_KEY: &str = "x-goog-user-project";
 pub(crate) const DEFAULT_UNIVERSE_DOMAIN: &str = "googleapis.com";
 
-/// An implementation of [crate::credentials::CredentialsTrait].
+/// An implementation of [crate::credentials::CredentialsProvider].
 ///
 /// Represents a [Credentials] used to obtain auth [Token][crate::token::Token]s
 /// and the corresponding request headers.
@@ -73,12 +73,12 @@ pub struct Credentials {
     // They also need to derive `Clone`, as the
     // `gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
     // `Box` will not do.
-    inner: Arc<dyn dynamic::CredentialsTrait>,
+    inner: Arc<dyn dynamic::CredentialsProvider>,
 }
 
 impl<T> std::convert::From<T> for Credentials
 where
-    T: crate::credentials::CredentialsTrait + Send + Sync + 'static,
+    T: crate::credentials::CredentialsProvider + Send + Sync + 'static,
 {
     fn from(value: T) -> Self {
         Self {
@@ -141,7 +141,7 @@ impl Credentials {
 /// [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 /// [Google Compute Engine]: https://cloud.google.com/products/compute
 /// [Google Kubernetes Engine]: https://cloud.google.com/kubernetes-engine
-pub trait CredentialsTrait: std::fmt::Debug {
+pub trait CredentialsProvider: std::fmt::Debug {
     /// Asynchronously retrieves a token.
     ///
     /// Returns a [Token][crate::token::Token] for the current credentials.
@@ -165,9 +165,9 @@ pub(crate) mod dynamic {
     use super::Result;
     use super::{HeaderName, HeaderValue};
 
-    /// A dyn-compatible, crate-private version of `CredentialsTrait`.
+    /// A dyn-compatible, crate-private version of `CredentialsProvider`.
     #[async_trait::async_trait]
-    pub trait CredentialsTrait: Send + Sync + std::fmt::Debug {
+    pub trait CredentialsProvider: Send + Sync + std::fmt::Debug {
         /// Asynchronously retrieves a token.
         ///
         /// Returns a [Token][crate::token::Token] for the current credentials.
@@ -189,11 +189,11 @@ pub(crate) mod dynamic {
         }
     }
 
-    /// The public CredentialsTrait implements the dyn-compatible CredentialsTrait.
+    /// The public CredentialsProvider implements the dyn-compatible CredentialsProvider.
     #[async_trait::async_trait]
-    impl<T> CredentialsTrait for T
+    impl<T> CredentialsProvider for T
     where
-        T: super::CredentialsTrait + Send + Sync,
+        T: super::CredentialsProvider + Send + Sync,
     {
         async fn token(&self) -> Result<crate::token::Token> {
             T::token(self).await
@@ -601,7 +601,7 @@ fn adc_well_known_path() -> Option<String> {
 pub mod testing {
     use crate::Result;
     use crate::credentials::Credentials;
-    use crate::credentials::dynamic::CredentialsTrait;
+    use crate::credentials::dynamic::CredentialsProvider;
     use crate::token::Token;
     use http::header::{HeaderName, HeaderValue};
     use std::sync::Arc;
@@ -619,7 +619,7 @@ pub mod testing {
     struct TestCredentials;
 
     #[async_trait::async_trait]
-    impl CredentialsTrait for TestCredentials {
+    impl CredentialsProvider for TestCredentials {
         async fn token(&self) -> Result<Token> {
             Ok(Token {
                 token: "test-only-token".to_string(),
@@ -651,7 +651,7 @@ pub mod testing {
     struct ErrorCredentials(bool);
 
     #[async_trait::async_trait]
-    impl CredentialsTrait for ErrorCredentials {
+    impl CredentialsProvider for ErrorCredentials {
         async fn token(&self) -> Result<Token> {
             Err(super::CredentialsError::from_str(self.0, "test-only"))
         }

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::dynamic::CredentialsTrait;
+use crate::credentials::dynamic::CredentialsProvider;
 use crate::credentials::{Credentials, Result};
 use crate::headers_util::build_api_key_headers;
 use crate::token::{Token, TokenProvider};
@@ -107,7 +107,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialsTrait for ApiKeyCredentials<T>
+impl<T> CredentialsProvider for ApiKeyCredentials<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -52,7 +52,7 @@
 //! [gke-link]: https://cloud.google.com/kubernetes-engine
 //! [Metadata Service]: https://cloud.google.com/compute/docs/metadata/overview
 
-use crate::credentials::dynamic::CredentialsTrait;
+use crate::credentials::dynamic::CredentialsProvider;
 use crate::credentials::{Credentials, DEFAULT_UNIVERSE_DOMAIN, Result};
 use crate::errors::{self, CredentialsError, is_retryable};
 use crate::headers_util::build_bearer_headers;
@@ -182,7 +182,7 @@ impl Builder {
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialsTrait for MDSCredentials<T>
+impl<T> CredentialsProvider for MDSCredentials<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -73,7 +73,7 @@
 
 mod jws;
 
-use crate::credentials::dynamic::CredentialsTrait;
+use crate::credentials::dynamic::CredentialsProvider;
 use crate::credentials::{Credentials, Result};
 use crate::errors::{self, CredentialsError};
 use crate::headers_util::build_bearer_headers;
@@ -390,7 +390,7 @@ impl ServiceAccountTokenProvider {
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialsTrait for ServiceAccountCredentials<T>
+impl<T> CredentialsProvider for ServiceAccountCredentials<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -66,7 +66,7 @@
 //! [User Account]: https://cloud.google.com/docs/authentication#user-accounts
 //! [Workforce Identity Federation]: https://cloud.google.com/iam/docs/workforce-identity-federation
 
-use crate::credentials::dynamic::CredentialsTrait;
+use crate::credentials::dynamic::CredentialsProvider;
 use crate::credentials::{Credentials, Result};
 use crate::errors::{self, CredentialsError, is_retryable};
 use crate::headers_util::build_bearer_headers;
@@ -306,7 +306,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T> CredentialsTrait for UserCredentials<T>
+impl<T> CredentialsProvider for UserCredentials<T>
 where
     T: TokenProvider,
 {

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -17,7 +17,7 @@ use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBu
 use google_cloud_auth::credentials::testing::test_credentials;
 use google_cloud_auth::credentials::user_account::Builder as UserAccountCredentialBuilder;
 use google_cloud_auth::credentials::{
-    ApiKeyOptions, Builder as AccessTokenCredentialBuilder, Credentials, CredentialsTrait,
+    ApiKeyOptions, Builder as AccessTokenCredentialBuilder, Credentials, CredentialsProvider,
     create_access_token_credentials, create_api_key_credentials,
 };
 use google_cloud_auth::errors::CredentialsError;
@@ -188,7 +188,7 @@ mod test {
         #[derive(Debug)]
         Credentials {}
 
-        impl CredentialsTrait for Credentials {
+        impl CredentialsProvider for Credentials {
             async fn token(&self) -> Result<Token>;
             async fn headers(&self) -> Result<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;

--- a/src/gax-internal/tests/grpc_auth.rs
+++ b/src/gax-internal/tests/grpc_auth.rs
@@ -14,7 +14,7 @@
 
 #[cfg(all(test, feature = "_internal_grpc_client"))]
 mod test {
-    use auth::credentials::{Credentials, CredentialsTrait};
+    use auth::credentials::{Credentials, CredentialsProvider};
     use auth::errors::CredentialsError;
     use auth::token::Token;
     use gax::options::*;
@@ -30,7 +30,7 @@ mod test {
         #[derive(Debug)]
         Credentials {}
 
-        impl CredentialsTrait for Credentials {
+        impl CredentialsProvider for Credentials {
             async fn token(&self) -> AuthResult<Token>;
             async fn headers(&self) -> AuthResult<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;

--- a/src/gax-internal/tests/http_auth.rs
+++ b/src/gax-internal/tests/http_auth.rs
@@ -14,7 +14,7 @@
 
 #[cfg(all(test, feature = "_internal_http_client"))]
 mod test {
-    use auth::credentials::{Credentials, CredentialsTrait};
+    use auth::credentials::{Credentials, CredentialsProvider};
     use auth::errors::CredentialsError;
     use auth::token::Token;
     use gax::options::*;
@@ -29,7 +29,7 @@ mod test {
         #[derive(Debug)]
         Credentials {}
 
-        impl CredentialsTrait for Credentials {
+        impl CredentialsProvider for Credentials {
             async fn token(&self) -> AuthResult<Token>;
             async fn headers(&self) -> AuthResult<Vec<(HeaderName, HeaderValue)>>;
             async fn universe_domain(&self) -> Option<String>;


### PR DESCRIPTION
As mentioned in https://github.com/googleapis/google-cloud-rust/issues/1843 updating the name of CredentialsTrait to CredentialsProvider to make it more rusty.