### PR TITLE
feat(generator): capture deprecated markers

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -171,6 +171,8 @@ type Service struct {
 	Name string
 	// ID is a unique identifier.
 	ID string
+	// Some source specifications allow marking services as deprecated.
+	Deprecated bool
 	// Methods associated with the Service.
 	Methods []*Method
 	// DefaultHost fragment of a URL.
@@ -192,6 +194,8 @@ type Method struct {
 	Name string
 	// ID is a unique identifier.
 	ID string
+	// Some source specifications allow marking methods as deprecated.
+	Deprecated bool
 	// InputType is the input to the Method
 	InputTypeID string
 	InputType   *Message
@@ -385,6 +389,8 @@ type Message struct {
 	Name string
 	// ID is a unique identifier.
 	ID string
+	// Some source specifications allow marking messages as deprecated.
+	Deprecated bool
 	// Fields associated with the Message.
 	Fields []*Field
 	// IsLocalToPackage is true if the message is defined in the current
@@ -425,6 +431,8 @@ type Enum struct {
 	Name string
 	// ID is a unique identifier.
 	ID string
+	// Some source specifications allow marking enums as deprecated.
+	Deprecated bool
 	// Values associated with the Enum.
 	Values []*EnumValue
 	// The unique integer values, some enums have multiple aliases for the
@@ -446,6 +454,8 @@ type EnumValue struct {
 	Name string
 	// ID is a unique identifier.
 	ID string
+	// Some source specifications allow marking enum values as deprecated.
+	Deprecated bool
 	// Number of the attribute.
 	Number int32
 	// Parent returns the ancestor of this node, if any.
@@ -474,6 +484,8 @@ type Field struct {
 	Optional bool
 	// Repeated is true if the field is a repeated field.
 	Repeated bool
+	// Some source specifications allow marking fields as deprecated.
+	Deprecated bool
 	// IsOneOf is true if the field is related to a one-of and not
 	// a proto3 optional field.
 	IsOneOf bool

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -217,6 +217,7 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 			m := &api.Method{
 				Name:          op.Operation.OperationId,
 				ID:            mID,
+				Deprecated:    op.Operation.Deprecated != nil && *op.Operation.Deprecated,
 				Documentation: op.Operation.Description,
 				InputTypeID:   requestMessage.ID,
 				OutputTypeID:  responseMessage.ID,
@@ -340,6 +341,7 @@ func makeRequestMessage(a *api.API, operation *v3.Operation, packageName, templa
 			Name:          p.Name,
 			JSONName:      p.Name, // OpenAPI fields are already camelCase
 			Documentation: documentation,
+			Deprecated:    p.Deprecated,
 			Optional:      openapiFieldIsOptional(p),
 			Typez:         typez,
 			TypezID:       typezID,
@@ -467,6 +469,7 @@ func makeScalarField(messageName, name string, schema *base.Schema, optional boo
 		Documentation: field.Description,
 		Typez:         typez,
 		TypezID:       typezID,
+		Deprecated:    field.Deprecated != nil && *field.Deprecated,
 		Optional:      optional || (typez == api.MESSAGE_TYPE),
 	}, nil
 }
@@ -489,6 +492,7 @@ func makeObjectField(state *api.APIState, packageName, messageName, name string,
 				Name:          name,
 				JSONName:      name, // OpenAPI field names are always camelCase
 				Documentation: field.Description,
+				Deprecated:    field.Deprecated != nil && *field.Deprecated,
 				Typez:         api.MESSAGE_TYPE,
 				TypezID:       ".google.protobuf.Any",
 				Optional:      true,
@@ -502,6 +506,7 @@ func makeObjectField(state *api.APIState, packageName, messageName, name string,
 			Name:          name,
 			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
+			Deprecated:    field.Deprecated != nil && *field.Deprecated,
 			Typez:         api.MESSAGE_TYPE,
 			TypezID:       message.ID,
 			Optional:      false,
@@ -514,6 +519,7 @@ func makeObjectField(state *api.APIState, packageName, messageName, name string,
 			Name:          name,
 			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
+			Deprecated:    field.Deprecated != nil && *field.Deprecated,
 			Typez:         api.MESSAGE_TYPE,
 			TypezID:       typezID,
 			Optional:      true,
@@ -545,6 +551,7 @@ func makeArrayField(state *api.APIState, packageName, messageName, name string, 
 				Name:          name,
 				JSONName:      name, // OpenAPI field names are always camelCase
 				Documentation: field.Description,
+				Deprecated:    field.Deprecated != nil && *field.Deprecated,
 				Typez:         api.MESSAGE_TYPE,
 				TypezID:       typezID,
 			}
@@ -570,6 +577,7 @@ func makeObjectFieldAllOf(packageName, messageName, name string, field *base.Sch
 			Name:          name,
 			JSONName:      name, // OpenAPI field names are always camelCase
 			Documentation: field.Description,
+			Deprecated:    field.Deprecated != nil && *field.Deprecated,
 			Typez:         api.MESSAGE_TYPE,
 			TypezID:       typezID,
 			Optional:      true,

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -114,6 +114,7 @@ func makeAPIForOpenAPI(serviceConfig *serviceconfig.Service, model *libopenapi.D
 			Name:          name,
 			ID:            id,
 			Package:       packageName,
+			Deprecated:    msg.Schema().Deprecated != nil && *msg.Schema().Deprecated,
 			Documentation: msg.Schema().Description,
 			Fields:        fields,
 		}

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -429,6 +429,7 @@ func processService(state *api.APIState, s *descriptorpb.ServiceDescriptorProto,
 		ID:          sFQN,
 		Package:     packagez,
 		DefaultHost: parseDefaultHost(s.GetOptions()),
+		Deprecated:  s.GetOptions().GetDeprecated(),
 	}
 	state.ServiceByID[service.ID] = service
 	return service
@@ -450,6 +451,7 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 		ID:                  mFQN,
 		PathInfo:            pathInfo,
 		Name:                m.GetName(),
+		Deprecated:          m.GetOptions().GetDeprecated(),
 		InputTypeID:         m.GetInputType(),
 		OutputTypeID:        outputTypeID,
 		ClientSideStreaming: m.GetClientStreaming(),
@@ -464,10 +466,11 @@ func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, m
 
 func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, packagez string, parent *api.Message) *api.Message {
 	message := &api.Message{
-		Name:    m.GetName(),
-		ID:      mFQN,
-		Parent:  parent,
-		Package: packagez,
+		Name:       m.GetName(),
+		ID:         mFQN,
+		Parent:     parent,
+		Package:    packagez,
+		Deprecated: m.GetOptions().GetDeprecated(),
 	}
 	state.MessageByID[mFQN] = message
 	if opts := m.GetOptions(); opts != nil && opts.GetMapEntry() {
@@ -498,6 +501,7 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 			Name:          mf.GetName(),
 			ID:            mFQN + "." + mf.GetName(),
 			JSONName:      mf.GetJsonName(),
+			Deprecated:    mf.GetOptions().GetDeprecated(),
 			Optional:      isProtoOptional,
 			Repeated:      mf.Label != nil && *mf.Label == descriptorpb.FieldDescriptorProto_LABEL_REPEATED,
 			IsOneOf:       mf.OneofIndex != nil && !isProtoOptional,
@@ -530,17 +534,19 @@ func processMessage(state *api.APIState, m *descriptorpb.DescriptorProto, mFQN, 
 
 func processEnum(state *api.APIState, e *descriptorpb.EnumDescriptorProto, eFQN, packagez string, parent *api.Message) *api.Enum {
 	enum := &api.Enum{
-		Name:    e.GetName(),
-		ID:      eFQN,
-		Parent:  parent,
-		Package: packagez,
+		Name:       e.GetName(),
+		ID:         eFQN,
+		Parent:     parent,
+		Package:    packagez,
+		Deprecated: e.GetOptions().GetDeprecated(),
 	}
 	state.EnumByID[eFQN] = enum
 	for _, ev := range e.Value {
 		enumValue := &api.EnumValue{
-			Name:   ev.GetName(),
-			Number: ev.GetNumber(),
-			Parent: enum,
+			Name:       ev.GetName(),
+			Number:     ev.GetNumber(),
+			Parent:     enum,
+			Deprecated: ev.GetOptions().GetDeprecated(),
 		}
 		enum.Values = append(enum.Values, enumValue)
 	}

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -1421,6 +1421,129 @@ func TestProtobuf_AutoPopulated(t *testing.T) {
 	})
 }
 
+func TestProtobuf_Deprecated(t *testing.T) {
+	test := makeAPIForProtobuf(nil, newTestCodeGeneratorRequest(t, "deprecated.proto"))
+	s, ok := test.State.ServiceByID[".test.ServiceA"]
+	if !ok {
+		t.Fatalf("Cannot find %s in API State", ".test.ServiceA")
+	}
+	checkService(t, s, &api.Service{
+		Name:       "ServiceA",
+		ID:         ".test.ServiceA",
+		Package:    "test",
+		Deprecated: true,
+	})
+
+	s, ok = test.State.ServiceByID[".test.ServiceB"]
+	if !ok {
+		t.Fatalf("Cannot find %s in API State", ".test.ServiceB")
+	}
+	checkService(t, s, &api.Service{
+		Name:       "ServiceB",
+		ID:         ".test.ServiceB",
+		Package:    "test",
+		Deprecated: false,
+		Methods: []*api.Method{
+			{
+				Name:         "RpcA",
+				ID:           ".test.ServiceB.RpcA",
+				Deprecated:   true,
+				InputTypeID:  ".test.Request",
+				OutputTypeID: ".test.Response",
+				PathInfo: &api.PathInfo{
+					Verb:            "POST",
+					PathTemplate:    []api.PathSegment{},
+					QueryParameters: map[string]bool{},
+					BodyFieldPath:   "*",
+				},
+			},
+		},
+	})
+
+	m, ok := test.State.MessageByID[".test.Request"]
+	if !ok {
+		t.Fatalf("Cannot find %s in API State", ".test.Request")
+	}
+	checkMessage(t, m, &api.Message{
+		Name:       "Request",
+		ID:         ".test.Request",
+		Package:    "test",
+		Deprecated: false,
+		Fields: []*api.Field{
+			{
+				Name:     "name",
+				JSONName: "name",
+				ID:       ".test.Request.name",
+				Typez:    api.STRING_TYPE,
+			},
+			{
+				Name:       "other",
+				JSONName:   "other",
+				ID:         ".test.Request.other",
+				Typez:      api.STRING_TYPE,
+				Deprecated: true,
+			},
+		},
+	})
+
+	m, ok = test.State.MessageByID[".test.Response"]
+	if !ok {
+		t.Fatalf("Cannot find %s in API State", ".test.Response")
+	}
+	checkMessage(t, m, &api.Message{
+		Name:       "Response",
+		ID:         ".test.Response",
+		Package:    "test",
+		Deprecated: true,
+	})
+
+	e, ok := test.State.EnumByID[".test.EnumA"]
+	if !ok {
+		t.Fatalf("Cannot find %s in API State", ".test.EnumA")
+	}
+	checkEnum(t, *e, api.Enum{
+		Name:       "EnumA",
+		ID:         ".test.EnumA",
+		Package:    "test",
+		Deprecated: true,
+		Values: []*api.EnumValue{
+			{
+				Name:   "ENUM_A_UNSPECIFIED",
+				Number: 0,
+			},
+		},
+	})
+
+	e, ok = test.State.EnumByID[".test.EnumB"]
+	if !ok {
+		t.Fatalf("Cannot find %s in API State", ".test.EnumB")
+	}
+	checkEnum(t, *e, api.Enum{
+		Name:    "EnumB",
+		ID:      ".test.EnumB",
+		Package: "test",
+		Values: []*api.EnumValue{
+			{
+				Name:   "ENUM_B_UNSPECIFIED",
+				Number: 0,
+			},
+			{
+				Name:       "RED",
+				Number:     1,
+				Deprecated: true,
+			},
+			{
+				Name:   "GREEN",
+				Number: 2,
+			},
+			{
+				Name:   "BLUE",
+				Number: 3,
+			},
+		},
+	})
+}
+
 func newTestCodeGeneratorRequest(t *testing.T, filename string) *pluginpb.CodeGeneratorRequest {
 	t.Helper()
 	options := map[string]string{

--- a/generator/internal/parser/testdata/deprecated.proto
+++ b/generator/internal/parser/testdata/deprecated.proto
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+package test;
+
+service ServiceA {
+    option deprecated = true;
+}
+
+service ServiceB {
+    rpc RpcA(Request) returns (Response) {
+        option deprecated = true;
+    }
+}
+
+message Request {
+    string name = 1;
+    string other = 2 [deprecated = true];
+}
+
+message Response {
+    option deprecated = true;
+}
+
+enum EnumA {
+    option deprecated = true;
+    ENUM_A_UNSPECIFIED = 0;
+}
+
+enum EnumB {
+    ENUM_B_UNSPECIFIED = 0;
+    RED   = 1 [deprecated = true];
+    GREEN = 2;
+    BLUE  = 3;
+}

--- a/generator/internal/parser/testdata/deprecated_openapi.json
+++ b/generator/internal/parser/testdata/deprecated_openapi.json
@@ -1,0 +1,95 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Test API",
+        "version": "v1"
+    },
+    "paths": {
+        "/v1/projects/{project}/rpc/a": {
+            "get": {
+                "operationId": "RpcA",
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter",
+                        "in": "query",
+                        "deprecated": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Response"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/projects/{project}/rpc/b": {
+            "get": {
+                "operationId": "RpcB",
+                "deprecated": true,
+                "parameters": [
+                    {
+                        "name": "project",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Response"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Response": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "other": {
+                        "type": "string",
+                        "deprecated": true
+                    }
+                }
+            },
+            "DeprecatedMessage": {
+                "type": "object",
+                "deprecated": true,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Both Protobuf and OpenAPIv3 supporting marking some fields, messages,
requests and (in the case of Protobuf) even complete services as
deprecated. In this change we capture the information, but no generated
code changes.

Part of the work for #1958
