### PR TITLE
feat(storage): IAM operations

### DIFF
--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -301,30 +301,15 @@ impl Storage {
     ///
     /// ```
     /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
-    ///     // Get the current IAM policy for this bucket
+    /// # use iam_v1::model::Policy;
+    /// async fn example(client: &Storage, updated_policy: Policy) -> gax::Result<()> {
     ///     let policy = client
-    ///         .get_iam_policy("projects/_/buckets/my-bucket")
-    ///         .send()
-    ///         .await?;
-    ///
-    ///     // Add a binding to the policy
-    ///     let mut new_policy = policy.clone();
-    ///     new_policy.bindings.push(
-    ///         iam_v1::model::Binding::new()
-    ///             .set_role("roles/storage.legacyBucketReader")
-    ///             .set_members(["user:me@example.com"]),
-    ///     );
-    ///
-    ///     // Update the IAM policy for this bucket
-    ///     let response = client
     ///         .set_iam_policy("projects/_/buckets/my-bucket")
     ///         .set_update_mask(wkt::FieldMask::default().set_paths(["bindings"]))
-    ///         .set_policy(new_policy)
+    ///         .set_policy(updated_policy)
     ///         .send()
     ///         .await?;
-    ///     println!("response details={response:?}");
-    ///
+    ///     println!("policy details={policy:?}");
     ///     Ok(())
     /// }
     /// ```

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -261,6 +261,112 @@ impl Storage {
         self.inner.list_objects().set_parent(parent)
     }
 
+    /// Gets the IAM policy for a specified bucket.
+    ///
+    /// # Parameters
+    /// * `resource` - the bucket name. In `projects/_/buckets/{bucket_id}`
+    ///   format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     let policy = client
+    ///         .get_iam_policy("projects/_/buckets/my-bucket")
+    ///         .send()
+    ///         .await?;
+    ///     println!("policy details={policy:?}");
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_iam_policy(
+        &self,
+        resource: impl Into<String>,
+    ) -> super::builder::storage::GetIamPolicy {
+        self.inner.get_iam_policy().set_resource(resource.into())
+    }
+
+    /// Updates the IAM policy for a specified bucket.
+    ///
+    /// This is not an update. The supplied policy will overwrite any existing
+    /// IAM Policy. You should first get the current IAM policy with
+    /// `get_iam_policy()` and then modify that policy before supplying it to
+    /// `set_iam_policy()`.
+    ///
+    /// # Parameters
+    /// * `resource` - the bucket name. In `projects/_/buckets/{bucket_id}`
+    ///   format.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     // Get the current IAM policy for this bucket
+    ///     let policy = client
+    ///         .get_iam_policy("projects/_/buckets/my-bucket")
+    ///         .send()
+    ///         .await?;
+    ///
+    ///     // Add a binding to the policy
+    ///     let mut new_policy = policy.clone();
+    ///     new_policy.bindings.push(
+    ///         iam_v1::model::Binding::new()
+    ///             .set_role("roles/storage.legacyBucketReader")
+    ///             .set_members(["user:me@example.com"]),
+    ///     );
+    ///
+    ///     // Update the IAM policy for this bucket
+    ///     let response = client
+    ///         .set_iam_policy("projects/_/buckets/my-bucket")
+    ///         .set_update_mask(wkt::FieldMask::default().set_paths(["bindings"]))
+    ///         .set_policy(new_policy)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response details={response:?}");
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn set_iam_policy(
+        &self,
+        resource: impl Into<String>,
+    ) -> super::builder::storage::SetIamPolicy {
+        self.inner.set_iam_policy().set_resource(resource.into())
+    }
+
+    /// Tests a set of permissions on the given bucket, object, or managed folder
+    /// to see which, if any, are held by the caller.
+    ///
+    /// # Parameters
+    /// * `resource` should be
+    ///   * `projects/_/buckets/{bucket}` for a bucket,
+    ///   * `projects/_/buckets/{bucket}/objects/{object}` for an object, or
+    ///   * `projects/_/buckets/{bucket}/managedFolders/{managedFolder}` for a
+    ///     managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions("projects/_/buckets/my-bucket")
+    ///         .set_permissions(["storage.buckets.get"])
+    ///         .send()
+    ///         .await?;
+    ///     println!("response details={response:?}");
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn test_iam_permissions(
+        &self,
+        resource: impl Into<String>,
+    ) -> super::builder::storage::TestIamPermissions {
+        self.inner
+            .test_iam_permissions()
+            .set_resource(resource.into())
+    }
+
     pub(crate) async fn new(config: gaxi::options::ClientConfig) -> crate::Result<Self> {
         let inner = super::generated::gapic::client::Storage::new(config).await?;
         Ok(Self { inner })


### PR DESCRIPTION
Fixes #1951 

Add the client surface for IAM operations from `google/storage/v2`, with examples (that build, but don't run), and integration tests for the new methods.

The method signatures (which are handwritten in this veneer) are consistent with the Get/Set/Test IAM methods from other crates.