### PR TITLE
feat(gax): return default value for struct for 204 NoContent responses

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -137,7 +137,7 @@ impl ReqwestClient {
             return Self::to_http_error(response).await;
         }
 
-        return Self::to_http_response(response).await;
+        Self::to_http_response(response).await
     }
 
     async fn to_http_error<O>(response: reqwest::Response) -> Result<O> {
@@ -168,7 +168,7 @@ impl ReqwestClient {
             .map_err(Error::io)?;
 
         let response = match body.to_bytes() {
-            content if (content.len() == 0 && is204ok) => O::default(), // 204 No Content has no body, throws EOF error if we try to parse
+            content if (content.is_empty() && is204ok) => O::default(), // 204 No Content has no body, throws EOF error if we try to parse
             content => serde_json::from_slice::<O>(&content).map_err(Error::serde)?,
         };
 

--- a/src/wkt/src/empty.rs
+++ b/src/wkt/src/empty.rs
@@ -21,7 +21,7 @@
 ///   rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 /// }
 /// ```
-/// 
+///
 #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Empty {}
 

--- a/src/wkt/src/empty.rs
+++ b/src/wkt/src/empty.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::{Deserialize, Deserializer, Serialize, de::IntoDeserializer};
+
 /// A generic empty message that you can re-use to avoid defining duplicated
 /// empty messages in your APIs. A typical example is to use it as the request
 /// or the response type of an API method. For instance:
@@ -21,9 +23,22 @@
 ///   rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 /// }
 /// ```
-///
-#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct Empty {}
+
+impl<'de> Deserialize<'de> for Empty {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let input = String::deserialize(deserializer).unwrap_or(String::default());
+        if input.trim().is_empty() || input.trim().eq("null") {
+            return Ok(Empty::default());
+        }
+        let string_deserializer = String::into_deserializer(input);
+        Ok(Option::<Empty>::deserialize(string_deserializer)?.unwrap())
+    }
+}
 
 impl crate::message::Message for Empty {
     fn typename() -> &'static str {
@@ -48,6 +63,20 @@ mod tests {
     #[test]
     fn deserialize() -> Result {
         let got = serde_json::from_value(json!({}))?;
+        assert_eq!(Empty::default(), got);
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_null() -> Result {
+        let got = serde_json::from_value(json!(null))?;
+        assert_eq!(Empty::default(), got);
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_empty() -> Result {
+        let got = serde_json::from_str("")?;
         assert_eq!(Empty::default(), got);
         Ok(())
     }

--- a/src/wkt/src/empty.rs
+++ b/src/wkt/src/empty.rs
@@ -21,6 +21,7 @@
 ///   rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 /// }
 /// ```
+/// 
 #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Empty {}
 

--- a/src/wkt/src/empty.rs
+++ b/src/wkt/src/empty.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::{Deserialize, Deserializer, Serialize, de::IntoDeserializer};
-
 /// A generic empty message that you can re-use to avoid defining duplicated
 /// empty messages in your APIs. A typical example is to use it as the request
 /// or the response type of an API method. For instance:
@@ -23,22 +21,8 @@ use serde::{Deserialize, Deserializer, Serialize, de::IntoDeserializer};
 ///   rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
 /// }
 /// ```
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Empty {}
-
-impl<'de> Deserialize<'de> for Empty {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let input = String::deserialize(deserializer).unwrap_or(String::default());
-        if input.trim().is_empty() || input.trim().eq("null") {
-            return Ok(Empty::default());
-        }
-        let string_deserializer = String::into_deserializer(input);
-        Ok(Option::<Empty>::deserialize(string_deserializer)?.unwrap())
-    }
-}
 
 impl crate::message::Message for Empty {
     fn typename() -> &'static str {
@@ -63,20 +47,6 @@ mod tests {
     #[test]
     fn deserialize() -> Result {
         let got = serde_json::from_value(json!({}))?;
-        assert_eq!(Empty::default(), got);
-        Ok(())
-    }
-
-    #[test]
-    fn deserialize_null() -> Result {
-        let got = serde_json::from_value(json!(null))?;
-        assert_eq!(Empty::default(), got);
-        Ok(())
-    }
-
-    #[test]
-    fn deserialize_empty() -> Result {
-        let got = serde_json::from_str("")?;
         assert_eq!(Empty::default(), got);
         Ok(())
     }


### PR DESCRIPTION
In a typical AIP compliant library, successful delete operations return google.protobuf.Empty as their response [AIP-135](https://google.aip.dev/135). When in REST Fallback mode  this means a response would be `{}` - empty JSON. However, certain services return `null` with a 204 `No Content` response, instead of an empty JSON response. This behavior happens with BigQuery and Compute for example. This means that with certain RPCs (mainly some delete operations), users using BigQuery or Compute in REST mode will get an error returned when the call actually succeeded on the call side.

`serde_json` throws an error when trying to deserialize with an empty byte array:
```
Error("EOF while parsing a value", line: 1, column: 0)
```

This PR refactor the `reqwest::Response` parsing to a separated method and handles the case for `204` responses with no body, returning the `Default` value for the target struct.