### PR TITLE
cleanup(lro)!: seal Poller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lro"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "axum",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ gaxi                          = { version = "0.1", path = "src/gax-internal", pa
 iam_v1                        = { version = "0.3", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 location                      = { version = "0.3", path = "src/generated/cloud/location", package = "google-cloud-location" }
 longrunning                   = { version = "0.24", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
-lro                           = { version = "0.1", path = "src/lro", package = "google-cloud-lro" }
+lro                           = { version = "0.2", path = "src/lro", package = "google-cloud-lro" }
 wkt                           = { version = "0.4", path = "src/wkt", package = "google-cloud-wkt" }
 api                           = { version = "0.3", path = "src/generated/api/types", package = "google-cloud-api" }
 cloud_common                  = { version = "0.3", path = "src/generated/cloud/common", package = "google-cloud-common" }

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -52,7 +52,6 @@ pub mod internal {
     }
 }
 
-// This fools clippy into thinking `sealed::Paginator` is public.
 mod sealed {
     pub trait Paginator {}
 }

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "Google Cloud Client Libraries for Rust - LRO Helpers"
 name        = "google-cloud-lro"
-version     = "0.1.1"
+version     = "0.2.0"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -100,7 +100,6 @@ impl<R, M> Operation<R, M> {
     }
 }
 
-// This fools clippy into thinking `sealed::Poller` is public.
 mod sealed {
     pub trait Poller {}
 }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -100,6 +100,11 @@ impl<R, M> Operation<R, M> {
     }
 }
 
+// This fools clippy into thinking `sealed::Poller` is public.
+mod sealed {
+    pub trait Poller {}
+}
+
 /// The trait implemented by LRO helpers.
 ///
 /// # Parameters
@@ -107,7 +112,7 @@ impl<R, M> Operation<R, M> {
 ///   long-running operation completes successfully.
 /// * `M` - the metadata type, that is, the type returned by the service when
 ///   the long-running operation is still in progress.
-pub trait Poller<R, M>: Send {
+pub trait Poller<R, M>: Send + sealed::Poller {
     /// Query the current status of the long-running operation.
     fn poll(&mut self) -> impl Future<Output = Option<PollingResult<R, M>>> + Send;
 
@@ -296,6 +301,24 @@ where
             None
         })
     }
+}
+
+impl<ResponseType, MetadataType, S, SF, P, PF> sealed::Poller
+    for PollerImpl<ResponseType, MetadataType, S, SF, P, PF>
+where
+    ResponseType:
+        wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
+    MetadataType:
+        wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<Operation<ResponseType, MetadataType>>>
+        + Send
+        + 'static,
+    P: Fn(String) -> PF + Send + Sync + Clone,
+    PF: std::future::Future<Output = Result<Operation<ResponseType, MetadataType>>>
+        + Send
+        + 'static,
+{
 }
 
 mod details;


### PR DESCRIPTION
Part of the work for #1609, analog of #1971 

Seal `lro::Poller`. This lets us add functions to the trait without breaking customers (because customers are not able to implement this trait).