### PR TITLE
impl(generator): fix protobuf auto populated fields

### DIFF
--- a/generator/internal/parser/protobuf_annotations.go
+++ b/generator/internal/parser/protobuf_annotations.go
@@ -154,14 +154,14 @@ func protobufIsAutoPopulated(field *descriptorpb.FieldDescriptorProto) bool {
 	}
 	extensionId = annotations.E_FieldBehavior
 	if !proto.HasExtension(field.GetOptions(), extensionId) {
-		return false
+		return true
 	}
 	fieldBehavior := proto.GetExtension(field.GetOptions(), extensionId).([]annotations.FieldBehavior)
 	for _, b := range fieldBehavior {
 		if b == annotations.FieldBehavior_REQUIRED {
-			return true
+			return false
 		}
 	}
 
-	return false
+	return true
 }

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1286,11 +1286,12 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 					AutoPopulatedFields: []string{
 						"request_id",
 						"request_id_optional",
+						"request_id_with_field_behavior",
 						// Intentionally add some fields that are not
 						// auto-populated to test the other conditions.
 						"not_request_id_bad_type",
-						"not_request_id_missing_field_behavior",
-						"not_request_id_bad_field_behavior",
+						"not_request_id_required",
+						"not_request_id_required_with_other_field_behavior",
 						"not_request_id_missing_field_info",
 						"not_request_id_missing_field_info_format",
 						"not_request_id_bad_field_info_format",
@@ -1342,9 +1343,9 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 				Name:     "request_id",
 				JSONName: "requestId",
 				ID:       ".test.CreateFooRequest.request_id",
-				Documentation: "Required. This is an auto-populated field. The remaining fields almost\n" +
-					"meet the requirements to be auto-populated, but fail for the reasons\n" +
-					"implied by their name.",
+				Documentation: "This is an auto-populated field. The remaining fields almost meet the\n" +
+					"requirements to be auto-populated, but fail for the reasons implied by\n" +
+					"their name.",
 				Typez:         api.STRING_TYPE,
 				AutoPopulated: true,
 			},
@@ -1356,6 +1357,13 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 				Optional:      true,
 				AutoPopulated: true,
 			},
+			{
+				Name:          "request_id_with_field_behavior",
+				ID:            ".test.CreateFooRequest.request_id_with_field_behavior",
+				Typez:         api.STRING_TYPE,
+				JSONName:      "requestIdWithFieldBehavior",
+				AutoPopulated: true,
+			},
 
 			{
 				Name:     "not_request_id_bad_type",
@@ -1364,16 +1372,16 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 				JSONName: "notRequestIdBadType",
 			},
 			{
-				Name:     "not_request_id_missing_field_behavior",
-				ID:       ".test.CreateFooRequest.not_request_id_missing_field_behavior",
+				Name:     "not_request_id_required",
+				ID:       ".test.CreateFooRequest.not_request_id_required",
 				Typez:    api.STRING_TYPE,
-				JSONName: "notRequestIdMissingFieldBehavior",
+				JSONName: "notRequestIdRequired",
 			},
 			{
-				Name:     "not_request_id_bad_field_behavior",
-				ID:       ".test.CreateFooRequest.not_request_id_bad_field_behavior",
+				Name:     "not_request_id_required_with_other_field_behavior",
+				ID:       ".test.CreateFooRequest.not_request_id_required_with_other_field_behavior",
 				Typez:    api.STRING_TYPE,
-				JSONName: "notRequestIdBadFieldBehavior",
+				JSONName: "notRequestIdRequiredWithOtherFieldBehavior",
 			},
 			{
 				Name:     "not_request_id_missing_field_info",

--- a/generator/internal/parser/testdata/auto_populated.proto
+++ b/generator/internal/parser/testdata/auto_populated.proto
@@ -67,49 +67,49 @@ message CreateFooRequest {
   // Required. A [Foo][test.Foo] with initial field values.
   Foo foo = 3 [(google.api.field_behavior) = REQUIRED];
 
-  // Required. This is an auto-populated field. The remaining fields almost
-  // meet the requirements to be auto-populated, but fail for the reasons
-  // implied by their name.
+  // This is an auto-populated field. The remaining fields almost meet the
+  // requirements to be auto-populated, but fail for the reasons implied by
+  // their name.
   string request_id = 4 [
-    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 
   optional string request_id_optional = 5 [
-    (google.api.field_behavior) = REQUIRED,
     (google.api.field_info).format = UUID4
   ];
 
-  bytes not_request_id_bad_type = 6 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.field_info).format = UUID4
-  ];
-
-  string not_request_id_missing_field_behavior = 7 [
-    (google.api.field_info).format = UUID4
-  ];
-
-  string not_request_id_bad_field_behavior = 8 [
+  string request_id_with_field_behavior = 6 [
     (google.api.field_behavior) = OPTIONAL,
+    (google.api.field_behavior) = INPUT_ONLY,
     (google.api.field_info).format = UUID4
   ];
 
-  string not_request_id_missing_field_info = 9 [
-    (google.api.field_behavior) = REQUIRED
+  bytes not_request_id_bad_type = 7 [
+    (google.api.field_info).format = UUID4
   ];
 
-  string not_request_id_missing_field_info_format = 10 [
+  string not_request_id_required = 8 [
     (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
+
+  string not_request_id_required_with_other_field_behavior = 9 [
+    (google.api.field_behavior) = INPUT_ONLY,
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.field_info).format = UUID4
+  ];
+
+  string not_request_id_missing_field_info = 10;
+
+  string not_request_id_missing_field_info_format = 11 [
     (google.api.field_info).referenced_types = {type_name: "*"}
   ];
 
-  string not_request_id_bad_field_info_format = 11 [
-    (google.api.field_behavior) = REQUIRED,
+  string not_request_id_bad_field_info_format = 12 [
     (google.api.field_info).format = IPV6
   ];
 
-  string not_request_id_missing_service_config = 12 [
-    (google.api.field_behavior) = REQUIRED,
+  string not_request_id_missing_service_config = 13 [
     (google.api.field_info).format = UUID4
   ];
 }


### PR DESCRIPTION
Part of the work for #439 

https://google.aip.dev/client-libraries/4235 says:

> The field must not be annotated with [`google.api.field_behavior = REQUIRED`](https://google.aip.dev/203#required).

I assume we will need to do the same thing for the OpenAPI version.

`impl` instead of `fix`, because we do not use the `AutoPopulated` field in practice.