### PR TITLE
refactor(wkt): refactor `wkt::message::Message` trait to use new design

### DIFF
--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -710,7 +710,7 @@ mod test {
     #[test_case(RetryInfo::default(), StatusDetails::RetryInfo(RetryInfo::default()))]
     fn status_from_rpc_status_known_detail_type<T>(detail: T, want: StatusDetails)
     where
-        T: wkt::message::Message + serde::ser::Serialize,
+        T: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
     {
         let input = rpc::model::Status::default()
             .set_code(Code::Unavailable as i32)

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -710,7 +710,7 @@ mod test {
     #[test_case(RetryInfo::default(), StatusDetails::RetryInfo(RetryInfo::default()))]
     fn status_from_rpc_status_known_detail_type<T>(detail: T, want: StatusDetails)
     where
-        T: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+        T: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
     {
         let input = rpc::model::Status::default()
             .set_code(Code::Unavailable as i32)

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -24,8 +24,8 @@ pub(crate) fn handle_start<R, M>(
     result: Result<Operation<R, M>>,
 ) -> (Option<String>, PollingResult<R, M>)
 where
-    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
-    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
 {
     match result {
         Err(e) => (None, PollingResult::Completed(Err(e))),
@@ -41,8 +41,8 @@ pub(crate) fn handle_poll<R, M>(
     result: Result<Operation<R, M>>,
 ) -> (Option<String>, PollingResult<R, M>)
 where
-    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
-    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
 {
     match result {
         Err(e) => {
@@ -85,8 +85,8 @@ where
 
 fn handle_common<R, M>(op: Operation<R, M>) -> (Option<String>, PollingResult<R, M>)
 where
-    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
-    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
 {
     if op.done() {
         let result = as_result(op);
@@ -99,7 +99,7 @@ where
 
 fn as_result<R, M>(op: Operation<R, M>) -> Result<R>
 where
-    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
     if let Some(any) = op.response() {
@@ -114,7 +114,7 @@ where
 fn as_metadata<R, M>(op: Operation<R, M>) -> Option<M>
 where
     R: wkt::message::Message + serde::de::DeserializeOwned,
-    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
 {
     op.metadata().and_then(|a| a.try_into_message::<M>().ok())
 }

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -24,8 +24,8 @@ pub(crate) fn handle_start<R, M>(
     result: Result<Operation<R, M>>,
 ) -> (Option<String>, PollingResult<R, M>)
 where
-    R: wkt::message::Message + serde::de::DeserializeOwned,
-    M: wkt::message::Message + serde::de::DeserializeOwned,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
 {
     match result {
         Err(e) => (None, PollingResult::Completed(Err(e))),
@@ -41,8 +41,8 @@ pub(crate) fn handle_poll<R, M>(
     result: Result<Operation<R, M>>,
 ) -> (Option<String>, PollingResult<R, M>)
 where
-    R: wkt::message::Message + serde::de::DeserializeOwned,
-    M: wkt::message::Message + serde::de::DeserializeOwned,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
 {
     match result {
         Err(e) => {
@@ -85,8 +85,8 @@ where
 
 fn handle_common<R, M>(op: Operation<R, M>) -> (Option<String>, PollingResult<R, M>)
 where
-    R: wkt::message::Message + serde::de::DeserializeOwned,
-    M: wkt::message::Message + serde::de::DeserializeOwned,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
 {
     if op.done() {
         let result = as_result(op);
@@ -99,7 +99,7 @@ where
 
 fn as_result<R, M>(op: Operation<R, M>) -> Result<R>
 where
-    R: wkt::message::Message + serde::de::DeserializeOwned,
+    R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
     M: wkt::message::Message + serde::de::DeserializeOwned,
 {
     if let Some(any) = op.response() {
@@ -114,7 +114,7 @@ where
 fn as_metadata<R, M>(op: Operation<R, M>) -> Option<M>
 where
     R: wkt::message::Message + serde::de::DeserializeOwned,
-    M: wkt::message::Message + serde::de::DeserializeOwned,
+    M: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + 'static,
 {
     op.metadata().and_then(|a| a.try_into_message::<M>().ok())
 }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -131,8 +131,16 @@ pub fn new_poller<ResponseType, MetadataType, S, SF, Q, QF>(
     query: Q,
 ) -> impl Poller<ResponseType, MetadataType>
 where
-    ResponseType: wkt::message::Message + serde::de::DeserializeOwned + Send,
-    MetadataType: wkt::message::Message + serde::de::DeserializeOwned + Send,
+    ResponseType: wkt::message::Message
+        + serde::ser::Serialize
+        + serde::de::DeserializeOwned
+        + Send
+        + 'static,
+    MetadataType: wkt::message::Message
+        + serde::ser::Serialize
+        + serde::de::DeserializeOwned
+        + Send
+        + 'static,
     S: FnOnce() -> SF + Send + Sync,
     SF: std::future::Future<Output = Result<Operation<ResponseType, MetadataType>>>
         + Send
@@ -218,8 +226,16 @@ where
 impl<ResponseType, MetadataType, S, SF, P, PF> Poller<ResponseType, MetadataType>
     for PollerImpl<ResponseType, MetadataType, S, SF, P, PF>
 where
-    ResponseType: wkt::message::Message + serde::de::DeserializeOwned + Send,
-    MetadataType: wkt::message::Message + serde::de::DeserializeOwned + Send,
+    ResponseType: wkt::message::Message
+        + serde::ser::Serialize
+        + serde::de::DeserializeOwned
+        + Send
+        + 'static,
+    MetadataType: wkt::message::Message
+        + serde::ser::Serialize
+        + serde::de::DeserializeOwned
+        + Send
+        + 'static,
     S: FnOnce() -> SF + Send + Sync,
     SF: std::future::Future<Output = Result<Operation<ResponseType, MetadataType>>>
         + Send

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -131,16 +131,10 @@ pub fn new_poller<ResponseType, MetadataType, S, SF, Q, QF>(
     query: Q,
 ) -> impl Poller<ResponseType, MetadataType>
 where
-    ResponseType: wkt::message::Message
-        + serde::ser::Serialize
-        + serde::de::DeserializeOwned
-        + Send
-        + 'static,
-    MetadataType: wkt::message::Message
-        + serde::ser::Serialize
-        + serde::de::DeserializeOwned
-        + Send
-        + 'static,
+    ResponseType:
+        wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
+    MetadataType:
+        wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
     S: FnOnce() -> SF + Send + Sync,
     SF: std::future::Future<Output = Result<Operation<ResponseType, MetadataType>>>
         + Send
@@ -226,16 +220,10 @@ where
 impl<ResponseType, MetadataType, S, SF, P, PF> Poller<ResponseType, MetadataType>
     for PollerImpl<ResponseType, MetadataType, S, SF, P, PF>
 where
-    ResponseType: wkt::message::Message
-        + serde::ser::Serialize
-        + serde::de::DeserializeOwned
-        + Send
-        + 'static,
-    MetadataType: wkt::message::Message
-        + serde::ser::Serialize
-        + serde::de::DeserializeOwned
-        + Send
-        + 'static,
+    ResponseType:
+        wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
+    MetadataType:
+        wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
     S: FnOnce() -> SF + Send + Sync,
     SF: std::future::Future<Output = Result<Operation<ResponseType, MetadataType>>>
         + Send

--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -105,7 +105,6 @@ impl Any {
     where
         T: crate::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
     {
-        // Get the serializer for type T and use it to convert the message to a map
         let serializer = T::serializer();
         let value = serializer.serialize_to_map(message)?;
         Ok(Any(value))
@@ -124,7 +123,6 @@ impl Any {
             .map_err(Error::deser)?;
         Self::check_typename(r#type, T::typename())?;
 
-        // Get the serializer for type T and use it to convert the map to a message
         let serializer = T::serializer();
         serializer.deserialize_from_map(map)
     }
@@ -144,7 +142,6 @@ impl crate::message::Message for Any {
         "type.googleapis.com/google.protobuf.Any"
     }
 
-    // Override the default serializer to use custom serialization
     #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         crate::message::ValueSerializer::<Self>::new()

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -166,23 +166,9 @@ impl crate::message::Message for Duration {
     }
 
     // Override the default serializer to use custom serialization
-    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
-    where
-        Self: Sized,
-    {
-        Box::new(DurationSerializer)
-    }
-}
-
-struct DurationSerializer;
-
-impl crate::message::MessageSerializer<Duration> for DurationSerializer {
-    fn to_map(&self, message: &Duration) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(message)
-    }
-
-    fn from_map(&self, map: &crate::message::Map) -> Result<Duration, crate::AnyError> {
-        crate::message::from_other(map)
+    #[allow(private_interfaces)]
+    fn serializer() -> impl crate::message::MessageSerializer<Self> {
+        crate::message::ValueSerializer::<Self>::new()
     }
 }
 

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -164,10 +164,24 @@ impl crate::message::Message for Duration {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Duration"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(self)
+
+    // Override the default serializer to use custom serialization
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(DurationSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct DurationSerializer;
+
+impl crate::message::MessageSerializer<Duration> for DurationSerializer {
+    fn to_map(&self, message: &Duration) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(message)
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<Duration, crate::AnyError> {
         crate::message::from_other(map)
     }
 }

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -165,7 +165,6 @@ impl crate::message::Message for Duration {
         "type.googleapis.com/google.protobuf.Duration"
     }
 
-    // Override the default serializer to use custom serialization
     #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         crate::message::ValueSerializer::<Self>::new()

--- a/src/wkt/src/message.rs
+++ b/src/wkt/src/message.rs
@@ -26,7 +26,7 @@ pub trait Message {
     /// The typename of this message.
     fn typename() -> &'static str;
 
-    /// Returns the serializer for this message type
+    /// Returns the serializer for this message type.
     #[doc(hidden)]
     #[allow(private_interfaces)]
     fn serializer() -> impl MessageSerializer<Self>
@@ -47,7 +47,7 @@ pub(crate) trait MessageSerializer<T> {
     fn deserialize_from_map(&self, map: &Map) -> Result<T, Error>;
 }
 
-// Default serializer that most types can use
+// Default serializer that most types can use.
 pub(crate) struct DefaultSerializer<T> {
     _phantom: std::marker::PhantomData<T>,
 }
@@ -205,7 +205,6 @@ mod test {
         });
         let map = input.as_object().cloned().unwrap();
 
-        // Get the serializer for TestMessage and use it to deserialize
         let serializer = TestMessage::serializer();
         let test = serializer.deserialize_from_map(&map).unwrap();
 

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -44,10 +44,24 @@ impl crate::message::Message for Struct {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Struct"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(self)
+
+    // Override the default serializer to use custom serialization
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(StructSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct StructSerializer;
+
+impl crate::message::MessageSerializer<Struct> for StructSerializer {
+    fn to_map(&self, message: &Struct) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(message)
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<Struct, crate::AnyError> {
         crate::message::from_other(map)
     }
 }
@@ -56,10 +70,24 @@ impl crate::message::Message for Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Value"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(self)
+
+    // Override the default serializer to use custom serialization
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(ValueSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct ValueSerializer;
+
+impl crate::message::MessageSerializer<Value> for ValueSerializer {
+    fn to_map(&self, message: &Value) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(message)
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<Value, crate::AnyError> {
         crate::message::from_other(map)
     }
 }
@@ -68,10 +96,24 @@ impl crate::message::Message for ListValue {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.ListValue"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(self)
+
+    // Override the default serializer to use custom serialization
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(ListValueSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct ListValueSerializer;
+
+impl crate::message::MessageSerializer<ListValue> for ListValueSerializer {
+    fn to_map(&self, message: &ListValue) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(message)
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<ListValue, crate::AnyError> {
         crate::message::from_other(map)
     }
 }

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -46,23 +46,9 @@ impl crate::message::Message for Struct {
     }
 
     // Override the default serializer to use custom serialization
-    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
-    where
-        Self: Sized,
-    {
-        Box::new(StructSerializer)
-    }
-}
-
-struct StructSerializer;
-
-impl crate::message::MessageSerializer<Struct> for StructSerializer {
-    fn to_map(&self, message: &Struct) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(message)
-    }
-
-    fn from_map(&self, map: &crate::message::Map) -> Result<Struct, crate::AnyError> {
-        crate::message::from_other(map)
+    #[allow(private_interfaces)]
+    fn serializer() -> impl crate::message::MessageSerializer<Self> {
+        crate::message::ValueSerializer::<Self>::new()
     }
 }
 
@@ -72,23 +58,9 @@ impl crate::message::Message for Value {
     }
 
     // Override the default serializer to use custom serialization
-    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
-    where
-        Self: Sized,
-    {
-        Box::new(ValueSerializer)
-    }
-}
-
-struct ValueSerializer;
-
-impl crate::message::MessageSerializer<Value> for ValueSerializer {
-    fn to_map(&self, message: &Value) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(message)
-    }
-
-    fn from_map(&self, map: &crate::message::Map) -> Result<Value, crate::AnyError> {
-        crate::message::from_other(map)
+    #[allow(private_interfaces)]
+    fn serializer() -> impl crate::message::MessageSerializer<Self> {
+        crate::message::ValueSerializer::<Self>::new()
     }
 }
 
@@ -98,23 +70,9 @@ impl crate::message::Message for ListValue {
     }
 
     // Override the default serializer to use custom serialization
-    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
-    where
-        Self: Sized,
-    {
-        Box::new(ListValueSerializer)
-    }
-}
-
-struct ListValueSerializer;
-
-impl crate::message::MessageSerializer<ListValue> for ListValueSerializer {
-    fn to_map(&self, message: &ListValue) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(message)
-    }
-
-    fn from_map(&self, map: &crate::message::Map) -> Result<ListValue, crate::AnyError> {
-        crate::message::from_other(map)
+    #[allow(private_interfaces)]
+    fn serializer() -> impl crate::message::MessageSerializer<Self> {
+        crate::message::ValueSerializer::<Self>::new()
     }
 }
 

--- a/src/wkt/src/rstruct.rs
+++ b/src/wkt/src/rstruct.rs
@@ -45,7 +45,6 @@ impl crate::message::Message for Struct {
         "type.googleapis.com/google.protobuf.Struct"
     }
 
-    // Override the default serializer to use custom serialization
     #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         crate::message::ValueSerializer::<Self>::new()
@@ -57,7 +56,6 @@ impl crate::message::Message for Value {
         "type.googleapis.com/google.protobuf.Value"
     }
 
-    // Override the default serializer to use custom serialization
     #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         crate::message::ValueSerializer::<Self>::new()
@@ -69,7 +67,6 @@ impl crate::message::Message for ListValue {
         "type.googleapis.com/google.protobuf.ListValue"
     }
 
-    // Override the default serializer to use custom serialization
     #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         crate::message::ValueSerializer::<Self>::new()

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -170,7 +170,6 @@ impl crate::message::Message for Timestamp {
         "type.googleapis.com/google.protobuf.Timestamp"
     }
 
-    // Override the default serializer to use custom serialization
     #[allow(private_interfaces)]
     fn serializer() -> impl crate::message::MessageSerializer<Self> {
         crate::message::ValueSerializer::<Self>::new()

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -171,23 +171,9 @@ impl crate::message::Message for Timestamp {
     }
 
     // Override the default serializer to use custom serialization
-    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
-    where
-        Self: Sized,
-    {
-        Box::new(TimestampSerializer)
-    }
-}
-
-struct TimestampSerializer;
-
-impl crate::message::MessageSerializer<Timestamp> for TimestampSerializer {
-    fn to_map(&self, message: &Timestamp) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(message)
-    }
-
-    fn from_map(&self, map: &crate::message::Map) -> Result<Timestamp, crate::AnyError> {
-        crate::message::from_other(map)
+    #[allow(private_interfaces)]
+    fn serializer() -> impl crate::message::MessageSerializer<Self> {
+        crate::message::ValueSerializer::<Self>::new()
     }
 }
 

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -169,10 +169,24 @@ impl crate::message::Message for Timestamp {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Timestamp"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        crate::message::to_json_other(self)
+
+    // Override the default serializer to use custom serialization
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(TimestampSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct TimestampSerializer;
+
+impl crate::message::MessageSerializer<Timestamp> for TimestampSerializer {
+    fn to_map(&self, message: &Timestamp) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(message)
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<Timestamp, crate::AnyError> {
         crate::message::from_other(map)
     }
 }

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -113,17 +113,43 @@ pub type StringValue = String;
 /// The JSON representation for `BytesValue` is JSON string.
 pub type BytesValue = bytes::Bytes;
 
+pub(crate) struct ProtobufTypeSerializer<T> {
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> ProtobufTypeSerializer<T> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> crate::message::MessageSerializer<T> for ProtobufTypeSerializer<T>
+where
+    T: serde::ser::Serialize + serde::de::DeserializeOwned + crate::message::Message,
+{
+    fn to_map(&self, message: &T) -> Result<crate::message::Map, crate::AnyError> {
+        crate::message::to_json_other(message)
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<T, crate::AnyError> {
+        crate::message::from_other(map)
+    }
+}
+
 macro_rules! impl_message {
     ($t: ty) => {
         impl crate::message::Message for $t {
             fn typename() -> &'static str {
                 concat!("type.googleapis.com/google.protobuf.", stringify!($t))
             }
-            fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-                crate::message::to_json_other(self)
-            }
-            fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
-                crate::message::from_other(map)
+
+            fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+            where
+                Self: Sized,
+            {
+                Box::new(ProtobufTypeSerializer::<Self>::new())
             }
         }
     };
@@ -157,10 +183,23 @@ impl crate::message::Message for UInt64Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.UInt64Value"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        encode_string::<Self>(self.to_string())
+
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(UInt64ValueSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct UInt64ValueSerializer;
+
+impl crate::message::MessageSerializer<UInt64Value> for UInt64ValueSerializer {
+    fn to_map(&self, message: &UInt64Value) -> Result<crate::message::Map, crate::AnyError> {
+        encode_string::<UInt64Value>(message.to_string())
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<UInt64Value, crate::AnyError> {
         map.get("value")
             .ok_or_else(crate::message::missing_value_field)?
             .as_str()
@@ -174,10 +213,23 @@ impl crate::message::Message for Int64Value {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.Int64Value"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        encode_string::<Self>(self.to_string())
+
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized + serde::ser::Serialize,
+    {
+        Box::new(Int64ValueSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct Int64ValueSerializer;
+
+impl crate::message::MessageSerializer<Int64Value> for Int64ValueSerializer {
+    fn to_map(&self, message: &Int64Value) -> Result<crate::message::Map, crate::AnyError> {
+        encode_string::<Int64Value>(message.to_string())
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<Int64Value, crate::AnyError> {
         map.get("value")
             .ok_or_else(crate::message::missing_value_field)?
             .as_str()
@@ -191,10 +243,23 @@ impl crate::message::Message for BytesValue {
     fn typename() -> &'static str {
         "type.googleapis.com/google.protobuf.BytesValue"
     }
-    fn to_map(&self) -> Result<crate::message::Map, crate::AnyError> {
-        encode_string::<Self>(STANDARD.encode(self))
+
+    fn serializer() -> Box<dyn crate::message::MessageSerializer<Self>>
+    where
+        Self: Sized,
+    {
+        Box::new(BytesValueSerializer)
     }
-    fn from_map(map: &crate::message::Map) -> Result<Self, crate::AnyError> {
+}
+
+struct BytesValueSerializer;
+
+impl crate::message::MessageSerializer<BytesValue> for BytesValueSerializer {
+    fn to_map(&self, message: &BytesValue) -> Result<crate::message::Map, crate::AnyError> {
+        encode_string::<BytesValue>(STANDARD.encode(message))
+    }
+
+    fn from_map(&self, map: &crate::message::Map) -> Result<BytesValue, crate::AnyError> {
         let s = map
             .get("value")
             .ok_or_else(crate::message::missing_value_field)?
@@ -237,7 +302,8 @@ mod test {
             + std::fmt::Debug
             + PartialEq
             + serde::de::DeserializeOwned
-            + serde::ser::Serialize,
+            + serde::ser::Serialize
+            + 'static,
         V: serde::ser::Serialize,
     {
         let any = Any::try_from(&input)?;
@@ -263,8 +329,16 @@ mod test {
     #[test_case(DoubleValue::default(), BytesValue::default())]
     fn test_wrapper_in_any_with_bad_typenames<T, U>(from: T, _into: U) -> Result
     where
-        T: Message + std::fmt::Debug + serde::ser::Serialize,
-        U: Message + std::fmt::Debug + serde::de::DeserializeOwned,
+        T: Message
+            + std::fmt::Debug
+            + serde::ser::Serialize
+            + serde::de::DeserializeOwned
+            + 'static,
+        U: Message
+            + std::fmt::Debug
+            + serde::ser::Serialize
+            + serde::de::DeserializeOwned
+            + 'static,
     {
         let any = Any::try_from(&from)?;
         assert!(any.try_into_message::<U>().is_err());
@@ -275,13 +349,22 @@ mod test {
     #[test_case(UInt64Value::default(), "UInt64Value")]
     fn test_wrapper_bad_encoding<T>(_input: T, typename: &str) -> Result
     where
-        T: Message + std::fmt::Debug + serde::ser::Serialize + serde::de::DeserializeOwned,
+        T: Message
+            + std::fmt::Debug
+            + serde::ser::Serialize
+            + serde::de::DeserializeOwned
+            + Sized
+            + 'static,
     {
         let map = serde_json::json!({
             "@type": format!("type.googleapis.com/google.protobuf.{}", typename),
             "value": 0,
         });
-        let e = T::from_map(map.as_object().unwrap());
+
+        // Get the serializer for type T and use it for deserialization
+        let serializer = T::serializer();
+        let e = serializer.from_map(map.as_object().unwrap());
+
         assert!(e.is_err());
         let fmt = format!("{:?}", e);
         assert!(fmt.contains("expected value field to be a string"), "{fmt}");
@@ -294,7 +377,11 @@ mod test {
             "@type": "type.googleapis.com/google.protobuf.BytesValue",
             "value": "Oops, I forgot to base64 encode this.",
         });
-        assert!(BytesValue::from_map(map.as_object().unwrap()).is_err());
+
+        // Get the serializer for BytesValue and use it for deserialization
+        let serializer = BytesValue::serializer();
+        assert!(serializer.from_map(map.as_object().unwrap()).is_err());
+
         Ok(())
     }
 }

--- a/src/wkt/src/wrappers.rs
+++ b/src/wkt/src/wrappers.rs
@@ -335,7 +335,6 @@ mod test {
             "value": 0,
         });
 
-        // Get the serializer for type T and use it for deserialization
         let serializer = T::serializer();
         let e = serializer.deserialize_from_map(map.as_object().unwrap());
 
@@ -352,7 +351,6 @@ mod test {
             "value": "Oops, I forgot to base64 encode this.",
         });
 
-        // Get the serializer for BytesValue and use it for deserialization
         let serializer = BytesValue::serializer();
         assert!(
             serializer


### PR DESCRIPTION
This PR is part of #1609.

What the PR does:

- Split up the old `Message` trait into two new traits (`Message` and `MessageSerializer<T>`)
- The `MessageSerializer<T>` is hidden, as it's an internal API that's not intended for direct use by consumers of the `wkt` crate.

**Note**:

- Even though in the initial design, we had proposed the `serializer()` function to have the following signature (using _static dispatch_):
```rust
fn serializer() -> impl MessageSerializer<Self> {
    DefaultSerializer::<Self>::new()
}
```
In this PR, I've decided to go with an approach that would allow dynamic dispatch through trait objects:

```rust
fn serializer() -> Box<dyn MessageSerializer<Self>> {
    Box::new(DefaultSerializer::<Self>::new())
}
```

The dynamic dispatch approach generally allows for more cleaner code (but I'm open to feedback on this during review).

- In order to make the code simpler (and solve for some compiler warnings), I chose to make `MessageSerializer` public and hide it using `#[doc(hidden)]`, instead of giving it the `pub(crate)` visibility.
- Clippy complains about the naming of `from_map()` function: `methods called `from_* ` usually take no `self``. I'm not sure if that should warrant us changing the name of the function.


This is my first take on this refactoring task. Sharing early to get feedback. I'll be waiting to make any recommended changes.

cc: @dbolduc @coryan 