### PR TITLE
feat(generator): better classify fields

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -482,8 +482,16 @@ type Field struct {
 	JSONName string
 	// Optional indicates that the field is marked as optional in proto3.
 	Optional bool
+
+	// For a given field, at most one of `Repeated` or `Map` is true.
+	//
+	// Using booleans (as opposed to an enum) makes it easier to write mustache
+	// templates.
+	//
 	// Repeated is true if the field is a repeated field.
 	Repeated bool
+	// Map is true if the field is a map.
+	Map bool
 	// Some source specifications allow marking fields as deprecated.
 	Deprecated bool
 	// IsOneOf is true if the field is related to a one-of and not
@@ -522,6 +530,10 @@ type Field struct {
 
 func (field *Field) DocumentAsRequired() bool {
 	return slices.Contains(field.Behavior, FIELD_BEHAVIOR_REQUIRED)
+}
+
+func (f *Field) Singular() bool {
+	return !f.Map && !f.Repeated
 }
 
 // Pair is a key-value pair.

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -511,6 +511,8 @@ func makeObjectField(state *api.APIState, packageName, messageName, name string,
 			Typez:         api.MESSAGE_TYPE,
 			TypezID:       message.ID,
 			Optional:      false,
+			Repeated:      false,
+			Map:           true,
 		}, nil
 	}
 	if field.Items != nil && field.Items.IsA() {
@@ -567,6 +569,7 @@ func makeArrayField(state *api.APIState, packageName, messageName, name string, 
 		return nil, err
 	}
 	result.Repeated = true
+	result.Map = false
 	result.Optional = false
 	return result, nil
 }

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -455,18 +455,21 @@ func TestOpenAPI_MapString(t *testing.T) {
 				JSONName: "fMap",
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  "$map<string, string>",
+				Map:      true,
 			},
 			{
 				Name:     "fMapS32",
 				JSONName: "fMapS32",
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  "$map<string, int32>",
+				Map:      true,
 			},
 			{
 				Name:     "fMapS64",
 				JSONName: "fMapS64",
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  "$map<string, int64>",
+				Map:      true,
 			},
 		},
 	})
@@ -504,13 +507,17 @@ func TestOpenAPI_MapInteger(t *testing.T) {
 				JSONName: "fMapI32",
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  "$map<string, int32>",
-				Optional: false},
+				Optional: false,
+				Map:      true,
+			},
 			{
 				Name:     "fMapI64",
 				JSONName: "fMapI64",
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  "$map<string, int64>",
-				Optional: false},
+				Optional: false,
+				Map:      true,
+			},
 		},
 	})
 }
@@ -570,6 +577,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 				Typez:         api.MESSAGE_TYPE,
 				TypezID:       "$map<string, string>",
 				Optional:      false,
+				Map:           true,
 			},
 			{
 				Name:          "metadata",

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -724,6 +724,7 @@ func TestProtobuf_MapFields(t *testing.T) {
 			{
 				Repeated: false,
 				Optional: false,
+				Map:      true,
 				Name:     "singular_map",
 				JSONName: "singularMap",
 				ID:       ".test.Fake.singular_map",
@@ -733,6 +734,7 @@ func TestProtobuf_MapFields(t *testing.T) {
 			{
 				Repeated: false,
 				Optional: false,
+				Map:      true,
 				Name:     "enum_value",
 				JSONName: "enumValue",
 				ID:       ".test.Fake.enum_value",


### PR DESCRIPTION
Add attributes to directly determine if fields are maps, repeated, or
singular.

I will use this to refactor some of the templates.
