### PR TITLE
feat(generator/dart): allow specifying packages that need import prefixes

### DIFF
--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -182,12 +182,6 @@ func httpPathFmt(pathInfo *api.PathInfo) string {
 	return builder.String()
 }
 
-func httpPathArgs(_ *api.PathInfo) []string {
-	var args []string
-	// TODO(#1577): Determine the correct format for Dart.
-	return args
-}
-
 // This regex matches Google API documentation reference links; it supports
 // both regular references as well as implit references.
 //


### PR DESCRIPTION
- allow specifying using an import prefix for specific packages

This is to address generating `google.cloud.aiplatform.v1`, which both defines a `Value` message and also needs to reference the `Value` from google.protobuf (which would otherwise be shadowed by the local definition). We can use a sidekick config:

```toml
[codec]
# Use an import prefix; this package defines a 'Value' message which would
# shadow 'Value' from google.protobuf.
'prefix:google.protobuf' = 'protobuf'
```

to have all references to `google.protobuf` types be prefixed by 'protobuf.':

```dart
import 'package:google_cloud_longrunning/longrunning.dart';
import 'package:google_cloud_protobuf/protobuf.dart' as protobuf;
import 'package:google_cloud_rpc/rpc.dart';

...

class BatchPredictionJob extends ProtoMessage {
  ...
  final protobuf.Value? modelParameters;
  ...
}
```

Other alternatives would be always prefixing everything (which would make the generated code harder to read and less idiomatic), or, auto-detecting the namespace conflict and automatically using an import prefix (slightly higher implementation cost). This implementation is ~simple and keeps the code readable.
