### PR TITLE
feat(generator/rust): workaround for veneers

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -83,6 +83,8 @@ type serviceAnnotations struct {
 	APITitle string
 	// If set, gate this service under a feature named `ModuleName`.
 	PerServiceFeatures bool
+	// If set, skip the builder documentation.
+	SkipBuilderDocs bool
 }
 
 func (a *messageAnnotation) MultiFeatureGates() bool {
@@ -153,6 +155,7 @@ type methodAnnotation struct {
 	OperationInfo       *operationInfo
 	SystemParameters    []systemParameter
 	ReturnType          string
+	SkipBuilderDocs     bool
 }
 
 type pathInfoAnnotation struct {
@@ -453,6 +456,7 @@ func (c *codec) annotateService(s *api.Service, model *api.API) {
 		HasLROs:            hasLROs,
 		APITitle:           model.Title,
 		PerServiceFeatures: c.perServiceFeatures,
+		SkipBuilderDocs:    c.skipBuilderDocs,
 	}
 	s.Codec = ann
 }
@@ -575,6 +579,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		ServiceNameToSnake:  toSnake(s.Name),
 		SystemParameters:    c.systemParameters,
 		ReturnType:          returnType,
+		SkipBuilderDocs:     c.skipBuilderDocs,
 	}
 	if m.OperationInfo != nil {
 		metadataType := c.methodInOutTypeName(m.OperationInfo.MetadataTypeID, state, sourceSpecificationPackageName)

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -117,6 +117,12 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 				return nil, fmt.Errorf("cannot convert `per-service-features` value %q to boolean: %w", definition, err)
 			}
 			codec.perServiceFeatures = value
+		case key == "skip-builder-docs":
+			value, err := strconv.ParseBool(definition)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert `skip-builder-docs` value %q to boolean: %w", definition, err)
+			}
+			codec.skipBuilderDocs = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -219,8 +225,10 @@ type codec struct {
 	// If true, this includes gRPC-only methods, such as methods without HTTP
 	// annotations.
 	includeGrpcOnlyMethods bool
-	// If true, the generator will produce per-client features
+	// If true, the generator will produce per-client features.
 	perServiceFeatures bool
+	// If true, skip the documentation for Client and Request builders.
+	skipBuilderDocs bool
 }
 
 type systemParameter struct {

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -27,6 +27,7 @@ pub mod {{Codec.ModuleName}} {
     use crate::Result;
     use std::sync::Arc;
 
+    {{^Codec.SkipBuilderDocs}}
     /// A builder for [{{Codec.Name}}][super::super::client::{{Codec.Name}}].
     ///
     /// ```
@@ -40,6 +41,7 @@ pub mod {{Codec.ModuleName}} {
     ///     .build().await?;
     /// # gax::Result::<()>::Ok(()) });
     /// ```
+    {{/Codec.SkipBuilderDocs}}
     pub type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
 
@@ -75,7 +77,9 @@ pub mod {{Codec.ModuleName}} {
     }
 
     {{#Codec.Methods}}
+    {{^Codec.SkipBuilderDocs}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][super::super::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
+    {{/Codec.SkipBuilderDocs}}
     #[derive(Clone, Debug)]
     pub struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 

--- a/src/storage/src/generated/gapic/.sidekick.toml
+++ b/src/storage/src/generated/gapic/.sidekick.toml
@@ -30,3 +30,5 @@ copyright-year            = '2025'
 template-override         = 'templates/grpc-client'
 package-name-override     = 'google-cloud-storage'
 include-grpc-only-methods = 'true'
+# TODO(#1813) - temporarily disable the docs because they don't compile.
+skip-builder-docs         = 'true'

--- a/src/storage/src/generated/gapic/builder.rs
+++ b/src/storage/src/generated/gapic/builder.rs
@@ -18,19 +18,6 @@ pub mod storage {
     use crate::Result;
     use std::sync::Arc;
 
-    /// A builder for [Storage][super::super::client::Storage].
-    ///
-    /// ```
-    /// # tokio_test::block_on(async {
-    /// # use google_cloud_storage::*;
-    /// # use builder::storage::ClientBuilder;
-    /// # use client::Storage;
-    /// let builder : ClientBuilder = Storage::builder();
-    /// let client = builder
-    ///     .with_endpoint("https://storage.googleapis.com")
-    ///     .build().await?;
-    /// # gax::Result::<()>::Ok(()) });
-    /// ```
     pub type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
 
@@ -67,7 +54,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::delete_bucket][super::super::client::Storage::delete_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteBucket(RequestBuilder<crate::model::DeleteBucketRequest>);
 
@@ -128,7 +114,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::get_bucket][super::super::client::Storage::get_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct GetBucket(RequestBuilder<crate::model::GetBucketRequest>);
 
@@ -195,7 +180,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::create_bucket][super::super::client::Storage::create_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct CreateBucket(RequestBuilder<crate::model::CreateBucketRequest>);
 
@@ -268,7 +252,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::list_buckets][super::super::client::Storage::list_buckets] calls.
     #[derive(Clone, Debug)]
     pub struct ListBuckets(RequestBuilder<crate::model::ListBucketsRequest>);
 
@@ -350,7 +333,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::lock_bucket_retention_policy][super::super::client::Storage::lock_bucket_retention_policy] calls.
     #[derive(Clone, Debug)]
     pub struct LockBucketRetentionPolicy(
         RequestBuilder<crate::model::LockBucketRetentionPolicyRequest>,
@@ -404,7 +386,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::update_bucket][super::super::client::Storage::update_bucket] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateBucket(RequestBuilder<crate::model::UpdateBucketRequest>);
 
@@ -492,7 +473,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::compose_object][super::super::client::Storage::compose_object] calls.
     #[derive(Clone, Debug)]
     pub struct ComposeObject(RequestBuilder<crate::model::ComposeObjectRequest>);
 
@@ -599,7 +579,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::delete_object][super::super::client::Storage::delete_object] calls.
     #[derive(Clone, Debug)]
     pub struct DeleteObject(RequestBuilder<crate::model::DeleteObjectRequest>);
 
@@ -698,7 +677,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::restore_object][super::super::client::Storage::restore_object] calls.
     #[derive(Clone, Debug)]
     pub struct RestoreObject(RequestBuilder<crate::model::RestoreObjectRequest>);
 
@@ -809,7 +787,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::cancel_resumable_write][super::super::client::Storage::cancel_resumable_write] calls.
     #[derive(Clone, Debug)]
     pub struct CancelResumableWrite(RequestBuilder<crate::model::CancelResumableWriteRequest>);
 
@@ -855,7 +832,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::get_object][super::super::client::Storage::get_object] calls.
     #[derive(Clone, Debug)]
     pub struct GetObject(RequestBuilder<crate::model::GetObjectRequest>);
 
@@ -972,7 +948,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::update_object][super::super::client::Storage::update_object] calls.
     #[derive(Clone, Debug)]
     pub struct UpdateObject(RequestBuilder<crate::model::UpdateObjectRequest>);
 
@@ -1077,7 +1052,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::list_objects][super::super::client::Storage::list_objects] calls.
     #[derive(Clone, Debug)]
     pub struct ListObjects(RequestBuilder<crate::model::ListObjectsRequest>);
 
@@ -1207,7 +1181,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::rewrite_object][super::super::client::Storage::rewrite_object] calls.
     #[derive(Clone, Debug)]
     pub struct RewriteObject(RequestBuilder<crate::model::RewriteObjectRequest>);
 
@@ -1426,7 +1399,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::start_resumable_write][super::super::client::Storage::start_resumable_write] calls.
     #[derive(Clone, Debug)]
     pub struct StartResumableWrite(RequestBuilder<crate::model::StartResumableWriteRequest>);
 
@@ -1497,7 +1469,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::query_write_status][super::super::client::Storage::query_write_status] calls.
     #[derive(Clone, Debug)]
     pub struct QueryWriteStatus(RequestBuilder<crate::model::QueryWriteStatusRequest>);
 
@@ -1554,7 +1525,6 @@ pub mod storage {
         }
     }
 
-    /// The request builder for [Storage::move_object][super::super::client::Storage::move_object] calls.
     #[derive(Clone, Debug)]
     pub struct MoveObject(RequestBuilder<crate::model::MoveObjectRequest>);
 


### PR DESCRIPTION
While we figure out how to generate properly linked documentation for
client and request builders, we just disable the comments. They break
the build and we need to unblock development of some clients.

Part of the work for #1813
