### PR TITLE
feat(generator/rust): gRPC clients use routinginfo

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -147,6 +147,10 @@ type Method struct {
 	Codec any
 }
 
+func (m *Method) HasRouting() bool {
+	return len(m.Routing) != 0
+}
+
 // Normalized request path information.
 type PathInfo struct {
 	// HTTP Verb.
@@ -231,6 +235,8 @@ type RoutingInfoVariant struct {
 	Matching RoutingPathSpec
 	// A path template that must match the end of the field value.
 	Suffix RoutingPathSpec
+	// Language specific information
+	Codec any
 }
 
 type RoutingPathSpec struct {

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -172,6 +172,14 @@ type operationInfo struct {
 	PackageNamespace   string
 }
 
+type routingVariantAnnotations struct {
+	FirstVariant     bool
+	FieldAccessors   []string
+	PrefixSegments   []string
+	MatchingSegments []string
+	SuffixSegments   []string
+}
+
 type oneOfAnnotation struct {
 	// In Rust, `oneof` fields are fields inside a struct. These must be
 	// `snake_case`. Possibly mangled with `r#` if the name is a Rust reserved
@@ -536,6 +544,19 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 	}
 	pathInfoAnnotation.HasPathArgs = len(pathInfoAnnotation.PathArgs) > 0
 
+	for _, routing := range m.Routing {
+		for index, variant := range routing.Variants {
+			routingVariantAnnotations := &routingVariantAnnotations{
+				FirstVariant:     index == 0,
+				FieldAccessors:   c.annotateRoutingAccessors(variant, m, state),
+				PrefixSegments:   annotateSegments(variant.Prefix.Segments),
+				MatchingSegments: annotateSegments(variant.Matching.Segments),
+				SuffixSegments:   annotateSegments(variant.Suffix.Segments),
+			}
+			variant.Codec = routingVariantAnnotations
+		}
+	}
+
 	m.PathInfo.Codec = pathInfoAnnotation
 	returnType := c.methodInOutTypeName(m.OutputTypeID, state, sourceSpecificationPackageName)
 	if m.ReturnsEmpty {
@@ -567,6 +588,67 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		}
 	}
 	m.Codec = annotation
+}
+
+func (c *codec) annotateRoutingAccessors(variant *api.RoutingInfoVariant, m *api.Method, state *api.APIState) []string {
+	findField := func(name string, message *api.Message) *api.Field {
+		for _, f := range message.Fields {
+			if f.Name == name {
+				return f
+			}
+		}
+		return nil
+	}
+	var accessors []string
+	message := m.InputType
+	for _, name := range variant.FieldPath {
+		field := findField(name, message)
+		if field == nil {
+			slog.Error("invalid routing field for request message", "field", name, "message ID", message.ID)
+			continue
+		}
+		switch {
+		case field.Optional:
+			accessors = append(accessors, fmt.Sprintf("v.%s.as_ref()", name))
+		case field.Typez == api.STRING_TYPE:
+			accessors = append(accessors, fmt.Sprintf("Some(v.%s.as_str())", name))
+		default:
+			accessors = append(accessors, fmt.Sprintf("Some(&v.%s)", name))
+		}
+		if field.Typez == api.MESSAGE_TYPE {
+			if fieldMessage, ok := state.MessageByID[field.TypezID]; ok {
+				message = fieldMessage
+			}
+		}
+	}
+	return accessors
+}
+
+func annotateSegments(segments []string) []string {
+	var ann []string
+	for index, segment := range segments {
+		switch {
+		case segment == api.RoutingMultiSegmentWildcard:
+			if len(segments) == 1 {
+				ann = append(ann, "Segment::MultiWildcard")
+			} else if len(segments) != index+1 {
+				ann = append(ann, "Segment::MultiWildcard")
+			} else {
+				ann = append(ann, "Segment::TrailingMultiWildcard")
+			}
+		case segment == api.RoutingSingleSegmentWildcard:
+			if index != 0 {
+				ann = append(ann, `Segment::Literal("/")`)
+			}
+			ann = append(ann, "Segment::SingleWildcard")
+		default:
+			if index != 0 {
+				ann = append(ann, `Segment::Literal("/")`)
+			}
+			ann = append(ann, fmt.Sprintf(`Segment::Literal("%s")`, segment))
+		}
+	}
+	return ann
 }
 
 func (c *codec) annotateOneOf(oneof *api.OneOf, message *api.Message, state *api.APIState, sourceSpecificationPackageName string) {

--- a/generator/internal/rust/templates/grpc-client/routinginfo.mustache
+++ b/generator/internal/rust/templates/grpc-client/routinginfo.mustache
@@ -1,0 +1,37 @@
+{{!
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+let x_goog_request_params = {
+    use gaxi::routing_parameter::Segment;
+    gaxi::routing_parameter::format(&[
+        {{#Routing}}
+        {{#Variants}}
+        {{^Codec.FirstVariant}}
+        .or_else(||
+        {{/Codec.FirstVariant}}
+        gaxi::routing_parameter::value(
+            Some(&req){{#Codec.FieldAccessors}}.and_then(|v| {{{.}}}){{/Codec.FieldAccessors}},
+            &[ {{#Codec.PrefixSegments}}{{{.}}}, {{/Codec.PrefixSegments}} ],
+            &[ {{#Codec.MatchingSegments}}{{{.}}}, {{/Codec.MatchingSegments}} ],
+            &[ {{#Codec.SuffixSegments}}{{{.}}}, {{/Codec.SuffixSegments}} ],
+        )
+        {{^Codec.FirstVariant}}
+        )
+        {{/Codec.FirstVariant}}
+        {{/Variants}}
+        .map(|v| ("{{Name}}", v)),
+        {{/Routing}}
+    ])
+};

--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -110,6 +110,20 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         let path = http::uri::PathAndQuery::from_static(
             "/{{Service.Package}}.{{Service.Name}}/{{Name}}"
         );
+        {{!
+        AIP-4222 says:
+
+            For any given RPC, if the explicit routing headers annotation is
+            present, the code generators **must** use it and **ignore** any
+            routing headers that might be implicitly specified in the
+            google.api.http annotation.
+
+        So we only need to generate one of the two code paths.
+        }}
+        {{#HasRouting}}
+        {{> routinginfo}}
+        {{/HasRouting}}
+        {{^HasRouting}}
         let x_goog_request_params = [
             {{#PathInfo.Codec.PathArgs}}
             format!("{{Name}}={}", req{{{Accessor}}}),
@@ -118,6 +132,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             ""; 0
             {{/PathInfo.Codec.PathArgs}}
         ].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        {{/HasRouting}}
 
         self.inner
           .execute(

--- a/src/storage/src/generated/gapic/transport.rs
+++ b/src/storage/src/generated/gapic/transport.rs
@@ -73,7 +73,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteBucket");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.name.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -103,7 +112,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetBucket");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.name.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -138,7 +156,26 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CreateBucket");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req)
+                    .and_then(|v| v.bucket.as_ref())
+                    .and_then(|v| Some(v.project.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .or_else(|| {
+                gaxi::routing_parameter::value(
+                    Some(&req).and_then(|v| Some(v.parent.as_str())),
+                    &[],
+                    &[Segment::MultiWildcard],
+                    &[],
+                )
+            })
+            .map(|v| ("project", v))])
+        };
 
         self.inner
             .execute(
@@ -173,7 +210,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListBuckets");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.parent.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("project", v))])
+        };
 
         self.inner
             .execute(
@@ -210,7 +256,16 @@ impl super::stub::Storage for Storage {
         let path = http::uri::PathAndQuery::from_static(
             "/google.storage.v2.Storage/LockBucketRetentionPolicy",
         );
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -245,7 +300,18 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateBucket");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req)
+                    .and_then(|v| v.bucket.as_ref())
+                    .and_then(|v| Some(v.name.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -280,7 +346,18 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ComposeObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req)
+                    .and_then(|v| v.destination.as_ref())
+                    .and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -315,7 +392,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/DeleteObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -345,7 +431,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/RestoreObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -381,7 +476,24 @@ impl super::stub::Storage for Storage {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/CancelResumableWrite");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.upload_id.as_str())),
+                &[],
+                &[
+                    Segment::Literal("projects"),
+                    Segment::Literal("/"),
+                    Segment::SingleWildcard,
+                    Segment::Literal("/"),
+                    Segment::Literal("buckets"),
+                    Segment::Literal("/"),
+                    Segment::SingleWildcard,
+                ],
+                &[Segment::MultiWildcard],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -416,7 +528,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/GetObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -451,7 +572,18 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/UpdateObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req)
+                    .and_then(|v| v.object.as_ref())
+                    .and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -486,7 +618,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ListObjects");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.parent.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -521,7 +662,25 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/RewriteObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[
+                gaxi::routing_parameter::value(
+                    Some(&req).and_then(|v| Some(v.destination_bucket.as_str())),
+                    &[],
+                    &[Segment::MultiWildcard],
+                    &[],
+                )
+                .map(|v| ("bucket", v)),
+                gaxi::routing_parameter::value(
+                    Some(&req).and_then(|v| Some(v.source_bucket.as_str())),
+                    &[],
+                    &[Segment::MultiWildcard],
+                    &[],
+                )
+                .map(|v| ("source_bucket", v)),
+            ])
+        };
 
         self.inner
             .execute(
@@ -557,7 +716,19 @@ impl super::stub::Storage for Storage {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/StartResumableWrite");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req)
+                    .and_then(|v| v.write_object_spec.as_ref())
+                    .and_then(|v| v.resource.as_ref())
+                    .and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -593,7 +764,24 @@ impl super::stub::Storage for Storage {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/QueryWriteStatus");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.upload_id.as_str())),
+                &[],
+                &[
+                    Segment::Literal("projects"),
+                    Segment::Literal("/"),
+                    Segment::SingleWildcard,
+                    Segment::Literal("/"),
+                    Segment::Literal("buckets"),
+                    Segment::Literal("/"),
+                    Segment::SingleWildcard,
+                ],
+                &[Segment::MultiWildcard],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(
@@ -628,7 +816,16 @@ impl super::stub::Storage for Storage {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/MoveObject");
-        let x_goog_request_params = [""; 0].into_iter().fold(String::new(), |b, p| b + "&" + &p);
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[gaxi::routing_parameter::value(
+                Some(&req).and_then(|v| Some(v.bucket.as_str())),
+                &[],
+                &[Segment::MultiWildcard],
+                &[],
+            )
+            .map(|v| ("bucket", v))])
+        };
 
         self.inner
             .execute(


### PR DESCRIPTION
With this change, the generator produces code to populate the
`x-goog-request-params` header using the routing info, if available.
A separate PR will change the gaxi::grpc::Client to ignore empty
headers.

Part of the work for #1846
