### PR TITLE
test: verify enums as query parameters work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4978,6 +4978,7 @@ dependencies = [
  "google-cloud-secretmanager-v1",
  "google-cloud-telcoautomation-v1",
  "google-cloud-wkt",
+ "google-cloud-workflows-executions-v1",
  "google-cloud-workflows-v1",
  "mockall",
  "rand 0.9.0",

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -57,6 +57,10 @@ path    = "../../src/generated/cloud/telcoautomation/v1"
 package = "google-cloud-workflows-v1"
 path    = "../../src/generated/cloud/workflows/v1"
 
+[dependencies.wfe]
+package = "google-cloud-workflows-executions-v1"
+path    = "../../src/generated/cloud/workflows/executions/v1"
+
 [dev-dependencies]
 anyhow     = "1"
 mockall    = "0.13"

--- a/src/integration-tests/src/lib.rs
+++ b/src/integration-tests/src/lib.rs
@@ -13,13 +13,18 @@
 // limitations under the License.
 
 use gax::error::Error;
+use rand::{Rng, distr::Alphanumeric};
+
 pub type Result<T> = std::result::Result<T, gax::error::Error>;
 pub mod error_details;
 pub mod firestore;
 pub mod secret_manager;
 pub mod workflows;
+pub mod workflows_executions;
 
 pub const SECRET_ID_LENGTH: usize = 64;
+
+pub const WORKFLOW_ID_LENGTH: usize = 64;
 
 /// Returns the project id used for the integration tests.
 pub fn project_id() -> Result<String> {
@@ -44,4 +49,16 @@ pub fn region_id() -> String {
 pub fn workflows_runner() -> Result<String> {
     let value = std::env::var("GOOGLE_CLOUD_RUST_TEST_WORKFLOWS_RUNNER").map_err(Error::other)?;
     Ok(value)
+}
+
+pub(crate) fn random_workflow_id() -> String {
+    // Workflow ids must start with a letter, we use `wf-` as a prefix to
+    // meet this requirement.
+    const PREFIX: &str = "wf-";
+    let workflow_id: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(WORKFLOW_ID_LENGTH - PREFIX.len())
+        .map(char::from)
+        .collect();
+    format!("{PREFIX}{workflow_id}")
 }

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -16,11 +16,8 @@ use crate::Result;
 use gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use gax::paginator::{ItemPaginator, Paginator};
 use gax::{error::Error, options::RequestOptionsBuilder};
-use rand::{Rng, distr::Alphanumeric};
 use std::time::Duration;
 use wf::Poller;
-
-pub const WORKFLOW_ID_LENGTH: usize = 64;
 
 pub async fn until_done(builder: wf::builder::workflows::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
@@ -51,15 +48,7 @@ main:
             return: Hello World
 "###;
     let source_code = wf::model::workflow::SourceCode::SourceContents(source_contents.to_string());
-    let prefix = "wf-";
-    let workflow_id: String = rand::rng()
-        .sample_iter(&Alphanumeric)
-        // Workflow ids must start with a letter, we use `wf-` as a prefix to
-        // this requirement (see below).
-        .take(WORKFLOW_ID_LENGTH - prefix.len())
-        .map(char::from)
-        .collect();
-    let workflow_id = format!("{prefix}{workflow_id}");
+    let workflow_id = crate::random_workflow_id();
 
     println!("\n\nStart create_workflow() LRO and poll it to completion");
     let response = client
@@ -119,15 +108,7 @@ main:
             return: Hello World
 "###;
     let source_code = wf::model::workflow::SourceCode::SourceContents(source_contents.to_string());
-    let prefix = "wf-";
-    let workflow_id: String = rand::rng()
-        .sample_iter(&Alphanumeric)
-        // Workflow ids must start with a letter, we use `wf-` as a prefix to
-        // this requirement (see below).
-        .take(WORKFLOW_ID_LENGTH - prefix.len())
-        .map(char::from)
-        .collect();
-    let workflow_id = format!("{prefix}{workflow_id}");
+    let workflow_id = crate::random_workflow_id();
 
     println!("\n\nStart create_workflow() LRO and poll it to completion");
     let mut create = client

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -112,7 +112,7 @@ main:
                 .set_service_account(&workflows_runner)
                 .set_source_code(source_code),
         )
-        .with_polling_backoff_policy(test_backoff()?)
+        .with_polling_backoff_policy(test_backoff())
         .poller()
         .until_done()
         .await?;

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
+use gax::options::RequestOptionsBuilder;
+use gax::paginator::{ItemPaginator, Paginator};
+use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+use std::time::Duration;
+use wf::Poller;
+
+// Verify enum query parameters are serialize correctly.
+pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()> {
+    // Enable a basic subscriber. Useful to troubleshoot problems and visually
+    // verify tracing is doing something.
+    #[cfg(feature = "log-integration-tests")]
+    let _guard = {
+        use tracing_subscriber::fmt::format::FmtSpan;
+        let subscriber = tracing_subscriber::fmt()
+            .with_level(true)
+            .with_thread_ids(true)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .finish();
+
+        tracing::subscriber::set_default(subscriber)
+    };
+
+    // Create a workflow so we can list its executions. We rely on the existing
+    // workflows integration tests to delete it if something fails or crashes
+    // in this test.
+    let parent = create_test_workflow().await?;
+    let client = builder.build().await?;
+
+    // Create an execution with a label. The label is not returned for the `BASIC` view.
+    let start = client
+        .create_execution(&parent)
+        .set_execution(wfe::model::Execution::new().set_labels([("test-label", "test-value")]))
+        .send()
+        .await?;
+    tracing::info!("start was successful={start:?}");
+
+    // The execution list using the `BASIC` view.
+    let mut executions = client
+        .list_executions(&parent)
+        .set_view(wfe::model::ExecutionView::BASIC)
+        .paginator()
+        .await
+        .items();
+
+    while let Some(execution) = executions.next().await {
+        let execution = execution?;
+        tracing::info!("list item={execution:?}");
+        assert!(execution.labels.is_empty(), "{execution:?}");
+    }
+
+    // The execution list using the `FULL` view.
+    let mut executions = client
+        .list_executions(&parent)
+        .set_view(wfe::model::ExecutionView::FULL)
+        .paginator()
+        .await
+        .items();
+
+    while let Some(execution) = executions.next().await {
+        let execution = execution?;
+        tracing::info!("list item={execution:?}");
+        assert!(!execution.labels.is_empty(), "{execution:?}");
+    }
+
+    delete_test_workflow(parent).await
+}
+
+async fn delete_test_workflow(name: String) -> Result<()> {
+    let client = workflow_client().await?;
+    let _ = client.delete_workflow(name).poller().until_done().await?;
+    Ok(())
+}
+
+async fn create_test_workflow() -> Result<String> {
+    let project_id = crate::project_id()?;
+    let location_id = crate::region_id();
+    let workflows_runner = crate::workflows_runner()?;
+    let client = workflow_client().await?;
+
+    let source_contents = r###"# Test only workflow
+main:
+    steps:
+        - sayHello:
+            return: Hello World
+"###;
+    let source_code = wf::model::workflow::SourceCode::SourceContents(source_contents.to_string());
+    let workflow_id = crate::random_workflow_id();
+
+    tracing::info!("Start create_workflow() LRO and poll it to completion");
+    let response = client
+        .create_workflow(format!("projects/{project_id}/locations/{location_id}"))
+        .set_workflow_id(&workflow_id)
+        .set_workflow(
+            wf::model::Workflow::new()
+                .set_labels([("integration-test", "true")])
+                .set_service_account(&workflows_runner)
+                .set_source_code(source_code),
+        )
+        .with_polling_backoff_policy(test_backoff()?)
+        .poller()
+        .until_done()
+        .await?;
+    tracing::info!("create LRO finished, name={}", &response.name);
+
+    Ok(response.name)
+}
+
+async fn workflow_client() -> Result<wf::client::Workflows> {
+    wf::client::Workflows::builder()
+        .with_retry_policy(
+            AlwaysRetry
+                .with_time_limit(Duration::from_secs(15))
+                .with_attempt_limit(5),
+        )
+        .build()
+        .await
+}
+
+fn test_backoff() -> Result<ExponentialBackoff> {
+    ExponentialBackoffBuilder::new()
+        .with_initial_delay(Duration::from_millis(100))
+        .with_maximum_delay(Duration::from_secs(1))
+        .build()
+}

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -20,7 +20,7 @@ use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
 use std::time::Duration;
 use wf::Poller;
 
-// Verify enum query parameters are serialize correctly.
+// Verify enum query parameters are serialized correctly.
 pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()> {
     // Enable a basic subscriber. Useful to troubleshoot problems and visually
     // verify tracing is doing something.
@@ -36,7 +36,7 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
         tracing::subscriber::set_default(subscriber)
     };
 
-    // Create a workflow so we can list its executions. We rely on the existing
+    // Create a workflow so we can list its executions. We rely on the other
     // workflows integration tests to delete it if something fails or crashes
     // in this test.
     let parent = create_test_workflow().await?;
@@ -132,9 +132,10 @@ async fn workflow_client() -> Result<wf::client::Workflows> {
         .await
 }
 
-fn test_backoff() -> Result<ExponentialBackoff> {
+fn test_backoff() -> ExponentialBackoff {
     ExponentialBackoffBuilder::new()
         .with_initial_delay(Duration::from_millis(100))
         .with_maximum_delay(Duration::from_secs(1))
         .build()
+        .unwrap()
 }

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -123,4 +123,14 @@ mod driver {
             .await
             .map_err(report)
     }
+
+    #[test_case(wfe::client::Executions::builder().with_retry_policy(retry_policy()).with_tracing(); "with tracing and retry enabled")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn workflows_executions(
+        builder: wfe::builder::executions::ClientBuilder,
+    ) -> integration_tests::Result<()> {
+        integration_tests::workflows_executions::list(builder)
+            .await
+            .map_err(report)
+    }
 }


### PR DESCRIPTION
Verify we can successfully send enums as query parameters. There was
some question as to whether these worked fine when serialized as
integers.

Fixes #1932
