### PR TITLE
feat(generator/rust): use deprecation attributes

### DIFF
--- a/generator/internal/api/deprecated.go
+++ b/generator/internal/api/deprecated.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+func (model *API) HasDeprecatedEntities() bool {
+	for _, e := range model.Enums {
+		if e.hasDeprecatedEntities() {
+			return true
+		}
+	}
+	for _, m := range model.Messages {
+		if m.hasDeprecatedEntities() {
+			return true
+		}
+	}
+	for _, s := range model.Services {
+		if s.hasDeprecatedEntities() {
+			return true
+		}
+	}
+	return false
+}
+
+func (message *Message) hasDeprecatedEntities() bool {
+	if message.Deprecated {
+		return true
+	}
+	for _, m := range message.Messages {
+		if m.hasDeprecatedEntities() {
+			return true
+		}
+	}
+	for _, e := range message.Enums {
+		if e.hasDeprecatedEntities() {
+			return true
+		}
+	}
+	for _, f := range message.Fields {
+		if f.Deprecated {
+			return true
+		}
+	}
+	return false
+}
+
+func (enum *Enum) hasDeprecatedEntities() bool {
+	if enum.Deprecated {
+		return true
+	}
+	for _, v := range enum.Values {
+		if v.Deprecated {
+			return true
+		}
+	}
+	return false
+}
+
+func (service *Service) hasDeprecatedEntities() bool {
+	if service.Deprecated {
+		return true
+	}
+	for _, m := range service.Methods {
+		if m.Deprecated {
+			return true
+		}
+	}
+	return false
+}

--- a/generator/internal/rust/templates/common/enum.mustache
+++ b/generator/internal/rust/templates/common/enum.mustache
@@ -34,11 +34,17 @@ limitations under the License.
 {{> /templates/common/feature_gate}}
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+{{#Deprecated}}
+#[deprecated]
+{{/Deprecated}}
 pub enum {{Codec.Name}} {
     {{#Codec.UniqueNames}}
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     {{Codec.VariantName}},
     {{/Codec.UniqueNames}}
     /// If set, the enum was initialized with an unknown value.

--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -22,6 +22,9 @@ limitations under the License.
 {{#Codec.MessageAttributes}}
 {{{.}}}
 {{/Codec.MessageAttributes}}
+{{#Deprecated}}
+#[deprecated]
+{{/Deprecated}}
 pub struct {{Codec.Name}} {
     {{#Codec.BasicFields}}
 
@@ -31,6 +34,9 @@ pub struct {{Codec.Name}} {
     {{#Codec.Attributes}}
     {{{.}}}
     {{/Codec.Attributes}}
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub {{Codec.FieldName}}: {{{Codec.FieldType}}},
     {{/Codec.BasicFields}}
     {{#OneOfs}}
@@ -54,6 +60,9 @@ impl {{Codec.Name}} {
     {{#Codec.SingularFields}}
 
     /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
         self.{{Codec.FieldName}} = v.into();
         self
@@ -62,6 +71,9 @@ impl {{Codec.Name}} {
     {{#Codec.RepeatedFields}}
 
     /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -75,6 +87,9 @@ impl {{Codec.Name}} {
     {{#Codec.MapFields}}
 
     /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -102,6 +117,9 @@ impl {{Codec.Name}} {
     /// The value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
     /// if it holds a `{{Codec.BranchName}}`, `None` if the field is not set or
     /// holds a different branch.
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn {{Codec.FieldName}}(&self) -> std::option::Option<&{{{Codec.FieldType}}}> {
         {{! Rarely, oneofs have a single branch and then the `_` case is never matched. }}
         #[allow(unreachable_patterns)]
@@ -118,6 +136,9 @@ impl {{Codec.Name}} {
     ///
     /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
     /// mutually exclusive.
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
         self.{{Group.Codec.FieldName}} = std::option::Option::Some(
             {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
@@ -133,6 +154,9 @@ impl {{Codec.Name}} {
     ///
     /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
     /// mutually exclusive.
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -153,6 +177,9 @@ impl {{Codec.Name}} {
     ///
     /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
     /// mutually exclusive.
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -173,6 +200,8 @@ impl {{Codec.Name}} {
 {{^Codec.HasSyntheticFields}}
 
 {{> /templates/common/feature_gate}}
+{{#Deprecated}}
+{{/Deprecated}}
 impl wkt::message::Message for {{Codec.Name}} {
     fn typename() -> &'static str {
         "type.googleapis.com/{{Codec.SourceFQN}}"
@@ -183,7 +212,7 @@ impl wkt::message::Message for {{Codec.Name}} {
 
 {{> /templates/common/feature_gate}}
 #[doc(hidden)]
-impl gax::paginator::internal::PageableResponse for {{Name}} {
+impl gax::paginator::internal::PageableResponse for {{Codec.Name}} {
     {{#PageableItem}}
     type PageItem = {{{Codec.PrimitiveFieldType}}};
 

--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -200,8 +200,6 @@ impl {{Codec.Name}} {
 {{^Codec.HasSyntheticFields}}
 
 {{> /templates/common/feature_gate}}
-{{#Deprecated}}
-{{/Deprecated}}
 impl wkt::message::Message for {{Codec.Name}} {
     fn typename() -> &'static str {
         "type.googleapis.com/{{Codec.SourceFQN}}"

--- a/generator/internal/rust/templates/common/oneof.mustache
+++ b/generator/internal/rust/templates/common/oneof.mustache
@@ -26,6 +26,9 @@ pub enum {{Codec.EnumName}} {
     {{#Codec.DocLines}}
     {{{.}}}
     {{/Codec.DocLines}}
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     {{Codec.BranchName}}({{{Codec.FieldType}}}),
     {{/Fields}}
 }

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -180,6 +180,9 @@ pub mod {{Codec.ModuleName}} {
         ///
         /// This is a **required** field for requests.
         {{/DocumentAsRequired}}
+        {{#Deprecated}}
+        #[deprecated]
+        {{/Deprecated}}
         pub fn set_{{Codec.SetterName}}<T: Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
             self.0.request.{{Codec.FieldName}} = v.into();
             self
@@ -192,6 +195,9 @@ pub mod {{Codec.ModuleName}} {
         ///
         /// This is a **required** field for requests.
         {{/DocumentAsRequired}}
+        {{#Deprecated}}
+        #[deprecated]
+        {{/Deprecated}}
         pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -209,6 +215,9 @@ pub mod {{Codec.ModuleName}} {
         ///
         /// This is a **required** field for requests.
         {{/DocumentAsRequired}}
+        {{#Deprecated}}
+        #[deprecated]
+        {{/Deprecated}}
         pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = (K, V)>,
@@ -236,6 +245,9 @@ pub mod {{Codec.ModuleName}} {
         ///
         /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
         /// mutually exclusive.
+        {{#Deprecated}}
+        #[deprecated]
+        {{/Deprecated}}
         pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
             self.0.request = self.0.request.set_{{Codec.SetterName}}(v);
             self
@@ -247,6 +259,9 @@ pub mod {{Codec.ModuleName}} {
         ///
         /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
         /// mutually exclusive.
+        {{#Deprecated}}
+        #[deprecated]
+        {{/Deprecated}}
         pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -267,6 +282,9 @@ pub mod {{Codec.ModuleName}} {
         ///
         /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
         /// mutually exclusive.
+        {{#Deprecated}}
+        #[deprecated]
+        {{/Deprecated}}
         pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = (K, V)>,

--- a/generator/internal/rust/templates/crate/src/client.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/client.rs.mustache
@@ -82,6 +82,9 @@ use std::sync::Arc;
 #[cfg_attr(docsrs, doc(cfg(feature = "{{Codec.ModuleName}}")))]
 {{/Codec.PerServiceFeatures}}
 #[derive(Clone, Debug)]
+{{#Deprecated}}
+#[deprecated]
+{{/Deprecated}}
 pub struct {{Codec.Name}} {
     inner: Arc<dyn super::stub::dynamic::{{Codec.Name}}>,
 }
@@ -147,6 +150,9 @@ impl {{Codec.Name}} {
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
     {{/OperationInfo}}
+    {{#Deprecated}}
+    #[deprecated]
+    {{/Deprecated}}
     pub fn {{Codec.Name}}(
         &self,
         {{#Codec.PathParams}}

--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -37,16 +37,19 @@ limitations under the License.
 #![cfg_attr(docsrs, feature(doc_cfg))]
 {{/Codec.PerServiceFeatures}}
 
-/// The messages and enums that are part of this client library.
-#[allow(clippy::module_inception)]
 {{!
     The generated code uses deprecated items in:
     - setters for deprecated fields.
     - fields that reference deprecated messages and enums.
+    - clients and stubs use deprecated RPCs.
+    - clients and stubs use deprecated services and deprecated request messages.
 }}
 {{#HasDeprecatedEntities}}
-#[allow(deprecated)]
+#![allow(deprecated)]
 {{/HasDeprecatedEntities}}
+
+/// The messages and enums that are part of this client library.
+#[allow(clippy::module_inception)]
 pub mod model;
 
 {{#Codec.HasServices}}
@@ -57,35 +60,15 @@ pub use gax::error::Error;
 #[allow(rustdoc::invalid_html_tags)]
 {{! We use explicit links because it is easier to generate the code with them. }}
 #[allow(rustdoc::redundant_explicit_links)]
-{{! The generated code may use deprecated request messages. }}
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-{{! The generated code may use clients and stubs because the corresponding service is deprecated. }}
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub mod client;
 
 /// Request builders.
-{{!
-    The generated code uses deprecated items in:
-    - setters for deprecated fields.
-    - fields that reference deprecated messages and enums.
-}}
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub mod builder;
 
 #[doc(hidden)]
-{{! The generated code may use deprecated request messages. }}
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -39,6 +39,14 @@ limitations under the License.
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+{{!
+    The generated code uses deprecated items in:
+    - setters for deprecated fields.
+    - fields that reference deprecated messages and enums.
+}}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod model;
 
 {{#Codec.HasServices}}
@@ -49,18 +57,41 @@ pub use gax::error::Error;
 #[allow(rustdoc::invalid_html_tags)]
 {{! We use explicit links because it is easier to generate the code with them. }}
 #[allow(rustdoc::redundant_explicit_links)]
+{{! The generated code may use deprecated request messages. }}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+{{! The generated code may use clients and stubs because the corresponding service is deprecated. }}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod client;
 
 /// Request builders.
+{{!
+    The generated code uses deprecated items in:
+    - setters for deprecated fields.
+    - fields that reference deprecated messages and enums.
+}}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod builder;
 
 #[doc(hidden)]
+{{! The generated code may use deprecated request messages. }}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/generator/internal/rust/templates/crate/src/stub.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/stub.rs.mustache
@@ -42,6 +42,10 @@ use gax::error::Error;
 use std::sync::Arc;
 {{/Codec.HasLROs}}
 
+{{! The generated code may use deprecated request messages. }}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub(crate) mod dynamic;
 
 {{/Codec.HasServices}}

--- a/generator/internal/rust/templates/grpc-client/mod.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/mod.rs.mustache
@@ -18,11 +18,19 @@ limitations under the License.
 //{{{.}}}
 {{/Codec.BoilerPlate}}
 
+{{!
+    The generated code uses deprecated items in:
+    - setters for deprecated fields.
+    - fields that reference deprecated messages and enums.
+    - clients and stubs use deprecated RPCs.
+    - clients and stubs use deprecated services and deprecated request messages.
+}}
+{{#HasDeprecatedEntities}}
+#![allow(deprecated)]
+{{/HasDeprecatedEntities}}
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub mod model;
 
 {{! We use explicit links because it is easier to generate the code with them. }}
@@ -30,23 +38,13 @@ pub mod model;
 pub mod stub;
 
 /// Request builders.
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub mod builder;
 
 /// The client(s) for this client library.
 pub mod client;
 
 #[doc(hidden)]
-{{! The generated code may use deprecated request messages. }}
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub(crate) mod transport;

--- a/generator/internal/rust/templates/grpc-client/mod.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/mod.rs.mustache
@@ -20,6 +20,9 @@ limitations under the License.
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod model;
 
 {{! We use explicit links because it is easier to generate the code with them. }}
@@ -27,13 +30,23 @@ pub mod model;
 pub mod stub;
 
 /// Request builders.
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod builder;
 
 /// The client(s) for this client library.
 pub mod client;
 
 #[doc(hidden)]
+{{! The generated code may use deprecated request messages. }}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub(crate) mod transport;

--- a/generator/internal/rust/templates/nosvc/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/nosvc/src/lib.rs.mustache
@@ -30,4 +30,12 @@ limitations under the License.
 //! module.
 
 /// The messages and enums that are part of this client library.
+{{!
+    The generated code uses deprecated items in:
+    - setters for deprecated fields.
+    - fields that reference deprecated messages and enums.
+}}
+{{#HasDeprecatedEntities}}
+#[allow(deprecated)]
+{{/HasDeprecatedEntities}}
 pub mod model;

--- a/src/generated/api/servicemanagement/v1/src/builder.rs
+++ b/src/generated/api/servicemanagement/v1/src/builder.rs
@@ -130,6 +130,7 @@ pub mod service_manager {
         }
 
         /// Sets the value of [consumer_id][crate::model::ListServicesRequest::consumer_id].
+        #[deprecated]
         pub fn set_consumer_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.consumer_id = v.into();
             self

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [ServiceManager](client/struct.ServiceManager.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -1376,6 +1376,7 @@ pub struct ListServicesRequest {
     ///
     /// - project:<project_id>
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub consumer_id: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1409,6 +1410,7 @@ impl ListServicesRequest {
     }
 
     /// Sets the value of [consumer_id][crate::model::ListServicesRequest::consumer_id].
+    #[deprecated]
     pub fn set_consumer_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.consumer_id = v.into();
         self

--- a/src/generated/api/servicemanagement/v1/src/stub.rs
+++ b/src/generated/api/servicemanagement/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ServiceManager].

--- a/src/generated/api/types/src/lib.rs
+++ b/src/generated/api/types/src/lib.rs
@@ -26,4 +26,5 @@
 //! module.
 
 /// The messages and enums that are part of this client library.
+#[allow(deprecated)]
 pub mod model;

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -689,6 +689,7 @@ pub struct BackendRule {
 
     /// Deprecated, do not use.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub min_deadline: f64,
 
     /// The number of seconds to wait for the completion of a long running
@@ -774,6 +775,7 @@ impl BackendRule {
     }
 
     /// Sets the value of [min_deadline][crate::model::BackendRule::min_deadline].
+    #[deprecated]
     pub fn set_min_deadline<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.min_deadline = v.into();
         self
@@ -1252,6 +1254,7 @@ pub struct CommonLanguageSettings {
     /// Link to automatically generated reference documentation.  Example:
     /// <https://cloud.google.com/nodejs/docs/reference/asset/latest>
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub reference_docs_uri: std::string::String,
 
     /// The destination where API teams want this client library to be published.
@@ -1272,6 +1275,7 @@ impl CommonLanguageSettings {
     }
 
     /// Sets the value of [reference_docs_uri][crate::model::CommonLanguageSettings::reference_docs_uri].
+    #[deprecated]
     pub fn set_reference_docs_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5849,6 +5853,7 @@ pub mod metric_descriptor {
         /// instead.
         ///
         /// [google.api.MetricDescriptor.launch_stage]: crate::model::MetricDescriptor::launch_stage
+        #[deprecated]
         pub launch_stage: crate::model::LaunchStage,
 
         /// The sampling period of metric data points. For metrics which are written
@@ -5878,6 +5883,7 @@ pub mod metric_descriptor {
         }
 
         /// Sets the value of [launch_stage][crate::model::metric_descriptor::MetricDescriptorMetadata::launch_stage].
+        #[deprecated]
         pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
             mut self,
             v: T,

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [BigtableInstanceAdmin](client/struct.BigtableInstanceAdmin.html)
 //! * [BigtableTableAdmin](client/struct.BigtableTableAdmin.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -7173,6 +7173,7 @@ impl AppProfile {
     /// The value of [isolation][crate::model::AppProfile::isolation]
     /// if it holds a `Priority`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn priority(&self) -> std::option::Option<&crate::model::app_profile::Priority> {
         #[allow(unreachable_patterns)]
         self.isolation.as_ref().and_then(|v| match v {
@@ -7217,6 +7218,7 @@ impl AppProfile {
     ///
     /// Note that all the setters affecting `isolation` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_priority<T: std::convert::Into<crate::model::app_profile::Priority>>(
         mut self,
         v: T,
@@ -7859,6 +7861,7 @@ pub mod app_profile {
         /// If you set this field, `standard_isolation.priority` will be set instead.
         ///
         /// The priority of requests sent using this app profile.
+        #[deprecated]
         Priority(crate::model::app_profile::Priority),
         /// The standard options used for isolating this app profile's traffic from
         /// other use cases.
@@ -11370,6 +11373,7 @@ pub mod r#type {
             /// The value of [encoding][crate::model::r#type::string::Encoding::encoding]
             /// if it holds a `Utf8Raw`, `None` if the field is not set or
             /// holds a different branch.
+            #[deprecated]
             pub fn utf8_raw(
                 &self,
             ) -> std::option::Option<
@@ -11406,6 +11410,7 @@ pub mod r#type {
             ///
             /// Note that all the setters affecting `encoding` are
             /// mutually exclusive.
+            #[deprecated]
             pub fn set_utf8_raw<
                 T: std::convert::Into<
                         std::boxed::Box<crate::model::r#type::string::encoding::Utf8Raw>,
@@ -11456,6 +11461,7 @@ pub mod r#type {
             #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
             #[serde(default, rename_all = "camelCase")]
             #[non_exhaustive]
+            #[deprecated]
             pub struct Utf8Raw {
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
                 _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
@@ -11514,6 +11520,7 @@ pub mod r#type {
             #[non_exhaustive]
             pub enum Encoding {
                 /// Deprecated: if set, converts to an empty `utf8_bytes`.
+                #[deprecated]
                 Utf8Raw(std::boxed::Box<crate::model::r#type::string::encoding::Utf8Raw>),
                 /// Use `Utf8Bytes` encoding.
                 Utf8Bytes(std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>),
@@ -11701,6 +11708,7 @@ pub mod r#type {
             pub struct BigEndianBytes {
                 /// Deprecated: ignored if set.
                 #[serde(skip_serializing_if = "std::option::Option::is_none")]
+                #[deprecated]
                 pub bytes_type: std::option::Option<crate::model::r#type::Bytes>,
 
                 #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11713,6 +11721,7 @@ pub mod r#type {
                 }
 
                 /// Sets the value of [bytes_type][crate::model::r#type::int_64::encoding::BigEndianBytes::bytes_type].
+                #[deprecated]
                 pub fn set_bytes_type<
                     T: std::convert::Into<std::option::Option<crate::model::r#type::Bytes>>,
                 >(

--- a/src/generated/bigtable/admin/v2/src/stub.rs
+++ b/src/generated/bigtable/admin/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::BigtableInstanceAdmin].

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -1268,6 +1268,7 @@ pub mod dataset_service {
         }
 
         /// Sets the value of [saved_query][crate::model::SearchDataItemsRequest::saved_query].
+        #[deprecated]
         pub fn set_saved_query<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.saved_query = v.into();
             self
@@ -1286,6 +1287,7 @@ pub mod dataset_service {
         }
 
         /// Sets the value of [annotations_filter][crate::model::SearchDataItemsRequest::annotations_filter].
+        #[deprecated]
         pub fn set_annotations_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.annotations_filter = v.into();
             self
@@ -1313,6 +1315,7 @@ pub mod dataset_service {
         }
 
         /// Sets the value of [order_by][crate::model::SearchDataItemsRequest::order_by].
+        #[deprecated]
         pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.order_by = v.into();
             self
@@ -22942,6 +22945,7 @@ pub mod metadata_service {
         }
 
         /// Sets the value of [force][crate::model::DeleteMetadataStoreRequest::force].
+        #[deprecated]
         pub fn set_force<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.force = v.into();
             self

--- a/src/generated/cloud/aiplatform/v1/src/lib.rs
+++ b/src/generated/cloud/aiplatform/v1/src/lib.rs
@@ -62,6 +62,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -69,18 +70,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/aiplatform/v1/src/lib.rs
+++ b/src/generated/cloud/aiplatform/v1/src/lib.rs
@@ -59,10 +59,10 @@
 //! * [VizierService](client/struct.VizierService.html)
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![allow(deprecated)]
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -70,19 +70,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -6976,8 +6976,10 @@ pub mod scheduling {
         /// Strategy will default to STANDARD.
         Unspecified,
         /// Deprecated. Regular on-demand provisioning strategy.
+        #[deprecated]
         OnDemand,
         /// Deprecated. Low cost by making potential use of spot resources.
+        #[deprecated]
         LowCost,
         /// Standard provisioning strategy uses regular on-demand resources.
         Standard,
@@ -10461,6 +10463,7 @@ pub struct SearchDataItemsRequest {
     /// `projects/{project}/locations/{location}/datasets/{dataset}/savedQueries/{saved_query}`
     /// All of the search will be done in the context of this SavedQuery.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub saved_query: std::string::String,
 
     /// The resource name of a DataLabelingJob.
@@ -10491,6 +10494,7 @@ pub struct SearchDataItemsRequest {
     ///
     /// * `annotation_spec_id` - for = or !=.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub annotations_filter: std::string::String,
 
     /// An expression that specifies what Annotations will be returned per
@@ -10523,6 +10527,7 @@ pub struct SearchDataItemsRequest {
     /// A comma-separated list of fields to order by, sorted in ascending order.
     /// Use "desc" after a field name for descending.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub order_by: std::string::String,
 
     /// A token identifying a page of results for the server to return
@@ -10557,6 +10562,7 @@ impl SearchDataItemsRequest {
     }
 
     /// Sets the value of [saved_query][crate::model::SearchDataItemsRequest::saved_query].
+    #[deprecated]
     pub fn set_saved_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.saved_query = v.into();
         self
@@ -10581,6 +10587,7 @@ impl SearchDataItemsRequest {
     }
 
     /// Sets the value of [annotations_filter][crate::model::SearchDataItemsRequest::annotations_filter].
+    #[deprecated]
     pub fn set_annotations_filter<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -10611,6 +10618,7 @@ impl SearchDataItemsRequest {
     }
 
     /// Sets the value of [order_by][crate::model::SearchDataItemsRequest::order_by].
+    #[deprecated]
     pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.order_by = v.into();
         self
@@ -12230,6 +12238,7 @@ impl wkt::message::Message for QueryDeployedModelsRequest {
 pub struct QueryDeployedModelsResponse {
     /// DEPRECATED Use deployed_model_refs instead.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub deployed_models: std::vec::Vec<crate::model::DeployedModel>,
 
     /// A token, which can be sent as `page_token` to retrieve the next page.
@@ -12280,6 +12289,7 @@ impl QueryDeployedModelsResponse {
     }
 
     /// Sets the value of [deployed_models][crate::model::QueryDeployedModelsResponse::deployed_models].
+    #[deprecated]
     pub fn set_deployed_models<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -12521,6 +12531,7 @@ pub struct Endpoint {
     /// [google.cloud.aiplatform.v1.Endpoint.enable_private_service_connect]: crate::model::Endpoint::enable_private_service_connect
     /// [google.cloud.aiplatform.v1.Endpoint.network]: crate::model::Endpoint::network
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enable_private_service_connect: bool,
 
     /// Optional. Configuration for private service connect.
@@ -12649,6 +12660,7 @@ impl Endpoint {
     }
 
     /// Sets the value of [enable_private_service_connect][crate::model::Endpoint::enable_private_service_connect].
+    #[deprecated]
     pub fn set_enable_private_service_connect<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_private_service_connect = v.into();
         self
@@ -44703,6 +44715,7 @@ pub struct IndexEndpoint {
     /// [google.cloud.aiplatform.v1.IndexEndpoint.enable_private_service_connect]: crate::model::IndexEndpoint::enable_private_service_connect
     /// [google.cloud.aiplatform.v1.IndexEndpoint.network]: crate::model::IndexEndpoint::network
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enable_private_service_connect: bool,
 
     /// Optional. Configuration for private service connect.
@@ -44804,6 +44817,7 @@ impl IndexEndpoint {
     }
 
     /// Sets the value of [enable_private_service_connect][crate::model::IndexEndpoint::enable_private_service_connect].
+    #[deprecated]
     pub fn set_enable_private_service_connect<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_private_service_connect = v.into();
         self
@@ -53716,6 +53730,7 @@ pub struct DeleteMetadataStoreRequest {
 
     /// Deprecated: Field is no longer supported.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub force: bool,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -53735,6 +53750,7 @@ impl DeleteMetadataStoreRequest {
     }
 
     /// Sets the value of [force][crate::model::DeleteMetadataStoreRequest::force].
+    #[deprecated]
     pub fn set_force<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.force = v.into();
         self
@@ -67417,6 +67433,7 @@ pub struct NasJob {
     /// Optional. Enable a separation of Custom model training
     /// and restricted image training for tenant project.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enable_restricted_image_training: bool,
 
     /// Output only. Reserved for future use.
@@ -67534,6 +67551,7 @@ impl NasJob {
     }
 
     /// Sets the value of [enable_restricted_image_training][crate::model::NasJob::enable_restricted_image_training].
+    #[deprecated]
     pub fn set_enable_restricted_image_training<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -69857,6 +69875,7 @@ pub struct NotebookRuntimeTemplate {
     ///
     /// The default template to use if not specified.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub is_default: bool,
 
     /// Optional. Immutable. The specification of a single machine for the
@@ -69891,6 +69910,7 @@ pub struct NotebookRuntimeTemplate {
     /// account](https://cloud.google.com/compute/docs/access/service-accounts#default_service_account)
     /// is used.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub service_account: std::string::String,
 
     /// Used to perform consistent read-modify-write updates. If not set, a blind
@@ -69976,6 +69996,7 @@ impl NotebookRuntimeTemplate {
     }
 
     /// Sets the value of [is_default][crate::model::NotebookRuntimeTemplate::is_default].
+    #[deprecated]
     pub fn set_is_default<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.is_default = v.into();
         self
@@ -70015,6 +70036,7 @@ impl NotebookRuntimeTemplate {
     }
 
     /// Sets the value of [service_account][crate::model::NotebookRuntimeTemplate::service_account].
+    #[deprecated]
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
@@ -75253,6 +75275,7 @@ pub mod pipeline_job {
         /// [google.cloud.aiplatform.v1.PipelineJob.RuntimeConfig.parameter_values]: crate::model::pipeline_job::RuntimeConfig::parameter_values
         /// [google.cloud.aiplatform.v1.PipelineJob.pipeline_spec]: crate::model::PipelineJob::pipeline_spec
         #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+        #[deprecated]
         pub parameters: std::collections::HashMap<std::string::String, crate::model::Value>,
 
         /// Required. A path in a Cloud Storage bucket, which will be treated as the
@@ -75322,6 +75345,7 @@ pub mod pipeline_job {
         }
 
         /// Sets the value of [parameters][crate::model::pipeline_job::RuntimeConfig::parameters].
+        #[deprecated]
         pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = (K, V)>,
@@ -79732,6 +79756,7 @@ pub mod publisher_model {
         /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
         /// if it holds a `UseCase`, `None` if the field is not set or
         /// holds a different branch.
+        #[deprecated]
         pub fn use_case(&self) -> std::option::Option<&std::string::String> {
             #[allow(unreachable_patterns)]
             self.reference.as_ref().and_then(|v| match v {
@@ -79745,6 +79770,7 @@ pub mod publisher_model {
         /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
         /// if it holds a `Description`, `None` if the field is not set or
         /// holds a different branch.
+        #[deprecated]
         pub fn description(&self) -> std::option::Option<&std::string::String> {
             #[allow(unreachable_patterns)]
             self.reference.as_ref().and_then(|v| match v {
@@ -79789,6 +79815,7 @@ pub mod publisher_model {
         ///
         /// Note that all the setters affecting `reference` are
         /// mutually exclusive.
+        #[deprecated]
         pub fn set_use_case<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.reference = std::option::Option::Some(
                 crate::model::publisher_model::resource_reference::Reference::UseCase(v.into()),
@@ -79801,6 +79828,7 @@ pub mod publisher_model {
         ///
         /// Note that all the setters affecting `reference` are
         /// mutually exclusive.
+        #[deprecated]
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.reference = std::option::Option::Some(
                 crate::model::publisher_model::resource_reference::Reference::Description(v.into()),
@@ -79832,8 +79860,10 @@ pub mod publisher_model {
             /// The resource name of the Google Cloud resource.
             ResourceName(std::string::String),
             /// Use case (CUJ) of the resource.
+            #[deprecated]
             UseCase(std::string::String),
             /// Description of the resource.
+            #[deprecated]
             Description(std::string::String),
         }
     }
@@ -92918,6 +92948,7 @@ pub mod code_execution_result {
 pub struct Retrieval {
     /// Optional. Deprecated. This option is no longer supported.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub disable_attribution: bool,
 
     /// The source of the retrieval.
@@ -92939,6 +92970,7 @@ impl Retrieval {
     }
 
     /// Sets the value of [disable_attribution][crate::model::Retrieval::disable_attribution].
+    #[deprecated]
     pub fn set_disable_attribution<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disable_attribution = v.into();
         self
@@ -93077,11 +93109,13 @@ pub struct VertexRagStore {
 
     /// Optional. Number of top k results to return from the selected corpora.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub similarity_top_k: std::option::Option<i32>,
 
     /// Optional. Only return results with vector distance smaller than the
     /// threshold.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub vector_distance_threshold: std::option::Option<f64>,
 
     /// Optional. The retrieval config for the Rag query.
@@ -93104,6 +93138,7 @@ impl VertexRagStore {
     }
 
     /// Sets the value of [similarity_top_k][crate::model::VertexRagStore::similarity_top_k].
+    #[deprecated]
     pub fn set_similarity_top_k<T: std::convert::Into<std::option::Option<i32>>>(
         mut self,
         v: T,
@@ -93113,6 +93148,7 @@ impl VertexRagStore {
     }
 
     /// Sets the value of [vector_distance_threshold][crate::model::VertexRagStore::vector_distance_threshold].
+    #[deprecated]
     pub fn set_vector_distance_threshold<T: std::convert::Into<std::option::Option<f64>>>(
         mut self,
         v: T,
@@ -96301,6 +96337,7 @@ pub struct SupervisedTuningDataStats {
     /// Output only. Number of billable characters in the tuning dataset.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[deprecated]
     pub total_billable_character_count: i64,
 
     /// Output only. Number of billable tokens in the tuning dataset.
@@ -96367,6 +96404,7 @@ impl SupervisedTuningDataStats {
     }
 
     /// Sets the value of [total_billable_character_count][crate::model::SupervisedTuningDataStats::total_billable_character_count].
+    #[deprecated]
     pub fn set_total_billable_character_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_billable_character_count = v.into();
         self
@@ -100147,6 +100185,7 @@ impl ImportRagFilesConfig {
     /// The value of [partial_failure_sink][crate::model::ImportRagFilesConfig::partial_failure_sink]
     /// if it holds a `PartialFailureGcsSink`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn partial_failure_gcs_sink(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::GcsDestination>> {
@@ -100162,6 +100201,7 @@ impl ImportRagFilesConfig {
     /// The value of [partial_failure_sink][crate::model::ImportRagFilesConfig::partial_failure_sink]
     /// if it holds a `PartialFailureBigquerySink`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn partial_failure_bigquery_sink(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
@@ -100177,6 +100217,7 @@ impl ImportRagFilesConfig {
     ///
     /// Note that all the setters affecting `partial_failure_sink` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_partial_failure_gcs_sink<
         T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
     >(
@@ -100196,6 +100237,7 @@ impl ImportRagFilesConfig {
     ///
     /// Note that all the setters affecting `partial_failure_sink` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_partial_failure_bigquery_sink<
         T: std::convert::Into<std::boxed::Box<crate::model::BigQueryDestination>>,
     >(
@@ -100338,6 +100380,7 @@ pub mod import_rag_files_config {
     pub enum PartialFailureSink {
         /// The Cloud Storage path to write partial failures to.
         /// Deprecated. Prefer to use `import_result_gcs_sink`.
+        #[deprecated]
         PartialFailureGcsSink(std::boxed::Box<crate::model::GcsDestination>),
         /// The BigQuery destination to write partial failures to. It should be a
         /// bigquery table resource name (e.g.
@@ -100346,6 +100389,7 @@ pub mod import_rag_files_config {
         /// table exists, the schema will be validated and data will be added to this
         /// existing table.
         /// Deprecated. Prefer to use `import_result_bq_sink`.
+        #[deprecated]
         PartialFailureBigquerySink(std::boxed::Box<crate::model::BigQueryDestination>),
     }
 
@@ -101722,6 +101766,7 @@ pub mod retrieve_contexts_request {
         /// Optional. Only return contexts with vector distance smaller than the
         /// threshold.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub vector_distance_threshold: std::option::Option<f64>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -101735,6 +101780,7 @@ pub mod retrieve_contexts_request {
         }
 
         /// Sets the value of [vector_distance_threshold][crate::model::retrieve_contexts_request::VertexRagStore::vector_distance_threshold].
+        #[deprecated]
         pub fn set_vector_distance_threshold<T: std::convert::Into<std::option::Option<f64>>>(
             mut self,
             v: T,
@@ -102464,6 +102510,7 @@ pub struct Fact {
 
     /// If present, the distance between the query vector and this fact vector.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub vector_distance: std::option::Option<f64>,
 
     /// If present, according to the underlying Vector DB and the selected metric
@@ -102528,6 +102575,7 @@ impl Fact {
     }
 
     /// Sets the value of [vector_distance][crate::model::Fact::vector_distance].
+    #[deprecated]
     pub fn set_vector_distance<T: std::convert::Into<std::option::Option<f64>>>(
         mut self,
         v: T,
@@ -103887,6 +103935,7 @@ pub enum AcceleratorType {
     Unspecified,
     /// Deprecated: Nvidia Tesla K80 GPU has reached end of support,
     /// see <https://cloud.google.com/compute/docs/eol/k80-eol>.
+    #[deprecated]
     NvidiaTeslaK80,
     /// Nvidia Tesla P100 GPU.
     NvidiaTeslaP100,

--- a/src/generated/cloud/aiplatform/v1/src/stub.rs
+++ b/src/generated/cloud/aiplatform/v1/src/stub.rs
@@ -62,6 +62,7 @@ use gax::error::Error;
 #[allow(unused_imports)]
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DatasetService].

--- a/src/generated/cloud/alloydb/v1/src/lib.rs
+++ b/src/generated/cloud/alloydb/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/alloydb/v1/src/lib.rs
+++ b/src/generated/cloud/alloydb/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [AlloyDBAdmin](client/struct.AlloyDBAdmin.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -754,14 +754,17 @@ pub mod ssl_config {
         /// SSL mode is not specified. Defaults to ENCRYPTED_ONLY.
         Unspecified,
         /// SSL connections are optional. CA verification not enforced.
+        #[deprecated]
         Allow,
         /// SSL connections are required. CA verification not enforced.
         /// Clients may use locally self-signed certificates (default psql client
         /// behavior).
+        #[deprecated]
         Require,
         /// SSL connections are required. CA verification enforced.
         /// Clients must have certificates signed by a Cluster CA, for example, using
         /// GenerateClientCertificate.
+        #[deprecated]
         VerifyCa,
         /// SSL connections are optional. CA verification not enforced.
         AllowUnencryptedAndEncrypted,
@@ -1891,6 +1894,7 @@ pub struct Cluster {
     /// form: `projects/{project}/global/networks/{network_id}`. This is required
     /// to create a cluster. Deprecated, use network_config.network instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub network: std::string::String,
 
     /// For Resource freshness validation (<https://google.aip.dev/154>)
@@ -1928,6 +1932,7 @@ pub struct Cluster {
 
     /// SSL configuration for this AlloyDB cluster.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub ssl_config: std::option::Option<crate::model::SslConfig>,
 
     /// Optional. The encryption config can be specified to encrypt the data disks
@@ -2089,6 +2094,7 @@ impl Cluster {
     }
 
     /// Sets the value of [network][crate::model::Cluster::network].
+    #[deprecated]
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
         self
@@ -2129,6 +2135,7 @@ impl Cluster {
     }
 
     /// Sets the value of [ssl_config][crate::model::Cluster::ssl_config].
+    #[deprecated]
     pub fn set_ssl_config<T: std::convert::Into<std::option::Option<crate::model::SslConfig>>>(
         mut self,
         v: T,
@@ -10233,6 +10240,7 @@ pub enum DatabaseVersion {
     /// This is an unknown database version.
     Unspecified,
     /// DEPRECATED - The database version is Postgres 13.
+    #[deprecated]
     Postgres13,
     /// The database version is Postgres 14.
     Postgres14,

--- a/src/generated/cloud/alloydb/v1/src/stub.rs
+++ b/src/generated/cloud/alloydb/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AlloyDBAdmin].

--- a/src/generated/cloud/asset/v1/src/lib.rs
+++ b/src/generated/cloud/asset/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [AssetService](client/struct.AssetService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/asset/v1/src/lib.rs
+++ b/src/generated/cloud/asset/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -8845,6 +8845,7 @@ pub struct Asset {
     /// The related assets of the asset of one relationship type. One asset
     /// only represents one type of relationship.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub related_assets: std::option::Option<crate::model::RelatedAssets>,
 
     /// One related asset of the current asset.
@@ -8927,6 +8928,7 @@ impl Asset {
     }
 
     /// Sets the value of [related_assets][crate::model::Asset::related_assets].
+    #[deprecated]
     pub fn set_related_assets<
         T: std::convert::Into<std::option::Option<crate::model::RelatedAssets>>,
     >(
@@ -9241,6 +9243,7 @@ impl wkt::message::Message for Resource {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct RelatedAssets {
     /// The detailed relationship attributes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -9297,6 +9300,7 @@ impl wkt::message::Message for RelatedAssets {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct RelationshipAttributes {
     /// The unique identifier of the relationship type. Example:
     /// `INSTANCE_TO_INSTANCEGROUP`
@@ -9738,6 +9742,7 @@ pub struct ResourceSearchResult {
     /// * Use a field query. Example: `kmsKey:key`
     /// * Use a free text query. Example: `key`
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub kms_key: std::string::String,
 
     /// The Cloud KMS
@@ -9883,6 +9888,7 @@ pub struct ResourceSearchResult {
     ///
     ///   - `env`
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub tag_keys: std::vec::Vec<std::string::String>,
 
     /// This field is only present for the purpose of backward compatibility.
@@ -9902,6 +9908,7 @@ pub struct ResourceSearchResult {
     ///
     ///   - `prod`
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub tag_values: std::vec::Vec<std::string::String>,
 
     /// This field is only present for the purpose of backward compatibility.
@@ -9917,6 +9924,7 @@ pub struct ResourceSearchResult {
     ///
     ///   - `456`
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub tag_value_ids: std::vec::Vec<std::string::String>,
 
     /// The tags directly attached to this resource.
@@ -10034,6 +10042,7 @@ impl ResourceSearchResult {
     }
 
     /// Sets the value of [kms_key][crate::model::ResourceSearchResult::kms_key].
+    #[deprecated]
     pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key = v.into();
         self
@@ -10146,6 +10155,7 @@ impl ResourceSearchResult {
     }
 
     /// Sets the value of [tag_keys][crate::model::ResourceSearchResult::tag_keys].
+    #[deprecated]
     pub fn set_tag_keys<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -10157,6 +10167,7 @@ impl ResourceSearchResult {
     }
 
     /// Sets the value of [tag_values][crate::model::ResourceSearchResult::tag_values].
+    #[deprecated]
     pub fn set_tag_values<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -10168,6 +10179,7 @@ impl ResourceSearchResult {
     }
 
     /// Sets the value of [tag_value_ids][crate::model::ResourceSearchResult::tag_value_ids].
+    #[deprecated]
     pub fn set_tag_value_ids<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/cloud/asset/v1/src/stub.rs
+++ b/src/generated/cloud/asset/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AssetService].

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [AssuredWorkloadsService](client/struct.AssuredWorkloadsService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -423,6 +423,7 @@ pub struct Workload {
     /// In order to create a Keyring, callers should specify,
     /// ENCRYPTION_KEYS_PROJECT or KEYRING in ResourceSettings.resource_type field.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub kms_settings: std::option::Option<crate::model::workload::KMSSettings>,
 
     /// Input only. Resource properties that are used to customize workload resources.
@@ -518,6 +519,7 @@ impl Workload {
     }
 
     /// Sets the value of [kms_settings][crate::model::Workload::kms_settings].
+    #[deprecated]
     pub fn set_kms_settings<
         T: std::convert::Into<std::option::Option<crate::model::workload::KMSSettings>>,
     >(
@@ -700,6 +702,7 @@ pub mod workload {
             /// ignored only in CreateWorkload requests. ListWorkloads and GetWorkload
             /// will continue to provide projects information.
             /// Use CONSUMER_FOLDER instead.
+            #[deprecated]
             ConsumerProject,
             /// Consumer Folder.
             ConsumerFolder,
@@ -839,6 +842,7 @@ pub mod workload {
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
+    #[deprecated]
     pub struct KMSSettings {
         /// Required. Input only. Immutable. The time at which the Key Management Service will automatically create a
         /// new version of the crypto key and mark it as the primary.
@@ -2090,6 +2094,7 @@ pub struct AcknowledgeViolationRequest {
     /// folders/{folder_id}/policies/{constraint_name}
     /// organizations/{organization_id}/policies/{constraint_name}
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub non_compliant_org_policy: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2114,6 +2119,7 @@ impl AcknowledgeViolationRequest {
     }
 
     /// Sets the value of [non_compliant_org_policy][crate::model::AcknowledgeViolationRequest::non_compliant_org_policy].
+    #[deprecated]
     pub fn set_non_compliant_org_policy<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,

--- a/src/generated/cloud/assuredworkloads/v1/src/stub.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AssuredWorkloadsService].

--- a/src/generated/cloud/backupdr/v1/src/lib.rs
+++ b/src/generated/cloud/backupdr/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/backupdr/v1/src/lib.rs
+++ b/src/generated/cloud/backupdr/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [BackupDR](client/struct.BackupDR.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -12058,6 +12058,7 @@ pub struct AttachedDisk {
 
     /// Specifies the type of the disk.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub disk_type_deprecated: std::option::Option<crate::model::attached_disk::DiskType>,
 
     /// Optional. The mode in which to attach this disk.
@@ -12161,6 +12162,7 @@ impl AttachedDisk {
     }
 
     /// Sets the value of [disk_type_deprecated][crate::model::AttachedDisk::disk_type_deprecated].
+    #[deprecated]
     pub fn set_disk_type_deprecated<
         T: std::convert::Into<std::option::Option<crate::model::attached_disk::DiskType>>,
     >(

--- a/src/generated/cloud/backupdr/v1/src/stub.rs
+++ b/src/generated/cloud/backupdr/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::BackupDR].

--- a/src/generated/cloud/baremetalsolution/v2/src/lib.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [BareMetalSolution](client/struct.BareMetalSolution.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/baremetalsolution/v2/src/lib.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -3135,6 +3135,7 @@ pub struct LogicalInterface {
     /// The index of the logical interface mapping to the index of the hardware
     /// bond or nic on the chosen network template. This field is deprecated.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub interface_index: i32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3153,6 +3154,7 @@ impl LogicalInterface {
     }
 
     /// Sets the value of [interface_index][crate::model::LogicalInterface::interface_index].
+    #[deprecated]
     pub fn set_interface_index<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.interface_index = v.into();
         self
@@ -4950,6 +4952,7 @@ pub struct ProvisioningConfig {
     /// Email provided to send a confirmation with provisioning config to.
     /// Deprecated in favour of email field in request messages.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub email: std::string::String,
 
     /// Output only. State of ProvisioningConfig.
@@ -5011,6 +5014,7 @@ impl ProvisioningConfig {
     }
 
     /// Sets the value of [email][crate::model::ProvisioningConfig::email].
+    #[deprecated]
     pub fn set_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.email = v.into();
         self
@@ -5913,11 +5917,13 @@ pub struct InstanceConfig {
 
     /// Client network address. Filled if InstanceConfig.multivlan_config is false.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub client_network: std::option::Option<crate::model::instance_config::NetworkAddress>,
 
     /// Private network address, if any. Filled if InstanceConfig.multivlan_config
     /// is false.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub private_network: std::option::Option<crate::model::instance_config::NetworkAddress>,
 
     /// User note field, it can be used by customers to add additional information
@@ -5987,6 +5993,7 @@ impl InstanceConfig {
     }
 
     /// Sets the value of [client_network][crate::model::InstanceConfig::client_network].
+    #[deprecated]
     pub fn set_client_network<
         T: std::convert::Into<std::option::Option<crate::model::instance_config::NetworkAddress>>,
     >(
@@ -5998,6 +6005,7 @@ impl InstanceConfig {
     }
 
     /// Sets the value of [private_network][crate::model::InstanceConfig::private_network].
+    #[deprecated]
     pub fn set_private_network<
         T: std::convert::Into<std::option::Option<crate::model::instance_config::NetworkAddress>>,
     >(
@@ -7680,6 +7688,7 @@ pub struct InstanceQuota {
     /// Instance type.
     /// Deprecated: use gcp_service.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub instance_type: std::string::String,
 
     /// The gcp service of the provisioning quota.
@@ -7711,6 +7720,7 @@ impl InstanceQuota {
     }
 
     /// Sets the value of [instance_type][crate::model::InstanceQuota::instance_type].
+    #[deprecated]
     pub fn set_instance_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance_type = v.into();
         self

--- a/src/generated/cloud/baremetalsolution/v2/src/stub.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::BareMetalSolution].

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [AnalyticsHubService](client/struct.AnalyticsHubService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -5023,6 +5023,7 @@ pub struct MessageTransform {
     /// Optional. This field is deprecated, use the `disabled` field to disable
     /// transforms.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enabled: bool,
 
     /// Optional. If true, the transform is disabled and will not be applied to
@@ -5044,6 +5045,7 @@ impl MessageTransform {
     }
 
     /// Sets the value of [enabled][crate::model::MessageTransform::enabled].
+    #[deprecated]
     pub fn set_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enabled = v.into();
         self

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AnalyticsHubService].

--- a/src/generated/cloud/bigquery/connection/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/connection/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [ConnectionService](client/struct.ConnectionService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -1079,6 +1079,7 @@ impl AwsProperties {
     /// The value of [authentication_method][crate::model::AwsProperties::authentication_method]
     /// if it holds a `CrossAccountRole`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn cross_account_role(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::AwsCrossAccountRole>> {
@@ -1111,6 +1112,7 @@ impl AwsProperties {
     ///
     /// Note that all the setters affecting `authentication_method` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_cross_account_role<
         T: std::convert::Into<std::boxed::Box<crate::model::AwsCrossAccountRole>>,
     >(
@@ -1158,6 +1160,7 @@ pub mod aws_properties {
         /// Authentication using Google owned AWS IAM user's access key to assume
         /// into customer's AWS IAM Role.
         /// Deprecated, do not use.
+        #[deprecated]
         CrossAccountRole(std::boxed::Box<crate::model::AwsCrossAccountRole>),
         /// Authentication using Google owned service account to assume into
         /// customer's AWS IAM Role.

--- a/src/generated/cloud/bigquery/connection/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ConnectionService].

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -236,6 +236,7 @@ pub mod data_transfer_service {
         }
 
         /// Sets the value of [authorization_code][crate::model::CreateTransferConfigRequest::authorization_code].
+        #[deprecated]
         pub fn set_authorization_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.authorization_code = v.into();
             self
@@ -305,6 +306,7 @@ pub mod data_transfer_service {
         }
 
         /// Sets the value of [authorization_code][crate::model::UpdateTransferConfigRequest::authorization_code].
+        #[deprecated]
         pub fn set_authorization_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.authorization_code = v.into();
             self

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
@@ -192,6 +192,7 @@ impl DataTransferService {
     /// range, one transfer run is created.
     /// Note that runs are created per UTC time in the time range.
     /// DEPRECATED: use StartManualTransferRuns instead.
+    #[deprecated]
     pub fn schedule_transfer_runs(
         &self,
         parent: impl Into<std::string::String>,

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [DataTransferService](client/struct.DataTransferService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -451,10 +451,12 @@ pub struct DataSource {
     pub scopes: std::vec::Vec<std::string::String>,
 
     /// Deprecated. This field has no effect.
+    #[deprecated]
     pub transfer_type: crate::model::TransferType,
 
     /// Deprecated. This field has no effect.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub supports_multiple_transfers: bool,
 
     /// The number of seconds to wait for an update from the data source
@@ -547,6 +549,7 @@ impl DataSource {
     }
 
     /// Sets the value of [transfer_type][crate::model::DataSource::transfer_type].
+    #[deprecated]
     pub fn set_transfer_type<T: std::convert::Into<crate::model::TransferType>>(
         mut self,
         v: T,
@@ -556,6 +559,7 @@ impl DataSource {
     }
 
     /// Sets the value of [supports_multiple_transfers][crate::model::DataSource::supports_multiple_transfers].
+    #[deprecated]
     pub fn set_supports_multiple_transfers<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.supports_multiple_transfers = v.into();
         self
@@ -1151,6 +1155,7 @@ pub struct CreateTransferConfigRequest {
     /// Note that this should not be set when `service_account_name` is used to
     /// create the transfer config.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub authorization_code: std::string::String,
 
     /// Optional version info. This parameter replaces `authorization_code` which
@@ -1208,6 +1213,7 @@ impl CreateTransferConfigRequest {
     }
 
     /// Sets the value of [authorization_code][crate::model::CreateTransferConfigRequest::authorization_code].
+    #[deprecated]
     pub fn set_authorization_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -1271,6 +1277,7 @@ pub struct UpdateTransferConfigRequest {
     /// Note that this should not be set when `service_account_name` is used to
     /// update the transfer config.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub authorization_code: std::string::String,
 
     /// Required. Required list of fields to be updated in this request.
@@ -1326,6 +1333,7 @@ impl UpdateTransferConfigRequest {
     }
 
     /// Sets the value of [authorization_code][crate::model::UpdateTransferConfigRequest::authorization_code].
+    #[deprecated]
     pub fn set_authorization_code<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -3888,6 +3896,7 @@ pub mod transfer_message {
 /// [Working with enums]: https://google-cloud-rust.github.io/working_with_enums.html
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+#[deprecated]
 pub enum TransferType {
     /// Invalid or Unknown transfer type placeholder.
     Unspecified,

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataTransferService].

--- a/src/generated/cloud/bigquery/reservation/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/client.rs
@@ -397,6 +397,7 @@ impl ReservationService {
     ///
     /// **Note** "-" cannot be used for projects
     /// nor locations.
+    #[deprecated]
     pub fn search_assignments(
         &self,
         parent: impl Into<std::string::String>,

--- a/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [ReservationService](client/struct.ReservationService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -594,11 +594,13 @@ pub mod capacity_commitment {
         Flex,
         /// Same as FLEX, should only be used if flat-rate commitments are still
         /// available.
+        #[deprecated]
         FlexFlatRate,
         /// Trial commitments have a committed period of 182 days after becoming
         /// ACTIVE. After that, they are converted to a new commitment based on the
         /// `renewal_plan`. Default `renewal_plan` for Trial commitment is Flex so
         /// that it can be deleted right after committed period ends.
+        #[deprecated]
         Trial,
         /// Monthly commitments have a committed period of 30 days after becoming
         /// ACTIVE. After that, they are not in a committed period anymore and can be
@@ -606,6 +608,7 @@ pub mod capacity_commitment {
         Monthly,
         /// Same as MONTHLY, should only be used if flat-rate commitments are still
         /// available.
+        #[deprecated]
         MonthlyFlatRate,
         /// Annual commitments have a committed period of 365 days after becoming
         /// ACTIVE. After that they are converted to a new commitment based on the
@@ -613,6 +616,7 @@ pub mod capacity_commitment {
         Annual,
         /// Same as ANNUAL, should only be used if flat-rate commitments are still
         /// available.
+        #[deprecated]
         AnnualFlatRate,
         /// 3-year commitments have a committed period of 1095(3 * 365) days after
         /// becoming ACTIVE. After that they are converted to a new commitment based

--- a/src/generated/cloud/bigquery/reservation/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ReservationService].

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -34,6 +34,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -41,18 +42,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -32,9 +32,10 @@
 //! * [RowAccessPolicyService](client/struct.RowAccessPolicyService.html)
 //! * [TableService](client/struct.TableService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -42,19 +43,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -982,6 +982,7 @@ pub struct Dataset {
     /// Output only. Tags for the dataset. To provide tags as inputs, use the
     /// `resourceTags` field.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub tags: std::vec::Vec<crate::model::GcpTag>,
 
     /// Optional. Updates storage_billing_model for the dataset.
@@ -1261,6 +1262,7 @@ impl Dataset {
     }
 
     /// Sets the value of [tags][crate::model::Dataset::tags].
+    #[deprecated]
     pub fn set_tags<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/cloud/bigquery/v2/src/stub.rs
+++ b/src/generated/cloud/bigquery/v2/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DatasetService].

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
@@ -177,6 +177,7 @@ impl CloudControlsPartnerCore {
 
     /// Deprecated: Only returns access approval requests directly associated with
     /// an assured workload folder.
+    #[deprecated]
     pub fn list_access_approval_requests(
         &self,
         parent: impl Into<std::string::String>,

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [CloudControlsPartnerCore](client/struct.CloudControlsPartnerCore.html)
 //! * [CloudControlsPartnerMonitoring](client/struct.CloudControlsPartnerMonitoring.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/stub.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudControlsPartnerCore].

--- a/src/generated/cloud/connectors/v1/src/lib.rs
+++ b/src/generated/cloud/connectors/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/connectors/v1/src/lib.rs
+++ b/src/generated/cloud/connectors/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [Connectors](client/struct.Connectors.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -5600,8 +5600,10 @@ pub mod runtime_config {
         /// STATE_UNSPECIFIED.
         Unspecified,
         /// INACTIVE.
+        #[deprecated]
         Inactive,
         /// ACTIVATING.
+        #[deprecated]
         Activating,
         /// ACTIVE.
         Active,
@@ -6525,6 +6527,7 @@ pub enum DataType {
     /// Data type is not specified.
     Unspecified,
     /// DEPRECATED! Use DATA_TYPE_INTEGER.
+    #[deprecated]
     Int,
     /// Short integer(int16) data type.
     Smallint,
@@ -6533,18 +6536,22 @@ pub enum DataType {
     /// Date data type.
     Date,
     /// DEPRECATED! Use DATA_TYPE_TIMESTAMP.
+    #[deprecated]
     Datetime,
     /// Time data type.
     Time,
     /// DEPRECATED! Use DATA_TYPE_VARCHAR.
+    #[deprecated]
     String,
     /// DEPRECATED! Use DATA_TYPE_BIGINT.
+    #[deprecated]
     Long,
     /// Boolean data type.
     Boolean,
     /// Decimal data type.
     Decimal,
     /// DEPRECATED! Use DATA_TYPE_VARCHAR.
+    #[deprecated]
     Uuid,
     /// UNSUPPORTED! Binary data type.
     Blob,

--- a/src/generated/cloud/connectors/v1/src/stub.rs
+++ b/src/generated/cloud/connectors/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Connectors].

--- a/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [ContactCenterInsights](client/struct.ContactCenterInsights.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -111,6 +111,7 @@ pub struct CalculateStatsResponse {
     /// `projects/<Project-ID>/locations/<Location-ID>/issueModels/<Issue-Model-ID>/issues/<Issue-ID>`
     /// Deprecated, use `issue_matches_stats` field instead.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[deprecated]
     pub issue_matches: std::collections::HashMap<std::string::String, i32>,
 
     /// A map associating each issue resource name with its respective number of
@@ -195,6 +196,7 @@ impl CalculateStatsResponse {
     }
 
     /// Sets the value of [issue_matches][crate::model::CalculateStatsResponse::issue_matches].
+    #[deprecated]
     pub fn set_issue_matches<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -13061,6 +13063,7 @@ pub mod issue_model {
         /// Medium of conversations used in training data. This field is being
         /// deprecated. To specify the medium to be used in training a new issue
         /// model, set the `medium` field on `filter`.
+        #[deprecated]
         pub medium: crate::model::conversation::Medium,
 
         /// Output only. Number of conversations used in training. Output only.
@@ -13083,6 +13086,7 @@ pub mod issue_model {
         }
 
         /// Sets the value of [medium][crate::model::issue_model::InputDataConfig::medium].
+        #[deprecated]
         pub fn set_medium<T: std::convert::Into<crate::model::conversation::Medium>>(
             mut self,
             v: T,
@@ -16070,6 +16074,7 @@ pub struct ConversationParticipant {
     /// The name of the Dialogflow participant. Format:
     /// projects/{project}/locations/{location}/conversations/{conversation}/participants/{participant}
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub dialogflow_participant: std::string::String,
 
     /// Obfuscated user ID from Dialogflow.
@@ -16092,6 +16097,7 @@ impl ConversationParticipant {
     }
 
     /// Sets the value of [dialogflow_participant][crate::model::ConversationParticipant::dialogflow_participant].
+    #[deprecated]
     pub fn set_dialogflow_participant<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,

--- a/src/generated/cloud/contactcenterinsights/v1/src/stub.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ContactCenterInsights].

--- a/src/generated/cloud/datacatalog/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/v1/src/client.rs
@@ -64,6 +64,7 @@ use std::sync::Arc;
 /// an [Rc](std::rc::Rc) or [Arc] to reuse it, because it already uses an `Arc`
 /// internally.
 #[derive(Clone, Debug)]
+#[deprecated]
 pub struct DataCatalog {
     inner: Arc<dyn super::stub::dynamic::DataCatalog>,
 }
@@ -137,6 +138,7 @@ impl DataCatalog {
     ///
     /// For more information, see [Data Catalog search syntax]
     /// (<https://cloud.google.com/data-catalog/docs/how-to/search-reference>).
+    #[deprecated]
     pub fn search_catalog(&self) -> super::builder::data_catalog::SearchCatalog {
         super::builder::data_catalog::SearchCatalog::new(self.inner.clone())
     }
@@ -168,6 +170,7 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `parent` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn create_entry_group(
         &self,
         parent: impl Into<std::string::String>,
@@ -177,6 +180,7 @@ impl DataCatalog {
     }
 
     /// Gets an entry group.
+    #[deprecated]
     pub fn get_entry_group(
         &self,
         name: impl Into<std::string::String>,
@@ -190,6 +194,7 @@ impl DataCatalog {
     /// the `entry_group.name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn update_entry_group(
         &self,
         entry_group: impl Into<crate::model::EntryGroup>,
@@ -204,6 +209,7 @@ impl DataCatalog {
     /// identified by the `name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn delete_entry_group(
         &self,
         name: impl Into<std::string::String>,
@@ -213,6 +219,7 @@ impl DataCatalog {
     }
 
     /// Lists entry groups.
+    #[deprecated]
     pub fn list_entry_groups(
         &self,
         parent: impl Into<std::string::String>,
@@ -232,6 +239,7 @@ impl DataCatalog {
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     ///
     /// An entry group can have a maximum of 100,000 entries.
+    #[deprecated]
     pub fn create_entry(
         &self,
         parent: impl Into<std::string::String>,
@@ -245,6 +253,7 @@ impl DataCatalog {
     /// the `entry.name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn update_entry(
         &self,
         entry: impl Into<crate::model::Entry>,
@@ -264,6 +273,7 @@ impl DataCatalog {
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     ///
     /// [google.cloud.datacatalog.v1.DataCatalog.CreateEntry]: crate::client::DataCatalog::create_entry
+    #[deprecated]
     pub fn delete_entry(
         &self,
         name: impl Into<std::string::String>,
@@ -272,6 +282,7 @@ impl DataCatalog {
     }
 
     /// Gets an entry.
+    #[deprecated]
     pub fn get_entry(
         &self,
         name: impl Into<std::string::String>,
@@ -282,6 +293,7 @@ impl DataCatalog {
     /// Gets an entry by its target resource name.
     ///
     /// The resource name comes from the source Google Cloud Platform service.
+    #[deprecated]
     pub fn lookup_entry(&self) -> super::builder::data_catalog::LookupEntry {
         super::builder::data_catalog::LookupEntry::new(self.inner.clone())
     }
@@ -293,6 +305,7 @@ impl DataCatalog {
     /// [SearchCatalog][google.cloud.datacatalog.v1.DataCatalog.SearchCatalog].
     ///
     /// [google.cloud.datacatalog.v1.DataCatalog.SearchCatalog]: crate::client::DataCatalog::search_catalog
+    #[deprecated]
     pub fn list_entries(
         &self,
         parent: impl Into<std::string::String>,
@@ -307,6 +320,7 @@ impl DataCatalog {
     /// IAM permission on the corresponding project.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    #[deprecated]
     pub fn modify_entry_overview(
         &self,
         name: impl Into<std::string::String>,
@@ -322,6 +336,7 @@ impl DataCatalog {
     /// IAM permission on the corresponding project.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    #[deprecated]
     pub fn modify_entry_contacts(
         &self,
         name: impl Into<std::string::String>,
@@ -336,6 +351,7 @@ impl DataCatalog {
     /// `parent` parameter.
     /// For more information, see [Data Catalog resource project]
     /// (<https://cloud.google.com/data-catalog/docs/concepts/resource-project>).
+    #[deprecated]
     pub fn create_tag_template(
         &self,
         parent: impl Into<std::string::String>,
@@ -345,6 +361,7 @@ impl DataCatalog {
     }
 
     /// Gets a tag template.
+    #[deprecated]
     pub fn get_tag_template(
         &self,
         name: impl Into<std::string::String>,
@@ -361,6 +378,7 @@ impl DataCatalog {
     /// the `tag_template.name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn update_tag_template(
         &self,
         tag_template: impl Into<crate::model::TagTemplate>,
@@ -374,6 +392,7 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `name` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn delete_tag_template(
         &self,
         name: impl Into<std::string::String>,
@@ -387,6 +406,7 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `parent` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn create_tag_template_field(
         &self,
         parent: impl Into<std::string::String>,
@@ -403,6 +423,7 @@ impl DataCatalog {
     /// identified by the `name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn update_tag_template_field(
         &self,
         name: impl Into<std::string::String>,
@@ -416,6 +437,7 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by the
     /// `name` parameter. For more information, see [Data Catalog resource project]
     /// (<https://cloud.google.com/data-catalog/docs/concepts/resource-project>).
+    #[deprecated]
     pub fn rename_tag_template_field(
         &self,
         name: impl Into<std::string::String>,
@@ -427,6 +449,7 @@ impl DataCatalog {
     /// Renames an enum value in a tag template.
     ///
     /// Within a single enum field, enum values must be unique.
+    #[deprecated]
     pub fn rename_tag_template_field_enum_value(
         &self,
         name: impl Into<std::string::String>,
@@ -441,6 +464,7 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `name` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    #[deprecated]
     pub fn delete_tag_template_field(
         &self,
         name: impl Into<std::string::String>,
@@ -464,6 +488,7 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     /// [google.cloud.datacatalog.v1.EntryGroup]: crate::model::EntryGroup
+    #[deprecated]
     pub fn create_tag(
         &self,
         parent: impl Into<std::string::String>,
@@ -472,6 +497,7 @@ impl DataCatalog {
     }
 
     /// Updates an existing tag.
+    #[deprecated]
     pub fn update_tag(
         &self,
         tag: impl Into<crate::model::Tag>,
@@ -480,6 +506,7 @@ impl DataCatalog {
     }
 
     /// Deletes a tag.
+    #[deprecated]
     pub fn delete_tag(
         &self,
         name: impl Into<std::string::String>,
@@ -493,6 +520,7 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     /// [google.cloud.datacatalog.v1.Tag.column]: crate::model::Tag::scope
+    #[deprecated]
     pub fn list_tags(
         &self,
         parent: impl Into<std::string::String>,
@@ -525,6 +553,7 @@ impl DataCatalog {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn reconcile_tags(
         &self,
         parent: impl Into<std::string::String>,
@@ -537,6 +566,7 @@ impl DataCatalog {
     /// the current user. Starring information is private to each user.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    #[deprecated]
     pub fn star_entry(
         &self,
         name: impl Into<std::string::String>,
@@ -548,6 +578,7 @@ impl DataCatalog {
     /// the current user. Starring information is private to each user.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    #[deprecated]
     pub fn unstar_entry(
         &self,
         name: impl Into<std::string::String>,
@@ -572,6 +603,7 @@ impl DataCatalog {
     /// - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
     ///   templates.
     /// - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
+    #[deprecated]
     pub fn set_iam_policy(
         &self,
         resource: impl Into<std::string::String>,
@@ -601,6 +633,7 @@ impl DataCatalog {
     /// - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
     ///   templates.
     /// - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
+    #[deprecated]
     pub fn get_iam_policy(
         &self,
         resource: impl Into<std::string::String>,
@@ -623,6 +656,7 @@ impl DataCatalog {
     /// external Google Cloud Platform resources ingested into Data Catalog.
     ///
     /// No Google IAM permissions are required to call this method.
+    #[deprecated]
     pub fn test_iam_permissions(
         &self,
         resource: impl Into<std::string::String>,
@@ -663,6 +697,7 @@ impl DataCatalog {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn import_entries(
         &self,
         parent: impl Into<std::string::String>,
@@ -673,6 +708,7 @@ impl DataCatalog {
 
     /// Sets the configuration related to the migration to Dataplex for an
     /// organization or project.
+    #[deprecated]
     pub fn set_config(
         &self,
         name: impl Into<std::string::String>,
@@ -683,6 +719,7 @@ impl DataCatalog {
     /// Retrieves the configuration related to the migration from Data Catalog to
     /// Dataplex for a specific organization, including all the projects under it
     /// which have a separate configuration set.
+    #[deprecated]
     pub fn retrieve_config(
         &self,
         name: impl Into<std::string::String>,
@@ -695,6 +732,7 @@ impl DataCatalog {
     /// specific configuration set for the resource, the setting is checked
     /// hierarchicahlly through the ancestors of the resource, starting from the
     /// resource itself.
+    #[deprecated]
     pub fn retrieve_effective_config(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -29,9 +29,10 @@
 //! * [PolicyTagManager](client/struct.PolicyTagManager.html)
 //! * [PolicyTagManagerSerialization](client/struct.PolicyTagManagerSerialization.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -39,19 +40,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -31,6 +31,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,18 +39,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -1060,6 +1060,7 @@ pub mod search_catalog_request {
         /// Optional. This field is deprecated. The search mechanism for public and
         /// private tag templates is the same.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[deprecated]
         pub include_public_tag_templates: bool,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1087,6 +1088,7 @@ pub mod search_catalog_request {
         }
 
         /// Sets the value of [include_public_tag_templates][crate::model::search_catalog_request::Scope::include_public_tag_templates].
+        #[deprecated]
         pub fn set_include_public_tag_templates<T: std::convert::Into<bool>>(
             mut self,
             v: T,
@@ -12097,6 +12099,7 @@ pub mod tag_template {
         /// Visible in both services. Editable in DataCatalog, read-only in Dataplex.
         /// Deprecated: Individual TagTemplate migration is deprecated in favor of
         /// organization or project wide TagTemplate migration opt-in.
+        #[deprecated]
         Migrated,
         /// TagTemplate and its tags are auto-copied to Dataplex service.
         /// Visible in both services. Editable in Dataplex, read-only in DataCatalog.

--- a/src/generated/cloud/datacatalog/v1/src/stub.rs
+++ b/src/generated/cloud/datacatalog/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataCatalog].

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [DataFusion](client/struct.DataFusion.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -742,6 +742,7 @@ pub struct Instance {
 
     /// Output only. Deprecated. Use tenant_project_id instead to extract the tenant project ID.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub service_account: std::string::String,
 
     /// Display name for an instance.
@@ -902,6 +903,7 @@ impl Instance {
     }
 
     /// Sets the value of [service_account][crate::model::Instance::service_account].
+    #[deprecated]
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self

--- a/src/generated/cloud/datafusion/v1/src/stub.rs
+++ b/src/generated/cloud/datafusion/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataFusion].

--- a/src/generated/cloud/dataplex/v1/src/builder.rs
+++ b/src/generated/cloud/dataplex/v1/src/builder.rs
@@ -8184,6 +8184,7 @@ pub mod metadata_service {
         }
 
         /// Sets the value of [etag][crate::model::DeletePartitionRequest::etag].
+        #[deprecated]
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self

--- a/src/generated/cloud/dataplex/v1/src/client.rs
+++ b/src/generated/cloud/dataplex/v1/src/client.rs
@@ -1121,6 +1121,7 @@ impl ContentService {
 /// an [Rc](std::rc::Rc) or [Arc] to reuse it, because it already uses an `Arc`
 /// internally.
 #[derive(Clone, Debug)]
+#[deprecated]
 pub struct DataTaxonomyService {
     inner: Arc<dyn super::stub::dynamic::DataTaxonomyService>,
 }
@@ -1192,6 +1193,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn create_data_taxonomy(
         &self,
         parent: impl Into<std::string::String>,
@@ -1211,6 +1213,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn update_data_taxonomy(
         &self,
         data_taxonomy: impl Into<crate::model::DataTaxonomy>,
@@ -1231,6 +1234,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn delete_data_taxonomy(
         &self,
         name: impl Into<std::string::String>,
@@ -1240,6 +1244,7 @@ impl DataTaxonomyService {
     }
 
     /// Lists DataTaxonomy resources in a project and location.
+    #[deprecated]
     pub fn list_data_taxonomies(
         &self,
         parent: impl Into<std::string::String>,
@@ -1249,6 +1254,7 @@ impl DataTaxonomyService {
     }
 
     /// Retrieves a DataTaxonomy resource.
+    #[deprecated]
     pub fn get_data_taxonomy(
         &self,
         name: impl Into<std::string::String>,
@@ -1268,6 +1274,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn create_data_attribute_binding(
         &self,
         parent: impl Into<std::string::String>,
@@ -1287,6 +1294,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn update_data_attribute_binding(
         &self,
         data_attribute_binding: impl Into<crate::model::DataAttributeBinding>,
@@ -1308,6 +1316,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn delete_data_attribute_binding(
         &self,
         name: impl Into<std::string::String>,
@@ -1317,6 +1326,7 @@ impl DataTaxonomyService {
     }
 
     /// Lists DataAttributeBinding resources in a project and location.
+    #[deprecated]
     pub fn list_data_attribute_bindings(
         &self,
         parent: impl Into<std::string::String>,
@@ -1326,6 +1336,7 @@ impl DataTaxonomyService {
     }
 
     /// Retrieves a DataAttributeBinding resource.
+    #[deprecated]
     pub fn get_data_attribute_binding(
         &self,
         name: impl Into<std::string::String>,
@@ -1345,6 +1356,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn create_data_attribute(
         &self,
         parent: impl Into<std::string::String>,
@@ -1364,6 +1376,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn update_data_attribute(
         &self,
         data_attribute: impl Into<crate::model::DataAttribute>,
@@ -1383,6 +1396,7 @@ impl DataTaxonomyService {
     /// [long-running operation]: https://google.aip.dev/151
     /// [user guide]: https://googleapis.github.io/google-cloud-rust/
     /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    #[deprecated]
     pub fn delete_data_attribute(
         &self,
         name: impl Into<std::string::String>,
@@ -1392,6 +1406,7 @@ impl DataTaxonomyService {
     }
 
     /// Lists Data Attribute resources in a DataTaxonomy.
+    #[deprecated]
     pub fn list_data_attributes(
         &self,
         parent: impl Into<std::string::String>,
@@ -1401,6 +1416,7 @@ impl DataTaxonomyService {
     }
 
     /// Retrieves a Data Attribute resource.
+    #[deprecated]
     pub fn get_data_attribute(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/dataplex/v1/src/lib.rs
+++ b/src/generated/cloud/dataplex/v1/src/lib.rs
@@ -35,6 +35,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -42,18 +43,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/dataplex/v1/src/lib.rs
+++ b/src/generated/cloud/dataplex/v1/src/lib.rs
@@ -33,9 +33,10 @@
 //! * [MetadataService](client/struct.MetadataService.html)
 //! * [DataplexService](client/struct.DataplexService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -43,19 +44,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -4542,6 +4542,7 @@ impl wkt::message::Message for SearchEntriesRequest {
 pub struct SearchEntriesResult {
     /// Linked resource name.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub linked_resource: std::string::String,
 
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -4549,6 +4550,7 @@ pub struct SearchEntriesResult {
 
     /// Snippets.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub snippets: std::option::Option<crate::model::search_entries_result::Snippets>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4561,6 +4563,7 @@ impl SearchEntriesResult {
     }
 
     /// Sets the value of [linked_resource][crate::model::SearchEntriesResult::linked_resource].
+    #[deprecated]
     pub fn set_linked_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.linked_resource = v.into();
         self
@@ -4576,6 +4579,7 @@ impl SearchEntriesResult {
     }
 
     /// Sets the value of [snippets][crate::model::SearchEntriesResult::snippets].
+    #[deprecated]
     pub fn set_snippets<
         T: std::convert::Into<std::option::Option<crate::model::search_entries_result::Snippets>>,
     >(
@@ -4604,9 +4608,11 @@ pub mod search_entries_result {
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
+    #[deprecated]
     pub struct Snippets {
         /// Entry
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub dataplex_entry: std::option::Option<crate::model::Entry>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4619,6 +4625,7 @@ pub mod search_entries_result {
         }
 
         /// Sets the value of [dataplex_entry][crate::model::search_entries_result::Snippets::dataplex_entry].
+        #[deprecated]
         pub fn set_dataplex_entry<
             T: std::convert::Into<std::option::Option<crate::model::Entry>>,
         >(
@@ -12042,6 +12049,7 @@ impl wkt::message::Message for DataQualityColumnResult {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct DataTaxonomy {
     /// Output only. The relative resource name of the DataTaxonomy, of the form:
     /// projects/{project_number}/locations/{location_id}/dataTaxonomies/{data_taxonomy_id}.
@@ -12191,6 +12199,7 @@ impl wkt::message::Message for DataTaxonomy {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct DataAttribute {
     /// Output only. The relative resource name of the dataAttribute, of the form:
     /// projects/{project_number}/locations/{location_id}/dataTaxonomies/{dataTaxonomy}/attributes/{data_attribute_id}.
@@ -12366,6 +12375,7 @@ impl wkt::message::Message for DataAttribute {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct DataAttributeBinding {
     /// Output only. The relative resource name of the Data Attribute Binding, of
     /// the form:
@@ -12640,6 +12650,7 @@ pub mod data_attribute_binding {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct CreateDataTaxonomyRequest {
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub parent: std::string::String,
@@ -12716,6 +12727,7 @@ impl wkt::message::Message for CreateDataTaxonomyRequest {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct UpdateDataTaxonomyRequest {
     /// Required. Mask of fields to update.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -12777,6 +12789,7 @@ impl wkt::message::Message for UpdateDataTaxonomyRequest {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct GetDataTaxonomyRequest {
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
     pub name: std::string::String,
@@ -12965,6 +12978,7 @@ impl gax::paginator::internal::PageableResponse for ListDataTaxonomiesResponse {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct DeleteDataTaxonomyRequest {
     /// Required. The resource name of the DataTaxonomy:
     /// projects/{project_number}/locations/{location_id}/dataTaxonomies/{data_taxonomy_id}
@@ -21924,6 +21938,7 @@ pub struct DeletePartitionRequest {
 
     /// Optional. The etag associated with the partition.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub etag: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21942,6 +21957,7 @@ impl DeletePartitionRequest {
     }
 
     /// Sets the value of [etag][crate::model::DeletePartitionRequest::etag].
+    #[deprecated]
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -22568,6 +22584,7 @@ pub struct Partition {
 
     /// Optional. The etag for this partition.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub etag: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -22592,6 +22609,7 @@ impl Partition {
     }
 
     /// Sets the value of [etag][crate::model::Partition::etag].
+    #[deprecated]
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self

--- a/src/generated/cloud/dataplex/v1/src/stub.rs
+++ b/src/generated/cloud/dataplex/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CatalogService].

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [CloudDeploy](client/struct.CloudDeploy.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -18823,6 +18823,7 @@ pub enum Type {
     /// Deploy Policy evaluation.
     DeployPolicyEvaluation,
     /// Deprecated: This field is never used. Use release_render log type instead.
+    #[deprecated]
     RenderStatuesChange,
     /// If set, the enum was initialized with an unknown value.
     ///

--- a/src/generated/cloud/deploy/v1/src/stub.rs
+++ b/src/generated/cloud/deploy/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudDeploy].

--- a/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
@@ -45,6 +45,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -52,18 +53,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
@@ -43,9 +43,10 @@
 //! * [Versions](client/struct.Versions.html)
 //! * [Webhooks](client/struct.Webhooks.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -53,19 +54,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -518,6 +518,7 @@ pub struct Agent {
     ///
     /// [google.cloud.dialogflow.cx.v3.AdvancedSettings.LoggingSettings]: crate::model::advanced_settings::LoggingSettings
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enable_stackdriver_logging: bool,
 
     /// Indicates if automatic spell correction is enabled in detect intent
@@ -651,6 +652,7 @@ impl Agent {
     }
 
     /// Sets the value of [enable_stackdriver_logging][crate::model::Agent::enable_stackdriver_logging].
+    #[deprecated]
     pub fn set_enable_stackdriver_logging<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_stackdriver_logging = v.into();
         self
@@ -14392,6 +14394,7 @@ pub mod import_intents_request {
         /// [REPORT_CONFLICT][ImportIntentsRequest.REPORT_CONFLICT] instead.
         /// Fail the request if there are intents whose display names conflict with
         /// the display names of intents in the agent.
+        #[deprecated]
         Reject,
         /// Replace the original intent in the agent with the new intent when display
         /// name conflicts exist.
@@ -21150,6 +21153,7 @@ pub struct QueryParameters {
     /// DetectIntentResponse.query_result.data_store_connection_signals
     /// will be filled with data that can help evaluations.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub populate_data_store_connection_signals: bool,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -21248,6 +21252,7 @@ impl QueryParameters {
     }
 
     /// Sets the value of [populate_data_store_connection_signals][crate::model::QueryParameters::populate_data_store_connection_signals].
+    #[deprecated]
     pub fn set_populate_data_store_connection_signals<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -22324,6 +22329,7 @@ pub struct QueryResult {
     /// [google.cloud.dialogflow.cx.v3.Intent]: crate::model::Intent
     /// [google.cloud.dialogflow.cx.v3.QueryResult.match]: crate::model::QueryResult::match
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub intent: std::option::Option<crate::model::Intent>,
 
     /// The intent detection confidence. Values range from 0.0 (completely
@@ -22338,6 +22344,7 @@ pub struct QueryResult {
     ///
     /// [google.cloud.dialogflow.cx.v3.QueryResult.match]: crate::model::QueryResult::match
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub intent_detection_confidence: f32,
 
     /// Intent match result, could be an intent or an event.
@@ -22438,6 +22445,7 @@ impl QueryResult {
     }
 
     /// Sets the value of [intent][crate::model::QueryResult::intent].
+    #[deprecated]
     pub fn set_intent<T: std::convert::Into<std::option::Option<crate::model::Intent>>>(
         mut self,
         v: T,
@@ -22447,6 +22455,7 @@ impl QueryResult {
     }
 
     /// Sets the value of [intent_detection_confidence][crate::model::QueryResult::intent_detection_confidence].
+    #[deprecated]
     pub fn set_intent_detection_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.intent_detection_confidence = v.into();
         self
@@ -28229,6 +28238,7 @@ pub struct ValidationMessage {
 
     /// The names of the resources where the message is found.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub resources: std::vec::Vec<std::string::String>,
 
     /// The resource names of the resources where the message is found.
@@ -28278,6 +28288,7 @@ impl ValidationMessage {
     }
 
     /// Sets the value of [resources][crate::model::ValidationMessage::resources].
+    #[deprecated]
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -29654,10 +29665,12 @@ pub mod webhook {
 
         /// The user name for HTTP Basic authentication.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub username: std::string::String,
 
         /// The password for HTTP Basic authentication.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub password: std::string::String,
 
         /// The HTTP request headers to send together with webhook requests.
@@ -29730,12 +29743,14 @@ pub mod webhook {
         }
 
         /// Sets the value of [username][crate::model::webhook::GenericWebService::username].
+        #[deprecated]
         pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.username = v.into();
             self
         }
 
         /// Sets the value of [password][crate::model::webhook::GenericWebService::password].
+        #[deprecated]
         pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.password = v.into();
             self

--- a/src/generated/cloud/dialogflow/cx/v3/src/stub.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Agents].

--- a/src/generated/cloud/dialogflow/v2/src/lib.rs
+++ b/src/generated/cloud/dialogflow/v2/src/lib.rs
@@ -45,9 +45,10 @@
 //! * [SessionEntityTypes](client/struct.SessionEntityTypes.html)
 //! * [Versions](client/struct.Versions.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -55,19 +56,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/dialogflow/v2/src/lib.rs
+++ b/src/generated/cloud/dialogflow/v2/src/lib.rs
@@ -47,6 +47,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -54,18 +55,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -95,6 +95,7 @@ pub struct Agent {
     pub enable_logging: bool,
 
     /// Optional. Determines how intents are detected from user queries.
+    #[deprecated]
     pub match_mode: crate::model::agent::MatchMode,
 
     /// Optional. To filter out false positive results and still get variety in
@@ -171,6 +172,7 @@ impl Agent {
     }
 
     /// Sets the value of [match_mode][crate::model::Agent::match_mode].
+    #[deprecated]
     pub fn set_match_mode<T: std::convert::Into<crate::model::agent::MatchMode>>(
         mut self,
         v: T,
@@ -522,6 +524,7 @@ pub mod agent {
         Enterprise,
         /// Essentials Edition (same as TIER_ENTERPRISE), previously known as
         /// Enterprise Plus Edition.
+        #[deprecated]
         EnterprisePlus,
         /// If set, the enum was initialized with an unknown value.
         ///
@@ -3132,6 +3135,7 @@ pub struct InputAudioConfig {
     /// specify both [`phrase_hints`]() and [`speech_contexts`](), Dialogflow will
     /// treat the [`phrase_hints`]() as a single additional [`SpeechContext`]().
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub phrase_hints: std::vec::Vec<std::string::String>,
 
     /// Context information to assist speech recognition.
@@ -3275,6 +3279,7 @@ impl InputAudioConfig {
     }
 
     /// Sets the value of [phrase_hints][crate::model::InputAudioConfig::phrase_hints].
+    #[deprecated]
     pub fn set_phrase_hints<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -18694,6 +18699,7 @@ pub mod fulfillment {
         /// is_cloud_function is deprecated. Cloud functions can be configured by
         /// its uri as a regular web service now.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[deprecated]
         pub is_cloud_function: bool,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -18724,6 +18730,7 @@ pub mod fulfillment {
         }
 
         /// Sets the value of [is_cloud_function][crate::model::fulfillment::GenericWebService::is_cloud_function].
+        #[deprecated]
         pub fn set_is_cloud_function<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.is_cloud_function = v.into();
             self
@@ -21355,6 +21362,7 @@ pub mod intent {
             /// way to create new training phrases. If you have existing training
             /// phrases that you've created in template mode, those will continue to
             /// work.
+            #[deprecated]
             Template,
             /// If set, the enum was initialized with an unknown value.
             ///
@@ -31089,6 +31097,7 @@ pub struct StreamingDetectIntentRequest {
     ///
     /// [google.cloud.dialogflow.v2.InputAudioConfig.single_utterance]: crate::model::InputAudioConfig::single_utterance
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub single_utterance: bool,
 
     /// Instructs the speech synthesizer how to generate the output
@@ -31157,6 +31166,7 @@ impl StreamingDetectIntentRequest {
     }
 
     /// Sets the value of [single_utterance][crate::model::StreamingDetectIntentRequest::single_utterance].
+    #[deprecated]
     pub fn set_single_utterance<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.single_utterance = v.into();
         self

--- a/src/generated/cloud/dialogflow/v2/src/stub.rs
+++ b/src/generated/cloud/dialogflow/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Agents].

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -1922,6 +1922,7 @@ pub mod conversational_search_service {
         }
 
         /// Sets the value of [asynchronous_mode][crate::model::AnswerQueryRequest::asynchronous_mode].
+        #[deprecated]
         pub fn set_asynchronous_mode<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.asynchronous_mode = v.into();
             self

--- a/src/generated/cloud/discoveryengine/v1/src/lib.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/lib.rs
@@ -44,6 +44,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -51,18 +52,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/discoveryengine/v1/src/lib.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/lib.rs
@@ -42,9 +42,10 @@
 //! * [SiteSearchEngineService](client/struct.SiteSearchEngineService.html)
 //! * [UserEventService](client/struct.UserEventService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -52,19 +53,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -4105,6 +4105,7 @@ pub mod control {
         /// Strength of the boost, which should be in [-1, 1]. Negative
         /// boost means demotion. Default is 0.0 (No-op).
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[deprecated]
         pub boost: f32,
 
         /// Required. Specifies which products to apply the boost to.
@@ -4137,6 +4138,7 @@ pub mod control {
         }
 
         /// Sets the value of [boost][crate::model::control::BoostAction::boost].
+        #[deprecated]
         pub fn set_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
             self.boost = v.into();
             self
@@ -6346,6 +6348,7 @@ pub struct AnswerQueryRequest {
     /// [google.cloud.discoveryengine.v1.ConversationalSearchService.GetAnswer]: crate::client::ConversationalSearchService::get_answer
     /// [google.cloud.discoveryengine.v1.ConversationalSearchService.GetSession]: crate::client::ConversationalSearchService::get_session
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub asynchronous_mode: bool,
 
     /// A unique identifier for tracking visitors. For example, this could be
@@ -6487,6 +6490,7 @@ impl AnswerQueryRequest {
     }
 
     /// Sets the value of [asynchronous_mode][crate::model::AnswerQueryRequest::asynchronous_mode].
+    #[deprecated]
     pub fn set_asynchronous_mode<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.asynchronous_mode = v.into();
         self
@@ -7699,6 +7703,7 @@ pub mod answer_query_request {
                     /// Please use document_contexts and extractive_segments fields.
                     /// List of extractive answers.
                     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+                    #[deprecated]
                     pub extractive_answers: std::vec::Vec<crate::model::answer_query_request::search_spec::search_result_list::search_result::unstructured_document_info::ExtractiveAnswer>,
 
                     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7760,6 +7765,7 @@ pub mod answer_query_request {
                     }
 
                     /// Sets the value of [extractive_answers][crate::model::answer_query_request::search_spec::search_result_list::search_result::UnstructuredDocumentInfo::extractive_answers].
+                    #[deprecated]
                     pub fn set_extractive_answers<T, V>(mut self, v: T) -> Self
                     where
                         T: std::iter::IntoIterator<Item = V>,
@@ -9274,6 +9280,7 @@ pub struct CustomTuningModel {
 
     /// Deprecated: Timestamp the Model was created at.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub create_time: std::option::Option<wkt::Timestamp>,
 
     /// Timestamp the model training was initiated.
@@ -9326,6 +9333,7 @@ impl CustomTuningModel {
     }
 
     /// Sets the value of [create_time][crate::model::CustomTuningModel::create_time].
+    #[deprecated]
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
@@ -11752,6 +11760,7 @@ pub mod document_processing_config {
             /// [DEPRECATED] This field is deprecated. To use the additional enhanced
             /// document elements processing, please switch to `layout_parsing_config`.
             #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+            #[deprecated]
             pub enhanced_document_elements: std::vec::Vec<std::string::String>,
 
             /// If true, will use native text instead of OCR text on pages containing
@@ -11775,6 +11784,7 @@ pub mod document_processing_config {
             }
 
             /// Sets the value of [enhanced_document_elements][crate::model::document_processing_config::parsing_config::OcrParsingConfig::enhanced_document_elements].
+            #[deprecated]
             pub fn set_enhanced_document_elements<T, V>(mut self, v: T) -> Self
             where
                 T: std::iter::IntoIterator<Item = V>,
@@ -24961,11 +24971,13 @@ pub mod search_request {
             /// `return_snippet` field. For backwards compatibility, we will return
             /// snippet if max_snippet_count > 0.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[deprecated]
             pub max_snippet_count: i32,
 
             /// [DEPRECATED] This field is deprecated and will have no affect on the
             /// snippet.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[deprecated]
             pub reference_only: bool,
 
             /// If `true`, then return snippet. If no snippet can be generated, we
@@ -24984,12 +24996,14 @@ pub mod search_request {
             }
 
             /// Sets the value of [max_snippet_count][crate::model::search_request::content_search_spec::SnippetSpec::max_snippet_count].
+            #[deprecated]
             pub fn set_max_snippet_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
                 self.max_snippet_count = v.into();
                 self
             }
 
             /// Sets the value of [reference_only][crate::model::search_request::content_search_spec::SnippetSpec::reference_only].
+            #[deprecated]
             pub fn set_reference_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
                 self.reference_only = v.into();
                 self

--- a/src/generated/cloud/discoveryengine/v1/src/stub.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CompletionService].

--- a/src/generated/cloud/documentai/v1/src/lib.rs
+++ b/src/generated/cloud/documentai/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/documentai/v1/src/lib.rs
+++ b/src/generated/cloud/documentai/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [DocumentProcessorService](client/struct.DocumentProcessorService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -146,6 +146,7 @@ pub struct Document {
     ///
     /// [google.cloud.documentai.v1.Document.text]: crate::model::Document::text
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub text_styles: std::vec::Vec<crate::model::document::Style>,
 
     /// Visual page layout for the [Document][google.cloud.documentai.v1.Document].
@@ -273,6 +274,7 @@ impl Document {
     }
 
     /// Sets the value of [text_styles][crate::model::Document::text_styles].
+    #[deprecated]
     pub fn set_text_styles<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -743,6 +745,7 @@ pub mod document {
 
         /// The history of this page.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub provenance: std::option::Option<crate::model::document::Provenance>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -807,6 +810,7 @@ pub mod document {
         }
 
         /// Sets the value of [provenance][crate::model::document::Page::provenance].
+        #[deprecated]
         pub fn set_provenance<
             T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
         >(
@@ -1408,6 +1412,7 @@ pub mod document {
 
             /// The history of this annotation.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[deprecated]
             pub provenance: std::option::Option<crate::model::document::Provenance>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1431,6 +1436,7 @@ pub mod document {
             }
 
             /// Sets the value of [provenance][crate::model::document::page::Block::provenance].
+            #[deprecated]
             pub fn set_provenance<
                 T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
             >(
@@ -1479,6 +1485,7 @@ pub mod document {
 
             /// The  history of this annotation.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[deprecated]
             pub provenance: std::option::Option<crate::model::document::Provenance>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1502,6 +1509,7 @@ pub mod document {
             }
 
             /// Sets the value of [provenance][crate::model::document::page::Paragraph::provenance].
+            #[deprecated]
             pub fn set_provenance<
                 T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
             >(
@@ -1551,6 +1559,7 @@ pub mod document {
 
             /// The  history of this annotation.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[deprecated]
             pub provenance: std::option::Option<crate::model::document::Provenance>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1574,6 +1583,7 @@ pub mod document {
             }
 
             /// Sets the value of [provenance][crate::model::document::page::Line::provenance].
+            #[deprecated]
             pub fn set_provenance<
                 T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
             >(
@@ -1630,6 +1640,7 @@ pub mod document {
 
             /// The history of this annotation.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[deprecated]
             pub provenance: std::option::Option<crate::model::document::Provenance>,
 
             /// Text style attributes.
@@ -1670,6 +1681,7 @@ pub mod document {
             }
 
             /// Sets the value of [provenance][crate::model::document::page::Token::provenance].
+            #[deprecated]
             pub fn set_provenance<
                 T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
             >(
@@ -2255,6 +2267,7 @@ pub mod document {
 
             /// The history of this table.
             #[serde(skip_serializing_if = "std::option::Option::is_none")]
+            #[deprecated]
             pub provenance: std::option::Option<crate::model::document::Provenance>,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2278,6 +2291,7 @@ pub mod document {
             }
 
             /// Sets the value of [provenance][crate::model::document::page::Table::provenance].
+            #[deprecated]
             pub fn set_provenance<
                 T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
             >(
@@ -3558,6 +3572,7 @@ pub mod document {
             ///
             /// [google.cloud.documentai.v1.Document.PageAnchor.PageRef.bounding_poly]: crate::model::document::page_anchor::PageRef::bounding_poly
             #[serde(skip_serializing_if = "std::string::String::is_empty")]
+            #[deprecated]
             pub layout_id: std::string::String,
 
             /// Optional. Identifies the bounding polygon of a layout element on the
@@ -3598,6 +3613,7 @@ pub mod document {
             }
 
             /// Sets the value of [layout_id][crate::model::document::page_anchor::PageRef::layout_id].
+            #[deprecated]
             pub fn set_layout_id<T: std::convert::Into<std::string::String>>(
                 mut self,
                 v: T,
@@ -3843,11 +3859,13 @@ pub mod document {
     pub struct Provenance {
         /// The index of the revision that produced this element.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[deprecated]
         pub revision: i32,
 
         /// The Id of this operation.  Needs to be unique within the scope of the
         /// revision.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[deprecated]
         pub id: i32,
 
         /// References to the original elements that are replaced.
@@ -3868,12 +3886,14 @@ pub mod document {
         }
 
         /// Sets the value of [revision][crate::model::document::Provenance::revision].
+        #[deprecated]
         pub fn set_revision<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.revision = v.into();
             self
         }
 
         /// Sets the value of [id][crate::model::document::Provenance::id].
+        #[deprecated]
         pub fn set_id<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.id = v.into();
             self
@@ -3931,6 +3951,7 @@ pub mod document {
 
             /// The id of the parent provenance.
             #[serde(skip_serializing_if = "wkt::internal::is_default")]
+            #[deprecated]
             pub id: i32,
 
             #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3955,6 +3976,7 @@ pub mod document {
             }
 
             /// Sets the value of [id][crate::model::document::provenance::Parent::id].
+            #[deprecated]
             pub fn set_id<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
                 self.id = v.into();
                 self
@@ -4001,11 +4023,14 @@ pub mod document {
             Replace,
             /// Deprecated. Request human review for the element identified by
             /// `parent`.
+            #[deprecated]
             EvalRequested,
             /// Deprecated. Element is reviewed and approved at human review,
             /// confidence will be set to 1.0.
+            #[deprecated]
             EvalApproved,
             /// Deprecated. Element is skipped in the validation process.
+            #[deprecated]
             EvalSkipped,
             /// If set, the enum was initialized with an unknown value.
             ///
@@ -4159,6 +4184,7 @@ pub mod document {
         /// more parent (when documents are merged.)  This field represents the
         /// index into the `revisions` field.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub parent: std::vec::Vec<i32>,
 
         /// The revisions that this revision is based on. Must include all the ids
@@ -4216,6 +4242,7 @@ pub mod document {
         }
 
         /// Sets the value of [parent][crate::model::document::Revision::parent].
+        #[deprecated]
         pub fn set_parent<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -4394,6 +4421,7 @@ pub mod document {
 
         /// The history of this annotation.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub provenance: std::vec::Vec<crate::model::document::Provenance>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4426,6 +4454,7 @@ pub mod document {
         }
 
         /// Sets the value of [provenance][crate::model::document::TextChange::provenance].
+        #[deprecated]
         pub fn set_provenance<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -5925,6 +5954,7 @@ pub struct OcrConfig {
     ///
     /// [google.cloud.documentai.v1.OcrConfig.PremiumFeatures.compute_style_info]: crate::model::ocr_config::PremiumFeatures::compute_style_info
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub compute_style_info: bool,
 
     /// Turn off character box detector in OCR engine. Character box detection is
@@ -5975,6 +6005,7 @@ impl OcrConfig {
     }
 
     /// Sets the value of [compute_style_info][crate::model::OcrConfig::compute_style_info].
+    #[deprecated]
     pub fn set_compute_style_info<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.compute_style_info = v.into();
         self

--- a/src/generated/cloud/documentai/v1/src/stub.rs
+++ b/src/generated/cloud/documentai/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DocumentProcessorService].

--- a/src/generated/cloud/edgecontainer/v1/src/lib.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/edgecontainer/v1/src/lib.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [EdgeContainer](client/struct.EdgeContainer.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -2751,6 +2751,7 @@ pub struct VpnConnection {
     pub nat_gateway_ip: std::string::String,
 
     /// Dynamic routing mode of the VPC network, `regional` or `global`.
+    #[deprecated]
     pub bgp_routing_mode: crate::model::vpn_connection::BgpRoutingMode,
 
     /// The canonical Cluster name to connect to. It is in the form of
@@ -2820,6 +2821,7 @@ impl VpnConnection {
     }
 
     /// Sets the value of [bgp_routing_mode][crate::model::VpnConnection::bgp_routing_mode].
+    #[deprecated]
     pub fn set_bgp_routing_mode<
         T: std::convert::Into<crate::model::vpn_connection::BgpRoutingMode>,
     >(
@@ -2913,6 +2915,7 @@ pub mod vpn_connection {
 
         /// Optional. Deprecated: do not use.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub service_account: std::string::String,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2931,6 +2934,7 @@ pub mod vpn_connection {
         }
 
         /// Sets the value of [service_account][crate::model::vpn_connection::VpcProject::service_account].
+        #[deprecated]
         pub fn set_service_account<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,

--- a/src/generated/cloud/edgecontainer/v1/src/stub.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::EdgeContainer].

--- a/src/generated/cloud/edgenetwork/v1/src/client.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/client.rs
@@ -132,6 +132,7 @@ impl EdgeNetwork {
 
     /// Deprecated: not implemented.
     /// Lists Zones in a given project and location.
+    #[deprecated]
     pub fn list_zones(
         &self,
         parent: impl Into<std::string::String>,
@@ -141,6 +142,7 @@ impl EdgeNetwork {
 
     /// Deprecated: not implemented.
     /// Gets details of a single Zone.
+    #[deprecated]
     pub fn get_zone(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/cloud/edgenetwork/v1/src/lib.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/edgenetwork/v1/src/lib.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [EdgeNetwork](client/struct.EdgeNetwork.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -54,11 +54,13 @@ pub struct Zone {
     /// Deprecated: not implemented.
     /// Labels as key value pairs.
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[deprecated]
     pub labels: std::collections::HashMap<std::string::String, std::string::String>,
 
     /// Deprecated: not implemented.
     /// The deployment layout type.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub layout_name: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -95,12 +97,14 @@ impl Zone {
     }
 
     /// Sets the value of [layout_name][crate::model::Zone::layout_name].
+    #[deprecated]
     pub fn set_layout_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.layout_name = v.into();
         self
     }
 
     /// Sets the value of [labels][crate::model::Zone::labels].
+    #[deprecated]
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -2450,6 +2454,7 @@ pub mod router_status {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct ListZonesRequest {
     /// Required. Parent value for ListZonesRequest
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -2524,6 +2529,7 @@ impl wkt::message::Message for ListZonesRequest {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct ListZonesResponse {
     /// The list of Zone
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -2601,6 +2607,7 @@ impl gax::paginator::internal::PageableResponse for ListZonesResponse {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct GetZoneRequest {
     /// Required. Name of the resource
     #[serde(skip_serializing_if = "std::string::String::is_empty")]

--- a/src/generated/cloud/edgenetwork/v1/src/stub.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::EdgeNetwork].

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [FunctionService](client/struct.FunctionService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -1122,6 +1122,7 @@ pub struct BuildConfig {
     /// If unspecified, it defaults to `ARTIFACT_REGISTRY`.
     /// If `docker_repository` field is specified, this field should either be left
     /// unspecified or set to `ARTIFACT_REGISTRY`.
+    #[deprecated]
     pub docker_registry: crate::model::build_config::DockerRegistry,
 
     /// Repository in Artifact Registry to which the function docker image will be
@@ -1199,6 +1200,7 @@ impl BuildConfig {
     }
 
     /// Sets the value of [docker_registry][crate::model::BuildConfig::docker_registry].
+    #[deprecated]
     pub fn set_docker_registry<
         T: std::convert::Into<crate::model::build_config::DockerRegistry>,
     >(

--- a/src/generated/cloud/functions/v2/src/stub.rs
+++ b/src/generated/cloud/functions/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::FunctionService].

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/lib.rs
@@ -26,4 +26,5 @@
 //! module.
 
 /// The messages and enums that are part of this client library.
+#[allow(deprecated)]
 pub mod model;

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -1727,6 +1727,7 @@ pub struct SyncState {
     /// Timestamp of when ACM last successfully synced the repo
     /// The time format is specified in <https://golang.org/pkg/time/#Time.String>
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub last_sync: std::string::String,
 
     /// Timestamp type of when ACM last successfully synced the repo
@@ -1770,6 +1771,7 @@ impl SyncState {
     }
 
     /// Sets the value of [last_sync][crate::model::SyncState::last_sync].
+    #[deprecated]
     pub fn set_last_sync<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.last_sync = v.into();
         self

--- a/src/generated/cloud/iap/v1/src/lib.rs
+++ b/src/generated/cloud/iap/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [IdentityAwareProxyAdminService](client/struct.IdentityAwareProxyAdminService.html)
 //! * [IdentityAwareProxyOAuthService](client/struct.IdentityAwareProxyOAuthService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/iap/v1/src/lib.rs
+++ b/src/generated/cloud/iap/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -1175,6 +1175,7 @@ pub mod reauth_settings {
         Unspecified,
         /// Prompts the user to log in again.
         Login,
+        #[deprecated]
         Password,
         /// User must use their secure key 2nd factor device.
         SecureKey,

--- a/src/generated/cloud/iap/v1/src/stub.rs
+++ b/src/generated/cloud/iap/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::IdentityAwareProxyAdminService].

--- a/src/generated/cloud/memorystore/v1/src/lib.rs
+++ b/src/generated/cloud/memorystore/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [Memorystore](client/struct.Memorystore.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/memorystore/v1/src/lib.rs
+++ b/src/generated/cloud/memorystore/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -1235,6 +1235,7 @@ pub mod instance {
         /// Mode is not specified.
         Unspecified,
         /// Deprecated: Use CLUSTER_DISABLED instead.
+        #[deprecated]
         Standalone,
         /// Instance is in cluster mode.
         Cluster,

--- a/src/generated/cloud/memorystore/v1/src/stub.rs
+++ b/src/generated/cloud/memorystore/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Memorystore].

--- a/src/generated/cloud/metastore/v1/src/lib.rs
+++ b/src/generated/cloud/metastore/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/metastore/v1/src/lib.rs
+++ b/src/generated/cloud/metastore/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [DataprocMetastore](client/struct.DataprocMetastore.html)
 //! * [DataprocMetastoreFederation](client/struct.DataprocMetastoreFederation.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -2041,6 +2041,7 @@ pub mod metadata_import {
     #[non_exhaustive]
     pub struct DatabaseDump {
         /// The type of the database.
+        #[deprecated]
         pub database_type: crate::model::metadata_import::database_dump::DatabaseType,
 
         /// A Cloud Storage object or folder URI that specifies the source from which
@@ -2050,6 +2051,7 @@ pub mod metadata_import {
 
         /// The name of the source database.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub source_database: std::string::String,
 
         /// Optional. The type of the database dump. If unspecified, defaults to
@@ -2067,6 +2069,7 @@ pub mod metadata_import {
         }
 
         /// Sets the value of [database_type][crate::model::metadata_import::DatabaseDump::database_type].
+        #[deprecated]
         pub fn set_database_type<
             T: std::convert::Into<crate::model::metadata_import::database_dump::DatabaseType>,
         >(
@@ -2084,6 +2087,7 @@ pub mod metadata_import {
         }
 
         /// Sets the value of [source_database][crate::model::metadata_import::DatabaseDump::source_database].
+        #[deprecated]
         pub fn set_source_database<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,

--- a/src/generated/cloud/metastore/v1/src/stub.rs
+++ b/src/generated/cloud/metastore/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataprocMetastore].

--- a/src/generated/cloud/migrationcenter/v1/src/lib.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/migrationcenter/v1/src/lib.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [MigrationCenter](client/struct.MigrationCenter.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -6947,6 +6947,7 @@ pub struct BiosDetails {
     /// BIOS name.
     /// This fields is deprecated. Please use the `id` field instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub bios_name: std::string::String,
 
     /// BIOS ID.
@@ -6979,6 +6980,7 @@ impl BiosDetails {
     }
 
     /// Sets the value of [bios_name][crate::model::BiosDetails::bios_name].
+    #[deprecated]
     pub fn set_bios_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.bios_name = v.into();
         self
@@ -13203,6 +13205,7 @@ pub mod import_error {
 pub struct ImportRowError {
     /// The row number where the error was detected.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub row_number: i32,
 
     /// The name of the VM in the row.
@@ -13227,6 +13230,7 @@ impl ImportRowError {
     }
 
     /// Sets the value of [row_number][crate::model::ImportRowError::row_number].
+    #[deprecated]
     pub fn set_row_number<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.row_number = v.into();
         self
@@ -15499,6 +15503,7 @@ pub mod report_summary {
         /// This field is deprecated, do not rely on it having a value.
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
         #[serde_as(as = "serde_with::DisplayFromStr")]
+        #[deprecated]
         pub overlapping_asset_count: i64,
 
         /// Findings for each of the PreferenceSets for this group.
@@ -15544,6 +15549,7 @@ pub mod report_summary {
         }
 
         /// Sets the value of [overlapping_asset_count][crate::model::report_summary::GroupFinding::overlapping_asset_count].
+        #[deprecated]
         pub fn set_overlapping_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.overlapping_asset_count = v.into();
             self

--- a/src/generated/cloud/migrationcenter/v1/src/stub.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::MigrationCenter].

--- a/src/generated/cloud/netapp/v1/src/lib.rs
+++ b/src/generated/cloud/netapp/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/netapp/v1/src/lib.rs
+++ b/src/generated/cloud/netapp/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [NetApp](client/struct.NetApp.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -7459,6 +7459,7 @@ pub struct StoragePool {
     /// Deprecated. Used to allow SO pool to access AD or DNS server from other
     /// regions.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub global_access_allowed: std::option::Option<bool>,
 
     /// Optional. True if the storage pool supports Auto Tiering enabled volumes.
@@ -7598,6 +7599,7 @@ impl StoragePool {
     }
 
     /// Sets the value of [global_access_allowed][crate::model::StoragePool::global_access_allowed].
+    #[deprecated]
     pub fn set_global_access_allowed<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
         v: T,

--- a/src/generated/cloud/netapp/v1/src/stub.rs
+++ b/src/generated/cloud/netapp/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::NetApp].

--- a/src/generated/cloud/networkconnectivity/v1/src/lib.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/lib.rs
@@ -29,9 +29,10 @@
 //! * [HubService](client/struct.HubService.html)
 //! * [PolicyBasedRoutingService](client/struct.PolicyBasedRoutingService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -39,19 +40,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/networkconnectivity/v1/src/lib.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/lib.rs
@@ -31,6 +31,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,18 +39,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -413,6 +413,7 @@ pub mod service_connection_map {
         /// Immutable. Deprecated. Use producer_instance_metadata instead.
         /// An immutable identifier for the producer instance.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub producer_instance_id: std::string::String,
 
         /// Output only. A map to store mapping between customer vip and target
@@ -479,6 +480,7 @@ pub mod service_connection_map {
         }
 
         /// Sets the value of [producer_instance_id][crate::model::service_connection_map::ConsumerPscConfig::producer_instance_id].
+        #[deprecated]
         pub fn set_producer_instance_id<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -744,10 +746,12 @@ pub mod service_connection_map {
 
         /// The error type indicates whether the error is consumer facing, producer
         /// facing or system internal.
+        #[deprecated]
         pub error_type: crate::model::ConnectionErrorType,
 
         /// The most recent error during operating this connection.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub error: std::option::Option<rpc::model::Status>,
 
         /// The last Compute Engine operation to setup PSC connection.
@@ -773,6 +777,7 @@ pub mod service_connection_map {
         /// Immutable. Deprecated. Use producer_instance_metadata instead.
         /// An immutable identifier for the producer instance.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub producer_instance_id: std::string::String,
 
         /// Immutable. An immutable map for the producer instance metadata.
@@ -843,6 +848,7 @@ pub mod service_connection_map {
         }
 
         /// Sets the value of [error_type][crate::model::service_connection_map::ConsumerPscConnection::error_type].
+        #[deprecated]
         pub fn set_error_type<T: std::convert::Into<crate::model::ConnectionErrorType>>(
             mut self,
             v: T,
@@ -852,6 +858,7 @@ pub mod service_connection_map {
         }
 
         /// Sets the value of [error][crate::model::service_connection_map::ConsumerPscConnection::error].
+        #[deprecated]
         pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
             mut self,
             v: T,
@@ -897,6 +904,7 @@ pub mod service_connection_map {
         }
 
         /// Sets the value of [producer_instance_id][crate::model::service_connection_map::ConsumerPscConnection::producer_instance_id].
+        #[deprecated]
         pub fn set_producer_instance_id<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
@@ -1968,11 +1976,13 @@ pub mod service_connection_policy {
 
         /// The error type indicates whether the error is consumer facing, producer
         /// facing or system internal.
+        #[deprecated]
         pub error_type: crate::model::ConnectionErrorType,
 
         /// The most recent error during operating this connection.
         /// Deprecated, please use error_info instead.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub error: std::option::Option<rpc::model::Status>,
 
         /// The last Compute Engine operation to setup PSC connection.
@@ -2000,6 +2010,7 @@ pub mod service_connection_policy {
         /// Immutable. Deprecated. Use producer_instance_metadata instead.
         /// An immutable identifier for the producer instance.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub producer_instance_id: std::string::String,
 
         /// Immutable. An immutable map for the producer instance metadata.
@@ -2054,6 +2065,7 @@ pub mod service_connection_policy {
         }
 
         /// Sets the value of [error_type][crate::model::service_connection_policy::PscConnection::error_type].
+        #[deprecated]
         pub fn set_error_type<T: std::convert::Into<crate::model::ConnectionErrorType>>(
             mut self,
             v: T,
@@ -2063,6 +2075,7 @@ pub mod service_connection_policy {
         }
 
         /// Sets the value of [error][crate::model::service_connection_policy::PscConnection::error].
+        #[deprecated]
         pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
             mut self,
             v: T,
@@ -2117,6 +2130,7 @@ pub mod service_connection_policy {
         }
 
         /// Sets the value of [producer_instance_id][crate::model::service_connection_policy::PscConnection::producer_instance_id].
+        #[deprecated]
         pub fn set_producer_instance_id<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,

--- a/src/generated/cloud/networkconnectivity/v1/src/stub.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CrossNetworkAutomationService].

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [ReachabilityService](client/struct.ReachabilityService.html)
 //! * [VpcFlowLogsService](client/struct.VpcFlowLogsService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -2564,6 +2564,7 @@ impl Step {
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `LoadBalancer`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn load_balancer(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::LoadBalancerInfo>> {
@@ -2961,6 +2962,7 @@ impl Step {
     ///
     /// Note that all the setters affecting `step_info` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_load_balancer<
         T: std::convert::Into<std::boxed::Box<crate::model::LoadBalancerInfo>>,
     >(
@@ -3270,10 +3272,12 @@ pub mod step {
         /// Forwarding state: arriving at a Compute Engine internal load balancer.
         /// Deprecated in favor of the `ANALYZE_LOAD_BALANCER_BACKEND` state, not
         /// used in new tests.
+        #[deprecated]
         ArriveAtInternalLoadBalancer,
         /// Forwarding state: arriving at a Compute Engine external load balancer.
         /// Deprecated in favor of the `ANALYZE_LOAD_BALANCER_BACKEND` state, not
         /// used in new tests.
+        #[deprecated]
         ArriveAtExternalLoadBalancer,
         /// Forwarding state: arriving at a Cloud VPN gateway.
         ArriveAtVpnGateway,
@@ -3661,6 +3665,7 @@ pub mod step {
         Drop(std::boxed::Box<crate::model::DropInfo>),
         /// Display information of the load balancers. Deprecated in favor of the
         /// `load_balancer_backend_info` field, not used in new tests.
+        #[deprecated]
         LoadBalancer(std::boxed::Box<crate::model::LoadBalancerInfo>),
         /// Display information of a Google Cloud network.
         Network(std::boxed::Box<crate::model::NetworkInfo>),
@@ -3728,6 +3733,7 @@ pub struct InstanceInfo {
 
     /// Service account authorized for the instance.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub service_account: std::string::String,
 
     /// URI of the PSC network attachment the NIC is attached to (if relevant).
@@ -3780,6 +3786,7 @@ impl InstanceInfo {
     }
 
     /// Sets the value of [service_account][crate::model::InstanceInfo::service_account].
+    #[deprecated]
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
         self
@@ -4281,6 +4288,7 @@ pub struct RouteInfo {
 
     /// Indicates where route is applicable. Deprecated, routes with NCC_HUB scope
     /// are not included in the trace in new tests.
+    #[deprecated]
     pub route_scope: crate::model::route_info::RouteScope,
 
     /// Name of a route.
@@ -4306,6 +4314,7 @@ pub struct RouteInfo {
     /// Deprecated in favor of the next_hop_type and next_hop_uri fields, not used
     /// in new tests.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub next_hop: std::string::String,
 
     /// URI of a VPC network where route is located.
@@ -4357,6 +4366,7 @@ pub struct RouteInfo {
     /// network. Deprecated in favor of the next_hop_uri field, not used in new
     /// tests.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub advertised_route_next_hop_uri: std::option::Option<std::string::String>,
 
     /// URI of the next hop resource.
@@ -4410,6 +4420,7 @@ impl RouteInfo {
     }
 
     /// Sets the value of [route_scope][crate::model::RouteInfo::route_scope].
+    #[deprecated]
     pub fn set_route_scope<T: std::convert::Into<crate::model::route_info::RouteScope>>(
         mut self,
         v: T,
@@ -4443,6 +4454,7 @@ impl RouteInfo {
     }
 
     /// Sets the value of [next_hop][crate::model::RouteInfo::next_hop].
+    #[deprecated]
     pub fn set_next_hop<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_hop = v.into();
         self
@@ -4496,6 +4508,7 @@ impl RouteInfo {
     }
 
     /// Sets the value of [advertised_route_next_hop_uri][crate::model::RouteInfo::advertised_route_next_hop_uri].
+    #[deprecated]
     pub fn set_advertised_route_next_hop_uri<
         T: std::convert::Into<std::option::Option<std::string::String>>,
     >(
@@ -5526,6 +5539,7 @@ pub struct LoadBalancerInfo {
     /// populated as different load balancer backends might have different health
     /// checks.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub health_check_uri: std::string::String,
 
     /// Information for the loadbalancer backends.
@@ -5560,6 +5574,7 @@ impl LoadBalancerInfo {
     }
 
     /// Sets the value of [health_check_uri][crate::model::LoadBalancerInfo::health_check_uri].
+    #[deprecated]
     pub fn set_health_check_uri<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -7004,10 +7019,12 @@ pub mod forward_info {
         /// Forwarded to a Cloud Interconnect connection.
         Interconnect,
         /// Forwarded to a Google Kubernetes Engine Container cluster master.
+        #[deprecated]
         GkeMaster,
         /// Forwarded to the next hop of a custom route imported from a peering VPC.
         ImportedCustomRouteNextHop,
         /// Forwarded to a Cloud SQL instance.
+        #[deprecated]
         CloudSqlInstance,
         /// Forwarded to a VPC network in another project.
         AnotherProject,
@@ -7257,28 +7274,36 @@ pub mod abort_info {
         /// Cause is unspecified.
         Unspecified,
         /// Aborted due to unknown network. Deprecated, not used in the new tests.
+        #[deprecated]
         UnknownNetwork,
         /// Aborted because no project information can be derived from the test
         /// input. Deprecated, not used in the new tests.
+        #[deprecated]
         UnknownProject,
         /// Aborted because traffic is sent from a public IP to an instance without
         /// an external IP. Deprecated, not used in the new tests.
+        #[deprecated]
         NoExternalIp,
         /// Aborted because none of the traces matches destination information
         /// specified in the input test request. Deprecated, not used in the new
         /// tests.
+        #[deprecated]
         UnintendedDestination,
         /// Aborted because the source endpoint could not be found. Deprecated, not
         /// used in the new tests.
+        #[deprecated]
         SourceEndpointNotFound,
         /// Aborted because the source network does not match the source endpoint.
         /// Deprecated, not used in the new tests.
+        #[deprecated]
         MismatchedSourceNetwork,
         /// Aborted because the destination endpoint could not be found. Deprecated,
         /// not used in the new tests.
+        #[deprecated]
         DestinationEndpointNotFound,
         /// Aborted because the destination network does not match the destination
         /// endpoint. Deprecated, not used in the new tests.
+        #[deprecated]
         MismatchedDestinationNetwork,
         /// Aborted because no endpoint with the packet's destination IP address is
         /// found.

--- a/src/generated/cloud/networkmanagement/v1/src/stub.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ReachabilityService].

--- a/src/generated/cloud/optimization/v1/src/builder.rs
+++ b/src/generated/cloud/optimization/v1/src/builder.rs
@@ -217,6 +217,7 @@ pub mod fleet_routing {
         }
 
         /// Sets the value of [populate_travel_step_polylines][crate::model::OptimizeToursRequest::populate_travel_step_polylines].
+        #[deprecated]
         pub fn set_populate_travel_step_polylines<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.populate_travel_step_polylines = v.into();
             self

--- a/src/generated/cloud/optimization/v1/src/lib.rs
+++ b/src/generated/cloud/optimization/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/optimization/v1/src/lib.rs
+++ b/src/generated/cloud/optimization/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [FleetRouting](client/struct.FleetRouting.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -769,6 +769,7 @@ pub struct OptimizeToursRequest {
     /// [google.cloud.optimization.v1.OptimizeToursRequest.populate_transition_polylines]: crate::model::OptimizeToursRequest::populate_transition_polylines
     /// [google.cloud.optimization.v1.ShipmentRoute.transitions]: crate::model::ShipmentRoute::transitions
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub populate_travel_step_polylines: bool,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -904,6 +905,7 @@ impl OptimizeToursRequest {
     }
 
     /// Sets the value of [populate_travel_step_polylines][crate::model::OptimizeToursRequest::populate_travel_step_polylines].
+    #[deprecated]
     pub fn set_populate_travel_step_polylines<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.populate_travel_step_polylines = v.into();
         self
@@ -1286,6 +1288,7 @@ pub struct OptimizeToursResponse {
     ///
     /// [google.cloud.optimization.v1.OptimizeToursResponse.Metrics.total_cost]: crate::model::optimize_tours_response::Metrics::total_cost
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub total_cost: f64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1315,6 +1318,7 @@ impl OptimizeToursResponse {
     }
 
     /// Sets the value of [total_cost][crate::model::OptimizeToursResponse::total_cost].
+    #[deprecated]
     pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.total_cost = v.into();
         self
@@ -1888,6 +1892,7 @@ pub struct ShipmentModel {
     ///
     /// [google.cloud.optimization.v1.Vehicle.break_rule_indices]: crate::model::Vehicle::break_rule_indices
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub break_rules: std::vec::Vec<crate::model::shipment_model::BreakRule>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2032,6 +2037,7 @@ impl ShipmentModel {
     }
 
     /// Sets the value of [break_rules][crate::model::ShipmentModel::break_rules].
+    #[deprecated]
     pub fn set_break_rules<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -2289,6 +2295,7 @@ pub mod shipment_model {
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
+    #[deprecated]
     pub struct BreakRule {
         /// Sequence of breaks. See the `BreakRequest` message.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
@@ -2656,6 +2663,7 @@ pub struct Shipment {
     ///
     /// [google.cloud.optimization.v1.Shipment.load_demands]: crate::model::Shipment::load_demands
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub demands: std::vec::Vec<crate::model::CapacityQuantity>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2783,6 +2791,7 @@ impl Shipment {
     }
 
     /// Sets the value of [demands][crate::model::Shipment::demands].
+    #[deprecated]
     pub fn set_demands<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -2928,6 +2937,7 @@ pub mod shipment {
         ///
         /// [google.cloud.optimization.v1.Shipment.VisitRequest.load_demands]: crate::model::shipment::VisitRequest::load_demands
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub demands: std::vec::Vec<crate::model::CapacityQuantity>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -3038,6 +3048,7 @@ pub mod shipment {
         }
 
         /// Sets the value of [demands][crate::model::shipment::VisitRequest::demands].
+        #[deprecated]
         pub fn set_demands<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -3872,6 +3883,7 @@ pub struct Vehicle {
     ///
     /// [google.cloud.optimization.v1.ShipmentModel]: crate::model::ShipmentModel
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub break_rule_indices: std::vec::Vec<i32>,
 
     /// Deprecated: Use
@@ -3880,6 +3892,7 @@ pub struct Vehicle {
     ///
     /// [google.cloud.optimization.v1.Vehicle.load_limits]: crate::model::Vehicle::load_limits
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub capacities: std::vec::Vec<crate::model::CapacityQuantity>,
 
     /// Deprecated: Use
@@ -3888,6 +3901,7 @@ pub struct Vehicle {
     ///
     /// [google.cloud.optimization.v1.Vehicle.LoadLimit.start_load_interval]: crate::model::vehicle::LoadLimit::start_load_interval
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub start_load_intervals: std::vec::Vec<crate::model::CapacityQuantityInterval>,
 
     /// Deprecated: Use
@@ -3896,6 +3910,7 @@ pub struct Vehicle {
     ///
     /// [google.cloud.optimization.v1.Vehicle.LoadLimit.end_load_interval]: crate::model::vehicle::LoadLimit::end_load_interval
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub end_load_intervals: std::vec::Vec<crate::model::CapacityQuantityInterval>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4112,6 +4127,7 @@ impl Vehicle {
     }
 
     /// Sets the value of [break_rule_indices][crate::model::Vehicle::break_rule_indices].
+    #[deprecated]
     pub fn set_break_rule_indices<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -4123,6 +4139,7 @@ impl Vehicle {
     }
 
     /// Sets the value of [capacities][crate::model::Vehicle::capacities].
+    #[deprecated]
     pub fn set_capacities<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -4134,6 +4151,7 @@ impl Vehicle {
     }
 
     /// Sets the value of [start_load_intervals][crate::model::Vehicle::start_load_intervals].
+    #[deprecated]
     pub fn set_start_load_intervals<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -4145,6 +4163,7 @@ impl Vehicle {
     }
 
     /// Sets the value of [end_load_intervals][crate::model::Vehicle::end_load_intervals].
+    #[deprecated]
     pub fn set_end_load_intervals<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -4930,6 +4949,7 @@ impl wkt::message::Message for TimeWindow {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct CapacityQuantity {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -4976,6 +4996,7 @@ impl wkt::message::Message for CapacityQuantity {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct CapacityQuantityInterval {
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -5869,6 +5890,7 @@ pub struct ShipmentRoute {
     /// [google.cloud.optimization.v1.ShipmentRoute.Transition.vehicle_loads]: crate::model::shipment_route::Transition::vehicle_loads
     /// [google.cloud.optimization.v1.Vehicle.capacities]: crate::model::Vehicle::capacities
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub end_loads: std::vec::Vec<crate::model::CapacityQuantity>,
 
     /// Deprecated: Use
@@ -5877,6 +5899,7 @@ pub struct ShipmentRoute {
     ///
     /// [google.cloud.optimization.v1.ShipmentRoute.transitions]: crate::model::ShipmentRoute::transitions
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub travel_steps: std::vec::Vec<crate::model::shipment_route::TravelStep>,
 
     /// Deprecated: No longer used.
@@ -5892,6 +5915,7 @@ pub struct ShipmentRoute {
     ///
     /// [google.cloud.optimization.v1.ShipmentRoute.Visit]: crate::model::shipment_route::Visit
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub vehicle_detour: std::option::Option<wkt::Duration>,
 
     /// Deprecated: Delay occurring before the vehicle end. See
@@ -5899,6 +5923,7 @@ pub struct ShipmentRoute {
     ///
     /// [google.cloud.optimization.v1.TransitionAttributes.delay]: crate::model::TransitionAttributes::delay
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub delay_before_vehicle_end: std::option::Option<crate::model::shipment_route::Delay>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5975,6 +6000,7 @@ impl ShipmentRoute {
     }
 
     /// Sets the value of [vehicle_detour][crate::model::ShipmentRoute::vehicle_detour].
+    #[deprecated]
     pub fn set_vehicle_detour<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
@@ -5984,6 +6010,7 @@ impl ShipmentRoute {
     }
 
     /// Sets the value of [delay_before_vehicle_end][crate::model::ShipmentRoute::delay_before_vehicle_end].
+    #[deprecated]
     pub fn set_delay_before_vehicle_end<
         T: std::convert::Into<std::option::Option<crate::model::shipment_route::Delay>>,
     >(
@@ -6028,6 +6055,7 @@ impl ShipmentRoute {
     }
 
     /// Sets the value of [end_loads][crate::model::ShipmentRoute::end_loads].
+    #[deprecated]
     pub fn set_end_loads<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -6039,6 +6067,7 @@ impl ShipmentRoute {
     }
 
     /// Sets the value of [travel_steps][crate::model::ShipmentRoute::travel_steps].
+    #[deprecated]
     pub fn set_travel_steps<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -6084,6 +6113,7 @@ pub mod shipment_route {
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
+    #[deprecated]
     pub struct Delay {
         /// Start of the delay.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -6215,6 +6245,7 @@ pub mod shipment_route {
         /// [google.cloud.optimization.v1.ShipmentRoute.Transition.vehicle_loads]: crate::model::shipment_route::Transition::vehicle_loads
         /// [google.cloud.optimization.v1.Vehicle.capacities]: crate::model::Vehicle::capacities
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub arrival_loads: std::vec::Vec<crate::model::CapacityQuantity>,
 
         /// Deprecated: Use
@@ -6223,6 +6254,7 @@ pub mod shipment_route {
         ///
         /// [google.cloud.optimization.v1.ShipmentRoute.Transition.delay_duration]: crate::model::shipment_route::Transition::delay_duration
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub delay_before_start: std::option::Option<crate::model::shipment_route::Delay>,
 
         /// Deprecated: Use
@@ -6231,6 +6263,7 @@ pub mod shipment_route {
         ///
         /// [google.cloud.optimization.v1.ShipmentRoute.Visit.load_demands]: crate::model::shipment_route::Visit::load_demands
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub demands: std::vec::Vec<crate::model::CapacityQuantity>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6294,6 +6327,7 @@ pub mod shipment_route {
         }
 
         /// Sets the value of [delay_before_start][crate::model::shipment_route::Visit::delay_before_start].
+        #[deprecated]
         pub fn set_delay_before_start<
             T: std::convert::Into<std::option::Option<crate::model::shipment_route::Delay>>,
         >(
@@ -6305,6 +6339,7 @@ pub mod shipment_route {
         }
 
         /// Sets the value of [arrival_loads][crate::model::shipment_route::Visit::arrival_loads].
+        #[deprecated]
         pub fn set_arrival_loads<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -6316,6 +6351,7 @@ pub mod shipment_route {
         }
 
         /// Sets the value of [demands][crate::model::shipment_route::Visit::demands].
+        #[deprecated]
         pub fn set_demands<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -6447,6 +6483,7 @@ pub mod shipment_route {
         ///
         /// [google.cloud.optimization.v1.ShipmentRoute.Transition.vehicle_loads]: crate::model::shipment_route::Transition::vehicle_loads
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub loads: std::vec::Vec<crate::model::CapacityQuantity>,
 
         #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6536,6 +6573,7 @@ pub mod shipment_route {
         }
 
         /// Sets the value of [loads][crate::model::shipment_route::Transition::loads].
+        #[deprecated]
         pub fn set_loads<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -6709,6 +6747,7 @@ pub mod shipment_route {
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
+    #[deprecated]
     pub struct TravelStep {
         /// Duration of the travel step.
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -7253,6 +7292,7 @@ pub struct AggregatedMetrics {
     /// [google.cloud.optimization.v1.OptimizeToursResponse.Metrics.costs]: crate::model::optimize_tours_response::Metrics::costs
     /// [google.cloud.optimization.v1.ShipmentRoute.route_costs]: crate::model::ShipmentRoute::route_costs
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[deprecated]
     pub costs: std::collections::HashMap<std::string::String, f64>,
 
     /// Deprecated: Use
@@ -7264,6 +7304,7 @@ pub struct AggregatedMetrics {
     /// [google.cloud.optimization.v1.OptimizeToursResponse.Metrics.total_cost]: crate::model::optimize_tours_response::Metrics::total_cost
     /// [google.cloud.optimization.v1.ShipmentRoute.route_total_cost]: crate::model::ShipmentRoute::route_total_cost
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub total_cost: f64,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7342,6 +7383,7 @@ impl AggregatedMetrics {
     }
 
     /// Sets the value of [total_cost][crate::model::AggregatedMetrics::total_cost].
+    #[deprecated]
     pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.total_cost = v.into();
         self
@@ -7360,6 +7402,7 @@ impl AggregatedMetrics {
     }
 
     /// Sets the value of [costs][crate::model::AggregatedMetrics::costs].
+    #[deprecated]
     pub fn set_costs<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,

--- a/src/generated/cloud/optimization/v1/src/stub.rs
+++ b/src/generated/cloud/optimization/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::FleetRouting].

--- a/src/generated/cloud/orgpolicy/v2/src/lib.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/orgpolicy/v2/src/lib.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [OrgPolicy](client/struct.OrgPolicy.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -1667,6 +1667,7 @@ pub struct Policy {
 
     /// Deprecated.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub alternate: std::option::Option<crate::model::AlternatePolicySpec>,
 
     /// Dry-run policy.
@@ -1707,6 +1708,7 @@ impl Policy {
     }
 
     /// Sets the value of [alternate][crate::model::Policy::alternate].
+    #[deprecated]
     pub fn set_alternate<
         T: std::convert::Into<std::option::Option<crate::model::AlternatePolicySpec>>,
     >(

--- a/src/generated/cloud/orgpolicy/v2/src/stub.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::OrgPolicy].

--- a/src/generated/cloud/osconfig/v1/src/lib.rs
+++ b/src/generated/cloud/osconfig/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/osconfig/v1/src/lib.rs
+++ b/src/generated/cloud/osconfig/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [OsConfigService](client/struct.OsConfigService.html)
 //! * [OsConfigZonalService](client/struct.OsConfigZonalService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -11969,6 +11969,7 @@ pub mod vulnerability_report {
         /// update, these values might not display in VM inventory. For some distros,
         /// this field may be empty.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub installed_inventory_item_ids: std::vec::Vec<std::string::String>,
 
         /// Corresponds to the `AVAILABLE_PACKAGE` inventory item on the VM.
@@ -11978,6 +11979,7 @@ pub mod vulnerability_report {
         /// the latest `SoftwarePackage` available to the VM that fixes the
         /// vulnerability.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub available_inventory_item_ids: std::vec::Vec<std::string::String>,
 
         /// The timestamp for when the vulnerability was first detected.
@@ -12033,6 +12035,7 @@ pub mod vulnerability_report {
         }
 
         /// Sets the value of [installed_inventory_item_ids][crate::model::vulnerability_report::Vulnerability::installed_inventory_item_ids].
+        #[deprecated]
         pub fn set_installed_inventory_item_ids<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -12044,6 +12047,7 @@ pub mod vulnerability_report {
         }
 
         /// Sets the value of [available_inventory_item_ids][crate::model::vulnerability_report::Vulnerability::available_inventory_item_ids].
+        #[deprecated]
         pub fn set_available_inventory_item_ids<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/cloud/osconfig/v1/src/stub.rs
+++ b/src/generated/cloud/osconfig/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::OsConfigService].

--- a/src/generated/cloud/parallelstore/v1/src/lib.rs
+++ b/src/generated/cloud/parallelstore/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/parallelstore/v1/src/lib.rs
+++ b/src/generated/cloud/parallelstore/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [Parallelstore](client/struct.Parallelstore.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -77,6 +77,7 @@ pub struct Instance {
     /// Output only. Deprecated 'daos_version' field.
     /// Output only. The version of DAOS software running in the instance.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub daos_version: std::string::String,
 
     /// Output only. A list of IPv4 addresses used for client side configuration.
@@ -180,6 +181,7 @@ impl Instance {
     }
 
     /// Sets the value of [daos_version][crate::model::Instance::daos_version].
+    #[deprecated]
     pub fn set_daos_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.daos_version = v.into();
         self

--- a/src/generated/cloud/parallelstore/v1/src/stub.rs
+++ b/src/generated/cloud/parallelstore/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Parallelstore].

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
@@ -1446,6 +1446,7 @@ pub mod recaptcha_enterprise_service {
         }
 
         /// Sets the value of [hashed_account_id][crate::model::SearchRelatedAccountGroupMembershipsRequest::hashed_account_id].
+        #[deprecated]
         pub fn set_hashed_account_id<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.hashed_account_id = v.into();
             self

--- a/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [RecaptchaEnterpriseService](client/struct.RecaptchaEnterpriseService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -581,10 +581,12 @@ pub mod annotate_assessment_request {
         /// Provides information that the event was related to a login event in which
         /// the user typed the correct password. Deprecated, prefer indicating
         /// CORRECT_PASSWORD through the reasons field instead.
+        #[deprecated]
         PasswordCorrect,
         /// Provides information that the event was related to a login event in which
         /// the user typed the incorrect password. Deprecated, prefer indicating
         /// INCORRECT_PASSWORD through the reasons field instead.
+        #[deprecated]
         PasswordIncorrect,
         /// If set, the enum was initialized with an unknown value.
         ///
@@ -1114,6 +1116,7 @@ pub struct AccountVerificationInfo {
     /// Username of the account that is being verified. Deprecated. Customers
     /// should now provide the `account_id` field in `event.user_info`.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub username: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1143,6 +1146,7 @@ impl AccountVerificationInfo {
     }
 
     /// Sets the value of [username][crate::model::AccountVerificationInfo::username].
+    #[deprecated]
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
@@ -1703,6 +1707,7 @@ pub struct Event {
     /// be hashed using hmac-sha256 with stable secret.
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
+    #[deprecated]
     pub hashed_account_id: ::bytes::Bytes,
 
     /// Optional. Flag for a reCAPTCHA express request for an assessment without a
@@ -1796,6 +1801,7 @@ impl Event {
     }
 
     /// Sets the value of [hashed_account_id][crate::model::Event::hashed_account_id].
+    #[deprecated]
     pub fn set_hashed_account_id<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.hashed_account_id = v.into();
         self
@@ -7267,6 +7273,7 @@ pub struct SearchRelatedAccountGroupMembershipsRequest {
     /// hashed_account_id or account_id must be set, but not both.
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
+    #[deprecated]
     pub hashed_account_id: ::bytes::Bytes,
 
     /// Optional. The maximum number of groups to return. The service might return
@@ -7307,6 +7314,7 @@ impl SearchRelatedAccountGroupMembershipsRequest {
     }
 
     /// Sets the value of [hashed_account_id][crate::model::SearchRelatedAccountGroupMembershipsRequest::hashed_account_id].
+    #[deprecated]
     pub fn set_hashed_account_id<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.hashed_account_id = v.into();
         self
@@ -7676,6 +7684,7 @@ pub struct RelatedAccountGroupMembership {
     /// `CreateAssessment` or `AnnotateAssessment` call.
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
+    #[deprecated]
     pub hashed_account_id: ::bytes::Bytes,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -7700,6 +7709,7 @@ impl RelatedAccountGroupMembership {
     }
 
     /// Sets the value of [hashed_account_id][crate::model::RelatedAccountGroupMembership::hashed_account_id].
+    #[deprecated]
     pub fn set_hashed_account_id<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.hashed_account_id = v.into();
         self

--- a/src/generated/cloud/recaptchaenterprise/v1/src/stub.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::RecaptchaEnterpriseService].

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [CloudRedis](client/struct.CloudRedis.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -2201,6 +2201,7 @@ pub struct MaintenanceSchedule {
 
     /// If the scheduled maintenance can be rescheduled, default is true.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub can_reschedule: bool,
 
     /// Output only. The deadline that the maintenance schedule start time can not
@@ -2236,6 +2237,7 @@ impl MaintenanceSchedule {
     }
 
     /// Sets the value of [can_reschedule][crate::model::MaintenanceSchedule::can_reschedule].
+    #[deprecated]
     pub fn set_can_reschedule<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.can_reschedule = v.into();
         self

--- a/src/generated/cloud/redis/v1/src/stub.rs
+++ b/src/generated/cloud/redis/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudRedis].

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -3248,6 +3248,7 @@ pub mod prediction_service {
         }
 
         /// Sets the value of [page_token][crate::model::PredictRequest::page_token].
+        #[deprecated]
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
             self
@@ -3952,6 +3953,7 @@ pub mod product_service {
         }
 
         /// Sets the value of [request_id][crate::model::ImportProductsRequest::request_id].
+        #[deprecated]
         pub fn set_request_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.request_id = v.into();
             self
@@ -4909,6 +4911,7 @@ pub mod search_service {
         }
 
         /// Sets the value of [dynamic_facet_spec][crate::model::SearchRequest::dynamic_facet_spec].
+        #[deprecated]
         pub fn set_dynamic_facet_spec<
             T: Into<std::option::Option<crate::model::search_request::DynamicFacetSpec>>,
         >(

--- a/src/generated/cloud/retail/v2/src/lib.rs
+++ b/src/generated/cloud/retail/v2/src/lib.rs
@@ -37,9 +37,10 @@
 //! * [ServingConfigService](client/struct.ServingConfigService.html)
 //! * [UserEventService](client/struct.UserEventService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -47,19 +48,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/retail/v2/src/lib.rs
+++ b/src/generated/cloud/retail/v2/src/lib.rs
@@ -39,6 +39,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -46,18 +47,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -4144,6 +4144,7 @@ pub struct CustomAttribute {
     /// [google.cloud.retail.v2.SearchService.Search]: crate::client::SearchService::search
     /// [google.cloud.retail.v2.UserEvent]: crate::model::UserEvent
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub searchable: std::option::Option<bool>,
 
     /// This field is normally ignored unless
@@ -4172,6 +4173,7 @@ pub struct CustomAttribute {
     /// [google.cloud.retail.v2.SearchService.Search]: crate::client::SearchService::search
     /// [google.cloud.retail.v2.UserEvent]: crate::model::UserEvent
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub indexable: std::option::Option<bool>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4184,6 +4186,7 @@ impl CustomAttribute {
     }
 
     /// Sets the value of [searchable][crate::model::CustomAttribute::searchable].
+    #[deprecated]
     pub fn set_searchable<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
         v: T,
@@ -4193,6 +4196,7 @@ impl CustomAttribute {
     }
 
     /// Sets the value of [indexable][crate::model::CustomAttribute::indexable].
+    #[deprecated]
     pub fn set_indexable<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
         self.indexable = v.into();
         self
@@ -5370,6 +5374,7 @@ pub struct CompleteQueryResponse {
     /// [google.cloud.retail.v2.CompleteQueryRequest.visitor_id]: crate::model::CompleteQueryRequest::visitor_id
     /// [google.cloud.retail.v2.UserEvent]: crate::model::UserEvent
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub recent_search_results:
         std::vec::Vec<crate::model::complete_query_response::RecentSearchResult>,
 
@@ -5418,6 +5423,7 @@ impl CompleteQueryResponse {
     }
 
     /// Sets the value of [recent_search_results][crate::model::CompleteQueryResponse::recent_search_results].
+    #[deprecated]
     pub fn set_recent_search_results<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -5517,6 +5523,7 @@ pub mod complete_query_response {
     #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
     #[serde(default, rename_all = "camelCase")]
     #[non_exhaustive]
+    #[deprecated]
     pub struct RecentSearchResult {
         /// The recent search query.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -7609,6 +7616,7 @@ pub struct ImportProductsRequest {
 
     /// Deprecated. This field has no effect.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub request_id: std::string::String,
 
     /// Required. The desired input location of the data.
@@ -7671,6 +7679,7 @@ impl ImportProductsRequest {
     }
 
     /// Sets the value of [request_id][crate::model::ImportProductsRequest::request_id].
+    #[deprecated]
     pub fn set_request_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request_id = v.into();
         self
@@ -8446,6 +8455,7 @@ pub struct ImportMetadata {
 
     /// Deprecated. This field is never set.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub request_id: std::string::String,
 
     /// Pub/Sub topic for receiving notification. If this field is set,
@@ -8498,6 +8508,7 @@ impl ImportMetadata {
     }
 
     /// Sets the value of [request_id][crate::model::ImportMetadata::request_id].
+    #[deprecated]
     pub fn set_request_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request_id = v.into();
         self
@@ -10452,6 +10463,7 @@ pub struct PredictRequest {
 
     /// This field is not used; leave it unset.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub page_token: std::string::String,
 
     /// Filter for restricting prediction results with a length limit of 5,000
@@ -10585,6 +10597,7 @@ impl PredictRequest {
     }
 
     /// Sets the value of [page_token][crate::model::PredictRequest::page_token].
+    #[deprecated]
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
@@ -11292,6 +11305,7 @@ pub struct Product {
     /// [google.cloud.retail.v2.Product.uri]: crate::model::Product::uri
     /// [google.cloud.retail.v2.SearchResponse]: crate::model::SearchResponse
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub retrievable_fields: std::option::Option<wkt::FieldMask>,
 
     /// Output only. Product variants grouped together on primary product which
@@ -11467,6 +11481,7 @@ impl Product {
     }
 
     /// Sets the value of [retrievable_fields][crate::model::Product::retrievable_fields].
+    #[deprecated]
     pub fn set_retrievable_fields<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
         v: T,
@@ -14310,6 +14325,7 @@ pub struct SearchRequest {
     /// The specification for dynamically generated facets. Notice that only
     /// textual facets can be dynamically generated.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub dynamic_facet_spec: std::option::Option<crate::model::search_request::DynamicFacetSpec>,
 
     /// Boost specification to boost certain products. For more information, see
@@ -14583,6 +14599,7 @@ impl SearchRequest {
     }
 
     /// Sets the value of [dynamic_facet_spec][crate::model::SearchRequest::dynamic_facet_spec].
+    #[deprecated]
     pub fn set_dynamic_facet_spec<
         T: std::convert::Into<std::option::Option<crate::model::search_request::DynamicFacetSpec>>,
     >(
@@ -16243,6 +16260,7 @@ pub mod search_request {
             pub struct SelectedAnswer {
                 /// This field is deprecated and should not be set.
                 #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+                #[deprecated]
                 pub product_attribute_values: std::vec::Vec<crate::model::ProductAttributeValue>,
 
                 /// This field specifies the selected answer which is a attribute
@@ -16272,6 +16290,7 @@ pub mod search_request {
                 }
 
                 /// Sets the value of [product_attribute_values][crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer::product_attribute_values].
+                #[deprecated]
                 pub fn set_product_attribute_values<T, V>(mut self, v: T) -> Self
                 where
                     T: std::iter::IntoIterator<Item = V>,
@@ -17301,6 +17320,7 @@ pub mod search_response {
         /// There is expected to have only one additional filter and the value will
         /// be the same to the same as field `additional_filter`.
         #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+        #[deprecated]
         pub additional_filters: std::vec::Vec<
             crate::model::search_response::conversational_search_result::AdditionalFilter,
         >,
@@ -17370,6 +17390,7 @@ pub mod search_response {
         }
 
         /// Sets the value of [additional_filters][crate::model::search_response::ConversationalSearchResult::additional_filters].
+        #[deprecated]
         pub fn set_additional_filters<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/cloud/retail/v2/src/stub.rs
+++ b/src/generated/cloud/retail/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AnalyticsService].

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -34,6 +34,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -41,18 +42,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -32,9 +32,10 @@
 //! * [Services](client/struct.Services.html)
 //! * [Tasks](client/struct.Tasks.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -42,19 +43,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -290,6 +290,7 @@ pub mod submit_build_request {
     pub struct BuildpacksBuild {
         /// The runtime name, e.g. 'go113'. Leave blank for generic builds.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub runtime: std::string::String,
 
         /// Optional. Name of the function target if the source is a function source.
@@ -336,6 +337,7 @@ pub mod submit_build_request {
         }
 
         /// Sets the value of [runtime][crate::model::submit_build_request::BuildpacksBuild::runtime].
+        #[deprecated]
         pub fn set_runtime<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.runtime = v.into();
             self

--- a/src/generated/cloud/run/v2/src/stub.rs
+++ b/src/generated/cloud/run/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Builds].

--- a/src/generated/cloud/securesourcemanager/v1/src/lib.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/securesourcemanager/v1/src/lib.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [SecureSourceManager](client/struct.SecureSourceManager.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -515,6 +515,7 @@ pub mod instance {
         PausedCmekUnavailable,
         /// INSTANCE_RESUMING indicates that the instance was previously paused
         /// and is under the process of being brought back.
+        #[deprecated]
         InstanceResuming,
         /// If set, the enum was initialized with an unknown value.
         ///

--- a/src/generated/cloud/securesourcemanager/v1/src/stub.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::SecureSourceManager].

--- a/src/generated/cloud/securitycenter/v2/src/lib.rs
+++ b/src/generated/cloud/securitycenter/v2/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [SecurityCenter](client/struct.SecurityCenter.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/securitycenter/v2/src/lib.rs
+++ b/src/generated/cloud/securitycenter/v2/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -1729,11 +1729,13 @@ pub struct Attack {
     /// Total PPS (packets per second) volume of attack. Deprecated - refer to
     /// volume_pps_long instead.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub volume_pps: i32,
 
     /// Total BPS (bytes per second) volume of attack. Deprecated - refer to
     /// volume_bps_long instead.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub volume_bps: i32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1764,12 +1766,14 @@ impl Attack {
     }
 
     /// Sets the value of [volume_pps][crate::model::Attack::volume_pps].
+    #[deprecated]
     pub fn set_volume_pps<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.volume_pps = v.into();
         self
     }
 
     /// Sets the value of [volume_bps][crate::model::Attack::volume_bps].
+    #[deprecated]
     pub fn set_volume_bps<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.volume_bps = v.into();
         self

--- a/src/generated/cloud/securitycenter/v2/src/stub.rs
+++ b/src/generated/cloud/securitycenter/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::SecurityCenter].

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [Speech](client/struct.Speech.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -429,6 +429,7 @@ impl OperationMetadata {
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `UpdateConfigRequest`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn update_config_request(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateConfigRequest>> {
@@ -667,6 +668,7 @@ impl OperationMetadata {
     ///
     /// Note that all the setters affecting `request` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_update_config_request<
         T: std::convert::Into<std::boxed::Box<crate::model::UpdateConfigRequest>>,
     >(
@@ -769,6 +771,7 @@ pub mod operation_metadata {
         /// The UndeletePhraseSetRequest that spawned the Operation.
         UndeletePhraseSetRequest(std::boxed::Box<crate::model::UndeletePhraseSetRequest>),
         /// The UpdateConfigRequest that spawned the Operation.
+        #[deprecated]
         UpdateConfigRequest(std::boxed::Box<crate::model::UpdateConfigRequest>),
     }
 
@@ -1196,6 +1199,7 @@ pub struct Recognizer {
     /// [google.cloud.speech.v2.RecognitionConfig]: crate::model::RecognitionConfig
     /// [google.cloud.speech.v2.RecognitionConfig.model]: crate::model::RecognitionConfig::model
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub model: std::string::String,
 
     /// Optional. This field is now deprecated. Prefer the
@@ -1219,6 +1223,7 @@ pub struct Recognizer {
     /// [google.cloud.speech.v2.RecognitionConfig]: crate::model::RecognitionConfig
     /// [google.cloud.speech.v2.RecognitionConfig.language_codes]: crate::model::RecognitionConfig::language_codes
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub language_codes: std::vec::Vec<std::string::String>,
 
     /// Default configuration to use for requests with this Recognizer.
@@ -1308,6 +1313,7 @@ impl Recognizer {
     }
 
     /// Sets the value of [model][crate::model::Recognizer::model].
+    #[deprecated]
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
         self
@@ -1397,6 +1403,7 @@ impl Recognizer {
     }
 
     /// Sets the value of [language_codes][crate::model::Recognizer::language_codes].
+    #[deprecated]
     pub fn set_language_codes<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -4534,10 +4541,12 @@ pub struct BatchRecognizeFileResult {
 
     /// Deprecated. Use `cloud_storage_result.native_format_uri` instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub uri: std::string::String,
 
     /// Deprecated. Use `inline_result.transcript` instead.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub transcript: std::option::Option<crate::model::BatchRecognizeResults>,
 
     #[serde(flatten, skip_serializing_if = "std::option::Option::is_none")]
@@ -4573,12 +4582,14 @@ impl BatchRecognizeFileResult {
     }
 
     /// Sets the value of [uri][crate::model::BatchRecognizeFileResult::uri].
+    #[deprecated]
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
         self
     }
 
     /// Sets the value of [transcript][crate::model::BatchRecognizeFileResult::transcript].
+    #[deprecated]
     pub fn set_transcript<
         T: std::convert::Into<std::option::Option<crate::model::BatchRecognizeResults>>,
     >(

--- a/src/generated/cloud/speech/v2/src/stub.rs
+++ b/src/generated/cloud/speech/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Speech].

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -35,9 +35,10 @@
 //! * [SqlTiersService](client/struct.SqlTiersService.html)
 //! * [SqlUsersService](client/struct.SqlUsersService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -45,19 +46,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -37,6 +37,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -44,18 +45,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -4639,6 +4639,7 @@ pub struct DatabaseInstance {
     /// The maximum disk size of the instance in bytes.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[deprecated]
     pub max_disk_size: std::option::Option<wkt::Int64Value>,
 
     /// The current disk usage of the instance in bytes. This property has been
@@ -4649,6 +4650,7 @@ pub struct DatabaseInstance {
     /// for details.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
     #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    #[deprecated]
     pub current_disk_size: std::option::Option<wkt::Int64Value>,
 
     /// The assigned IP addresses for the instance.
@@ -4671,6 +4673,7 @@ pub struct DatabaseInstance {
     /// (Deprecated) This property was applicable only
     /// to First Generation instances.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub ipv6_address: std::string::String,
 
     /// The service account email address assigned to the instance.\This
@@ -4804,6 +4807,7 @@ pub struct DatabaseInstance {
 
     /// Output only. DEPRECATED: please use write_endpoint instead.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub primary_dns_name: std::option::Option<std::string::String>,
 
     /// Output only. The dns name of the primary instance in a replication group.
@@ -4884,12 +4888,14 @@ impl DatabaseInstance {
     }
 
     /// Sets the value of [max_disk_size][crate::model::DatabaseInstance::max_disk_size].
+    #[deprecated]
     pub fn set_max_disk_size<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.max_disk_size = v.into();
         self
     }
 
     /// Sets the value of [current_disk_size][crate::model::DatabaseInstance::current_disk_size].
+    #[deprecated]
     pub fn set_current_disk_size<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.current_disk_size = v.into();
         self
@@ -4914,6 +4920,7 @@ impl DatabaseInstance {
     }
 
     /// Sets the value of [ipv6_address][crate::model::DatabaseInstance::ipv6_address].
+    #[deprecated]
     pub fn set_ipv6_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ipv6_address = v.into();
         self
@@ -5052,6 +5059,7 @@ impl DatabaseInstance {
     }
 
     /// Sets the value of [primary_dns_name][crate::model::DatabaseInstance::primary_dns_name].
+    #[deprecated]
     pub fn set_primary_dns_name<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
         self.primary_dns_name = v.into();
         self
@@ -5213,6 +5221,7 @@ pub mod database_instance {
         pub start_time: std::option::Option<wkt::Timestamp>,
 
         #[serde(skip_serializing_if = "wkt::internal::is_default")]
+        #[deprecated]
         pub can_defer: bool,
 
         /// If the scheduled maintenance can be rescheduled.
@@ -5239,6 +5248,7 @@ pub mod database_instance {
         }
 
         /// Sets the value of [can_defer][crate::model::database_instance::SqlScheduledMaintenance::can_defer].
+        #[deprecated]
         pub fn set_can_defer<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.can_defer = v.into();
             self
@@ -5486,6 +5496,7 @@ pub mod database_instance {
         /// maintenance.
         Failed,
         /// Deprecated
+        #[deprecated]
         OnlineMaintenance,
         /// If set, the enum was initialized with an unknown value.
         ///
@@ -9313,6 +9324,7 @@ pub mod export_context {
 
         /// Deprecated: copy_only is deprecated. Use differential_base instead
         #[serde(skip_serializing_if = "std::option::Option::is_none")]
+        #[deprecated]
         pub copy_only: std::option::Option<wkt::BoolValue>,
 
         /// Whether or not the backup can be used as a differential base
@@ -9348,6 +9360,7 @@ pub mod export_context {
         }
 
         /// Sets the value of [copy_only][crate::model::export_context::SqlBakExportOptions::copy_only].
+        #[deprecated]
         pub fn set_copy_only<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.copy_only = v.into();
             self
@@ -10356,6 +10369,7 @@ pub struct LocationPreference {
     /// The App Engine application to follow, it must be in the same region as the
     /// Cloud SQL instance. WARNING: Changing this might restart the instance.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub follow_gae_application: std::string::String,
 
     /// The preferred Compute Engine zone (for example: us-central1-a,
@@ -10383,6 +10397,7 @@ impl LocationPreference {
     }
 
     /// Sets the value of [follow_gae_application][crate::model::LocationPreference::follow_gae_application].
+    #[deprecated]
     pub fn set_follow_gae_application<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.follow_gae_application = v.into();
         self
@@ -11169,7 +11184,9 @@ pub mod operation {
         Delete,
         /// Restarts the Cloud SQL instance.
         Restart,
+        #[deprecated]
         Backup,
+        #[deprecated]
         Snapshot,
         /// Performs instance backup.
         BackupVolume,
@@ -11216,9 +11233,12 @@ pub mod operation {
         /// typically causes the instance to be unavailable for 1-3 minutes.
         Maintenance,
         /// This field is deprecated, and will be removed in future version of API.
+        #[deprecated]
         EnablePrivateIp,
+        #[deprecated]
         DeferMaintenance,
         /// Creates clone instance.
+        #[deprecated]
         CreateClone,
         /// Reschedule maintenance to another time.
         RescheduleMaintenance,
@@ -11848,6 +11868,7 @@ pub struct PasswordValidationPolicy {
     /// This field is deprecated and will be removed in a future version of the
     /// API.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub disallow_compromised_credentials: std::option::Option<wkt::BoolValue>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -11896,6 +11917,7 @@ impl PasswordValidationPolicy {
     }
 
     /// Sets the value of [disallow_compromised_credentials][crate::model::PasswordValidationPolicy::disallow_compromised_credentials].
+    #[deprecated]
     pub fn set_disallow_compromised_credentials<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.disallow_compromised_credentials = v.into();
         self
@@ -12087,6 +12109,7 @@ pub struct Settings {
     /// The App Engine app IDs that can access this instance.
     /// (Deprecated) Applied to First Generation instances only.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub authorized_gae_applications: std::vec::Vec<std::string::String>,
 
     /// The tier (or machine type) for this instance, for example
@@ -12121,6 +12144,7 @@ pub struct Settings {
     /// The type of replication this instance uses. This can be either
     /// `ASYNCHRONOUS` or `SYNCHRONOUS`. (Deprecated) This property was only
     /// applicable to First Generation instances.
+    #[deprecated]
     pub replication_type: crate::model::SqlReplicationType,
 
     /// The maximum size to which storage capacity can be automatically increased.
@@ -12183,6 +12207,7 @@ pub struct Settings {
     /// database flags for crash-safe replication are enabled. This property was
     /// only applicable to First Generation instances.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub crash_safe_replication_enabled: std::option::Option<wkt::BoolValue>,
 
     /// The size of data disk, in GB. The data disk size minimum is 10GB.
@@ -12299,6 +12324,7 @@ impl Settings {
     }
 
     /// Sets the value of [replication_type][crate::model::Settings::replication_type].
+    #[deprecated]
     pub fn set_replication_type<T: std::convert::Into<crate::model::SqlReplicationType>>(mut self, v: T) -> Self {
         self.replication_type = v.into();
         self
@@ -12359,6 +12385,7 @@ impl Settings {
     }
 
     /// Sets the value of [crash_safe_replication_enabled][crate::model::Settings::crash_safe_replication_enabled].
+    #[deprecated]
     pub fn set_crash_safe_replication_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.crash_safe_replication_enabled = v.into();
         self
@@ -12449,6 +12476,7 @@ impl Settings {
     }
 
     /// Sets the value of [authorized_gae_applications][crate::model::Settings::authorized_gae_applications].
+    #[deprecated]
     pub fn set_authorized_gae_applications<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -12531,6 +12559,7 @@ pub mod settings {
         /// The instance never starts.
         Never,
         /// The instance starts upon receiving requests.
+        #[deprecated]
         OnDemand,
         /// If set, the enum was initialized with an unknown value.
         ///
@@ -14711,6 +14740,7 @@ pub struct UsersListResponse {
 
     /// Unused.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub next_page_token: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -14729,6 +14759,7 @@ impl UsersListResponse {
     }
 
     /// Sets the value of [next_page_token][crate::model::UsersListResponse::next_page_token].
+    #[deprecated]
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
         self
@@ -16045,6 +16076,7 @@ pub enum SqlBackendType {
     /// This is an unknown backend type for instance.
     Unspecified,
     /// V1 speckle instance.
+    #[deprecated]
     FirstGen,
     /// V2 speckle instance.
     SecondGen,
@@ -16325,8 +16357,10 @@ pub enum SqlDatabaseVersion {
     /// This is an unknown database version.
     Unspecified,
     /// The database version is MySQL 5.1.
+    #[deprecated]
     Mysql51,
     /// The database version is MySQL 5.5.
+    #[deprecated]
     Mysql55,
     /// The database version is MySQL 5.6.
     Mysql56,
@@ -16367,6 +16401,7 @@ pub enum SqlDatabaseVersion {
     /// The database major version is MySQL 8.0 and the minor version is 28.
     Mysql8028,
     /// The database major version is MySQL 8.0 and the minor version is 29.
+    #[deprecated]
     Mysql8029,
     /// The database major version is MySQL 8.0 and the minor version is 30.
     Mysql8030,
@@ -17001,6 +17036,7 @@ pub enum SqlDataDiskType {
     PdHdd,
     /// This field is deprecated and will be removed from a future version of the
     /// API.
+    #[deprecated]
     ObsoleteLocalSsd,
     /// If set, the enum was initialized with an unknown value.
     ///

--- a/src/generated/cloud/sql/v1/src/stub.rs
+++ b/src/generated/cloud/sql/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::SqlBackupRunsService].

--- a/src/generated/cloud/talent/v4/src/builder.rs
+++ b/src/generated/cloud/talent/v4/src/builder.rs
@@ -1515,6 +1515,7 @@ pub mod job_service {
         }
 
         /// Sets the value of [disable_keyword_match][crate::model::SearchJobsRequest::disable_keyword_match].
+        #[deprecated]
         pub fn set_disable_keyword_match<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.disable_keyword_match = v.into();
             self
@@ -1686,6 +1687,7 @@ pub mod job_service {
         }
 
         /// Sets the value of [disable_keyword_match][crate::model::SearchJobsRequest::disable_keyword_match].
+        #[deprecated]
         pub fn set_disable_keyword_match<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.disable_keyword_match = v.into();
             self

--- a/src/generated/cloud/talent/v4/src/lib.rs
+++ b/src/generated/cloud/talent/v4/src/lib.rs
@@ -31,9 +31,10 @@
 //! * [JobService](client/struct.JobService.html)
 //! * [TenantService](client/struct.TenantService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -41,19 +42,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/talent/v4/src/lib.rs
+++ b/src/generated/cloud/talent/v4/src/lib.rs
@@ -33,6 +33,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -40,18 +41,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -2083,6 +2083,7 @@ pub struct Company {
     ///
     /// [google.cloud.talent.v4.Job.custom_attributes]: crate::model::Job::custom_attributes
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub keyword_searchable_job_custom_attributes: std::vec::Vec<std::string::String>,
 
     /// Output only. Derived details about the company.
@@ -2185,6 +2186,7 @@ impl Company {
     }
 
     /// Sets the value of [keyword_searchable_job_custom_attributes][crate::model::Company::keyword_searchable_job_custom_attributes].
+    #[deprecated]
     pub fn set_keyword_searchable_job_custom_attributes<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -4203,6 +4205,7 @@ pub mod location_filter {
         Unspecified,
         /// Deprecated: Ignore telecommute status of jobs. Use
         /// TELECOMMUTE_JOBS_EXCLUDED if want to exclude telecommute jobs.
+        #[deprecated]
         TelecommuteExcluded,
         /// Allow telecommute jobs.
         TelecommuteAllowed,
@@ -5266,6 +5269,7 @@ pub struct Job {
     /// if not specified.
     ///
     /// [google.cloud.talent.v4.Visibility.ACCOUNT_ONLY]: crate::model::Visibility::AccountOnly
+    #[deprecated]
     pub visibility: crate::model::Visibility,
 
     /// The start timestamp of the job in UTC time zone. Typically this field
@@ -5486,6 +5490,7 @@ impl Job {
     }
 
     /// Sets the value of [visibility][crate::model::Job::visibility].
+    #[deprecated]
     pub fn set_visibility<T: std::convert::Into<crate::model::Visibility>>(mut self, v: T) -> Self {
         self.visibility = v.into();
         self
@@ -6552,6 +6557,7 @@ pub struct SearchJobsRequest {
     /// [google.cloud.talent.v4.SearchJobsRequest.KeywordMatchMode.KEYWORD_MATCH_DISABLED]: crate::model::search_jobs_request::KeywordMatchMode::KeywordMatchDisabled
     /// [google.cloud.talent.v4.SearchJobsRequest.keyword_match_mode]: crate::model::SearchJobsRequest::keyword_match_mode
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub disable_keyword_match: bool,
 
     /// Controls what keyword match options to use. If both keyword_match_mode and
@@ -6676,6 +6682,7 @@ impl SearchJobsRequest {
     }
 
     /// Sets the value of [disable_keyword_match][crate::model::SearchJobsRequest::disable_keyword_match].
+    #[deprecated]
     pub fn set_disable_keyword_match<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disable_keyword_match = v.into();
         self
@@ -10176,6 +10183,7 @@ impl<'de> serde::de::Deserialize<'de> for PostingRegion {
 /// [Working with enums]: https://google-cloud-rust.github.io/working_with_enums.html
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+#[deprecated]
 pub enum Visibility {
     /// Default value.
     Unspecified,

--- a/src/generated/cloud/talent/v4/src/stub.rs
+++ b/src/generated/cloud/talent/v4/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CompanyService].

--- a/src/generated/cloud/texttospeech/v1/src/lib.rs
+++ b/src/generated/cloud/texttospeech/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [TextToSpeech](client/struct.TextToSpeech.html)
 //! * [TextToSpeechLongAudioSynthesize](client/struct.TextToSpeechLongAudioSynthesize.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/texttospeech/v1/src/lib.rs
+++ b/src/generated/cloud/texttospeech/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -1021,6 +1021,7 @@ pub struct CustomVoiceParams {
     pub model: std::string::String,
 
     /// Optional. Deprecated. The usage of the synthesized audio to be reported.
+    #[deprecated]
     pub reported_usage: crate::model::custom_voice_params::ReportedUsage,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1039,6 +1040,7 @@ impl CustomVoiceParams {
     }
 
     /// Sets the value of [reported_usage][crate::model::CustomVoiceParams::reported_usage].
+    #[deprecated]
     pub fn set_reported_usage<
         T: std::convert::Into<crate::model::custom_voice_params::ReportedUsage>,
     >(
@@ -1778,6 +1780,7 @@ pub struct SynthesizeLongAudioMetadata {
 
     /// Deprecated. Do not use.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub last_update_time: std::option::Option<wkt::Timestamp>,
 
     /// The progress of the most recent processing update in percentage, ie. 70.0%.
@@ -1803,6 +1806,7 @@ impl SynthesizeLongAudioMetadata {
     }
 
     /// Sets the value of [last_update_time][crate::model::SynthesizeLongAudioMetadata::last_update_time].
+    #[deprecated]
     pub fn set_last_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,

--- a/src/generated/cloud/texttospeech/v1/src/stub.rs
+++ b/src/generated/cloud/texttospeech/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::TextToSpeech].

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [VideoIntelligenceService](client/struct.VideoIntelligenceService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -1258,6 +1258,7 @@ impl wkt::message::Message for FaceSegment {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct FaceFrame {
     /// Normalized Bounding boxes in a frame.
     /// There can be more than one boxes if the same face is detected in multiple
@@ -1311,6 +1312,7 @@ impl wkt::message::Message for FaceFrame {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct FaceAnnotation {
     /// Thumbnail of a representative face view (in JPEG format).
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
@@ -1687,6 +1689,7 @@ pub struct VideoAnnotationResults {
 
     /// Deprecated. Please use `face_detection_annotations` instead.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub face_annotations: std::vec::Vec<crate::model::FaceAnnotation>,
 
     /// Face detection annotations.
@@ -1828,6 +1831,7 @@ impl VideoAnnotationResults {
     }
 
     /// Sets the value of [face_annotations][crate::model::VideoAnnotationResults::face_annotations].
+    #[deprecated]
     pub fn set_face_annotations<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/cloud/videointelligence/v1/src/stub.rs
+++ b/src/generated/cloud/videointelligence/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::VideoIntelligenceService].

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -30,6 +30,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,18 +38,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -28,9 +28,10 @@
 //! * [ImageAnnotator](client/struct.ImageAnnotator.html)
 //! * [ProductSearch](client/struct.ProductSearch.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,19 +39,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -1401,6 +1401,7 @@ pub struct EntityAnnotation {
     /// this field represents the confidence that there is a tower in the query
     /// image. Range [0, 1].
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub confidence: f32,
 
     /// The relevancy of the ICA (Image Content Annotation) label to the
@@ -1463,6 +1464,7 @@ impl EntityAnnotation {
     }
 
     /// Sets the value of [confidence][crate::model::EntityAnnotation::confidence].
+    #[deprecated]
     pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.confidence = v.into();
         self
@@ -1996,6 +1998,7 @@ impl wkt::message::Message for CropHintsParams {
 pub struct WebDetectionParams {
     /// This field has no effect on results.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub include_geo_results: bool,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -2008,6 +2011,7 @@ impl WebDetectionParams {
     }
 
     /// Sets the value of [include_geo_results][crate::model::WebDetectionParams::include_geo_results].
+    #[deprecated]
     pub fn set_include_geo_results<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.include_geo_results = v.into();
         self

--- a/src/generated/cloud/vision/v1/src/stub.rs
+++ b/src/generated/cloud/vision/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ImageAnnotator].

--- a/src/generated/cloud/vmmigration/v1/src/lib.rs
+++ b/src/generated/cloud/vmmigration/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/vmmigration/v1/src/lib.rs
+++ b/src/generated/cloud/vmmigration/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [VmMigration](client/struct.VmMigration.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -65,6 +65,7 @@ pub struct ReplicationCycle {
     /// Was replaced by 'steps' field, which breaks down the cycle progression more
     /// accurately.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub progress_percent: i32,
 
     /// The cycle's steps list representing its progress.
@@ -127,6 +128,7 @@ impl ReplicationCycle {
     }
 
     /// Sets the value of [progress_percent][crate::model::ReplicationCycle::progress_percent].
+    #[deprecated]
     pub fn set_progress_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.progress_percent = v.into();
         self

--- a/src/generated/cloud/vmmigration/v1/src/stub.rs
+++ b/src/generated/cloud/vmmigration/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::VmMigration].

--- a/src/generated/cloud/websecurityscanner/v1/src/lib.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/websecurityscanner/v1/src/lib.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [WebSecurityScanner](client/struct.WebSecurityScanner.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -1526,6 +1526,7 @@ pub mod scan_config {
         /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
         /// if it holds a `GoogleAccount`, `None` if the field is not set or
         /// holds a different branch.
+        #[deprecated]
         pub fn google_account(
             &self,
         ) -> std::option::Option<
@@ -1579,6 +1580,7 @@ pub mod scan_config {
         ///
         /// Note that all the setters affecting `authentication` are
         /// mutually exclusive.
+        #[deprecated]
         pub fn set_google_account<
             T: std::convert::Into<
                     std::boxed::Box<crate::model::scan_config::authentication::GoogleAccount>,
@@ -1648,6 +1650,7 @@ pub mod scan_config {
         #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
         #[serde(default, rename_all = "camelCase")]
         #[non_exhaustive]
+        #[deprecated]
         pub struct GoogleAccount {
             /// Required. The user name of the Google account.
             #[serde(skip_serializing_if = "std::string::String::is_empty")]
@@ -1877,6 +1880,7 @@ pub mod scan_config {
         #[non_exhaustive]
         pub enum Authentication {
             /// Authentication using a Google account.
+            #[deprecated]
             GoogleAccount(
                 std::boxed::Box<crate::model::scan_config::authentication::GoogleAccount>,
             ),

--- a/src/generated/cloud/websecurityscanner/v1/src/stub.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::WebSecurityScanner].

--- a/src/generated/container/v1/src/builder.rs
+++ b/src/generated/container/v1/src/builder.rs
@@ -97,12 +97,14 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::ListClustersRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::ListClustersRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
@@ -152,18 +154,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::GetClusterRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::GetClusterRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::GetClusterRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -213,12 +218,14 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::CreateClusterRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::CreateClusterRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
@@ -279,18 +286,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::UpdateClusterRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::UpdateClusterRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::UpdateClusterRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -351,24 +361,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::UpdateNodePoolRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::UpdateNodePoolRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::UpdateNodePoolRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::UpdateNodePoolRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -676,24 +690,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetNodePoolAutoscalingRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetNodePoolAutoscalingRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetNodePoolAutoscalingRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::SetNodePoolAutoscalingRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -757,18 +775,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetLoggingServiceRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetLoggingServiceRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetLoggingServiceRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -829,18 +850,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetMonitoringServiceRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetMonitoringServiceRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetMonitoringServiceRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -898,18 +922,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetAddonsConfigRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetAddonsConfigRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetAddonsConfigRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -970,18 +997,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetLocationsRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetLocationsRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetLocationsRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -1044,18 +1074,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::UpdateMasterRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::UpdateMasterRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::UpdateMasterRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -1113,18 +1146,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetMasterAuthRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetMasterAuthRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetMasterAuthRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -1196,18 +1232,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::DeleteClusterRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::DeleteClusterRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::DeleteClusterRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -1257,12 +1296,14 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::ListOperationsRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::ListOperationsRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
@@ -1312,18 +1353,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::GetOperationRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::GetOperationRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [operation_id][crate::model::GetOperationRequest::operation_id].
+        #[deprecated]
         pub fn set_operation_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.operation_id = v.into();
             self
@@ -1373,18 +1417,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::CancelOperationRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::CancelOperationRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [operation_id][crate::model::CancelOperationRequest::operation_id].
+        #[deprecated]
         pub fn set_operation_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.operation_id = v.into();
             self
@@ -1434,12 +1481,14 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::GetServerConfigRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::GetServerConfigRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
@@ -1532,18 +1581,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::ListNodePoolsRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::ListNodePoolsRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::ListNodePoolsRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -1593,24 +1645,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::GetNodePoolRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::GetNodePoolRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::GetNodePoolRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::GetNodePoolRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -1660,18 +1716,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::CreateNodePoolRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::CreateNodePoolRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::CreateNodePoolRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -1732,24 +1791,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::DeleteNodePoolRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::DeleteNodePoolRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::DeleteNodePoolRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::DeleteNodePoolRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -1852,24 +1915,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::RollbackNodePoolUpgradeRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::RollbackNodePoolUpgradeRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::RollbackNodePoolUpgradeRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::RollbackNodePoolUpgradeRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -1928,24 +1995,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetNodePoolManagementRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetNodePoolManagementRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetNodePoolManagementRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::SetNodePoolManagementRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -2006,18 +2077,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetLabelsRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetLabelsRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetLabelsRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -2089,18 +2163,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetLegacyAbacRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetLegacyAbacRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetLegacyAbacRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -2158,18 +2235,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::StartIPRotationRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::StartIPRotationRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::StartIPRotationRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -2228,18 +2308,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::CompleteIPRotationRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::CompleteIPRotationRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::CompleteIPRotationRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
@@ -2289,24 +2372,28 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetNodePoolSizeRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetNodePoolSizeRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetNodePoolSizeRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self
         }
 
         /// Sets the value of [node_pool_id][crate::model::SetNodePoolSizeRequest::node_pool_id].
+        #[deprecated]
         pub fn set_node_pool_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.node_pool_id = v.into();
             self
@@ -2367,18 +2454,21 @@ pub mod cluster_manager {
         }
 
         /// Sets the value of [project_id][crate::model::SetNetworkPolicyRequest::project_id].
+        #[deprecated]
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();
             self
         }
 
         /// Sets the value of [zone][crate::model::SetNetworkPolicyRequest::zone].
+        #[deprecated]
         pub fn set_zone<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.zone = v.into();
             self
         }
 
         /// Sets the value of [cluster_id][crate::model::SetNetworkPolicyRequest::cluster_id].
+        #[deprecated]
         pub fn set_cluster_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.cluster_id = v.into();
             self

--- a/src/generated/container/v1/src/client.rs
+++ b/src/generated/container/v1/src/client.rs
@@ -217,6 +217,7 @@ impl ClusterManager {
     /// Deprecated. Use
     /// [projects.locations.clusters.update](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters/update)
     /// instead.
+    #[deprecated]
     pub fn set_locations(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [ClusterManager](client/struct.ClusterManager.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -3448,6 +3448,7 @@ pub struct MasterAuth {
     /// authentication methods, see:
     /// <https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication>
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub username: std::string::String,
 
     /// The password to use for HTTP basic authentication to the master endpoint.
@@ -3460,6 +3461,7 @@ pub struct MasterAuth {
     /// authentication methods, see:
     /// <https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication>
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub password: std::string::String,
 
     /// Configuration for client certificate authentication on the cluster. For
@@ -3494,12 +3496,14 @@ impl MasterAuth {
     }
 
     /// Sets the value of [username][crate::model::MasterAuth::username].
+    #[deprecated]
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
         self
     }
 
     /// Sets the value of [password][crate::model::MasterAuth::password].
+    #[deprecated]
     pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.password = v.into();
         self
@@ -3603,6 +3607,7 @@ pub struct AddonsConfig {
     /// workloads and applications. For more information, see:
     /// <https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards>
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub kubernetes_dashboard: std::option::Option<crate::model::KubernetesDashboard>,
 
     /// Configuration for NetworkPolicy. This only tracks whether the addon
@@ -3688,6 +3693,7 @@ impl AddonsConfig {
     }
 
     /// Sets the value of [kubernetes_dashboard][crate::model::AddonsConfig::kubernetes_dashboard].
+    #[deprecated]
     pub fn set_kubernetes_dashboard<
         T: std::convert::Into<std::option::Option<crate::model::KubernetesDashboard>>,
     >(
@@ -4043,6 +4049,7 @@ pub struct PrivateClusterConfig {
     ///
     /// [google.container.v1.NetworkConfig.default_enable_private_nodes]: crate::model::NetworkConfig::default_enable_private_nodes
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enable_private_nodes: bool,
 
     /// Whether the master's internal IP address is used as the cluster endpoint.
@@ -4054,6 +4061,7 @@ pub struct PrivateClusterConfig {
     ///
     /// [google.container.v1.ControlPlaneEndpointsConfig.IPEndpointsConfig.enable_public_endpoint]: crate::model::control_plane_endpoints_config::IPEndpointsConfig::enable_public_endpoint
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enable_private_endpoint: bool,
 
     /// The IP range in CIDR notation to use for the hosted master network. This
@@ -4071,6 +4079,7 @@ pub struct PrivateClusterConfig {
     ///
     /// [google.container.v1.ControlPlaneEndpointsConfig.IPEndpointsConfig.private_endpoint]: crate::model::control_plane_endpoints_config::IPEndpointsConfig::private_endpoint
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub private_endpoint: std::string::String,
 
     /// Output only. The external IP address of this cluster's master endpoint.
@@ -4081,6 +4090,7 @@ pub struct PrivateClusterConfig {
     ///
     /// [google.container.v1.ControlPlaneEndpointsConfig.IPEndpointsConfig.public_endpoint]: crate::model::control_plane_endpoints_config::IPEndpointsConfig::public_endpoint
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub public_endpoint: std::string::String,
 
     /// Output only. The peering name in the customer VPC used by this cluster.
@@ -4093,6 +4103,7 @@ pub struct PrivateClusterConfig {
     /// [ControlPlaneEndpointsConfig.IPEndpointsConfig.enable_global_access][]
     /// instead.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub master_global_access_config:
         std::option::Option<crate::model::PrivateClusterMasterGlobalAccessConfig>,
 
@@ -4105,6 +4116,7 @@ pub struct PrivateClusterConfig {
     ///
     /// [google.container.v1.ControlPlaneEndpointsConfig.IPEndpointsConfig.private_endpoint_subnetwork]: crate::model::control_plane_endpoints_config::IPEndpointsConfig::private_endpoint_subnetwork
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub private_endpoint_subnetwork: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4117,12 +4129,14 @@ impl PrivateClusterConfig {
     }
 
     /// Sets the value of [enable_private_nodes][crate::model::PrivateClusterConfig::enable_private_nodes].
+    #[deprecated]
     pub fn set_enable_private_nodes<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_private_nodes = v.into();
         self
     }
 
     /// Sets the value of [enable_private_endpoint][crate::model::PrivateClusterConfig::enable_private_endpoint].
+    #[deprecated]
     pub fn set_enable_private_endpoint<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_private_endpoint = v.into();
         self
@@ -4138,6 +4152,7 @@ impl PrivateClusterConfig {
     }
 
     /// Sets the value of [private_endpoint][crate::model::PrivateClusterConfig::private_endpoint].
+    #[deprecated]
     pub fn set_private_endpoint<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -4147,6 +4162,7 @@ impl PrivateClusterConfig {
     }
 
     /// Sets the value of [public_endpoint][crate::model::PrivateClusterConfig::public_endpoint].
+    #[deprecated]
     pub fn set_public_endpoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.public_endpoint = v.into();
         self
@@ -4159,6 +4175,7 @@ impl PrivateClusterConfig {
     }
 
     /// Sets the value of [master_global_access_config][crate::model::PrivateClusterConfig::master_global_access_config].
+    #[deprecated]
     pub fn set_master_global_access_config<
         T: std::convert::Into<
                 std::option::Option<crate::model::PrivateClusterMasterGlobalAccessConfig>,
@@ -4172,6 +4189,7 @@ impl PrivateClusterConfig {
     }
 
     /// Sets the value of [private_endpoint_subnetwork][crate::model::PrivateClusterConfig::private_endpoint_subnetwork].
+    #[deprecated]
     pub fn set_private_endpoint_subnetwork<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5055,6 +5073,7 @@ pub struct BinaryAuthorization {
     /// BinaryAuthorization using evaluation_mode. If evaluation_mode is set to
     /// anything other than EVALUATION_MODE_UNSPECIFIED, this field is ignored.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub enabled: bool,
 
     /// Mode of operation for binauthz policy evaluation. If unspecified, defaults
@@ -5071,6 +5090,7 @@ impl BinaryAuthorization {
     }
 
     /// Sets the value of [enabled][crate::model::BinaryAuthorization::enabled].
+    #[deprecated]
     pub fn set_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enabled = v.into();
         self
@@ -5297,14 +5317,17 @@ pub struct IPAllocationPolicy {
 
     /// This field is deprecated, use cluster_ipv4_cidr_block.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_ipv4_cidr: std::string::String,
 
     /// This field is deprecated, use node_ipv4_cidr_block.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_ipv4_cidr: std::string::String,
 
     /// This field is deprecated, use services_ipv4_cidr_block.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub services_ipv4_cidr: std::string::String,
 
     /// The name of the secondary range to be used for the cluster CIDR
@@ -5476,6 +5499,7 @@ impl IPAllocationPolicy {
     }
 
     /// Sets the value of [cluster_ipv4_cidr][crate::model::IPAllocationPolicy::cluster_ipv4_cidr].
+    #[deprecated]
     pub fn set_cluster_ipv4_cidr<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5485,12 +5509,14 @@ impl IPAllocationPolicy {
     }
 
     /// Sets the value of [node_ipv4_cidr][crate::model::IPAllocationPolicy::node_ipv4_cidr].
+    #[deprecated]
     pub fn set_node_ipv4_cidr<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_ipv4_cidr = v.into();
         self
     }
 
     /// Sets the value of [services_ipv4_cidr][crate::model::IPAllocationPolicy::services_ipv4_cidr].
+    #[deprecated]
     pub fn set_services_ipv4_cidr<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -5661,6 +5687,7 @@ pub struct Cluster {
     ///
     /// This field is deprecated, use node_pool.initial_node_count instead.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub initial_node_count: i32,
 
     /// Parameters used in creating the cluster's nodes.
@@ -5675,6 +5702,7 @@ pub struct Cluster {
     /// If unspecified, the defaults are used.
     /// This field is deprecated, use node_pool.config instead.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub node_config: std::option::Option<crate::model::NodeConfig>,
 
     /// The authentication information for accessing the master endpoint.
@@ -5795,6 +5823,7 @@ pub struct Cluster {
     ///
     /// [google.container.v1.ControlPlaneEndpointsConfig.IPEndpointsConfig.authorized_networks_config]: crate::model::control_plane_endpoints_config::IPEndpointsConfig::authorized_networks_config
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub master_authorized_networks_config:
         std::option::Option<crate::model::MasterAuthorizedNetworksConfig>,
 
@@ -5889,6 +5918,7 @@ pub struct Cluster {
     /// [zone](https://cloud.google.com/compute/docs/zones#available) in which the
     /// cluster resides. This field is deprecated, use location instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Output only. The IP address of this cluster's master endpoint.
@@ -5926,6 +5956,7 @@ pub struct Cluster {
     /// currently at multiple versions because they're in the process of being
     /// upgraded, this reflects the minimum version of all nodes.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub current_node_version: std::string::String,
 
     /// Output only. The time the cluster was created, in
@@ -5940,6 +5971,7 @@ pub struct Cluster {
     /// Additional information about the current status of this
     /// cluster, if available.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub status_message: std::string::String,
 
     /// Output only. The size of the address space on each node for hosting
@@ -5959,11 +5991,13 @@ pub struct Cluster {
 
     /// Output only. Deprecated. Use node_pools.instance_group_urls.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub instance_group_urls: std::vec::Vec<std::string::String>,
 
     /// Output only. The number of nodes currently in the cluster. Deprecated.
     /// Call Kubernetes API directly to retrieve node information.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub current_node_count: i32,
 
     /// Output only. The time the cluster will be automatically
@@ -6094,12 +6128,14 @@ impl Cluster {
     }
 
     /// Sets the value of [initial_node_count][crate::model::Cluster::initial_node_count].
+    #[deprecated]
     pub fn set_initial_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.initial_node_count = v.into();
         self
     }
 
     /// Sets the value of [node_config][crate::model::Cluster::node_config].
+    #[deprecated]
     pub fn set_node_config<T: std::convert::Into<std::option::Option<crate::model::NodeConfig>>>(
         mut self,
         v: T,
@@ -6211,6 +6247,7 @@ impl Cluster {
     }
 
     /// Sets the value of [master_authorized_networks_config][crate::model::Cluster::master_authorized_networks_config].
+    #[deprecated]
     pub fn set_master_authorized_networks_config<
         T: std::convert::Into<std::option::Option<crate::model::MasterAuthorizedNetworksConfig>>,
     >(
@@ -6426,6 +6463,7 @@ impl Cluster {
     }
 
     /// Sets the value of [zone][crate::model::Cluster::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
@@ -6456,6 +6494,7 @@ impl Cluster {
     }
 
     /// Sets the value of [current_node_version][crate::model::Cluster::current_node_version].
+    #[deprecated]
     pub fn set_current_node_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -6480,6 +6519,7 @@ impl Cluster {
     }
 
     /// Sets the value of [status_message][crate::model::Cluster::status_message].
+    #[deprecated]
     pub fn set_status_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.status_message = v.into();
         self
@@ -6501,6 +6541,7 @@ impl Cluster {
     }
 
     /// Sets the value of [current_node_count][crate::model::Cluster::current_node_count].
+    #[deprecated]
     pub fn set_current_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.current_node_count = v.into();
         self
@@ -6736,6 +6777,7 @@ impl Cluster {
     }
 
     /// Sets the value of [instance_group_urls][crate::model::Cluster::instance_group_urls].
+    #[deprecated]
     pub fn set_instance_group_urls<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -8051,6 +8093,7 @@ pub struct ClusterUpdate {
     /// desired_control_plane_endpoints_config.ip_endpoints_config.authorized_networks_config
     /// instead.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub desired_master_authorized_networks_config:
         std::option::Option<crate::model::MasterAuthorizedNetworksConfig>,
 
@@ -8099,6 +8142,7 @@ pub struct ClusterUpdate {
     /// [google.container.v1.ClusterUpdate.desired_enable_private_endpoint]: crate::model::ClusterUpdate::desired_enable_private_endpoint
     /// [google.container.v1.PrivateClusterConfig]: crate::model::PrivateClusterConfig
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub desired_private_cluster_config: std::option::Option<crate::model::PrivateClusterConfig>,
 
     /// The desired config of Intra-node visibility.
@@ -8159,6 +8203,7 @@ pub struct ClusterUpdate {
     /// instead. Note that the value of enable_public_endpoint is reversed: if
     /// enable_private_endpoint is false, then enable_public_endpoint will be true.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub desired_enable_private_endpoint: std::option::Option<bool>,
 
     /// Override the default setting of whether future created
@@ -8460,6 +8505,7 @@ impl ClusterUpdate {
     }
 
     /// Sets the value of [desired_master_authorized_networks_config][crate::model::ClusterUpdate::desired_master_authorized_networks_config].
+    #[deprecated]
     pub fn set_desired_master_authorized_networks_config<
         T: std::convert::Into<std::option::Option<crate::model::MasterAuthorizedNetworksConfig>>,
     >(
@@ -8524,6 +8570,7 @@ impl ClusterUpdate {
     }
 
     /// Sets the value of [desired_private_cluster_config][crate::model::ClusterUpdate::desired_private_cluster_config].
+    #[deprecated]
     pub fn set_desired_private_cluster_config<
         T: std::convert::Into<std::option::Option<crate::model::PrivateClusterConfig>>,
     >(
@@ -8665,6 +8712,7 @@ impl ClusterUpdate {
     }
 
     /// Sets the value of [desired_enable_private_endpoint][crate::model::ClusterUpdate::desired_enable_private_endpoint].
+    #[deprecated]
     pub fn set_desired_enable_private_endpoint<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
         v: T,
@@ -9165,6 +9213,7 @@ pub struct Operation {
     /// [zone](https://cloud.google.com/compute/docs/zones#available) in which the
     /// operation is taking place. This field is deprecated, use location instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Output only. The operation type.
@@ -9180,6 +9229,7 @@ pub struct Operation {
     /// Output only. If an error has occurred, a textual description of the error.
     /// Deprecated. Use the field error instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub status_message: std::string::String,
 
     /// Output only. Server-defined URI for the operation. Example:
@@ -9232,11 +9282,13 @@ pub struct Operation {
     /// Which conditions caused the current cluster state.
     /// Deprecated. Use field error instead.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub cluster_conditions: std::vec::Vec<crate::model::StatusCondition>,
 
     /// Which conditions caused the current node pool state.
     /// Deprecated. Use field error instead.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub nodepool_conditions: std::vec::Vec<crate::model::StatusCondition>,
 
     /// The error result of the operation in case of failure.
@@ -9259,6 +9311,7 @@ impl Operation {
     }
 
     /// Sets the value of [zone][crate::model::Operation::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
@@ -9289,6 +9342,7 @@ impl Operation {
     }
 
     /// Sets the value of [status_message][crate::model::Operation::status_message].
+    #[deprecated]
     pub fn set_status_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.status_message = v.into();
         self
@@ -9345,6 +9399,7 @@ impl Operation {
     }
 
     /// Sets the value of [cluster_conditions][crate::model::Operation::cluster_conditions].
+    #[deprecated]
     pub fn set_cluster_conditions<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -9356,6 +9411,7 @@ impl Operation {
     }
 
     /// Sets the value of [nodepool_conditions][crate::model::Operation::nodepool_conditions].
+    #[deprecated]
     pub fn set_nodepool_conditions<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -9632,16 +9688,19 @@ pub mod operation {
         /// [UPGRADE_NODES][google.container.v1.Operation.Type.UPGRADE_NODES].
         ///
         /// [google.container.v1.Operation.Type.UPGRADE_NODES]: crate::model::operation::Type::UpgradeNodes
+        #[deprecated]
         AutoUpgradeNodes,
         /// Unused. Updating labels uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        #[deprecated]
         SetLabels,
         /// Unused. Updating master auth uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        #[deprecated]
         SetMasterAuth,
         /// The node pool is being resized. With the exception of resizing to or from
         /// size zero, the node pool is generally usable during this operation.
@@ -9650,11 +9709,13 @@ pub mod operation {
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        #[deprecated]
         SetNetworkPolicy,
         /// Unused. Updating maintenance policy uses
         /// [UPDATE_CLUSTER][google.container.v1.Operation.Type.UPDATE_CLUSTER].
         ///
         /// [google.container.v1.Operation.Type.UPDATE_CLUSTER]: crate::model::operation::Type::UpdateCluster
+        #[deprecated]
         SetMaintenancePolicy,
         /// The control plane is being resized. This operation type is initiated by
         /// GKE. These operations are often performed preemptively to ensure that the
@@ -10103,6 +10164,7 @@ pub struct CreateClusterRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -10110,6 +10172,7 @@ pub struct CreateClusterRequest {
     /// cluster resides. This field has been deprecated and replaced by the parent
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Required. A [cluster
@@ -10132,12 +10195,14 @@ impl CreateClusterRequest {
     }
 
     /// Sets the value of [project_id][crate::model::CreateClusterRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::CreateClusterRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
@@ -10175,6 +10240,7 @@ pub struct GetClusterRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -10182,11 +10248,13 @@ pub struct GetClusterRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to retrieve.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// The name (project, location, cluster) of the cluster to retrieve.
@@ -10204,18 +10272,21 @@ impl GetClusterRequest {
     }
 
     /// Sets the value of [project_id][crate::model::GetClusterRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::GetClusterRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::GetClusterRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -10244,6 +10315,7 @@ pub struct UpdateClusterRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -10251,11 +10323,13 @@ pub struct UpdateClusterRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. A description of the update.
@@ -10277,18 +10351,21 @@ impl UpdateClusterRequest {
     }
 
     /// Sets the value of [project_id][crate::model::UpdateClusterRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::UpdateClusterRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::UpdateClusterRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -10326,6 +10403,7 @@ pub struct UpdateNodePoolRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -10333,16 +10411,19 @@ pub struct UpdateNodePoolRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// Required. The Kubernetes version to change the nodes to (typically an
@@ -10512,24 +10593,28 @@ impl UpdateNodePoolRequest {
     }
 
     /// Sets the value of [project_id][crate::model::UpdateNodePoolRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::UpdateNodePoolRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::UpdateNodePoolRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::UpdateNodePoolRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -10813,6 +10898,7 @@ pub struct SetNodePoolAutoscalingRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -10820,16 +10906,19 @@ pub struct SetNodePoolAutoscalingRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// Required. Autoscaling configuration for the node pool.
@@ -10852,24 +10941,28 @@ impl SetNodePoolAutoscalingRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetNodePoolAutoscalingRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetNodePoolAutoscalingRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetNodePoolAutoscalingRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::SetNodePoolAutoscalingRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -10909,6 +11002,7 @@ pub struct SetLoggingServiceRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -10916,11 +11010,13 @@ pub struct SetLoggingServiceRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The logging service the cluster should use to write logs.
@@ -10952,18 +11048,21 @@ impl SetLoggingServiceRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetLoggingServiceRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetLoggingServiceRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetLoggingServiceRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -10998,6 +11097,7 @@ pub struct SetMonitoringServiceRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11005,11 +11105,13 @@ pub struct SetMonitoringServiceRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The monitoring service the cluster should use to write metrics.
@@ -11041,18 +11143,21 @@ impl SetMonitoringServiceRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetMonitoringServiceRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetMonitoringServiceRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetMonitoringServiceRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -11090,6 +11195,7 @@ pub struct SetAddonsConfigRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11097,11 +11203,13 @@ pub struct SetAddonsConfigRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The desired configurations for the various addons available to
@@ -11124,18 +11232,21 @@ impl SetAddonsConfigRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetAddonsConfigRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetAddonsConfigRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetAddonsConfigRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -11175,6 +11286,7 @@ pub struct SetLocationsRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11182,11 +11294,13 @@ pub struct SetLocationsRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The desired list of Google Compute Engine
@@ -11214,18 +11328,21 @@ impl SetLocationsRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetLocationsRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetLocationsRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetLocationsRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -11265,6 +11382,7 @@ pub struct UpdateMasterRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11272,11 +11390,13 @@ pub struct UpdateMasterRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The Kubernetes version to change the master to.
@@ -11307,18 +11427,21 @@ impl UpdateMasterRequest {
     }
 
     /// Sets the value of [project_id][crate::model::UpdateMasterRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::UpdateMasterRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::UpdateMasterRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -11353,6 +11476,7 @@ pub struct SetMasterAuthRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11360,11 +11484,13 @@ pub struct SetMasterAuthRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to upgrade.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The exact form of action to be taken on the master auth.
@@ -11389,18 +11515,21 @@ impl SetMasterAuthRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetMasterAuthRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetMasterAuthRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetMasterAuthRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -11595,6 +11724,7 @@ pub struct DeleteClusterRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11602,11 +11732,13 @@ pub struct DeleteClusterRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to delete.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// The name (project, location, cluster) of the cluster to delete.
@@ -11624,18 +11756,21 @@ impl DeleteClusterRequest {
     }
 
     /// Sets the value of [project_id][crate::model::DeleteClusterRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::DeleteClusterRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::DeleteClusterRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -11664,6 +11799,7 @@ pub struct ListClustersRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11671,6 +11807,7 @@ pub struct ListClustersRequest {
     /// cluster resides, or "-" for all zones. This field has been deprecated and
     /// replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// The parent (project and location) where the clusters will be listed.
@@ -11689,12 +11826,14 @@ impl ListClustersRequest {
     }
 
     /// Sets the value of [project_id][crate::model::ListClustersRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::ListClustersRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
@@ -11777,6 +11916,7 @@ pub struct GetOperationRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11784,11 +11924,13 @@ pub struct GetOperationRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The server-assigned `name` of the operation.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub operation_id: std::string::String,
 
     /// The name (project, location, operation id) of the operation to get.
@@ -11806,18 +11948,21 @@ impl GetOperationRequest {
     }
 
     /// Sets the value of [project_id][crate::model::GetOperationRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::GetOperationRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [operation_id][crate::model::GetOperationRequest::operation_id].
+    #[deprecated]
     pub fn set_operation_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_id = v.into();
         self
@@ -11846,6 +11991,7 @@ pub struct ListOperationsRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11853,6 +11999,7 @@ pub struct ListOperationsRequest {
     /// operations for, or `-` for all zones. This field has been deprecated and
     /// replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// The parent (project and location) where the operations will be listed.
@@ -11871,12 +12018,14 @@ impl ListOperationsRequest {
     }
 
     /// Sets the value of [project_id][crate::model::ListOperationsRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::ListOperationsRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
@@ -11905,6 +12054,7 @@ pub struct CancelOperationRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -11912,11 +12062,13 @@ pub struct CancelOperationRequest {
     /// operation resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The server-assigned `name` of the operation.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub operation_id: std::string::String,
 
     /// The name (project, location, operation id) of the operation to cancel.
@@ -11934,18 +12086,21 @@ impl CancelOperationRequest {
     }
 
     /// Sets the value of [project_id][crate::model::CancelOperationRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::CancelOperationRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [operation_id][crate::model::CancelOperationRequest::operation_id].
+    #[deprecated]
     pub fn set_operation_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_id = v.into();
         self
@@ -12027,6 +12182,7 @@ pub struct GetServerConfigRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -12034,6 +12190,7 @@ pub struct GetServerConfigRequest {
     /// operations for. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// The name (project and location) of the server config to get,
@@ -12051,12 +12208,14 @@ impl GetServerConfigRequest {
     }
 
     /// Sets the value of [project_id][crate::model::GetServerConfigRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::GetServerConfigRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
@@ -12274,6 +12433,7 @@ pub struct CreateNodePoolRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -12281,11 +12441,13 @@ pub struct CreateNodePoolRequest {
     /// cluster resides. This field has been deprecated and replaced by the parent
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The node pool to create.
@@ -12308,18 +12470,21 @@ impl CreateNodePoolRequest {
     }
 
     /// Sets the value of [project_id][crate::model::CreateNodePoolRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::CreateNodePoolRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::CreateNodePoolRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -12357,6 +12522,7 @@ pub struct DeleteNodePoolRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -12364,16 +12530,19 @@ pub struct DeleteNodePoolRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool to delete.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// The name (project, location, cluster, node pool id) of the node pool to
@@ -12392,24 +12561,28 @@ impl DeleteNodePoolRequest {
     }
 
     /// Sets the value of [project_id][crate::model::DeleteNodePoolRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::DeleteNodePoolRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::DeleteNodePoolRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::DeleteNodePoolRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -12438,6 +12611,7 @@ pub struct ListNodePoolsRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -12445,11 +12619,13 @@ pub struct ListNodePoolsRequest {
     /// cluster resides. This field has been deprecated and replaced by the parent
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the parent field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// The parent (project, location, cluster name) where the node pools will be
@@ -12467,18 +12643,21 @@ impl ListNodePoolsRequest {
     }
 
     /// Sets the value of [project_id][crate::model::ListNodePoolsRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::ListNodePoolsRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::ListNodePoolsRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -12507,6 +12686,7 @@ pub struct GetNodePoolRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -12514,16 +12694,19 @@ pub struct GetNodePoolRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// The name (project, location, cluster, node pool id) of the node pool to
@@ -12542,24 +12725,28 @@ impl GetNodePoolRequest {
     }
 
     /// Sets the value of [project_id][crate::model::GetNodePoolRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::GetNodePoolRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::GetNodePoolRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::GetNodePoolRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -12885,6 +13072,7 @@ pub struct NodePool {
     /// Additional information about the current status of this
     /// node pool instance, if available.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub status_message: std::string::String,
 
     /// Autoscaler configuration for this NodePool. Autoscaler is enabled
@@ -12999,6 +13187,7 @@ impl NodePool {
     }
 
     /// Sets the value of [status_message][crate::model::NodePool::status_message].
+    #[deprecated]
     pub fn set_status_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.status_message = v.into();
         self
@@ -14770,6 +14959,7 @@ pub struct SetNodePoolManagementRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -14777,16 +14967,19 @@ pub struct SetNodePoolManagementRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to update.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool to update.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// Required. NodeManagement configuration for the node pool.
@@ -14809,24 +15002,28 @@ impl SetNodePoolManagementRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetNodePoolManagementRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetNodePoolManagementRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetNodePoolManagementRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::SetNodePoolManagementRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -14866,6 +15063,7 @@ pub struct SetNodePoolSizeRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -14873,16 +15071,19 @@ pub struct SetNodePoolSizeRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to update.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool to update.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// Required. The desired node count for the pool.
@@ -14905,24 +15106,28 @@ impl SetNodePoolSizeRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetNodePoolSizeRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetNodePoolSizeRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetNodePoolSizeRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::SetNodePoolSizeRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -14994,6 +15199,7 @@ pub struct RollbackNodePoolUpgradeRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -15001,16 +15207,19 @@ pub struct RollbackNodePoolUpgradeRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to rollback.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Deprecated. The name of the node pool to rollback.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub node_pool_id: std::string::String,
 
     /// The name (project, location, cluster, node pool id) of the node poll to
@@ -15034,24 +15243,28 @@ impl RollbackNodePoolUpgradeRequest {
     }
 
     /// Sets the value of [project_id][crate::model::RollbackNodePoolUpgradeRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::RollbackNodePoolUpgradeRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::RollbackNodePoolUpgradeRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
     }
 
     /// Sets the value of [node_pool_id][crate::model::RollbackNodePoolUpgradeRequest::node_pool_id].
+    #[deprecated]
     pub fn set_node_pool_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_pool_id = v.into();
         self
@@ -15385,6 +15598,7 @@ pub struct AutoprovisioningNodePoolDefaults {
     /// To unset the min cpu platform field pass "automatic"
     /// as field value.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub min_cpu_platform: std::string::String,
 
     /// Size of the disk attached to each node, specified in GB.
@@ -15462,6 +15676,7 @@ impl AutoprovisioningNodePoolDefaults {
     }
 
     /// Sets the value of [min_cpu_platform][crate::model::AutoprovisioningNodePoolDefaults::min_cpu_platform].
+    #[deprecated]
     pub fn set_min_cpu_platform<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -15849,6 +16064,7 @@ pub struct SetLabelsRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -15856,11 +16072,13 @@ pub struct SetLabelsRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. The labels to set for that cluster.
@@ -15891,18 +16109,21 @@ impl SetLabelsRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetLabelsRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetLabelsRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetLabelsRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -15953,6 +16174,7 @@ pub struct SetLegacyAbacRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -15960,11 +16182,13 @@ pub struct SetLegacyAbacRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster to update.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. Whether ABAC authorization will be enabled in the cluster.
@@ -15986,18 +16210,21 @@ impl SetLegacyAbacRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetLegacyAbacRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetLegacyAbacRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetLegacyAbacRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -16033,6 +16260,7 @@ pub struct StartIPRotationRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -16040,11 +16268,13 @@ pub struct StartIPRotationRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// The name (project, location, cluster name) of the cluster to start IP
@@ -16066,18 +16296,21 @@ impl StartIPRotationRequest {
     }
 
     /// Sets the value of [project_id][crate::model::StartIPRotationRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::StartIPRotationRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::StartIPRotationRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -16112,6 +16345,7 @@ pub struct CompleteIPRotationRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -16119,11 +16353,13 @@ pub struct CompleteIPRotationRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// The name (project, location, cluster name) of the cluster to complete IP
@@ -16141,18 +16377,21 @@ impl CompleteIPRotationRequest {
     }
 
     /// Sets the value of [project_id][crate::model::CompleteIPRotationRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::CompleteIPRotationRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::CompleteIPRotationRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -16829,6 +17068,7 @@ pub struct SetNetworkPolicyRequest {
     /// number](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub project_id: std::string::String,
 
     /// Deprecated. The name of the Google Compute Engine
@@ -16836,11 +17076,13 @@ pub struct SetNetworkPolicyRequest {
     /// cluster resides. This field has been deprecated and replaced by the name
     /// field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub zone: std::string::String,
 
     /// Deprecated. The name of the cluster.
     /// This field has been deprecated and replaced by the name field.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub cluster_id: std::string::String,
 
     /// Required. Configuration options for the NetworkPolicy feature.
@@ -16862,18 +17104,21 @@ impl SetNetworkPolicyRequest {
     }
 
     /// Sets the value of [project_id][crate::model::SetNetworkPolicyRequest::project_id].
+    #[deprecated]
     pub fn set_project_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project_id = v.into();
         self
     }
 
     /// Sets the value of [zone][crate::model::SetNetworkPolicyRequest::zone].
+    #[deprecated]
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
         self
     }
 
     /// Sets the value of [cluster_id][crate::model::SetNetworkPolicyRequest::cluster_id].
+    #[deprecated]
     pub fn set_cluster_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_id = v.into();
         self
@@ -16995,6 +17240,7 @@ impl wkt::message::Message for SetMaintenancePolicyRequest {
 pub struct StatusCondition {
     /// Machine-friendly representation of the condition
     /// Deprecated. Use canonical_code instead.
+    #[deprecated]
     pub code: crate::model::status_condition::Code,
 
     /// Human-friendly representation of the condition
@@ -17014,6 +17260,7 @@ impl StatusCondition {
     }
 
     /// Sets the value of [code][crate::model::StatusCondition::code].
+    #[deprecated]
     pub fn set_code<T: std::convert::Into<crate::model::status_condition::Code>>(
         mut self,
         v: T,
@@ -17712,6 +17959,7 @@ pub mod gateway_api_config {
         Disabled,
         /// Deprecated: use CHANNEL_STANDARD instead.
         /// Gateway API support is enabled, experimental CRDs are installed
+        #[deprecated]
         Experimental,
         /// Gateway API support is enabled, standard CRDs are installed
         Standard,

--- a/src/generated/container/v1/src/stub.rs
+++ b/src/generated/container/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ClusterManager].

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [ArtifactRegistry](client/struct.ArtifactRegistry.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -8794,6 +8794,7 @@ pub mod project_settings {
         /// Redirection is enabled.
         RedirectionFromGcrIoEnabled,
         /// Redirection is enabled, and has been finalized so cannot be reverted.
+        #[deprecated]
         RedirectionFromGcrIoFinalized,
         /// Redirection is enabled and missing images are copied from GCR
         RedirectionFromGcrIoEnabledAndCopying,

--- a/src/generated/devtools/artifactregistry/v1/src/stub.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ArtifactRegistry].

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [CloudBuild](client/struct.CloudBuild.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -6427,6 +6427,7 @@ pub struct GitHubEventsConfig {
     /// The installationID that emits the GitHub event.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
     #[serde_as(as = "serde_with::DisplayFromStr")]
+    #[deprecated]
     pub installation_id: i64,
 
     /// Owner of the repository. For example: The owner for
@@ -6455,6 +6456,7 @@ impl GitHubEventsConfig {
     }
 
     /// Sets the value of [installation_id][crate::model::GitHubEventsConfig::installation_id].
+    #[deprecated]
     pub fn set_installation_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.installation_id = v.into();
         self
@@ -7815,6 +7817,7 @@ pub struct BuildOptions {
 
     /// This field deprecated; please use `pool.name` instead.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub worker_pool: std::string::String,
 
     /// Optional. Specification for execution on a `WorkerPool`.
@@ -7936,6 +7939,7 @@ impl BuildOptions {
     }
 
     /// Sets the value of [worker_pool][crate::model::BuildOptions::worker_pool].
+    #[deprecated]
     pub fn set_worker_pool<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.worker_pool = v.into();
         self
@@ -8648,6 +8652,7 @@ pub mod build_options {
         /// Build logs are stored in Cloud Storage.
         GcsOnly,
         /// This option is the same as CLOUD_LOGGING_ONLY.
+        #[deprecated]
         StackdriverOnly,
         /// Build logs are stored in Cloud Logging. Selecting this option will not
         /// allow [logs

--- a/src/generated/devtools/cloudbuild/v1/src/stub.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudBuild].

--- a/src/generated/grafeas/v1/src/lib.rs
+++ b/src/generated/grafeas/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [Grafeas](client/struct.Grafeas.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/grafeas/v1/src/lib.rs
+++ b/src/generated/grafeas/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -11678,6 +11678,7 @@ pub mod vulnerability_assessment_note {
         /// tracking number for the vulnerability.
         /// Deprecated: Use vulnerability_id instead to denote CVEs.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub cve: std::string::String,
 
         /// The vulnerability identifier for this Assessment. Will hold one of
@@ -11730,6 +11731,7 @@ pub mod vulnerability_assessment_note {
         }
 
         /// Sets the value of [cve][crate::model::vulnerability_assessment_note::Assessment::cve].
+        #[deprecated]
         pub fn set_cve<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.cve = v.into();
             self
@@ -13306,6 +13308,7 @@ pub mod vulnerability_occurrence {
         /// tracking number for the vulnerability.
         /// Deprecated: Use vulnerability_id instead to denote CVEs.
         #[serde(skip_serializing_if = "std::string::String::is_empty")]
+        #[deprecated]
         pub cve: std::string::String,
 
         /// The vulnerability identifier for this Assessment. Will hold one of
@@ -13356,6 +13359,7 @@ pub mod vulnerability_occurrence {
         }
 
         /// Sets the value of [cve][crate::model::vulnerability_occurrence::VexAssessment::cve].
+        #[deprecated]
         pub fn set_cve<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.cve = v.into();
             self

--- a/src/generated/grafeas/v1/src/stub.rs
+++ b/src/generated/grafeas/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Grafeas].

--- a/src/generated/iam/admin/v1/src/builder.rs
+++ b/src/generated/iam/admin/v1/src/builder.rs
@@ -315,6 +315,7 @@ pub mod iam {
         }
 
         /// Sets the value of [etag][crate::model::ServiceAccount::etag].
+        #[deprecated]
         pub fn set_etag<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
             self
@@ -1010,6 +1011,7 @@ pub mod iam {
         /// Sets the value of [name][crate::model::SignBlobRequest::name].
         ///
         /// This is a **required** field for requests.
+        #[deprecated]
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1018,6 +1020,7 @@ pub mod iam {
         /// Sets the value of [bytes_to_sign][crate::model::SignBlobRequest::bytes_to_sign].
         ///
         /// This is a **required** field for requests.
+        #[deprecated]
         pub fn set_bytes_to_sign<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.bytes_to_sign = v.into();
             self
@@ -1063,6 +1066,7 @@ pub mod iam {
         /// Sets the value of [name][crate::model::SignJwtRequest::name].
         ///
         /// This is a **required** field for requests.
+        #[deprecated]
         pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.name = v.into();
             self
@@ -1071,6 +1075,7 @@ pub mod iam {
         /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
         ///
         /// This is a **required** field for requests.
+        #[deprecated]
         pub fn set_payload<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.payload = v.into();
             self

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -377,6 +377,7 @@ impl Iam {
     /// Signs a blob using the system-managed private key for a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    #[deprecated]
     pub fn sign_blob(&self, name: impl Into<std::string::String>) -> super::builder::iam::SignBlob {
         super::builder::iam::SignBlob::new(self.inner.clone()).set_name(name.into())
     }
@@ -392,6 +393,7 @@ impl Iam {
     /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    #[deprecated]
     pub fn sign_jwt(&self, name: impl Into<std::string::String>) -> super::builder::iam::SignJwt {
         super::builder::iam::SignJwt::new(self.inner.clone()).set_name(name.into())
     }

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [Iam](client/struct.Iam.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -193,6 +193,7 @@ pub struct ServiceAccount {
     /// Deprecated. Do not use.
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
+    #[deprecated]
     pub etag: ::bytes::Bytes,
 
     /// Optional. A user-specified, human-readable description of the service account. The
@@ -248,6 +249,7 @@ impl ServiceAccount {
     }
 
     /// Sets the value of [etag][crate::model::ServiceAccount::etag].
+    #[deprecated]
     pub fn set_etag<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
@@ -1448,6 +1450,7 @@ pub struct SignBlobRequest {
     /// the account. The `ACCOUNT` value can be the `email` address or the
     /// `unique_id` of the service account.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub name: std::string::String,
 
     /// Required. Deprecated. [Migrate to Service Account Credentials
@@ -1456,6 +1459,7 @@ pub struct SignBlobRequest {
     /// The bytes to sign.
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
+    #[deprecated]
     pub bytes_to_sign: ::bytes::Bytes,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1468,12 +1472,14 @@ impl SignBlobRequest {
     }
 
     /// Sets the value of [name][crate::model::SignBlobRequest::name].
+    #[deprecated]
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
     /// Sets the value of [bytes_to_sign][crate::model::SignBlobRequest::bytes_to_sign].
+    #[deprecated]
     pub fn set_bytes_to_sign<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.bytes_to_sign = v.into();
         self
@@ -1500,6 +1506,7 @@ pub struct SignBlobResponse {
     ///
     /// The id of the key used to sign the blob.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub key_id: std::string::String,
 
     /// Deprecated. [Migrate to Service Account Credentials
@@ -1508,6 +1515,7 @@ pub struct SignBlobResponse {
     /// The signed blob.
     #[serde(skip_serializing_if = "::bytes::Bytes::is_empty")]
     #[serde_as(as = "serde_with::base64::Base64")]
+    #[deprecated]
     pub signature: ::bytes::Bytes,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1520,12 +1528,14 @@ impl SignBlobResponse {
     }
 
     /// Sets the value of [key_id][crate::model::SignBlobResponse::key_id].
+    #[deprecated]
     pub fn set_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_id = v.into();
         self
     }
 
     /// Sets the value of [signature][crate::model::SignBlobResponse::signature].
+    #[deprecated]
     pub fn set_signature<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.signature = v.into();
         self
@@ -1556,6 +1566,7 @@ pub struct SignJwtRequest {
     /// the account. The `ACCOUNT` value can be the `email` address or the
     /// `unique_id` of the service account.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub name: std::string::String,
 
     /// Required. Deprecated. [Migrate to Service Account Credentials
@@ -1572,6 +1583,7 @@ pub struct SignJwtRequest {
     /// this claim is added automatically, with a timestamp that is 1 hour in the
     /// future.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub payload: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1584,12 +1596,14 @@ impl SignJwtRequest {
     }
 
     /// Sets the value of [name][crate::model::SignJwtRequest::name].
+    #[deprecated]
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
         self
     }
 
     /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
+    #[deprecated]
     pub fn set_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.payload = v.into();
         self
@@ -1616,6 +1630,7 @@ pub struct SignJwtResponse {
     ///
     /// The id of the key used to sign the JWT.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub key_id: std::string::String,
 
     /// Deprecated. [Migrate to Service Account Credentials
@@ -1623,6 +1638,7 @@ pub struct SignJwtResponse {
     ///
     /// The signed JWT.
     #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    #[deprecated]
     pub signed_jwt: std::string::String,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -1635,12 +1651,14 @@ impl SignJwtResponse {
     }
 
     /// Sets the value of [key_id][crate::model::SignJwtResponse::key_id].
+    #[deprecated]
     pub fn set_key_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key_id = v.into();
         self
     }
 
     /// Sets the value of [signed_jwt][crate::model::SignJwtResponse::signed_jwt].
+    #[deprecated]
     pub fn set_signed_jwt<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.signed_jwt = v.into();
         self
@@ -2603,6 +2621,7 @@ pub struct Permission {
     pub description: std::string::String,
 
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub only_in_predefined_roles: bool,
 
     /// The current launch stage of the permission.
@@ -2648,6 +2667,7 @@ impl Permission {
     }
 
     /// Sets the value of [only_in_predefined_roles][crate::model::Permission::only_in_predefined_roles].
+    #[deprecated]
     pub fn set_only_in_predefined_roles<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.only_in_predefined_roles = v.into();
         self

--- a/src/generated/iam/admin/v1/src/stub.rs
+++ b/src/generated/iam/admin/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Iam].

--- a/src/generated/logging/v2/src/lib.rs
+++ b/src/generated/logging/v2/src/lib.rs
@@ -29,9 +29,10 @@
 //! * [ConfigServiceV2](client/struct.ConfigServiceV2.html)
 //! * [MetricsServiceV2](client/struct.MetricsServiceV2.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -39,19 +40,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/logging/v2/src/lib.rs
+++ b/src/generated/logging/v2/src/lib.rs
@@ -31,6 +31,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -38,18 +39,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -2100,6 +2100,7 @@ pub struct LogSink {
     pub exclusions: std::vec::Vec<crate::model::LogExclusion>,
 
     /// Deprecated. This field is unused.
+    #[deprecated]
     pub output_version_format: crate::model::log_sink::VersionFormat,
 
     /// Output only. An IAM identity&mdash;a service account or group&mdash;under
@@ -2202,6 +2203,7 @@ impl LogSink {
     }
 
     /// Sets the value of [output_version_format][crate::model::LogSink::output_version_format].
+    #[deprecated]
     pub fn set_output_version_format<
         T: std::convert::Into<crate::model::log_sink::VersionFormat>,
     >(
@@ -5754,6 +5756,7 @@ pub struct LogMetric {
 
     /// Deprecated. The API version that created or updated this metric.
     /// The v2 format is used by default and cannot be changed.
+    #[deprecated]
     pub version: crate::model::log_metric::ApiVersion,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -5842,6 +5845,7 @@ impl LogMetric {
     }
 
     /// Sets the value of [version][crate::model::LogMetric::version].
+    #[deprecated]
     pub fn set_version<T: std::convert::Into<crate::model::log_metric::ApiVersion>>(
         mut self,
         v: T,

--- a/src/generated/logging/v2/src/stub.rs
+++ b/src/generated/logging/v2/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::LoggingServiceV2].

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [DashboardsService](client/struct.DashboardsService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -3104,6 +3104,7 @@ impl TimeSeriesFilter {
     /// The value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
     /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn statistical_time_series_filter(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
@@ -3138,6 +3139,7 @@ impl TimeSeriesFilter {
     ///
     /// Note that all the setters affecting `output_filter` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_statistical_time_series_filter<
         T: std::convert::Into<std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>>,
     >(
@@ -3171,6 +3173,7 @@ pub mod time_series_filter {
         PickTimeSeriesFilter(std::boxed::Box<crate::model::PickTimeSeriesFilter>),
         /// Statistics based time series filter.
         /// Note: This field is deprecated and completely ignored by the API.
+        #[deprecated]
         StatisticalTimeSeriesFilter(std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>),
     }
 }
@@ -3276,6 +3279,7 @@ impl TimeSeriesFilterRatio {
     /// The value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
     /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
     /// holds a different branch.
+    #[deprecated]
     pub fn statistical_time_series_filter(
         &self,
     ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
@@ -3310,6 +3314,7 @@ impl TimeSeriesFilterRatio {
     ///
     /// Note that all the setters affecting `output_filter` are
     /// mutually exclusive.
+    #[deprecated]
     pub fn set_statistical_time_series_filter<
         T: std::convert::Into<std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>>,
     >(
@@ -3398,6 +3403,7 @@ pub mod time_series_filter_ratio {
         PickTimeSeriesFilter(std::boxed::Box<crate::model::PickTimeSeriesFilter>),
         /// Statistics based time series filter.
         /// Note: This field is deprecated and completely ignored by the API.
+        #[deprecated]
         StatisticalTimeSeriesFilter(std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>),
     }
 }
@@ -4889,6 +4895,7 @@ pub struct TableDisplayOptions {
     /// Optional. This field is unused and has been replaced by
     /// TimeSeriesTable.column_settings
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub shown_columns: std::vec::Vec<std::string::String>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -4901,6 +4908,7 @@ impl TableDisplayOptions {
     }
 
     /// Sets the value of [shown_columns][crate::model::TableDisplayOptions::shown_columns].
+    #[deprecated]
     pub fn set_shown_columns<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/monitoring/dashboard/v1/src/stub.rs
+++ b/src/generated/monitoring/dashboard/v1/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DashboardsService].

--- a/src/generated/monitoring/v3/src/client.rs
+++ b/src/generated/monitoring/v3/src/client.rs
@@ -926,6 +926,7 @@ impl QueryService {
     /// using PromQL instead of MQL. For more information about the status of MQL,
     /// see the [MQL deprecation
     /// notice](https://cloud.google.com/stackdriver/docs/deprecations/mql).
+    #[deprecated]
     pub fn query_time_series(
         &self,
         name: impl Into<std::string::String>,

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -36,6 +36,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -43,18 +44,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -34,9 +34,10 @@
 //! * [SnoozeService](client/struct.SnoozeService.html)
 //! * [UptimeCheckService](client/struct.UptimeCheckService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -44,19 +45,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -6939,10 +6939,12 @@ impl wkt::message::Message for CreateTimeSeriesRequest {
 pub struct CreateTimeSeriesError {
     /// DEPRECATED. Time series ID that resulted in the `status` error.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub time_series: std::option::Option<crate::model::TimeSeries>,
 
     /// DEPRECATED. The status of the requested write operation for `time_series`.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub status: std::option::Option<rpc::model::Status>,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -6955,6 +6957,7 @@ impl CreateTimeSeriesError {
     }
 
     /// Sets the value of [time_series][crate::model::CreateTimeSeriesError::time_series].
+    #[deprecated]
     pub fn set_time_series<T: std::convert::Into<std::option::Option<crate::model::TimeSeries>>>(
         mut self,
         v: T,
@@ -6964,6 +6967,7 @@ impl CreateTimeSeriesError {
     }
 
     /// Sets the value of [status][crate::model::CreateTimeSeriesError::status].
+    #[deprecated]
     pub fn set_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
         v: T,
@@ -7094,6 +7098,7 @@ pub mod create_time_series_summary {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct QueryTimeSeriesRequest {
     /// Required. The
     /// [project](https://cloud.google.com/monitoring/api/v3#project_name) on which
@@ -7168,6 +7173,7 @@ impl wkt::message::Message for QueryTimeSeriesRequest {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct QueryTimeSeriesResponse {
     /// The descriptor for the time series data.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
@@ -7398,6 +7404,7 @@ pub struct NotificationChannelDescriptor {
     /// The tiers that support this notification channel; the project service tier
     /// must be one of the supported_tiers.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub supported_tiers: std::vec::Vec<crate::model::ServiceTier>,
 
     /// The product launch stage for channels of this type.
@@ -7457,6 +7464,7 @@ impl NotificationChannelDescriptor {
     }
 
     /// Sets the value of [supported_tiers][crate::model::NotificationChannelDescriptor::supported_tiers].
+    #[deprecated]
     pub fn set_supported_tiers<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -12383,6 +12391,7 @@ impl wkt::message::Message for SpanContext {
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default, rename_all = "camelCase")]
 #[non_exhaustive]
+#[deprecated]
 pub struct InternalChecker {
     /// A unique resource name for this InternalChecker. The format is:
     ///
@@ -12832,6 +12841,7 @@ pub struct UptimeCheckConfig {
     /// It is an error to provide 'selected_regions' when is_internal is `true`,
     /// or to provide 'internal_checkers' when is_internal is `false`.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub is_internal: bool,
 
     /// The internal checkers that this check will egress from. If `is_internal` is
@@ -12839,6 +12849,7 @@ pub struct UptimeCheckConfig {
     /// InternalCheckers configured for the project that owns this
     /// `UptimeCheckConfig`.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub internal_checkers: std::vec::Vec<crate::model::InternalChecker>,
 
     /// User-supplied key/value data to be used for organizing and
@@ -12911,6 +12922,7 @@ impl UptimeCheckConfig {
     }
 
     /// Sets the value of [is_internal][crate::model::UptimeCheckConfig::is_internal].
+    #[deprecated]
     pub fn set_is_internal<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.is_internal = v.into();
         self
@@ -12939,6 +12951,7 @@ impl UptimeCheckConfig {
     }
 
     /// Sets the value of [internal_checkers][crate::model::UptimeCheckConfig::internal_checkers].
+    #[deprecated]
     pub fn set_internal_checkers<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -15776,6 +15789,7 @@ impl<'de> serde::de::Deserialize<'de> for ComparisonType {
 /// [Working with enums]: https://google-cloud-rust.github.io/working_with_enums.html
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
+#[deprecated]
 pub enum ServiceTier {
     /// An invalid sentinel value, used to indicate that a tier has not
     /// been provided explicitly.

--- a/src/generated/monitoring/v3/src/stub.rs
+++ b/src/generated/monitoring/v3/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AlertPolicyService].

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [DlpService](client/struct.DlpService.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -28040,6 +28040,7 @@ pub struct DataProfileConfigSnapshot {
     /// for backwards compatibility, but will not be updated with new fields, while
     /// DiscoveryConfig will.
     #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[deprecated]
     pub data_profile_job: std::option::Option<crate::model::DataProfileJobConfig>,
 
     /// A copy of the configuration used to generate this profile.
@@ -28075,6 +28076,7 @@ impl DataProfileConfigSnapshot {
     }
 
     /// Sets the value of [data_profile_job][crate::model::DataProfileConfigSnapshot::data_profile_job].
+    #[deprecated]
     pub fn set_data_profile_job<
         T: std::convert::Into<std::option::Option<crate::model::DataProfileJobConfig>>,
     >(
@@ -28734,6 +28736,7 @@ pub struct InfoTypeSummary {
 
     /// Not populated for predicted infotypes.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub estimated_prevalence: i32,
 
     #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -28755,6 +28758,7 @@ impl InfoTypeSummary {
     }
 
     /// Sets the value of [estimated_prevalence][crate::model::InfoTypeSummary::estimated_prevalence].
+    #[deprecated]
     pub fn set_estimated_prevalence<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.estimated_prevalence = v.into();
         self

--- a/src/generated/privacy/dlp/v2/src/stub.rs
+++ b/src/generated/privacy/dlp/v2/src/stub.rs
@@ -26,6 +26,7 @@
 
 use gax::error::Error;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DlpService].

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -27,9 +27,10 @@
 //!
 //! * [InstanceAdmin](client/struct.InstanceAdmin.html)
 
+#![allow(deprecated)]
+
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
-#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -37,19 +38,15 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
-#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
-#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -29,6 +29,7 @@
 
 /// The messages and enums that are part of this client library.
 #[allow(clippy::module_inception)]
+#[allow(deprecated)]
 pub mod model;
 
 pub use gax::Result;
@@ -36,18 +37,23 @@ pub use gax::error::Error;
 
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
+#[allow(deprecated)]
 pub mod stub;
 
 /// Concrete implementations of this client library traits.
+#[allow(deprecated)]
 pub mod client;
 
 /// Request builders.
+#[allow(deprecated)]
 pub mod builder;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod tracing;
 
 #[doc(hidden)]
+#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -4241,6 +4241,7 @@ pub struct InstancePartition {
     /// existence of any referencing backup prevents the instance partition from
     /// being deleted.
     #[serde(skip_serializing_if = "std::vec::Vec::is_empty")]
+    #[deprecated]
     pub referencing_backups: std::vec::Vec<std::string::String>,
 
     /// Used for optimistic concurrency control as a way
@@ -4337,6 +4338,7 @@ impl InstancePartition {
     }
 
     /// Sets the value of [referencing_backups][crate::model::InstancePartition::referencing_backups].
+    #[deprecated]
     pub fn set_referencing_backups<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,

--- a/src/generated/spanner/admin/instance/v1/src/stub.rs
+++ b/src/generated/spanner/admin/instance/v1/src/stub.rs
@@ -27,6 +27,7 @@
 use gax::error::Error;
 use std::sync::Arc;
 
+#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::InstanceAdmin].

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -2116,6 +2116,7 @@ pub struct FileOptions {
 
     /// This option does nothing.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub java_generate_equals_and_hash: bool,
 
     /// A proto2 file can set this to true to opt in to UTF-8 checking for Java,
@@ -2252,6 +2253,7 @@ impl FileOptions {
     }
 
     /// Sets the value of [java_generate_equals_and_hash][crate::FileOptions::java_generate_equals_and_hash].
+    #[deprecated]
     pub fn set_java_generate_equals_and_hash<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.java_generate_equals_and_hash = v.into();
         self
@@ -2599,6 +2601,7 @@ pub struct MessageOptions {
     /// TODO This is legacy behavior we plan to remove once downstream
     /// teams have had time to migrate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub deprecated_legacy_json_field_conflicts: bool,
 
     /// Any features defined in the specific edition.
@@ -2646,6 +2649,7 @@ impl MessageOptions {
     }
 
     /// Sets the value of [deprecated_legacy_json_field_conflicts][crate::MessageOptions::deprecated_legacy_json_field_conflicts].
+    #[deprecated]
     pub fn set_deprecated_legacy_json_field_conflicts<T: std::convert::Into<bool>>(
         mut self,
         v: T,
@@ -3671,6 +3675,7 @@ pub struct EnumOptions {
     /// TODO Remove this legacy behavior once downstream teams have
     /// had time to migrate.
     #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[deprecated]
     pub deprecated_legacy_json_field_conflicts: bool,
 
     /// Any features defined in the specific edition.
@@ -3703,6 +3708,7 @@ impl EnumOptions {
     }
 
     /// Sets the value of [deprecated_legacy_json_field_conflicts][crate::EnumOptions::deprecated_legacy_json_field_conflicts].
+    #[deprecated]
     pub fn set_deprecated_legacy_json_field_conflicts<T: std::convert::Into<bool>>(
         mut self,
         v: T,

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -31,6 +31,8 @@ mod empty;
 pub use crate::empty::*;
 mod field_mask;
 pub use crate::field_mask::*;
+// The generated code contains (and uses) deprecated code.
+#[allow(deprecated)]
 mod generated;
 #[doc(hidden)]
 pub mod internal;


### PR DESCRIPTION
When a field, enum value, enum, message, rpc, or service is marked as
deprecated in the API specification we use `#[deprecated]` for the
corresponding thing in the generated Rust code.

Because the generated code must use these things we disable the
corresponding warnings.

I kept the warnings enabled for client libraries that have nothing
deprecated. This allows us to detect any usage of deprecated types or
functions from external or common dependencies.

Fixes #1958 