### PR TITLE
cleanup: remove excessive `#[allow(deprecated)]`

### DIFF
--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -72,9 +72,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/generator/internal/rust/templates/crate/src/stub.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/stub.rs.mustache
@@ -42,10 +42,6 @@ use gax::error::Error;
 use std::sync::Arc;
 {{/Codec.HasLROs}}
 
-{{! The generated code may use deprecated request messages. }}
-{{#HasDeprecatedEntities}}
-#[allow(deprecated)]
-{{/HasDeprecatedEntities}}
 pub(crate) mod dynamic;
 
 {{/Codec.HasServices}}

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/api/servicemanagement/v1/src/stub.rs
+++ b/src/generated/api/servicemanagement/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ServiceManager].

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/bigtable/admin/v2/src/stub.rs
+++ b/src/generated/bigtable/admin/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::BigtableInstanceAdmin].

--- a/src/generated/cloud/aiplatform/v1/src/lib.rs
+++ b/src/generated/cloud/aiplatform/v1/src/lib.rs
@@ -82,7 +82,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/aiplatform/v1/src/stub.rs
+++ b/src/generated/cloud/aiplatform/v1/src/stub.rs
@@ -62,7 +62,6 @@ use gax::error::Error;
 #[allow(unused_imports)]
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DatasetService].

--- a/src/generated/cloud/alloydb/v1/src/lib.rs
+++ b/src/generated/cloud/alloydb/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/alloydb/v1/src/stub.rs
+++ b/src/generated/cloud/alloydb/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AlloyDBAdmin].

--- a/src/generated/cloud/asset/v1/src/lib.rs
+++ b/src/generated/cloud/asset/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/asset/v1/src/stub.rs
+++ b/src/generated/cloud/asset/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AssetService].

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/assuredworkloads/v1/src/stub.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AssuredWorkloadsService].

--- a/src/generated/cloud/backupdr/v1/src/lib.rs
+++ b/src/generated/cloud/backupdr/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/backupdr/v1/src/stub.rs
+++ b/src/generated/cloud/backupdr/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::BackupDR].

--- a/src/generated/cloud/baremetalsolution/v2/src/lib.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/baremetalsolution/v2/src/stub.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::BareMetalSolution].

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AnalyticsHubService].

--- a/src/generated/cloud/bigquery/connection/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/connection/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ConnectionService].

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataTransferService].

--- a/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/reservation/v1/src/stub.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ReservationService].

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -55,7 +55,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/bigquery/v2/src/stub.rs
+++ b/src/generated/cloud/bigquery/v2/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DatasetService].

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/stub.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudControlsPartnerCore].

--- a/src/generated/cloud/connectors/v1/src/lib.rs
+++ b/src/generated/cloud/connectors/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/connectors/v1/src/stub.rs
+++ b/src/generated/cloud/connectors/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Connectors].

--- a/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/contactcenterinsights/v1/src/stub.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ContactCenterInsights].

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -52,7 +52,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/datacatalog/v1/src/stub.rs
+++ b/src/generated/cloud/datacatalog/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataCatalog].

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/datafusion/v1/src/stub.rs
+++ b/src/generated/cloud/datafusion/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataFusion].

--- a/src/generated/cloud/dataplex/v1/src/lib.rs
+++ b/src/generated/cloud/dataplex/v1/src/lib.rs
@@ -56,7 +56,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/dataplex/v1/src/stub.rs
+++ b/src/generated/cloud/dataplex/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CatalogService].

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/deploy/v1/src/stub.rs
+++ b/src/generated/cloud/deploy/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudDeploy].

--- a/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
@@ -66,7 +66,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/dialogflow/cx/v3/src/stub.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Agents].

--- a/src/generated/cloud/dialogflow/v2/src/lib.rs
+++ b/src/generated/cloud/dialogflow/v2/src/lib.rs
@@ -68,7 +68,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/dialogflow/v2/src/stub.rs
+++ b/src/generated/cloud/dialogflow/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Agents].

--- a/src/generated/cloud/discoveryengine/v1/src/lib.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/lib.rs
@@ -65,7 +65,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/discoveryengine/v1/src/stub.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CompletionService].

--- a/src/generated/cloud/documentai/v1/src/lib.rs
+++ b/src/generated/cloud/documentai/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/documentai/v1/src/stub.rs
+++ b/src/generated/cloud/documentai/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DocumentProcessorService].

--- a/src/generated/cloud/edgecontainer/v1/src/lib.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/edgecontainer/v1/src/stub.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::EdgeContainer].

--- a/src/generated/cloud/edgenetwork/v1/src/lib.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/edgenetwork/v1/src/stub.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::EdgeNetwork].

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/functions/v2/src/stub.rs
+++ b/src/generated/cloud/functions/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::FunctionService].

--- a/src/generated/cloud/iap/v1/src/lib.rs
+++ b/src/generated/cloud/iap/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/iap/v1/src/stub.rs
+++ b/src/generated/cloud/iap/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::IdentityAwareProxyAdminService].

--- a/src/generated/cloud/memorystore/v1/src/lib.rs
+++ b/src/generated/cloud/memorystore/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/memorystore/v1/src/stub.rs
+++ b/src/generated/cloud/memorystore/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Memorystore].

--- a/src/generated/cloud/metastore/v1/src/lib.rs
+++ b/src/generated/cloud/metastore/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/metastore/v1/src/stub.rs
+++ b/src/generated/cloud/metastore/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DataprocMetastore].

--- a/src/generated/cloud/migrationcenter/v1/src/lib.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/migrationcenter/v1/src/stub.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::MigrationCenter].

--- a/src/generated/cloud/netapp/v1/src/lib.rs
+++ b/src/generated/cloud/netapp/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/netapp/v1/src/stub.rs
+++ b/src/generated/cloud/netapp/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::NetApp].

--- a/src/generated/cloud/networkconnectivity/v1/src/lib.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/lib.rs
@@ -52,7 +52,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/networkconnectivity/v1/src/stub.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CrossNetworkAutomationService].

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/networkmanagement/v1/src/stub.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ReachabilityService].

--- a/src/generated/cloud/optimization/v1/src/lib.rs
+++ b/src/generated/cloud/optimization/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/optimization/v1/src/stub.rs
+++ b/src/generated/cloud/optimization/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::FleetRouting].

--- a/src/generated/cloud/orgpolicy/v2/src/lib.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/orgpolicy/v2/src/stub.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::OrgPolicy].

--- a/src/generated/cloud/osconfig/v1/src/lib.rs
+++ b/src/generated/cloud/osconfig/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/osconfig/v1/src/stub.rs
+++ b/src/generated/cloud/osconfig/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::OsConfigService].

--- a/src/generated/cloud/parallelstore/v1/src/lib.rs
+++ b/src/generated/cloud/parallelstore/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/parallelstore/v1/src/stub.rs
+++ b/src/generated/cloud/parallelstore/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Parallelstore].

--- a/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/recaptchaenterprise/v1/src/stub.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::RecaptchaEnterpriseService].

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/redis/v1/src/stub.rs
+++ b/src/generated/cloud/redis/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudRedis].

--- a/src/generated/cloud/retail/v2/src/lib.rs
+++ b/src/generated/cloud/retail/v2/src/lib.rs
@@ -60,7 +60,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/retail/v2/src/stub.rs
+++ b/src/generated/cloud/retail/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AnalyticsService].

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -55,7 +55,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/run/v2/src/stub.rs
+++ b/src/generated/cloud/run/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Builds].

--- a/src/generated/cloud/securesourcemanager/v1/src/lib.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/securesourcemanager/v1/src/stub.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::SecureSourceManager].

--- a/src/generated/cloud/securitycenter/v2/src/lib.rs
+++ b/src/generated/cloud/securitycenter/v2/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/securitycenter/v2/src/stub.rs
+++ b/src/generated/cloud/securitycenter/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::SecurityCenter].

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/speech/v2/src/stub.rs
+++ b/src/generated/cloud/speech/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Speech].

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -58,7 +58,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/sql/v1/src/stub.rs
+++ b/src/generated/cloud/sql/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::SqlBackupRunsService].

--- a/src/generated/cloud/talent/v4/src/lib.rs
+++ b/src/generated/cloud/talent/v4/src/lib.rs
@@ -54,7 +54,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/talent/v4/src/stub.rs
+++ b/src/generated/cloud/talent/v4/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CompanyService].

--- a/src/generated/cloud/texttospeech/v1/src/lib.rs
+++ b/src/generated/cloud/texttospeech/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/texttospeech/v1/src/stub.rs
+++ b/src/generated/cloud/texttospeech/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::TextToSpeech].

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/videointelligence/v1/src/stub.rs
+++ b/src/generated/cloud/videointelligence/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::VideoIntelligenceService].

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -51,7 +51,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/vision/v1/src/stub.rs
+++ b/src/generated/cloud/vision/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ImageAnnotator].

--- a/src/generated/cloud/vmmigration/v1/src/lib.rs
+++ b/src/generated/cloud/vmmigration/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/vmmigration/v1/src/stub.rs
+++ b/src/generated/cloud/vmmigration/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::VmMigration].

--- a/src/generated/cloud/websecurityscanner/v1/src/lib.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/cloud/websecurityscanner/v1/src/stub.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::WebSecurityScanner].

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/container/v1/src/stub.rs
+++ b/src/generated/container/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ClusterManager].

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/devtools/artifactregistry/v1/src/stub.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::ArtifactRegistry].

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/devtools/cloudbuild/v1/src/stub.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::CloudBuild].

--- a/src/generated/grafeas/v1/src/lib.rs
+++ b/src/generated/grafeas/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/grafeas/v1/src/stub.rs
+++ b/src/generated/grafeas/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Grafeas].

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/iam/admin/v1/src/stub.rs
+++ b/src/generated/iam/admin/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::Iam].

--- a/src/generated/logging/v2/src/lib.rs
+++ b/src/generated/logging/v2/src/lib.rs
@@ -52,7 +52,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/logging/v2/src/stub.rs
+++ b/src/generated/logging/v2/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::LoggingServiceV2].

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/monitoring/dashboard/v1/src/stub.rs
+++ b/src/generated/monitoring/dashboard/v1/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DashboardsService].

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -57,7 +57,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/monitoring/v3/src/stub.rs
+++ b/src/generated/monitoring/v3/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::AlertPolicyService].

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/privacy/dlp/v2/src/stub.rs
+++ b/src/generated/privacy/dlp/v2/src/stub.rs
@@ -26,7 +26,6 @@
 
 use gax::error::Error;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::DlpService].

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -50,7 +50,6 @@ pub mod builder;
 pub(crate) mod tracing;
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub(crate) mod transport;
 
 /// The default host used by the service.

--- a/src/generated/spanner/admin/instance/v1/src/stub.rs
+++ b/src/generated/spanner/admin/instance/v1/src/stub.rs
@@ -27,7 +27,6 @@
 use gax::error::Error;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 pub(crate) mod dynamic;
 
 /// Defines the trait used to implement [super::client::InstanceAdmin].


### PR DESCRIPTION
I missed some comments in #1983
