### PR TITLE
cleanup(wkt)!: hide message serialize fns

### DIFF
--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -26,6 +26,7 @@ pub trait Message {
     /// The typename of this message.
     fn typename() -> &'static str;
 
+    #[doc(hidden)]
     /// Store the value into a JSON object.
     fn to_map(&self) -> Result<Map, Error>
     where
@@ -34,6 +35,7 @@ pub trait Message {
         to_json_object(self)
     }
 
+    #[doc(hidden)]
     /// Extract the value from a JSON object.
     fn from_map(map: &Map) -> Result<Self, Error>
     where


### PR DESCRIPTION
Part of the work for #1609 

In Rust, hiding something from the docs is akin to removing it from the public API.

Downstream crates can override the default implementation for these functions... they just shouldn't. The rest of #1609 has to do with making it so downstream crates can't override the default implementation.

cc: @chrischiedo 