### PR TITLE
impl(gaxi-internal): ignore empty request params

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -202,7 +202,7 @@ impl Client {
             //
             //     If none of the routing parameters matched their respective
             //     fields, the routing header **must not** be sent.
-            // 
+            //
             headers.append(
                 http::header::HeaderName::from_static("x-goog-request-params"),
                 http::header::HeaderValue::from_str(request_params).map_err(Error::other)?,

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -196,10 +196,18 @@ impl Client {
             http::header::HeaderName::from_static("x-goog-api-client"),
             http::header::HeaderValue::from_static(api_client_header),
         );
-        headers.append(
-            http::header::HeaderName::from_static("x-goog-request-params"),
-            http::header::HeaderValue::from_str(request_params).map_err(Error::other)?,
-        );
+        if !request_params.is_empty() {
+            // When using routing info to populate the request parameters it is
+            // possible that none of the path template matches. AIP-4222 says:
+            //
+            //     If none of the routing parameters matched their respective
+            //     fields, the routing header **must not** be sent.
+            // 
+            headers.append(
+                http::header::HeaderName::from_static("x-goog-request-params"),
+                http::header::HeaderValue::from_str(request_params).map_err(Error::other)?,
+            );
+        }
         Ok(headers)
     }
 


### PR DESCRIPTION
When using routing info to populate the request parameters, it is
possible that none of the path templates matches, in which case we need
to omit the header.

Part of the work for #1846
