### PR TITLE
fix(generator): initialize ID field for enums

### DIFF
--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -531,6 +531,7 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 func processEnum(state *api.APIState, e *descriptorpb.EnumDescriptorProto, eFQN, packagez string, parent *api.Message) *api.Enum {
 	enum := &api.Enum{
 		Name:    e.GetName(),
+		ID:      eFQN,
 		Parent:  parent,
 		Package: packagez,
 	}

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -334,6 +334,7 @@ func TestProtobuf_SkipExternaEnums(t *testing.T) {
 	}
 	checkEnum(t, *enum, api.Enum{
 		Name:          "LocalEnum",
+		ID:            ".test.LocalEnum",
 		Package:       "test",
 		Documentation: "This is a local enum, it should be generated.",
 		Values: []*api.EnumValue{
@@ -407,6 +408,7 @@ func TestProtobuf_Comments(t *testing.T) {
 	}
 	checkEnum(t, *e, api.Enum{
 		Name:          "Status",
+		ID:            ".test.Response.Status",
 		Package:       "test",
 		Documentation: "Some enum.\n\nLine 1.\nLine 2.",
 		Values: []*api.EnumValue{
@@ -972,6 +974,7 @@ func TestProtobuf_Enum(t *testing.T) {
 	}
 	checkEnum(t, *e, api.Enum{
 		Name:          "Code",
+		ID:            ".test.Code",
 		Package:       "test",
 		Documentation: "An enum.",
 		Values: []*api.EnumValue{
@@ -1416,7 +1419,6 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {

--- a/src/storage-control/src/generated/convert/storage/convert.rs
+++ b/src/storage-control/src/generated/convert/storage/convert.rs
@@ -548,6 +548,13 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::CommonObjectRequestP
     }
 }
 
+impl gaxi::prost::ToProto<service_constants::Values> for crate::generated::gapic::model::service_constants::Values {
+    type Output = i32;
+    fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
+        Ok(self.value())
+    }
+}
+
 impl gaxi::prost::ToProto<ServiceConstants> for crate::generated::gapic::model::ServiceConstants {
     type Output = ServiceConstants;
     fn to_proto(self) -> std::result::Result<ServiceConstants, gaxi::prost::ConvertError> {


### PR DESCRIPTION
I am not sure why, but this field was not initialized. And I also do not
understand why this changed the generated code (for one enum).
