### PR TITLE
fix: support nan, inf and -inf serde for f32 in generated code

### DIFF
--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -396,6 +396,8 @@ func fieldFormatter(typez api.Typez) string {
 		api.SFIXED64_TYPE,
 		api.SINT64_TYPE:
 		return "serde_with::DisplayFromStr"
+	case api.FLOAT_TYPE:
+		return "wkt::internal::F32"
 	case api.BYTES_TYPE:
 		return "serde_with::base64::Base64"
 	default:
@@ -451,6 +453,8 @@ func wrapperFieldAttributes(f *api.Field, attributes []string) []string {
 		formatter = fieldFormatter(api.UINT64_TYPE)
 	case ".google.protobuf.Int64Value":
 		formatter = fieldFormatter(api.INT64_TYPE)
+	case ".google.protobuf.FloatValue":
+		formatter = fieldFormatter(api.FLOAT_TYPE)
 	default:
 		return attributes
 	}
@@ -478,7 +482,6 @@ func fieldAttributes(f *api.Field, state *api.APIState) []string {
 	attributes := fieldBaseAttributes(f)
 	switch f.Typez {
 	case api.DOUBLE_TYPE,
-		api.FLOAT_TYPE,
 		api.INT32_TYPE,
 		api.FIXED32_TYPE,
 		api.BOOL_TYPE,
@@ -501,7 +504,8 @@ func fieldAttributes(f *api.Field, state *api.APIState) []string {
 		api.FIXED64_TYPE,
 		api.SFIXED64_TYPE,
 		api.SINT64_TYPE,
-		api.BYTES_TYPE:
+		api.BYTES_TYPE,
+		api.FLOAT_TYPE:
 		formatter := fieldFormatter(f.Typez)
 		if f.Optional {
 			attributes = append(attributes, `#[serde(skip_serializing_if = "std::option::Option::is_none")]`)

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -2252,6 +2252,7 @@ pub mod method_settings {
         /// reaches max_poll_delay.
         /// Default value: 1.5.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub poll_delay_multiplier: f32,
 
         /// Maximum time between two subsequent poll requests.

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -5051,6 +5051,7 @@ pub struct Instance {
 
     /// Output only. Average queries per second (QPS) over the last minute.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub qps: f32,
 
     /// Output only. Average latency (ms) over the last minute.

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -7377,6 +7377,7 @@ pub struct HotTablet {
     /// by the node to serve the tablet, from 0% (tablet was not interacted with)
     /// to 100% (the node spent all cycles serving the hot tablet).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub node_cpu_usage_percent: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -2967,14 +2967,17 @@ impl wkt::message::Message for VideoMetadata {
 pub struct GenerationConfig {
     /// Optional. Controls the randomness of predictions.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub temperature: std::option::Option<f32>,
 
     /// Optional. If specified, nucleus sampling will be used.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub top_p: std::option::Option<f32>,
 
     /// Optional. If specified, top-k sampling will be used.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub top_k: std::option::Option<f32>,
 
     /// Optional. Number of candidates to generate.
@@ -2999,10 +3002,12 @@ pub struct GenerationConfig {
 
     /// Optional. Positive penalties.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub presence_penalty: std::option::Option<f32>,
 
     /// Optional. Frequency penalties.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub frequency_penalty: std::option::Option<f32>,
 
     /// Optional. Seed.
@@ -3703,6 +3708,7 @@ pub struct SafetyRating {
 
     /// Output only. Harm probability score.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub probability_score: f32,
 
     /// Output only. Harm severity levels in the content.
@@ -3710,6 +3716,7 @@ pub struct SafetyRating {
 
     /// Output only. Harm severity score.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub severity_score: f32,
 
     /// Output only. Indicates whether the content was filtered out because of this
@@ -4412,6 +4419,7 @@ pub mod logprobs_result {
 
         /// The candidate's log probability.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub log_probability: std::option::Option<f32>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4895,6 +4903,7 @@ pub struct GroundingSupport {
     /// most confident. This list must have the same size as the
     /// grounding_chunk_indices.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
     pub confidence_scores: std::vec::Vec<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5110,6 +5119,7 @@ pub struct RetrievalMetadata {
     /// Google Search grounding and dynamic retrieval is enabled. It will be
     /// compared to the threshold to determine whether to trigger Google Search.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub google_search_dynamic_retrieval_score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -16899,6 +16909,7 @@ impl wkt::message::Message for ExactMatchResults {
 pub struct ExactMatchMetricValue {
     /// Output only. Exact match score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17114,6 +17125,7 @@ impl wkt::message::Message for BleuResults {
 pub struct BleuMetricValue {
     /// Output only. Bleu score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17349,6 +17361,7 @@ impl wkt::message::Message for RougeResults {
 pub struct RougeMetricValue {
     /// Output only. Rouge score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17512,6 +17525,7 @@ impl wkt::message::Message for CoherenceSpec {
 pub struct CoherenceResult {
     /// Output only. Coherence score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for coherence score.
@@ -17520,6 +17534,7 @@ pub struct CoherenceResult {
 
     /// Output only. Confidence for coherence score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17695,6 +17710,7 @@ impl wkt::message::Message for FluencySpec {
 pub struct FluencyResult {
     /// Output only. Fluency score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for fluency score.
@@ -17703,6 +17719,7 @@ pub struct FluencyResult {
 
     /// Output only. Confidence for fluency score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17876,6 +17893,7 @@ impl wkt::message::Message for SafetySpec {
 pub struct SafetyResult {
     /// Output only. Safety score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for safety score.
@@ -17884,6 +17902,7 @@ pub struct SafetyResult {
 
     /// Output only. Confidence for safety score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18073,6 +18092,7 @@ impl wkt::message::Message for GroundednessSpec {
 pub struct GroundednessResult {
     /// Output only. Groundedness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for groundedness score.
@@ -18081,6 +18101,7 @@ pub struct GroundednessResult {
 
     /// Output only. Confidence for groundedness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18269,6 +18290,7 @@ impl wkt::message::Message for FulfillmentSpec {
 pub struct FulfillmentResult {
     /// Output only. Fulfillment score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for fulfillment score.
@@ -18277,6 +18299,7 @@ pub struct FulfillmentResult {
 
     /// Output only. Confidence for fulfillment score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18502,6 +18525,7 @@ impl wkt::message::Message for SummarizationQualitySpec {
 pub struct SummarizationQualityResult {
     /// Output only. Summarization Quality score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for summarization quality score.
@@ -18510,6 +18534,7 @@ pub struct SummarizationQualityResult {
 
     /// Output only. Confidence for summarization quality score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18757,6 +18782,7 @@ pub struct PairwiseSummarizationQualityResult {
 
     /// Output only. Confidence for summarization quality score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18985,6 +19011,7 @@ impl wkt::message::Message for SummarizationHelpfulnessSpec {
 pub struct SummarizationHelpfulnessResult {
     /// Output only. Summarization Helpfulness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for summarization helpfulness score.
@@ -18993,6 +19020,7 @@ pub struct SummarizationHelpfulnessResult {
 
     /// Output only. Confidence for summarization helpfulness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -19218,6 +19246,7 @@ impl wkt::message::Message for SummarizationVerbositySpec {
 pub struct SummarizationVerbosityResult {
     /// Output only. Summarization Verbosity score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for summarization verbosity score.
@@ -19226,6 +19255,7 @@ pub struct SummarizationVerbosityResult {
 
     /// Output only. Confidence for summarization verbosity score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -19451,6 +19481,7 @@ impl wkt::message::Message for QuestionAnsweringQualitySpec {
 pub struct QuestionAnsweringQualityResult {
     /// Output only. Question Answering Quality score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for question answering quality score.
@@ -19459,6 +19490,7 @@ pub struct QuestionAnsweringQualityResult {
 
     /// Output only. Confidence for question answering quality score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -19708,6 +19740,7 @@ pub struct PairwiseQuestionAnsweringQualityResult {
 
     /// Output only. Confidence for question answering quality score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -19936,6 +19969,7 @@ impl wkt::message::Message for QuestionAnsweringRelevanceSpec {
 pub struct QuestionAnsweringRelevanceResult {
     /// Output only. Question Answering Relevance score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for question answering relevance score.
@@ -19944,6 +19978,7 @@ pub struct QuestionAnsweringRelevanceResult {
 
     /// Output only. Confidence for question answering relevance score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20169,6 +20204,7 @@ impl wkt::message::Message for QuestionAnsweringHelpfulnessSpec {
 pub struct QuestionAnsweringHelpfulnessResult {
     /// Output only. Question Answering Helpfulness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for question answering helpfulness score.
@@ -20177,6 +20213,7 @@ pub struct QuestionAnsweringHelpfulnessResult {
 
     /// Output only. Confidence for question answering helpfulness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20402,6 +20439,7 @@ impl wkt::message::Message for QuestionAnsweringCorrectnessSpec {
 pub struct QuestionAnsweringCorrectnessResult {
     /// Output only. Question Answering Correctness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for question answering correctness score.
@@ -20410,6 +20448,7 @@ pub struct QuestionAnsweringCorrectnessResult {
 
     /// Output only. Confidence for question answering correctness score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub confidence: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20640,6 +20679,7 @@ impl wkt::message::Message for PointwiseMetricSpec {
 pub struct PointwiseMetricResult {
     /// Output only. Pointwise metric score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. Explanation for pointwise metric score.
@@ -21086,6 +21126,7 @@ impl wkt::message::Message for ToolCallValidResults {
 pub struct ToolCallValidMetricValue {
     /// Output only. Tool call valid score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21292,6 +21333,7 @@ impl wkt::message::Message for ToolNameMatchResults {
 pub struct ToolNameMatchMetricValue {
     /// Output only. Tool name match score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21499,6 +21541,7 @@ impl wkt::message::Message for ToolParameterKeyMatchResults {
 pub struct ToolParameterKeyMatchMetricValue {
     /// Output only. Tool parameter key match score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21716,6 +21759,7 @@ impl wkt::message::Message for ToolParameterKVMatchResults {
 pub struct ToolParameterKVMatchMetricValue {
     /// Output only. Tool parameter key value match score.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21995,6 +22039,7 @@ impl wkt::message::Message for CometInstance {
 pub struct CometResult {
     /// Output only. Comet score. Range depends on version.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22288,6 +22333,7 @@ impl wkt::message::Message for MetricxInstance {
 pub struct MetricxResult {
     /// Output only. MetricX score. Range depends on version.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -24149,6 +24195,7 @@ pub mod feature_noise_sigma {
         ///
         /// [google.cloud.aiplatform.v1.SmoothGradConfig.noise_sigma]: crate::model::SmoothGradConfig::gradient_noise_sigma
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub sigma: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -24223,6 +24270,7 @@ pub struct BlurBaselineConfig {
     /// dimension. If not set, the method defaults to the zero (i.e. black for
     /// images) baseline.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub max_blur_sigma: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -25852,22 +25900,26 @@ pub mod explanation_metadata {
         pub struct FeatureValueDomain {
             /// The minimum permissible value for this feature.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub min_value: f32,
 
             /// The maximum permissible value for this feature.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub max_value: f32,
 
             /// If this input feature has been normalized to a mean value of 0,
             /// the original_mean specifies the mean value of the domain prior to
             /// normalization.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub original_mean: f32,
 
             /// If this input feature has been normalized to a standard deviation of
             /// 1.0, the original_stddev specifies the standard deviation of the domain
             /// prior to normalization.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub original_stddev: f32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -25979,11 +26031,13 @@ pub mod explanation_metadata {
             /// and making it easier to see areas of strong attribution. Defaults to
             /// 99.9.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub clip_percent_upperbound: f32,
 
             /// Excludes attributions below the specified percentile, from the
             /// highlighted areas. Defaults to 62.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub clip_percent_lowerbound: f32,
 
             /// How the original image is displayed in the visualization.
@@ -30400,6 +30454,7 @@ pub mod nearest_neighbor_query {
     pub struct Embedding {
         /// Optional. Individual value in the embedding.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
         pub value: std::vec::Vec<f32>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -40720,6 +40775,7 @@ pub struct IndexDatapoint {
     /// Required. Feature embedding vector for dense index. An array of numbers
     /// with the length of [NearestNeighborSearchConfig.dimensions].
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
     pub feature_vector: std::vec::Vec<f32>,
 
     /// Optional. Feature embedding vector for sparse index.
@@ -40839,6 +40895,7 @@ pub mod index_datapoint {
     pub struct SparseEmbedding {
         /// Required. The list of embedding values of the sparse vector.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
         pub values: std::vec::Vec<f32>,
 
         /// Required. The list of indexes for the embedding values of the sparse
@@ -49329,6 +49386,7 @@ pub mod find_neighbors_request {
             /// vs sparse results. For example, if the alpha is 0, we only return
             /// sparse and if the alpha is 1, we only return dense.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub alpha: f32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -59424,10 +59482,12 @@ pub mod model_evaluation_slice {
             pub struct Range {
                 /// Inclusive low value for the range.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                #[serde_as(as = "wkt::internal::F32")]
                 pub low: f32,
 
                 /// Exclusive high value for the range.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                #[serde_as(as = "wkt::internal::F32")]
                 pub high: f32,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -87103,6 +87163,7 @@ pub struct DynamicRetrievalConfig {
     /// Optional. The threshold to be used in dynamic retrieval.
     /// If not set, a system default value is used.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub dynamic_threshold: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -90653,6 +90714,7 @@ pub struct Tensor {
     ///
     /// [google.cloud.aiplatform.v1.Tensor.DataType.FLOAT]: crate::model::tensor::data_type::FLOAT
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
     pub float_val: std::vec::Vec<f32>,
 
     /// [DOUBLE][google.cloud.aiplatform.v1.Tensor.DataType.DOUBLE]
@@ -95567,6 +95629,7 @@ pub struct CorroborateContentResponse {
     /// Confidence score of corroborating content. Value is [0,1] with 1 is the
     /// most confidence.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub corroboration_score: std::option::Option<f32>,
 
     /// Claims that are extracted from the input content and facts that support the
@@ -95753,6 +95816,7 @@ pub struct Claim {
 
     /// Confidence score of this corroboration.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/chronicle/v1/src/model.rs
+++ b/src/generated/cloud/chronicle/v1/src/model.rs
@@ -1274,6 +1274,7 @@ pub struct Watchlist {
     /// in this watchlist.
     /// The default is 1.0 if it is not specified.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub multiplying_factor: f32,
 
     /// Required. Mechanism to populate entities in the watchlist.
@@ -3153,6 +3154,7 @@ pub struct Retrohunt {
     /// Output only. Percent progress of the retrohunt towards completion, from
     /// 0.00 to 100.00.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub progress_percentage: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4450,6 +4452,7 @@ pub struct RetrohuntMetadata {
 
     /// Percent progress of the retrohunt towards completion, from 0.00 to 100.00.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub progress_percentage: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -1897,6 +1897,7 @@ pub struct BulkAnalyzeConversationsRequest {
     /// Required. Percentage of selected conversation to analyze, between
     /// [0, 100].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub analysis_percentage: f32,
 
     /// To select the annotators to run and the phrase matchers to use
@@ -6055,6 +6056,7 @@ pub mod query_metrics_response {
 
                 /// The average silence percentage.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub average_silence_percentage: std::option::Option<f32>,
 
                 /// The average duration.
@@ -6063,14 +6065,17 @@ pub mod query_metrics_response {
 
                 /// The average turn count.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub average_turn_count: std::option::Option<f32>,
 
                 /// The average agent's sentiment score.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub average_agent_sentiment_score: std::option::Option<f32>,
 
                 /// The average client's sentiment score.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub average_client_sentiment_score: std::option::Option<f32>,
 
                 /// The average customer satisfaction rating.
@@ -9776,6 +9781,7 @@ pub mod conversation {
             /// A confidence estimate between 0.0 and 1.0 of the fidelity of this
             /// segment. A default value of 0.0 indicates that the value is unset.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub confidence: f32,
 
             /// A list of the word-specific information for each word in the segment.
@@ -9928,6 +9934,7 @@ pub mod conversation {
                 /// A confidence estimate between 0.0 and 1.0 of the fidelity of this
                 /// word. A default value of 0.0 indicates that the value is unset.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                #[serde_as(as = "wkt::internal::F32")]
                 pub confidence: f32,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -10920,6 +10927,7 @@ pub struct ConversationLevelSilence {
 
     /// Percentage of the total conversation spent in silence.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub silence_percentage: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11475,6 +11483,7 @@ pub struct Entity {
     /// Scores closer to 0 are less salient, while scores closer to 1.0 are highly
     /// salient.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub salience: f32,
 
     /// The aggregate sentiment expressed for this entity in the conversation.
@@ -12051,10 +12060,12 @@ pub struct SentimentData {
     /// A non-negative number from 0 to infinity which represents the abolute
     /// magnitude of sentiment regardless of score.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub magnitude: f32,
 
     /// The sentiment score between -1.0 (negative) and 1.0 (positive).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14360,6 +14371,7 @@ pub struct ArticleSuggestionData {
     /// conversation, ranging from 0.0 (completely uncertain) to 1.0 (completely
     /// certain).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence_score: f32,
 
     /// Map that contains metadata about the Article Suggestion and the document
@@ -14451,6 +14463,7 @@ pub struct FaqAnswerData {
     /// conversation, ranging from 0.0 (completely uncertain) to 1.0 (completely
     /// certain).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence_score: f32,
 
     /// The corresponding FAQ question.
@@ -14692,6 +14705,7 @@ pub struct DialogflowInteractionData {
     /// The confidence of the match ranging from 0.0 (completely uncertain) to 1.0
     /// (completely certain).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14743,6 +14757,7 @@ pub struct ConversationSummarizationSuggestionData {
 
     /// The confidence score of the summarization.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// A map that contains metadata about the summarization and the document

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -11448,18 +11448,22 @@ impl wkt::message::Message for SystemTimestamps {
 pub struct UsageStats {
     /// The number of successful uses of the underlying entry.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub total_completions: f32,
 
     /// The number of failed attempts to use the underlying entry.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub total_failures: f32,
 
     /// The number of cancelled attempts to use the underlying entry.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub total_cancellations: f32,
 
     /// Total time spent only on successful uses, in milliseconds.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub total_execution_time_for_completions_millis: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -8001,6 +8001,7 @@ pub struct DataProfileSpec {
     /// * Sampling is not applied if `sampling_percent` is not specified, 0 or
     ///
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub sampling_percent: f32,
 
     /// Optional. A filter applied to all rows in a single DataScan job.
@@ -9104,6 +9105,7 @@ pub struct DataQualitySpec {
     /// * Sampling is not applied if `sampling_percent` is not specified, 0 or
     ///
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub sampling_percent: f32,
 
     /// Optional. A filter applied to all rows in a single DataScan job.
@@ -9331,6 +9333,7 @@ pub mod data_quality_spec {
         pub struct ScoreThresholdTrigger {
             /// Optional. The score range is in [0,100].
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub score_threshold: f32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9513,6 +9516,7 @@ pub struct DataQualityResult {
     ///
     /// The score ranges between [0, 100] (up to two decimal points).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     /// Output only. A list of results at the dimension level.
@@ -9950,6 +9954,7 @@ pub struct DataQualityDimensionResult {
     /// The score ranges between [0, 100] (up to two decimal
     /// points).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11004,6 +11009,7 @@ pub struct DataQualityColumnResult {
     /// The score ranges between between [0, 100] (up to two decimal
     /// points).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub score: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -16924,6 +16930,7 @@ pub mod data_scan_event {
         /// The data quality score ranges between [0, 100] (up to two decimal
         /// points).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         /// The score of each dimension for data quality result.
@@ -16933,6 +16940,7 @@ pub mod data_scan_event {
         /// The score ranges between [0, 100] (up to two decimal
         /// points).
         #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+        #[serde_as(as = "std::collections::HashMap<_, wkt::internal::F32>")]
         pub dimension_score: std::collections::HashMap<std::string::String, f32>,
 
         /// The score of each column scanned in the data scan job.
@@ -16942,6 +16950,7 @@ pub mod data_scan_event {
         /// The score ranges between [0, 100] (up to two decimal
         /// points).
         #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+        #[serde_as(as = "std::collections::HashMap<_, wkt::internal::F32>")]
         pub column_score: std::collections::HashMap<std::string::String, f32>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17025,6 +17034,7 @@ pub mod data_scan_event {
         /// * Value ranges between 0.0 and 100.0.
         /// * Value 0.0 or 100.0 imply that sampling was not applied.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub sampling_percent: f32,
 
         /// Boolean indicating whether a row filter was applied in the DataScan job.
@@ -17081,6 +17091,7 @@ pub mod data_scan_event {
         /// * Value ranges between 0.0 and 100.0.
         /// * Value 0.0 or 100.0 imply that sampling was not applied.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub sampling_percent: f32,
 
         /// Boolean indicating whether a row filter was applied in the DataScan job.

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -9099,6 +9099,7 @@ pub struct YarnApplication {
 
     /// Required. The numerical progress of the application, from 1 to 100.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub progress: f32,
 
     /// Optional. The HTTP URL of the ApplicationMaster, HistoryServer, or

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -2375,6 +2375,7 @@ pub struct SpeechWordInfo {
     /// This field is not guaranteed to be fully stable over time for the same
     /// audio input. Users should also not rely on it to always be provided.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8339,6 +8340,7 @@ pub mod version_variants {
         /// Percentage of the traffic which should be routed to this
         /// version of flow. Traffic allocation for a single flow must sum up to 1.0.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub traffic_allocation: f32,
 
         /// Whether the variant is for the control group.
@@ -9076,6 +9078,7 @@ pub struct NluSettings {
     /// to 0.0, the default of 0.3 is used. You can set a separate classification
     /// threshold for the flow in each language enabled for the agent.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub classification_threshold: f32,
 
     /// Indicates NLU model training mode.
@@ -11591,6 +11594,7 @@ pub mod generator {
         /// Valid range: [0.0, 1.0]
         /// Low temperature = less random. High temperature = more random.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub temperature: std::option::Option<f32>,
 
         /// The maximum number of tokens to generate.
@@ -11604,6 +11608,7 @@ pub mod generator {
         /// Valid range: (0.0, 1.0].
         /// Small topP = less random. Large topP = more random.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub top_p: std::option::Option<f32>,
 
         /// If set, the sampling process in each step is limited to the top_k tokens
@@ -18629,6 +18634,7 @@ pub struct StreamingRecognitionResult {
     /// This field is typically only provided if `is_final` is true and you should
     /// not rely on it being accurate or even set.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// An estimate of the likelihood that the speech recognizer will
@@ -18640,6 +18646,7 @@ pub struct StreamingRecognitionResult {
     /// * Otherwise, the value is in (0.0, 1.0] where 0.0 means completely
     ///   unstable and 1.0 means completely stable.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub stability: f32,
 
     /// Word-specific information for the words recognized by Speech in
@@ -19277,6 +19284,7 @@ pub mod boost_spec {
         /// Setting to 0.0 means no boost applied. The boosting condition is
         /// ignored.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub boost: f32,
 
         /// Optional. Complex specification for custom ranking based on customer
@@ -19438,6 +19446,7 @@ pub mod boost_spec {
                 /// Optional. The value between -1 to 1 by which to boost the score if
                 /// the attribute_value evaluates to the value specified above.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                #[serde_as(as = "wkt::internal::F32")]
                 pub boost_amount: f32,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20023,6 +20032,7 @@ pub struct QueryResult {
     ///
     /// [google.cloud.dialogflow.cx.v3.QueryResult.match]: crate::model::QueryResult::match
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub intent_detection_confidence: f32,
 
     /// Intent match result, could be an intent or an event.
@@ -20704,6 +20714,7 @@ pub struct Match {
     /// for the same end-user expression at any time due to a model retraining or
     /// change in implementation.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21311,11 +21322,13 @@ pub struct SentimentAnalysisResult {
     /// Sentiment score between -1.0 (negative sentiment) and 1.0 (positive
     /// sentiment).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     /// A non-negative number in the [0, +inf) range, which represents the absolute
     /// magnitude of sentiment, regardless of score (positive or negative).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub magnitude: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22536,6 +22549,7 @@ pub struct TransitionCoverage {
 
     /// The percent of transitions in the agent that are covered.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub coverage_score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22891,6 +22905,7 @@ pub struct TransitionRouteGroupCoverage {
     /// The percent of transition routes in all the transition route groups that
     /// are covered.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub coverage_score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22949,6 +22964,7 @@ pub mod transition_route_group_coverage {
         /// The percent of transition routes in the transition route group that are
         /// covered.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub coverage_score: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -23065,6 +23081,7 @@ pub struct IntentCoverage {
 
     /// The percent of intents in the agent that are covered.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub coverage_score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -27895,6 +27912,7 @@ pub mod webhook_request {
         /// The confidence of the matched intent. Values range from 0.0 (completely
         /// uncertain) to 1.0 (completely certain).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub confidence: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -28013,12 +28031,14 @@ pub mod webhook_request {
         /// Sentiment score between -1.0 (negative sentiment) and 1.0 (positive
         /// sentiment).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         /// A non-negative number in the [0, +inf) range, which represents the
         /// absolute magnitude of sentiment, regardless of score (positive or
         /// negative).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub magnitude: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -28803,6 +28823,7 @@ pub struct LanguageInfo {
 
     /// The confidence score of the detected language between 0 and 1.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence_score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -105,6 +105,7 @@ pub struct Agent {
     /// values range from 0.0 (completely uncertain) to 1.0 (completely certain).
     /// If set to 0.0, the default of 0.3 is used.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub classification_threshold: f32,
 
     /// Optional. API version displayed in Dialogflow console. If not specified,
@@ -2452,6 +2453,7 @@ pub struct SpeechContext {
     /// Dialogflow recommends that you use boosts in the range (0, 20] and that you
     /// find a value that fits your use case with binary search.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub boost: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2517,6 +2519,7 @@ pub struct SpeechWordInfo {
     /// This field is not guaranteed to be fully stable over time for the same
     /// audio input. Users should also not rely on it to always be provided.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6137,6 +6140,7 @@ pub mod search_knowledge_request {
                     /// Setting to 0.0 means no boost applied. The boosting condition is
                     /// ignored.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                    #[serde_as(as = "wkt::internal::F32")]
                     pub boost: f32,
 
                     /// Optional. Complex specification for custom ranking based on
@@ -6297,6 +6301,7 @@ pub mod search_knowledge_request {
                             /// Optional. The value between -1 to 1 by which to boost the score
                             /// if the attribute_value evaluates to the value specified above.
                             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                            #[serde_as(as = "wkt::internal::F32")]
                             pub boost_amount: f32,
 
                             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8827,6 +8832,7 @@ pub struct SmartReplyMetrics {
     /// which similar messages have appeared at least once in the allowlist. Should
     /// be [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub allowlist_coverage: f32,
 
     /// Metrics of top n smart replies, sorted by [TopNMetric.n][].
@@ -8899,6 +8905,7 @@ pub mod smart_reply_metrics {
         /// real reply` divided by `number of queries with at least one smart reply`.
         /// Value ranges from 0.0 to 1.0 inclusive.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub recall: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11045,6 +11052,7 @@ pub mod human_agent_assistant_config {
         /// Supported features: ARTICLE_SUGGESTION, FAQ, SMART_REPLY, SMART_COMPOSE,
         /// KNOWLEDGE_SEARCH, KNOWLEDGE_ASSIST, ENTITY_EXTRACTION.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub confidence_threshold: f32,
 
         /// Determines how recent conversation context is filtered when generating
@@ -25456,6 +25464,7 @@ pub struct ArticleAnswer {
     /// conversation, as a value from 0.0 (completely uncertain) to 1.0
     /// (completely certain).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// A map that contains metadata about the answer and the
@@ -25546,6 +25555,7 @@ pub struct FaqAnswer {
     /// for this conversational query, range from 0.0 (completely uncertain)
     /// to 1.0 (completely certain).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// The corresponding FAQ question.
@@ -25643,6 +25653,7 @@ pub struct SmartReplyAnswer {
     /// this conversation, as a value from 0.0 (completely uncertain) to 1.0
     /// (completely certain).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// The name of answer record, in the format of
@@ -27585,6 +27596,7 @@ pub struct QueryResult {
     /// has separate confidence estimates per portion of the audio in
     /// StreamingRecognitionResult.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub speech_recognition_confidence: f32,
 
     /// The action name from the matched intent.
@@ -27664,6 +27676,7 @@ pub struct QueryResult {
     /// If there are `multiple knowledge_answers` messages, this value is set to
     /// the greatest `knowledgeAnswers.match_confidence` value in the list.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub intent_detection_confidence: f32,
 
     /// Free-form diagnostic information for the associated detect intent request.
@@ -28509,6 +28522,7 @@ pub struct StreamingRecognitionResult {
     /// This field is typically only provided if `is_final` is true and you should
     /// not rely on it being accurate or even set.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Word-specific information for the words recognized by Speech in
@@ -28904,11 +28918,13 @@ pub struct Sentiment {
     /// Sentiment score between -1.0 (negative sentiment) and 1.0 (positive
     /// sentiment).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     /// A non-negative number in the [0, +inf) range, which represents the absolute
     /// magnitude of sentiment, regardless of score (positive or negative).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub magnitude: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -707,6 +707,7 @@ pub mod answer {
                 /// the same query and chunk at any time due to a model retraining or
                 /// change in implementation.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub relevance_score: std::option::Option<f32>,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -773,6 +774,7 @@ pub mod answer {
             /// the same query and chunk at any time due to a model retraining or
             /// change in implementation.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
             pub relevance_score: std::option::Option<f32>,
 
             /// Document metadata.
@@ -1455,6 +1457,7 @@ pub mod answer {
                         /// the same query and chunk at any time due to a model retraining or
                         /// change in implementation.
                         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                         pub relevance_score: std::option::Option<f32>,
 
                         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3710,6 +3713,7 @@ pub mod control {
         /// Strength of the boost, which should be in [-1, 1]. Negative
         /// boost means demotion. Default is 0.0 (No-op).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub boost: f32,
 
         /// Required. Specifies which products to apply the boost to.
@@ -3956,6 +3960,7 @@ pub mod control {
                 /// Optional. The value between -1 to 1 by which to boost the score if
                 /// the attribute_value evaluates to the value specified above.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                #[serde_as(as = "wkt::internal::F32")]
                 pub boost_amount: f32,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13173,10 +13178,12 @@ pub mod generate_grounded_content_request {
 
         /// If specified, custom value for the temperature will be used.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub temperature: std::option::Option<f32>,
 
         /// If specified, custom value for nucleus sampling will be used.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub top_p: std::option::Option<f32>,
 
         /// If specified, custom value for top-k sampling will be used.
@@ -13185,6 +13192,7 @@ pub mod generate_grounded_content_request {
 
         /// If specified, custom value for frequency penalty will be used.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub frequency_penalty: std::option::Option<f32>,
 
         /// If specified, custom value for the seed will be used.
@@ -13193,6 +13201,7 @@ pub mod generate_grounded_content_request {
 
         /// If specified, custom value for presence penalty will be used.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub presence_penalty: std::option::Option<f32>,
 
         /// If specified, custom value for max output tokens will be used.
@@ -13335,6 +13344,7 @@ pub mod generate_grounded_content_request {
             /// The value of the threshold. If the predictor will predict a
             /// value smaller than this, it would suppress grounding in the source.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
             pub threshold: std::option::Option<f32>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -13893,6 +13903,7 @@ pub mod generate_grounded_content_response {
 
         /// The overall grounding score for the candidate, in the range of [0, 1].
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
         pub grounding_score: std::option::Option<f32>,
 
         /// Grounding metadata for the generated content.
@@ -14239,6 +14250,7 @@ pub mod generate_grounded_content_response {
                 /// In between values allow to differentiate between different usefulness
                 /// scores for grounding.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub prediction: std::option::Option<f32>,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14402,6 +14414,7 @@ pub mod generate_grounded_content_response {
                 /// claim in the support chunks indicated.
                 /// Higher value means that the claim is better supported by the chunks.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
                 pub support_score: std::option::Option<f32>,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14787,6 +14800,7 @@ pub struct CheckGroundingResponse {
     /// Higher the score, higher is the fraction of claims that are supported by
     /// the provided facts. This is always set when a response is returned.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub support_score: std::option::Option<f32>,
 
     /// List of facts cited across all claims in the answer candidate.
@@ -19432,6 +19446,7 @@ pub struct RankingRecord {
     /// The score will be rounded to 2 decimal places. If the score is close to 0,
     /// it will be rounded to 0.0001 to avoid returning unset.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -20046,6 +20061,7 @@ pub struct SafetyRating {
 
     /// Output only. Harm probability score.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub probability_score: f32,
 
     /// Output only. Harm severity levels in the content.
@@ -20053,6 +20069,7 @@ pub struct SafetyRating {
 
     /// Output only. Harm severity score.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub severity_score: f32,
 
     /// Output only. Indicates whether the content was filtered out because of this
@@ -22012,6 +22029,7 @@ pub mod search_request {
             /// boost_control_spec below are set. If both are set then the global boost
             /// is ignored and the more fine-grained boost_control_spec is applied.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub boost: f32,
 
             /// Complex specification for custom ranking based on customer defined
@@ -22170,6 +22188,7 @@ pub mod search_request {
                     /// The value between -1 to 1 by which to boost the score if the
                     /// attribute_value evaluates to the value specified above.
                     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                    #[serde_as(as = "wkt::internal::F32")]
                     pub boost_amount: f32,
 
                     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -24338,6 +24357,7 @@ pub mod search_response {
             /// The confidence scores of the each category, higher
             /// value means higher confidence. Order matches the Categories.
             #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+            #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
             pub scores: std::vec::Vec<f32>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -30172,6 +30192,7 @@ pub struct TransactionInfo {
     /// may include shipping, tax, or other adjustments to the total value that you
     /// want to include.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub value: std::option::Option<f32>,
 
     /// Required. Currency code. Use three-character ISO-4217 code.
@@ -30184,6 +30205,7 @@ pub struct TransactionInfo {
 
     /// All the taxes associated with the transaction.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub tax: std::option::Option<f32>,
 
     /// All the costs associated with the products. These can be manufacturing
@@ -30198,6 +30220,7 @@ pub struct TransactionInfo {
     /// [google.cloud.discoveryengine.v1.TransactionInfo.tax]: crate::model::TransactionInfo::tax
     /// [google.cloud.discoveryengine.v1.TransactionInfo.value]: crate::model::TransactionInfo::value
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub cost: std::option::Option<f32>,
 
     /// The total discount(s) value applied to this transaction.
@@ -30226,6 +30249,7 @@ pub struct TransactionInfo {
     /// [google.cloud.discoveryengine.v1.TransactionInfo.tax]: crate::model::TransactionInfo::tax
     /// [google.cloud.discoveryengine.v1.TransactionInfo.value]: crate::model::TransactionInfo::value
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub discount_value: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -30321,6 +30345,7 @@ pub struct DocumentInfo {
     ///
     /// [google.cloud.discoveryengine.v1.UserEvent.event_type]: crate::model::UserEvent::event_type
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub conversion_value: std::option::Option<f32>,
 
     /// A required descriptor of the associated
@@ -30638,6 +30663,7 @@ pub struct MediaInfo {
     ///
     /// [google.cloud.discoveryengine.v1.MediaInfo.media_progress_duration]: crate::model::MediaInfo::media_progress_duration
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub media_progress_percentage: std::option::Option<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -613,6 +613,7 @@ pub mod document {
         pub struct FontSize {
             /// Font size for the text.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub size: f32,
 
             /// Unit for the font size. Follows CSS naming (such as `in`, `px`, and
@@ -958,10 +959,12 @@ pub mod document {
         pub struct Dimension {
             /// Page width.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub width: f32,
 
             /// Page height.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub height: f32,
 
             /// Dimension unit.
@@ -1159,6 +1162,7 @@ pub mod document {
             ///
             /// [google.cloud.documentai.v1.Document.Page.Layout]: crate::model::document::page::Layout
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub confidence: f32,
 
             /// The bounding polygon for the
@@ -2517,6 +2521,7 @@ pub mod document {
 
             /// Confidence of detected language. Range `[0, 1]`.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub confidence: f32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2558,6 +2563,7 @@ pub mod document {
         pub struct ImageQualityScores {
             /// The overall quality score. Range `[0, 1]` where `1` is perfect quality.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub quality_score: f32,
 
             /// A list of detected defects.
@@ -2628,6 +2634,7 @@ pub mod document {
                 /// Confidence of detected defect. Range `[0, 1]` where `1` indicates
                 /// strong confidence that the defect exists.
                 #[serde(skip_serializing_if = "wkt::internal::is_default")]
+                #[serde_as(as = "wkt::internal::F32")]
                 pub confidence: f32,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2694,6 +2701,7 @@ pub mod document {
 
         /// Optional. Confidence of detected Schema entity. Range `[0, 1]`.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub confidence: f32,
 
         /// Optional. Represents the provenance of this entity wrt. the location on
@@ -3409,6 +3417,7 @@ pub mod document {
             /// Optional. Confidence of detected page element, if applicable. Range
             /// `[0, 1]`.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub confidence: f32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -8681,6 +8690,7 @@ pub mod train_processor_version_request {
         /// values are between 0.1 and 10. If not provided, recommended learning rate
         /// will be used.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub learning_rate_multiplier: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -10377,14 +10387,17 @@ pub mod evaluation {
     pub struct Metrics {
         /// The calculated precision.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub precision: f32,
 
         /// The calculated recall.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub recall: f32,
 
         /// The calculated f1 score.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub f1_score: f32,
 
         /// The amount of occurrences in predicted documents.
@@ -10512,6 +10525,7 @@ pub mod evaluation {
     pub struct ConfidenceLevelMetrics {
         /// The confidence level.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub confidence_level: f32,
 
         /// The metrics at the specific confidence level.
@@ -10570,21 +10584,25 @@ pub mod evaluation {
         /// The calculated area under the precision recall curve (AUPRC), computed by
         /// integrating over all confidence thresholds.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub auprc: f32,
 
         /// The Estimated Calibration Error (ECE) of the confidence of the predicted
         /// entities.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub estimated_calibration_error: f32,
 
         /// The AUPRC for metrics with fuzzy matching disabled, i.e., exact matching
         /// only.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub auprc_exact: f32,
 
         /// The ECE for the predicted entities with fuzzy matching disabled, i.e.,
         /// exact matching only.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub estimated_calibration_error_exact: f32,
 
         /// The metrics type for the label.
@@ -10786,10 +10804,12 @@ impl wkt::message::Message for Vertex {
 pub struct NormalizedVertex {
     /// X coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub x: f32,
 
     /// Y coordinate (starts from the top of the image).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub y: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -528,11 +528,13 @@ pub struct Sentiment {
     /// the absolute magnitude of sentiment regardless of score (positive or
     /// negative).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub magnitude: f32,
 
     /// Sentiment score between -1.0 (negative sentiment) and 1.0
     /// (positive sentiment).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -590,6 +592,7 @@ pub struct EntityMention {
     /// The score shows the probability of the entity mention being the entity
     /// type. The score is in (0, 1] range.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub probability: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -764,12 +767,14 @@ pub struct ClassificationCategory {
     /// The classifier's confidence of the category. Number represents how certain
     /// the classifier is that this category represents the given text.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Optional. The classifier's severity of the category. This is only present
     /// when the ModerateTextRequest.ModelVersion is set to MODEL_VERSION_2, and
     /// the corresponding category has a severity score.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub severity: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -9488,6 +9488,7 @@ impl wkt::message::Message for PhysicalPlatformDetails {
 pub struct MemoryUsageSample {
     /// Percentage of system memory utilized. Must be in the interval [0, 100].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub utilized_percentage: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9521,6 +9522,7 @@ pub struct CpuUsageSample {
     /// Percentage of total CPU capacity utilized. Must be in the interval [0,
     /// 100]. On most systems can be calculated using 100 - idle percentage.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub utilized_percentage: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9554,11 +9556,13 @@ pub struct NetworkUsageSample {
     /// Average network ingress in B/s sampled over a short window.
     /// Must be non-negative.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub average_ingress_bps: f32,
 
     /// Average network egress in B/s sampled over a short window.
     /// Must be non-negative.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub average_egress_bps: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9597,6 +9601,7 @@ impl wkt::message::Message for NetworkUsageSample {
 pub struct DiskUsageSample {
     /// Average IOPS sampled over a short window. Must be non-negative.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub average_iops: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -9869,18 +9874,22 @@ pub mod daily_resource_usage_aggregation {
     pub struct Stats {
         /// Average usage value.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub average: f32,
 
         /// Median usage value.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub median: f32,
 
         /// 95th percentile usage value.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub nintey_fifth_percentile: f32,
 
         /// Peak usage value.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub peak: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -8673,6 +8673,7 @@ pub struct VpcFlowLogsConfig {
     /// sampling rate to 0.0 is not allowed. If you want to disable VPC Flow Logs,
     /// use the state field instead. Default value is 1.0.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub flow_sampling: std::option::Option<f32>,
 
     /// Optional. Configures whether all, none or a subset of metadata fields

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -191,6 +191,7 @@ pub struct AutonomousDatabaseProperties {
 
     /// Optional. The number of compute servers for the Autonomous Database.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub compute_count: f32,
 
     /// Optional. The number of CPU cores to be made available to the database.
@@ -421,6 +422,7 @@ pub struct AutonomousDatabaseProperties {
     /// Output only. The storage space used by automatic backups of Autonomous
     /// Database, in gigabytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub total_auto_backup_storage_size_gbs: f32,
 
     /// Output only. The long term backup schedule of the Autonomous Database.
@@ -2888,6 +2890,7 @@ pub struct AutonomousDatabaseBackupProperties {
 
     /// Output only. The quantity of data in the database, in terabytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub database_size_tb: f32,
 
     /// Output only. A valid Oracle Database version for Autonomous Database.
@@ -2938,6 +2941,7 @@ pub struct AutonomousDatabaseBackupProperties {
 
     /// Output only. The backup size in terabytes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub size_tb: f32,
 
     /// Output only. Timestamp until when the backup will be available.
@@ -7566,6 +7570,7 @@ pub struct CloudVmClusterProperties {
 
     /// Optional. OCPU count per VM. Minimum is 0.1.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub ocpu_count: f32,
 
     /// Optional. Memory allocated in GBs.

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -4457,16 +4457,19 @@ pub mod workloads_config {
     pub struct SchedulerResource {
         /// Optional. CPU request and limit for a single Airflow scheduler replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub cpu: f32,
 
         /// Optional. Memory (GB) request and limit for a single Airflow scheduler
         /// replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub memory_gb: f32,
 
         /// Optional. Storage (GB) request and limit for a single Airflow scheduler
         /// replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub storage_gb: f32,
 
         /// Optional. The number of schedulers.
@@ -4521,14 +4524,17 @@ pub mod workloads_config {
     pub struct WebServerResource {
         /// Optional. CPU request and limit for Airflow web server.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub cpu: f32,
 
         /// Optional. Memory (GB) request and limit for Airflow web server.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub memory_gb: f32,
 
         /// Optional. Storage (GB) request and limit for Airflow web server.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub storage_gb: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4573,16 +4579,19 @@ pub mod workloads_config {
     pub struct WorkerResource {
         /// Optional. CPU request and limit for a single Airflow worker replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub cpu: f32,
 
         /// Optional. Memory (GB) request and limit for a single Airflow worker
         /// replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub memory_gb: f32,
 
         /// Optional. Storage (GB) request and limit for a single Airflow worker
         /// replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub storage_gb: f32,
 
         /// Optional. Minimum number of workers for autoscaling.
@@ -4651,11 +4660,13 @@ pub mod workloads_config {
 
         /// Optional. CPU request and limit for a single Airflow triggerer replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub cpu: f32,
 
         /// Optional. Memory (GB) request and limit for a single Airflow triggerer
         /// replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub memory_gb: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4704,16 +4715,19 @@ pub mod workloads_config {
         /// Optional. CPU request and limit for a single Airflow DAG processor
         /// replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub cpu: f32,
 
         /// Optional. Memory (GB) request and limit for a single Airflow DAG
         /// processor replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub memory_gb: f32,
 
         /// Optional. Storage (GB) request and limit for a single Airflow DAG
         /// processor replica.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub storage_gb: f32,
 
         /// Optional. The number of DAG processors. If not provided or set to 0, a

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -10369,6 +10369,7 @@ pub mod vulnerability_report {
             /// The CVSS V2 score of this vulnerability. CVSS V2 score is on a scale of
             /// 0 - 10 where 0 indicates low severity and 10 indicates high severity.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub cvss_v2_score: f32,
 
             /// The full description of the CVSSv3 for this vulnerability from NVD.
@@ -10777,16 +10778,19 @@ pub struct CVSSv3 {
     /// The base score is a function of the base metric scores.
     /// <https://www.first.org/cvss/specification-document#Base-Metrics>
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub base_score: f32,
 
     /// The Exploitability sub-score equation is derived from the Base
     /// Exploitability metrics.
     /// <https://www.first.org/cvss/specification-document#2-1-Exploitability-Metrics>
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub exploitability_score: f32,
 
     /// The Impact sub-score equation is derived from the Base Impact metrics.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub impact_score: f32,
 
     /// This metric reflects the context by which vulnerability exploitation is

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -2318,6 +2318,7 @@ pub struct RiskAnalysis {
     /// (1.0 means very likely legitimate traffic while 0.0 means very likely
     /// non-legitimate traffic).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     /// Output only. Reasons contributing to the risk analysis verdict.
@@ -2749,6 +2750,7 @@ pub struct FraudPreventionAssessment {
     /// the combined risk of attack vectors below. Values are from 0.0 (lowest)
     /// to 1.0 (highest).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub transaction_risk: f32,
 
     /// Output only. Assessment of this transaction for risk of a stolen
@@ -2848,6 +2850,7 @@ pub mod fraud_prevention_assessment {
         /// Output only. Probability of this transaction being executed with a stolen
         /// instrument. Values are from 0.0 (lowest) to 1.0 (highest).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub risk: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2882,6 +2885,7 @@ pub mod fraud_prevention_assessment {
         /// Output only. Probability of this transaction attempt being part of a card
         /// testing attack. Values are from 0.0 (lowest) to 1.0 (highest).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub risk: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2916,6 +2920,7 @@ pub mod fraud_prevention_assessment {
         /// behaviorally trustworthy way. Values are from 0.0 (lowest) to 1.0
         /// (highest).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub trust: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3014,6 +3019,7 @@ pub mod fraud_signals {
         /// components in their identity, such as a randomly generated email address,
         /// temporary phone number, or fake shipping address.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub synthetic_risk: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3164,6 +3170,7 @@ pub struct SmsTollFraudVerdict {
     /// Output only. Probability of an SMS event being fraudulent.
     /// Values are from 0.0 (lowest) to 1.0 (highest).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub risk: f32,
 
     /// Output only. Reasons contributing to the SMS toll fraud verdict.
@@ -4562,6 +4569,7 @@ pub struct TestingOptions {
     /// Optional. All assessments for this Key return this score. Must be between 0
     /// (likely not legitimate) and 1 (likely legitimate) inclusive.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub testing_score: f32,
 
     /// Optional. For challenge-based keys only (CHECKBOX, INVISIBLE), all

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -2822,6 +2822,7 @@ pub mod rule {
         /// Setting to 0.0 means no boost applied. The boosting condition is
         /// ignored.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub boost: f32,
 
         /// The filter can have a max size of 5000 characters.
@@ -4152,6 +4153,7 @@ pub struct PriceInfo {
     /// [price](https://support.google.com/merchants/answer/6324371). Schema.org
     /// property [Offer.price](https://schema.org/price).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub price: f32,
 
     /// Price of the product without any discount. If zero, by default set to be
@@ -4163,6 +4165,7 @@ pub struct PriceInfo {
     /// [google.cloud.retail.v2.PriceInfo.original_price]: crate::model::PriceInfo::original_price
     /// [google.cloud.retail.v2.PriceInfo.price]: crate::model::PriceInfo::price
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub original_price: f32,
 
     /// The costs associated with the sale of a particular product. Used for gross
@@ -4177,6 +4180,7 @@ pub struct PriceInfo {
     /// [google.cloud.retail.v2.PriceInfo.cost]: crate::model::PriceInfo::cost
     /// [google.cloud.retail.v2.PriceInfo.price]: crate::model::PriceInfo::price
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub cost: f32,
 
     /// The timestamp when the [price][google.cloud.retail.v2.PriceInfo.price]
@@ -4412,6 +4416,7 @@ pub struct Rating {
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub average_rating: f32,
 
     /// List of rating counts per rating value (index = rating - 1). The list is
@@ -6358,6 +6363,7 @@ pub struct GenerativeQuestionConfig {
 
     /// Output only. The ratio of how often a question was asked.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub frequency: f32,
 
     /// Optional. Whether the question is asked at serving time.
@@ -14331,6 +14337,7 @@ pub mod search_request {
             /// Setting to 0.0 means no boost applied. The boosting condition is
             /// ignored.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[serde_as(as = "wkt::internal::F32")]
             pub boost: f32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -17850,10 +17857,12 @@ pub struct PurchaseTransaction {
     /// total revenue that you want to include as part of your revenue
     /// calculations.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub revenue: f32,
 
     /// All the taxes associated with the transaction.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub tax: f32,
 
     /// All the costs associated with the products. These can be manufacturing
@@ -17868,6 +17877,7 @@ pub struct PurchaseTransaction {
     /// [google.cloud.retail.v2.PurchaseTransaction.revenue]: crate::model::PurchaseTransaction::revenue
     /// [google.cloud.retail.v2.PurchaseTransaction.tax]: crate::model::PurchaseTransaction::tax
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub cost: f32,
 
     /// Required. Currency code. Use three-character ISO-4217 code.

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -2786,6 +2786,7 @@ pub struct SpeechRecognitionAlternative {
     ///
     /// [google.cloud.speech.v2.StreamingRecognitionResult.is_final]: crate::model::StreamingRecognitionResult::is_final
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// A list of word-specific information for each recognized word.
@@ -2879,6 +2880,7 @@ pub struct WordInfo {
     ///
     /// [google.cloud.speech.v2.StreamingRecognitionResult.is_final]: crate::model::StreamingRecognitionResult::is_final
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// A distinct label is assigned for every speaker within the audio. This field
@@ -4658,6 +4660,7 @@ pub struct StreamingRecognitionResult {
     ///
     /// [google.cloud.speech.v2.StreamingRecognitionResult.is_final]: crate::model::StreamingRecognitionResult::is_final
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub stability: f32,
 
     /// Time offset of the end of this result relative to the beginning of the
@@ -5444,6 +5447,7 @@ pub struct PhraseSet {
     /// binary search approach to finding the optimal value for your use case as
     /// well as adding phrases both with and without boost to your requests.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub boost: f32,
 
     /// User-settable, human-readable name for the PhraseSet. Must be 63
@@ -5669,6 +5673,7 @@ pub mod phrase_set {
         /// for your use case as well as adding phrases both with and without boost
         /// to your requests.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub boost: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -4328,6 +4328,7 @@ pub struct DetectedLanguage {
 
     /// The confidence of the detection result for this language.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -337,6 +337,7 @@ pub struct LabelDetectionConfig {
     /// Note: For best results, follow the default threshold. We will update
     /// the default threshold everytime when we release a new model.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub frame_confidence_threshold: f32,
 
     /// The confidence threshold we perform filtering on the labels from
@@ -346,6 +347,7 @@ pub struct LabelDetectionConfig {
     /// Note: For best results, follow the default threshold. We will update
     /// the default threshold everytime when we release a new model.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub video_confidence_threshold: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -726,6 +728,7 @@ pub struct LabelSegment {
 
     /// Confidence that the label is accurate. Range: [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -772,6 +775,7 @@ pub struct LabelFrame {
 
     /// Confidence that the label is accurate. Range: [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1059,18 +1063,22 @@ impl wkt::message::Message for ExplicitContentAnnotation {
 pub struct NormalizedBoundingBox {
     /// Left X coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub left: f32,
 
     /// Top Y coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub top: f32,
 
     /// Right X coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub right: f32,
 
     /// Bottom Y coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub bottom: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1472,6 +1480,7 @@ pub struct Track {
 
     /// Optional. The confidence score of the tracked object.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1540,6 +1549,7 @@ pub struct DetectedAttribute {
 
     /// Detected attribute confidence. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Text value of the detection result. For example, the value for "HairColor"
@@ -1599,6 +1609,7 @@ pub struct DetectedLandmark {
 
     /// The confidence score of the detected landmark. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2355,6 +2366,7 @@ pub struct SpeechRecognitionAlternative {
     /// to be always provided.
     /// The default of 0.0 is a sentinel value indicating `confidence` was not set.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Output only. A list of word-specific information for each recognized word.
@@ -2435,6 +2447,7 @@ pub struct WordInfo {
     /// to be always provided.
     /// The default of 0.0 is a sentinel value indicating `confidence` was not set.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Output only. A distinct integer value is assigned for every speaker within
@@ -2506,10 +2519,12 @@ impl wkt::message::Message for WordInfo {
 pub struct NormalizedVertex {
     /// X coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub x: f32,
 
     /// Y coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub y: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2606,6 +2621,7 @@ pub struct TextSegment {
     /// Confidence for the track of detected text. It is calculated as the highest
     /// over all frames where OCR detected text appears.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Information related to the frames where OCR detected text appears.
@@ -2828,6 +2844,7 @@ pub struct ObjectTrackingAnnotation {
 
     /// Object category's labeling confidence of this track.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Information corresponding to all frames where this object track appears.

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -87,10 +87,12 @@ impl wkt::message::Message for Vertex {
 pub struct NormalizedVertex {
     /// X coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub x: f32,
 
     /// Y coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub y: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -183,14 +185,17 @@ impl wkt::message::Message for BoundingPoly {
 pub struct Position {
     /// X coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub x: f32,
 
     /// Y coordinate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub y: f32,
 
     /// Z coordinate (or depth).
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub z: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -555,25 +560,30 @@ pub struct FaceAnnotation {
     /// of the face relative to the image vertical about the axis perpendicular to
     /// the face. Range [-180,180].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub roll_angle: f32,
 
     /// Yaw angle, which indicates the leftward/rightward angle that the face is
     /// pointing relative to the vertical plane perpendicular to the image. Range
     /// [-180,180].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub pan_angle: f32,
 
     /// Pitch angle, which indicates the upwards/downwards angle that the face is
     /// pointing relative to the image's horizontal plane. Range [-180,180].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub tilt_angle: f32,
 
     /// Detection confidence. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub detection_confidence: f32,
 
     /// Face landmarking confidence. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub landmarking_confidence: f32,
 
     /// Joy likelihood.
@@ -1166,6 +1176,7 @@ pub struct EntityAnnotation {
 
     /// Overall score of the result. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     /// **Deprecated. Use `score` instead.**
@@ -1174,6 +1185,7 @@ pub struct EntityAnnotation {
     /// this field represents the confidence that there is a tower in the query
     /// image. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// The relevancy of the ICA (Image Content Annotation) label to the
@@ -1182,6 +1194,7 @@ pub struct EntityAnnotation {
     /// detected distant towering building, even though the confidence that
     /// there is a tower in each image may be the same. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub topicality: f32,
 
     /// Image region to which this entity belongs. Not produced
@@ -1309,6 +1322,7 @@ pub struct LocalizedObjectAnnotation {
 
     /// Score of the result. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     /// Image region to which this object belongs. This must be populated.
@@ -1505,11 +1519,13 @@ pub struct ColorInfo {
 
     /// Image-specific score for this color. Value in range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub score: f32,
 
     /// The fraction of pixels the color occupies in the image.
     /// Value in range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub pixel_fraction: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1636,11 +1652,13 @@ pub struct CropHint {
 
     /// Confidence of this being a salient region.  Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     /// Fraction of importance of this salient region with respect to the original
     /// image.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub importance_fraction: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1732,6 +1750,7 @@ pub struct CropHintsParams {
     /// limited to a maximum of 16; any aspect ratios provided after the 16th are
     /// ignored.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[serde_as(as = "std::vec::Vec<wkt::internal::F32>")]
     pub aspect_ratios: std::vec::Vec<f32>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3612,6 +3631,7 @@ pub mod product_search_results {
         /// A confidence level on the match, ranging from 0 (no confidence) to
         /// 1 (full confidence).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         /// The resource name of the image from the product that is the closest match
@@ -3678,6 +3698,7 @@ pub mod product_search_results {
 
         /// Score of the result. Range [0, 1].
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5880,6 +5901,7 @@ pub mod text_annotation {
 
         /// Confidence of detected language. Range [0, 1].
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub confidence: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6118,6 +6140,7 @@ pub struct Page {
 
     /// Confidence of the OCR results on the page. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6223,6 +6246,7 @@ pub struct Block {
 
     /// Confidence of the OCR results on the block. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6402,6 +6426,7 @@ pub struct Paragraph {
 
     /// Confidence of the OCR results for the paragraph. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6495,6 +6520,7 @@ pub struct Word {
 
     /// Confidence of the OCR results for the word. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6587,6 +6613,7 @@ pub struct Symbol {
 
     /// Confidence of the OCR results for the symbol. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub confidence: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6773,6 +6800,7 @@ pub mod web_detection {
         /// Overall relevancy score for the entity.
         /// Not normalized and not comparable across different image queries.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         /// Canonical description of the entity, in English.
@@ -6825,6 +6853,7 @@ pub mod web_detection {
 
         /// (Deprecated) Overall relevancy score for the image.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6867,6 +6896,7 @@ pub mod web_detection {
 
         /// (Deprecated) Overall relevancy score for the web page.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[serde_as(as = "wkt::internal::F32")]
         pub score: f32,
 
         /// Title for the web page, may contain HTML markups.

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -1156,12 +1156,15 @@ impl wkt::message::Message for NonCompliantFile {
 pub struct CVSSv3 {
     /// The base score is a function of the base metric scores.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub base_score: f32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub exploitability_score: f32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub impact_score: f32,
 
     /// Base Metrics
@@ -1657,12 +1660,15 @@ pub mod cvs_sv_3 {
 pub struct Cvss {
     /// The base score is a function of the base metric scores.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub base_score: f32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub exploitability_score: f32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub impact_score: f32,
 
     /// Base Metrics
@@ -10708,6 +10714,7 @@ pub struct VulnerabilityNote {
     /// The CVSS score of this vulnerability. CVSS score is on a scale of 0 - 10
     /// where 0 indicates low severity and 10 indicates high severity.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub cvss_score: f32,
 
     /// The note provider assigned severity of this vulnerability.
@@ -11195,6 +11202,7 @@ pub struct VulnerabilityOccurrence {
     /// scale of 0 - 10 where 0 indicates low severity and 10 indicates high
     /// severity.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub cvss_score: f32,
 
     /// The cvss v3 score for the vulnerability.

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -2684,14 +2684,17 @@ pub mod redact_image_request {
 pub struct Color {
     /// The amount of red in the color as a value in the interval [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub red: f32,
 
     /// The amount of green in the color as a value in the interval [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub green: f32,
 
     /// The amount of blue in the color as a value in the interval [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub blue: f32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -352,6 +352,7 @@ pub struct ComplianceData {
     pub f_double: f64,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub f_float: f32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -645,6 +646,7 @@ pub struct ComplianceDataChild {
     pub f_string: std::string::String,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub f_float: f32,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
@@ -662,6 +664,7 @@ pub struct ComplianceDataChild {
     pub p_string: std::option::Option<std::string::String>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub p_float: std::option::Option<f32>,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -161,14 +161,17 @@ extern crate wkt;
 pub struct Color {
     /// The amount of red in the color as a value in the interval [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub red: f32,
 
     /// The amount of green in the color as a value in the interval [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub green: f32,
 
     /// The amount of blue in the color as a value in the interval [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "wkt::internal::F32")]
     pub blue: f32,
 
     /// The fraction of this color that should be applied to the pixel. That is,
@@ -183,6 +186,7 @@ pub struct Color {
     /// If omitted, this color object is rendered as a solid color
     /// (as if the alpha value had been explicitly given a value of 1.0).
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<wkt::internal::F32>")]
     pub alpha: std::option::Option<wkt::FloatValue>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]

--- a/src/wkt/tests/wrappers.rs
+++ b/src/wkt/tests/wrappers.rs
@@ -23,7 +23,10 @@ type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 #[non_exhaustive]
 pub struct Helper {
     pub field_double: Option<wkt::DoubleValue>,
+    #[serde_as(as = "Option<wkt::internal::F32>")]
     pub field_float: Option<wkt::FloatValue>,
+    #[serde_as(as = "Option<wkt::internal::F32>")]
+    pub field_float_inf: Option<wkt::FloatValue>,
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub field_int64: Option<wkt::Int64Value>,
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
@@ -43,6 +46,7 @@ pub struct Helper {
 #[non_exhaustive]
 pub struct Repeated {
     pub field_double: Vec<wkt::DoubleValue>,
+    #[serde_as(as = "Vec<wkt::internal::F32>")]
     pub field_float: Vec<wkt::FloatValue>,
     #[serde_as(as = "Vec<serde_with::DisplayFromStr>")]
     pub field_int64: Vec<wkt::Int64Value>,
@@ -61,6 +65,7 @@ fn serialize_in_struct() -> Result {
     let input = Helper {
         field_double: Some(42.0_f64),
         field_float: Some(42.0_f32),
+        field_float_inf: Some(f32::INFINITY),
         field_int64: Some(42),
         field_uint64: Some(42),
         field_int32: Some(42),
@@ -75,6 +80,7 @@ fn serialize_in_struct() -> Result {
     let want = json!({
         "fieldDouble": 42_f64,
         "fieldFloat":  42_f32,
+        "fieldFloatInf": "Infinity",
         "fieldInt64":  "42",
         "fieldUint64": "42",
         "fieldInt32":  42,
@@ -94,7 +100,7 @@ fn serialize_in_struct() -> Result {
 fn serialize_in_repeated() -> Result {
     let input = Repeated {
         field_double: vec![42.0_f64],
-        field_float: vec![42.0_f32],
+        field_float: vec![42.0_f32, f32::INFINITY],
         field_int64: vec![42_i64],
         field_uint64: vec![42_u64],
         field_int32: vec![42_i32],
@@ -108,7 +114,7 @@ fn serialize_in_repeated() -> Result {
     let json = serde_json::to_value(&input)?;
     let want = json!({
         "fieldDouble":  [42_f64],
-        "fieldFloat":   [42_f32],
+        "fieldFloat":   [42_f32, "Infinity"],
         "fieldInt64":   ["42"],
         "fieldUint64":  ["42"],
         "fieldInt32":   [42],


### PR DESCRIPTION
Update the generator to produce `serde_as` annotations for floats in the generated code.

Also update the wrappers integration test to use the new annotation for floats.

For #1767