### PR TITLE
refactor(generator/rust): use field classification

### DIFF
--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -57,23 +57,19 @@ impl {{Codec.Name}} {
     pub fn new() -> Self {
         std::default::Default::default()
     }
-    {{#Codec.SingularFields}}
+    {{#Codec.BasicFields}}
 
     /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
     {{#Deprecated}}
     #[deprecated]
     {{/Deprecated}}
+    {{#Singular}}
     pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
         self.{{Codec.FieldName}} = v.into();
         self
     }
-    {{/Codec.SingularFields}}
-    {{#Codec.RepeatedFields}}
-
-    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
-    {{#Deprecated}}
-    #[deprecated]
-    {{/Deprecated}}
+    {{/Singular}}
+    {{#Repeated}}
     pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -83,13 +79,8 @@ impl {{Codec.Name}} {
         self.{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
         self
     }
-    {{/Codec.RepeatedFields}}
-    {{#Codec.MapFields}}
-
-    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
-    {{#Deprecated}}
-    #[deprecated]
-    {{/Deprecated}}
+    {{/Repeated}}
+    {{#Map}}
     pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -100,7 +91,8 @@ impl {{Codec.Name}} {
         self.{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
-    {{/Codec.MapFields}}
+    {{/Map}}
+    {{/Codec.BasicFields}}
     {{#OneOfs}}
 
     /// Sets the value of [{{Codec.FieldName}}][{{Codec.StructQualifiedName}}::{{Codec.SetterName}}].
@@ -128,8 +120,6 @@ impl {{Codec.Name}} {
             _ => std::option::Option::None,
         })
     }
-    {{/Fields}}
-    {{#Codec.SingularFields}}
 
     /// Sets the value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
     /// to hold a `{{Codec.BranchName}}`.
@@ -139,6 +129,7 @@ impl {{Codec.Name}} {
     {{#Deprecated}}
     #[deprecated]
     {{/Deprecated}}
+    {{#Singular}}
     pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
         self.{{Group.Codec.FieldName}} = std::option::Option::Some(
             {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
@@ -147,16 +138,8 @@ impl {{Codec.Name}} {
         );
         self
     }
-    {{/Codec.SingularFields}}
-    {{#Codec.RepeatedFields}}
-
-    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.SetterName}}].
-    ///
-    /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
-    /// mutually exclusive.
-    {{#Deprecated}}
-    #[deprecated]
-    {{/Deprecated}}
+    {{/Singular}}
+    {{#Repeated}}
     pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -170,16 +153,8 @@ impl {{Codec.Name}} {
         );
         self
     }
-    {{/Codec.RepeatedFields}}
-    {{#Codec.MapFields}}
-
-    /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.SetterName}}].
-    ///
-    /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
-    /// mutually exclusive.
-    {{#Deprecated}}
-    #[deprecated]
-    {{/Deprecated}}
+    {{/Repeated}}
+    {{#Map}}
     pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -194,7 +169,8 @@ impl {{Codec.Name}} {
         );
         self
     }
-    {{/Codec.MapFields}}
+    {{/Map}}
+    {{/Fields}}
     {{/OneOfs}}
 }
 {{^Codec.HasSyntheticFields}}

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -172,7 +172,7 @@ pub mod {{Codec.ModuleName}} {
             lro::new_poller(polling_error_policy, polling_backoff_policy, start, query)
         }
         {{/OperationInfo}}
-        {{#InputType.Codec.SingularFields}}
+        {{#InputType.Codec.BasicFields}}
 
         /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
         {{#DocumentAsRequired}}
@@ -182,21 +182,13 @@ pub mod {{Codec.ModuleName}} {
         {{#Deprecated}}
         #[deprecated]
         {{/Deprecated}}
+        {{#Singular}}
         pub fn set_{{Codec.SetterName}}<T: Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
             self.0.request.{{Codec.FieldName}} = v.into();
             self
         }
-        {{/InputType.Codec.SingularFields}}
-        {{#InputType.Codec.RepeatedFields}}
-
-        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
-        {{#DocumentAsRequired}}
-        ///
-        /// This is a **required** field for requests.
-        {{/DocumentAsRequired}}
-        {{#Deprecated}}
-        #[deprecated]
-        {{/Deprecated}}
+        {{/Singular}}
+        {{#Repeated}}
         pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -206,17 +198,8 @@ pub mod {{Codec.ModuleName}} {
             self.0.request.{{Codec.FieldName}} = v.into_iter().map(|i| i.into()).collect();
             self
         }
-        {{/InputType.Codec.RepeatedFields}}
-        {{#InputType.Codec.MapFields}}
-
-        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Codec.SetterName}}].
-        {{#DocumentAsRequired}}
-        ///
-        /// This is a **required** field for requests.
-        {{/DocumentAsRequired}}
-        {{#Deprecated}}
-        #[deprecated]
-        {{/Deprecated}}
+        {{/Repeated}}
+        {{#Map}}
         pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = (K, V)>,
@@ -226,7 +209,8 @@ pub mod {{Codec.ModuleName}} {
             self.0.request.{{Codec.FieldName}} = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
-        {{/InputType.Codec.MapFields}}
+        {{/Map}}
+        {{/InputType.Codec.BasicFields}}
         {{#InputType.OneOfs}}
 
         /// Sets the value of [{{Codec.FieldName}}][{{Codec.StructQualifiedName}}::{{Codec.SetterName}}].
@@ -237,7 +221,7 @@ pub mod {{Codec.ModuleName}} {
             self.0.request.{{Codec.FieldName}} = v.into();
             self
         }
-        {{#Codec.SingularFields}}
+        {{#Fields}}
 
         /// Sets the value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
         /// to hold a `{{Codec.BranchName}}`.
@@ -247,20 +231,13 @@ pub mod {{Codec.ModuleName}} {
         {{#Deprecated}}
         #[deprecated]
         {{/Deprecated}}
+        {{#Singular}}
         pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
             self.0.request = self.0.request.set_{{Codec.SetterName}}(v);
             self
         }
-        {{/Codec.SingularFields}}
-        {{#Codec.RepeatedFields}}
-
-        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.SetterName}}].
-        ///
-        /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
-        /// mutually exclusive.
-        {{#Deprecated}}
-        #[deprecated]
-        {{/Deprecated}}
+        {{/Singular}}
+        {{#Repeated}}
         pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = V>,
@@ -274,16 +251,8 @@ pub mod {{Codec.ModuleName}} {
             );
             self
         }
-        {{/Codec.RepeatedFields}}
-        {{#Codec.MapFields}}
-
-        /// Sets the value of [{{Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.SetterName}}].
-        ///
-        /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
-        /// mutually exclusive.
-        {{#Deprecated}}
-        #[deprecated]
-        {{/Deprecated}}
+        {{/Repeated}}
+        {{#Map}}
         pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
         where
             T: std::iter::IntoIterator<Item = (K, V)>,
@@ -298,7 +267,8 @@ pub mod {{Codec.ModuleName}} {
             );
             self
         }
-        {{/Codec.MapFields}}
+        {{/Map}}
+        {{/Fields}}
         {{/InputType.OneOfs}}
     }
 

--- a/src/firestore/src/generated/gapic/builder.rs
+++ b/src/firestore/src/generated/gapic/builder.rs
@@ -530,12 +530,6 @@ pub mod firestore {
             self
         }
 
-        /// Sets the value of [transaction][crate::model::CommitRequest::transaction].
-        pub fn set_transaction<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request.transaction = v.into();
-            self
-        }
-
         /// Sets the value of [writes][crate::model::CommitRequest::writes].
         pub fn set_writes<T, V>(mut self, v: T) -> Self
         where
@@ -544,6 +538,12 @@ pub mod firestore {
         {
             use std::iter::Iterator;
             self.0.request.writes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [transaction][crate::model::CommitRequest::transaction].
+        pub fn set_transaction<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.transaction = v.into();
             self
         }
     }

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -278,6 +278,17 @@ impl Precondition {
         })
     }
 
+    /// Sets the value of [condition_type][crate::model::Precondition::condition_type]
+    /// to hold a `Exists`.
+    ///
+    /// Note that all the setters affecting `condition_type` are
+    /// mutually exclusive.
+    pub fn set_exists<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.condition_type =
+            std::option::Option::Some(crate::model::precondition::ConditionType::Exists(v.into()));
+        self
+    }
+
     /// The value of [condition_type][crate::model::Precondition::condition_type]
     /// if it holds a `UpdateTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -289,17 +300,6 @@ impl Precondition {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [condition_type][crate::model::Precondition::condition_type]
-    /// to hold a `Exists`.
-    ///
-    /// Note that all the setters affecting `condition_type` are
-    /// mutually exclusive.
-    pub fn set_exists<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.condition_type =
-            std::option::Option::Some(crate::model::precondition::ConditionType::Exists(v.into()));
-        self
     }
 
     /// Sets the value of [condition_type][crate::model::Precondition::condition_type]
@@ -402,19 +402,6 @@ impl TransactionOptions {
         })
     }
 
-    /// The value of [mode][crate::model::TransactionOptions::mode]
-    /// if it holds a `ReadWrite`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn read_write(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::transaction_options::ReadWrite>> {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::transaction_options::Mode::ReadWrite(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::TransactionOptions::mode]
     /// to hold a `ReadOnly`.
     ///
@@ -429,6 +416,19 @@ impl TransactionOptions {
         self.mode =
             std::option::Option::Some(crate::model::transaction_options::Mode::ReadOnly(v.into()));
         self
+    }
+
+    /// The value of [mode][crate::model::TransactionOptions::mode]
+    /// if it holds a `ReadWrite`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn read_write(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::transaction_options::ReadWrite>> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::transaction_options::Mode::ReadWrite(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::TransactionOptions::mode]
@@ -703,6 +703,18 @@ impl Document {
         self
     }
 
+    /// Sets the value of [fields][crate::model::Document::fields].
+    pub fn set_fields<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::Value>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Document::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -718,18 +730,6 @@ impl Document {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [fields][crate::model::Document::fields].
-    pub fn set_fields<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::Value>,
-    {
-        use std::iter::Iterator;
-        self.fields = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -784,116 +784,6 @@ impl Value {
         })
     }
 
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `BooleanValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn boolean_value(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::BooleanValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `IntegerValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn integer_value(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::IntegerValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `DoubleValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_value(&self) -> std::option::Option<&f64> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::DoubleValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `TimestampValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn timestamp_value(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::TimestampValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `StringValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::StringValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `BytesValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bytes_value(&self) -> std::option::Option<&::bytes::Bytes> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::BytesValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `ReferenceValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn reference_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::ReferenceValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `GeoPointValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn geo_point_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::LatLng>> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::GeoPointValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `ArrayValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn array_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::ArrayValue>> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::ArrayValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value_type][crate::model::Value::value_type]
-    /// if it holds a `MapValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn map_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::MapValue>> {
-        #[allow(unreachable_patterns)]
-        self.value_type.as_ref().and_then(|v| match v {
-            crate::model::value::ValueType::MapValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value_type][crate::model::Value::value_type]
     /// to hold a `NullValue`.
     ///
@@ -903,6 +793,17 @@ impl Value {
         self.value_type =
             std::option::Option::Some(crate::model::value::ValueType::NullValue(v.into()));
         self
+    }
+
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `BooleanValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn boolean_value(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::BooleanValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value_type][crate::model::Value::value_type]
@@ -916,6 +817,17 @@ impl Value {
         self
     }
 
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `IntegerValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn integer_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::IntegerValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value_type][crate::model::Value::value_type]
     /// to hold a `IntegerValue`.
     ///
@@ -927,6 +839,17 @@ impl Value {
         self
     }
 
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `DoubleValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_value(&self) -> std::option::Option<&f64> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::DoubleValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value_type][crate::model::Value::value_type]
     /// to hold a `DoubleValue`.
     ///
@@ -936,6 +859,17 @@ impl Value {
         self.value_type =
             std::option::Option::Some(crate::model::value::ValueType::DoubleValue(v.into()));
         self
+    }
+
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `TimestampValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn timestamp_value(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::TimestampValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value_type][crate::model::Value::value_type]
@@ -952,6 +886,17 @@ impl Value {
         self
     }
 
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value_type][crate::model::Value::value_type]
     /// to hold a `StringValue`.
     ///
@@ -961,6 +906,17 @@ impl Value {
         self.value_type =
             std::option::Option::Some(crate::model::value::ValueType::StringValue(v.into()));
         self
+    }
+
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `BytesValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bytes_value(&self) -> std::option::Option<&::bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::BytesValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value_type][crate::model::Value::value_type]
@@ -974,6 +930,17 @@ impl Value {
         self
     }
 
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `ReferenceValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn reference_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::ReferenceValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value_type][crate::model::Value::value_type]
     /// to hold a `ReferenceValue`.
     ///
@@ -983,6 +950,17 @@ impl Value {
         self.value_type =
             std::option::Option::Some(crate::model::value::ValueType::ReferenceValue(v.into()));
         self
+    }
+
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `GeoPointValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn geo_point_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::LatLng>> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::GeoPointValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value_type][crate::model::Value::value_type]
@@ -999,6 +977,17 @@ impl Value {
         self
     }
 
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `ArrayValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn array_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::ArrayValue>> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::ArrayValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value_type][crate::model::Value::value_type]
     /// to hold a `ArrayValue`.
     ///
@@ -1011,6 +1000,17 @@ impl Value {
         self.value_type =
             std::option::Option::Some(crate::model::value::ValueType::ArrayValue(v.into()));
         self
+    }
+
+    /// The value of [value_type][crate::model::Value::value_type]
+    /// if it holds a `MapValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn map_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::MapValue>> {
+        #[allow(unreachable_patterns)]
+        self.value_type.as_ref().and_then(|v| match v {
+            crate::model::value::ValueType::MapValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value_type][crate::model::Value::value_type]
@@ -1298,6 +1298,18 @@ impl GetDocumentRequest {
         })
     }
 
+    /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
+    /// to hold a `Transaction`.
+    ///
+    /// Note that all the setters affecting `consistency_selector` are
+    /// mutually exclusive.
+    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.consistency_selector = std::option::Option::Some(
+            crate::model::get_document_request::ConsistencySelector::Transaction(v.into()),
+        );
+        self
+    }
+
     /// The value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -1309,18 +1321,6 @@ impl GetDocumentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::get_document_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
@@ -1545,6 +1545,18 @@ impl ListDocumentsRequest {
         })
     }
 
+    /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
+    /// to hold a `Transaction`.
+    ///
+    /// Note that all the setters affecting `consistency_selector` are
+    /// mutually exclusive.
+    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.consistency_selector = std::option::Option::Some(
+            crate::model::list_documents_request::ConsistencySelector::Transaction(v.into()),
+        );
+        self
+    }
+
     /// The value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -1556,18 +1568,6 @@ impl ListDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::list_documents_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
@@ -1655,12 +1655,6 @@ impl ListDocumentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDocumentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [documents][crate::model::ListDocumentsResponse::documents].
     pub fn set_documents<T, V>(mut self, v: T) -> Self
     where
@@ -1669,6 +1663,12 @@ impl ListDocumentsResponse {
     {
         use std::iter::Iterator;
         self.documents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDocumentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1973,15 +1973,6 @@ impl BatchGetDocumentsRequest {
         self
     }
 
-    /// Sets the value of [mask][crate::model::BatchGetDocumentsRequest::mask].
-    pub fn set_mask<T: std::convert::Into<std::option::Option<crate::model::DocumentMask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mask = v.into();
-        self
-    }
-
     /// Sets the value of [documents][crate::model::BatchGetDocumentsRequest::documents].
     pub fn set_documents<T, V>(mut self, v: T) -> Self
     where
@@ -1990,6 +1981,15 @@ impl BatchGetDocumentsRequest {
     {
         use std::iter::Iterator;
         self.documents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [mask][crate::model::BatchGetDocumentsRequest::mask].
+    pub fn set_mask<T: std::convert::Into<std::option::Option<crate::model::DocumentMask>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.mask = v.into();
         self
     }
 
@@ -2022,6 +2022,18 @@ impl BatchGetDocumentsRequest {
         })
     }
 
+    /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
+    /// to hold a `Transaction`.
+    ///
+    /// Note that all the setters affecting `consistency_selector` are
+    /// mutually exclusive.
+    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.consistency_selector = std::option::Option::Some(
+            crate::model::batch_get_documents_request::ConsistencySelector::Transaction(v.into()),
+        );
+        self
+    }
+
     /// The value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
     /// if it holds a `NewTransaction`, `None` if the field is not set or
     /// holds a different branch.
@@ -2035,31 +2047,6 @@ impl BatchGetDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
-    /// if it holds a `ReadTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.consistency_selector.as_ref().and_then(|v| match v {
-            crate::model::batch_get_documents_request::ConsistencySelector::ReadTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::batch_get_documents_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
@@ -2079,6 +2066,19 @@ impl BatchGetDocumentsRequest {
             ),
         );
         self
+    }
+
+    /// The value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
+    /// if it holds a `ReadTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.consistency_selector.as_ref().and_then(|v| match v {
+            crate::model::batch_get_documents_request::ConsistencySelector::ReadTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
@@ -2229,19 +2229,6 @@ impl BatchGetDocumentsResponse {
         })
     }
 
-    /// The value of [result][crate::model::BatchGetDocumentsResponse::result]
-    /// if it holds a `Missing`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn missing(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::batch_get_documents_response::Result::Missing(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::BatchGetDocumentsResponse::result]
     /// to hold a `Found`.
     ///
@@ -2255,6 +2242,19 @@ impl BatchGetDocumentsResponse {
             crate::model::batch_get_documents_response::Result::Found(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::BatchGetDocumentsResponse::result]
+    /// if it holds a `Missing`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn missing(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::batch_get_documents_response::Result::Missing(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::BatchGetDocumentsResponse::result]
@@ -2435,12 +2435,6 @@ impl CommitRequest {
         self
     }
 
-    /// Sets the value of [transaction][crate::model::CommitRequest::transaction].
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.transaction = v.into();
-        self
-    }
-
     /// Sets the value of [writes][crate::model::CommitRequest::writes].
     pub fn set_writes<T, V>(mut self, v: T) -> Self
     where
@@ -2449,6 +2443,12 @@ impl CommitRequest {
     {
         use std::iter::Iterator;
         self.writes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [transaction][crate::model::CommitRequest::transaction].
+    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.transaction = v.into();
         self
     }
 }
@@ -2488,15 +2488,6 @@ impl CommitResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [commit_time][crate::model::CommitResponse::commit_time].
-    pub fn set_commit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.commit_time = v.into();
-        self
-    }
-
     /// Sets the value of [write_results][crate::model::CommitResponse::write_results].
     pub fn set_write_results<T, V>(mut self, v: T) -> Self
     where
@@ -2505,6 +2496,15 @@ impl CommitResponse {
     {
         use std::iter::Iterator;
         self.write_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [commit_time][crate::model::CommitResponse::commit_time].
+    pub fn set_commit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.commit_time = v.into();
         self
     }
 }
@@ -2692,6 +2692,18 @@ impl RunQueryRequest {
         })
     }
 
+    /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
+    /// to hold a `Transaction`.
+    ///
+    /// Note that all the setters affecting `consistency_selector` are
+    /// mutually exclusive.
+    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.consistency_selector = std::option::Option::Some(
+            crate::model::run_query_request::ConsistencySelector::Transaction(v.into()),
+        );
+        self
+    }
+
     /// The value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
     /// if it holds a `NewTransaction`, `None` if the field is not set or
     /// holds a different branch.
@@ -2705,31 +2717,6 @@ impl RunQueryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
-    /// if it holds a `ReadTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.consistency_selector.as_ref().and_then(|v| match v {
-            crate::model::run_query_request::ConsistencySelector::ReadTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_query_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
@@ -2747,6 +2734,19 @@ impl RunQueryRequest {
             crate::model::run_query_request::ConsistencySelector::NewTransaction(v.into()),
         );
         self
+    }
+
+    /// The value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
+    /// if it holds a `ReadTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.consistency_selector.as_ref().and_then(|v| match v {
+            crate::model::run_query_request::ConsistencySelector::ReadTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
@@ -3149,6 +3149,18 @@ impl RunAggregationQueryRequest {
         })
     }
 
+    /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
+    /// to hold a `Transaction`.
+    ///
+    /// Note that all the setters affecting `consistency_selector` are
+    /// mutually exclusive.
+    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.consistency_selector = std::option::Option::Some(
+            crate::model::run_aggregation_query_request::ConsistencySelector::Transaction(v.into()),
+        );
+        self
+    }
+
     /// The value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
     /// if it holds a `NewTransaction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3162,31 +3174,6 @@ impl RunAggregationQueryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
-    /// if it holds a `ReadTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.consistency_selector.as_ref().and_then(|v| match v {
-            crate::model::run_aggregation_query_request::ConsistencySelector::ReadTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_aggregation_query_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
@@ -3206,6 +3193,19 @@ impl RunAggregationQueryRequest {
             ),
         );
         self
+    }
+
+    /// The value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
+    /// if it holds a `ReadTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.consistency_selector.as_ref().and_then(|v| match v {
+            crate::model::run_aggregation_query_request::ConsistencySelector::ReadTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
@@ -3676,12 +3676,6 @@ impl PartitionQueryResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::PartitionQueryResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [partitions][crate::model::PartitionQueryResponse::partitions].
     pub fn set_partitions<T, V>(mut self, v: T) -> Self
     where
@@ -3690,6 +3684,12 @@ impl PartitionQueryResponse {
     {
         use std::iter::Iterator;
         self.partitions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::PartitionQueryResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3795,12 +3795,6 @@ impl WriteRequest {
         self
     }
 
-    /// Sets the value of [stream_token][crate::model::WriteRequest::stream_token].
-    pub fn set_stream_token<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.stream_token = v.into();
-        self
-    }
-
     /// Sets the value of [writes][crate::model::WriteRequest::writes].
     pub fn set_writes<T, V>(mut self, v: T) -> Self
     where
@@ -3809,6 +3803,12 @@ impl WriteRequest {
     {
         use std::iter::Iterator;
         self.writes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [stream_token][crate::model::WriteRequest::stream_token].
+    pub fn set_stream_token<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.stream_token = v.into();
         self
     }
 
@@ -3883,15 +3883,6 @@ impl WriteResponse {
         self
     }
 
-    /// Sets the value of [commit_time][crate::model::WriteResponse::commit_time].
-    pub fn set_commit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.commit_time = v.into();
-        self
-    }
-
     /// Sets the value of [write_results][crate::model::WriteResponse::write_results].
     pub fn set_write_results<T, V>(mut self, v: T) -> Self
     where
@@ -3900,6 +3891,15 @@ impl WriteResponse {
     {
         use std::iter::Iterator;
         self.write_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [commit_time][crate::model::WriteResponse::commit_time].
+    pub fn set_commit_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.commit_time = v.into();
         self
     }
 }
@@ -3983,19 +3983,6 @@ impl ListenRequest {
         })
     }
 
-    /// The value of [target_change][crate::model::ListenRequest::target_change]
-    /// if it holds a `RemoveTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn remove_target(&self) -> std::option::Option<&i32> {
-        #[allow(unreachable_patterns)]
-        self.target_change.as_ref().and_then(|v| match v {
-            crate::model::listen_request::TargetChange::RemoveTarget(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target_change][crate::model::ListenRequest::target_change]
     /// to hold a `AddTarget`.
     ///
@@ -4009,6 +3996,19 @@ impl ListenRequest {
             crate::model::listen_request::TargetChange::AddTarget(v.into()),
         );
         self
+    }
+
+    /// The value of [target_change][crate::model::ListenRequest::target_change]
+    /// if it holds a `RemoveTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn remove_target(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.target_change.as_ref().and_then(|v| match v {
+            crate::model::listen_request::TargetChange::RemoveTarget(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target_change][crate::model::ListenRequest::target_change]
@@ -4108,62 +4108,6 @@ impl ListenResponse {
         })
     }
 
-    /// The value of [response_type][crate::model::ListenResponse::response_type]
-    /// if it holds a `DocumentChange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn document_change(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentChange>> {
-        #[allow(unreachable_patterns)]
-        self.response_type.as_ref().and_then(|v| match v {
-            crate::model::listen_response::ResponseType::DocumentChange(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [response_type][crate::model::ListenResponse::response_type]
-    /// if it holds a `DocumentDelete`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn document_delete(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentDelete>> {
-        #[allow(unreachable_patterns)]
-        self.response_type.as_ref().and_then(|v| match v {
-            crate::model::listen_response::ResponseType::DocumentDelete(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [response_type][crate::model::ListenResponse::response_type]
-    /// if it holds a `DocumentRemove`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn document_remove(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentRemove>> {
-        #[allow(unreachable_patterns)]
-        self.response_type.as_ref().and_then(|v| match v {
-            crate::model::listen_response::ResponseType::DocumentRemove(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [response_type][crate::model::ListenResponse::response_type]
-    /// if it holds a `Filter`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filter(&self) -> std::option::Option<&std::boxed::Box<crate::model::ExistenceFilter>> {
-        #[allow(unreachable_patterns)]
-        self.response_type.as_ref().and_then(|v| match v {
-            crate::model::listen_response::ResponseType::Filter(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
     /// to hold a `TargetChange`.
     ///
@@ -4177,6 +4121,21 @@ impl ListenResponse {
             crate::model::listen_response::ResponseType::TargetChange(v.into()),
         );
         self
+    }
+
+    /// The value of [response_type][crate::model::ListenResponse::response_type]
+    /// if it holds a `DocumentChange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn document_change(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentChange>> {
+        #[allow(unreachable_patterns)]
+        self.response_type.as_ref().and_then(|v| match v {
+            crate::model::listen_response::ResponseType::DocumentChange(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
@@ -4196,6 +4155,21 @@ impl ListenResponse {
         self
     }
 
+    /// The value of [response_type][crate::model::ListenResponse::response_type]
+    /// if it holds a `DocumentDelete`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn document_delete(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentDelete>> {
+        #[allow(unreachable_patterns)]
+        self.response_type.as_ref().and_then(|v| match v {
+            crate::model::listen_response::ResponseType::DocumentDelete(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
     /// to hold a `DocumentDelete`.
     ///
@@ -4213,6 +4187,21 @@ impl ListenResponse {
         self
     }
 
+    /// The value of [response_type][crate::model::ListenResponse::response_type]
+    /// if it holds a `DocumentRemove`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn document_remove(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentRemove>> {
+        #[allow(unreachable_patterns)]
+        self.response_type.as_ref().and_then(|v| match v {
+            crate::model::listen_response::ResponseType::DocumentRemove(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
     /// to hold a `DocumentRemove`.
     ///
@@ -4228,6 +4217,17 @@ impl ListenResponse {
             crate::model::listen_response::ResponseType::DocumentRemove(v.into()),
         );
         self
+    }
+
+    /// The value of [response_type][crate::model::ListenResponse::response_type]
+    /// if it holds a `Filter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filter(&self) -> std::option::Option<&std::boxed::Box<crate::model::ExistenceFilter>> {
+        #[allow(unreachable_patterns)]
+        self.response_type.as_ref().and_then(|v| match v {
+            crate::model::listen_response::ResponseType::Filter(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
@@ -4427,19 +4427,6 @@ impl Target {
         })
     }
 
-    /// The value of [target_type][crate::model::Target::target_type]
-    /// if it holds a `Documents`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn documents(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::target::DocumentsTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target_type.as_ref().and_then(|v| match v {
-            crate::model::target::TargetType::Documents(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target_type][crate::model::Target::target_type]
     /// to hold a `Query`.
     ///
@@ -4452,6 +4439,19 @@ impl Target {
         self.target_type =
             std::option::Option::Some(crate::model::target::TargetType::Query(v.into()));
         self
+    }
+
+    /// The value of [target_type][crate::model::Target::target_type]
+    /// if it holds a `Documents`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn documents(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::target::DocumentsTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target_type.as_ref().and_then(|v| match v {
+            crate::model::target::TargetType::Documents(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target_type][crate::model::Target::target_type]
@@ -4495,17 +4495,6 @@ impl Target {
         })
     }
 
-    /// The value of [resume_type][crate::model::Target::resume_type]
-    /// if it holds a `ReadTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.resume_type.as_ref().and_then(|v| match v {
-            crate::model::target::ResumeType::ReadTime(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [resume_type][crate::model::Target::resume_type]
     /// to hold a `ResumeToken`.
     ///
@@ -4515,6 +4504,17 @@ impl Target {
         self.resume_type =
             std::option::Option::Some(crate::model::target::ResumeType::ResumeToken(v.into()));
         self
+    }
+
+    /// The value of [resume_type][crate::model::Target::resume_type]
+    /// if it holds a `ReadTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.resume_type.as_ref().and_then(|v| match v {
+            crate::model::target::ResumeType::ReadTime(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resume_type][crate::model::Target::resume_type]
@@ -4818,6 +4818,17 @@ impl TargetChange {
         self
     }
 
+    /// Sets the value of [target_ids][crate::model::TargetChange::target_ids].
+    pub fn set_target_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.target_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cause][crate::model::TargetChange::cause].
     pub fn set_cause<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
@@ -4839,17 +4850,6 @@ impl TargetChange {
         v: T,
     ) -> Self {
         self.read_time = v.into();
-        self
-    }
-
-    /// Sets the value of [target_ids][crate::model::TargetChange::target_ids].
-    pub fn set_target_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.target_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5189,12 +5189,6 @@ impl ListCollectionIdsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCollectionIdsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [collection_ids][crate::model::ListCollectionIdsResponse::collection_ids].
     pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
     where
@@ -5203,6 +5197,12 @@ impl ListCollectionIdsResponse {
     {
         use std::iter::Iterator;
         self.collection_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCollectionIdsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5498,6 +5498,17 @@ impl StructuredQuery {
         self
     }
 
+    /// Sets the value of [from][crate::model::StructuredQuery::from].
+    pub fn set_from<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::structured_query::CollectionSelector>,
+    {
+        use std::iter::Iterator;
+        self.from = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [r#where][crate::model::StructuredQuery::where].
     pub fn set_where<
         T: std::convert::Into<std::option::Option<crate::model::structured_query::Filter>>,
@@ -5506,6 +5517,17 @@ impl StructuredQuery {
         v: T,
     ) -> Self {
         self.r#where = v.into();
+        self
+    }
+
+    /// Sets the value of [order_by][crate::model::StructuredQuery::order_by].
+    pub fn set_order_by<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::structured_query::Order>,
+    {
+        use std::iter::Iterator;
+        self.order_by = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5550,28 +5572,6 @@ impl StructuredQuery {
         v: T,
     ) -> Self {
         self.find_nearest = v.into();
-        self
-    }
-
-    /// Sets the value of [from][crate::model::StructuredQuery::from].
-    pub fn set_from<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::structured_query::CollectionSelector>,
-    {
-        use std::iter::Iterator;
-        self.from = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [order_by][crate::model::StructuredQuery::order_by].
-    pub fn set_order_by<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::structured_query::Order>,
-    {
-        use std::iter::Iterator;
-        self.order_by = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5686,38 +5686,6 @@ pub mod structured_query {
             })
         }
 
-        /// The value of [filter_type][crate::model::structured_query::Filter::filter_type]
-        /// if it holds a `FieldFilter`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn field_filter(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::structured_query::FieldFilter>>
-        {
-            #[allow(unreachable_patterns)]
-            self.filter_type.as_ref().and_then(|v| match v {
-                crate::model::structured_query::filter::FilterType::FieldFilter(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [filter_type][crate::model::structured_query::Filter::filter_type]
-        /// if it holds a `UnaryFilter`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn unary_filter(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::structured_query::UnaryFilter>>
-        {
-            #[allow(unreachable_patterns)]
-            self.filter_type.as_ref().and_then(|v| match v {
-                crate::model::structured_query::filter::FilterType::UnaryFilter(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [filter_type][crate::model::structured_query::Filter::filter_type]
         /// to hold a `CompositeFilter`.
         ///
@@ -5735,6 +5703,22 @@ pub mod structured_query {
             self
         }
 
+        /// The value of [filter_type][crate::model::structured_query::Filter::filter_type]
+        /// if it holds a `FieldFilter`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn field_filter(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::structured_query::FieldFilter>>
+        {
+            #[allow(unreachable_patterns)]
+            self.filter_type.as_ref().and_then(|v| match v {
+                crate::model::structured_query::filter::FilterType::FieldFilter(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [filter_type][crate::model::structured_query::Filter::filter_type]
         /// to hold a `FieldFilter`.
         ///
@@ -5750,6 +5734,22 @@ pub mod structured_query {
                 crate::model::structured_query::filter::FilterType::FieldFilter(v.into()),
             );
             self
+        }
+
+        /// The value of [filter_type][crate::model::structured_query::Filter::filter_type]
+        /// if it holds a `UnaryFilter`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn unary_filter(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::structured_query::UnaryFilter>>
+        {
+            #[allow(unreachable_patterns)]
+            self.filter_type.as_ref().and_then(|v| match v {
+                crate::model::structured_query::filter::FilterType::UnaryFilter(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [filter_type][crate::model::structured_query::Filter::filter_type]
@@ -7344,40 +7344,6 @@ pub mod structured_aggregation_query {
             })
         }
 
-        /// The value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
-        /// if it holds a `Sum`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sum(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Sum>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.operator.as_ref().and_then(|v| match v {
-                crate::model::structured_aggregation_query::aggregation::Operator::Sum(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
-        /// if it holds a `Avg`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn avg(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Avg>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.operator.as_ref().and_then(|v| match v {
-                crate::model::structured_aggregation_query::aggregation::Operator::Avg(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
         /// to hold a `Count`.
         ///
@@ -7397,6 +7363,23 @@ pub mod structured_aggregation_query {
             self
         }
 
+        /// The value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
+        /// if it holds a `Sum`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sum(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Sum>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.operator.as_ref().and_then(|v| match v {
+                crate::model::structured_aggregation_query::aggregation::Operator::Sum(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
         /// to hold a `Sum`.
         ///
@@ -7414,6 +7397,23 @@ pub mod structured_aggregation_query {
                 crate::model::structured_aggregation_query::aggregation::Operator::Sum(v.into()),
             );
             self
+        }
+
+        /// The value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
+        /// if it holds a `Avg`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn avg(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Avg>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.operator.as_ref().and_then(|v| match v {
+                crate::model::structured_aggregation_query::aggregation::Operator::Avg(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
@@ -7699,12 +7699,6 @@ impl Cursor {
         std::default::Default::default()
     }
 
-    /// Sets the value of [before][crate::model::Cursor::before].
-    pub fn set_before<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.before = v.into();
-        self
-    }
-
     /// Sets the value of [values][crate::model::Cursor::values].
     pub fn set_values<T, V>(mut self, v: T) -> Self
     where
@@ -7713,6 +7707,12 @@ impl Cursor {
     {
         use std::iter::Iterator;
         self.values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [before][crate::model::Cursor::before].
+    pub fn set_before<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.before = v.into();
         self
     }
 }
@@ -7997,17 +7997,6 @@ impl Write {
         self
     }
 
-    /// Sets the value of [current_document][crate::model::Write::current_document].
-    pub fn set_current_document<
-        T: std::convert::Into<std::option::Option<crate::model::Precondition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.current_document = v.into();
-        self
-    }
-
     /// Sets the value of [update_transforms][crate::model::Write::update_transforms].
     pub fn set_update_transforms<T, V>(mut self, v: T) -> Self
     where
@@ -8016,6 +8005,17 @@ impl Write {
     {
         use std::iter::Iterator;
         self.update_transforms = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [current_document][crate::model::Write::current_document].
+    pub fn set_current_document<
+        T: std::convert::Into<std::option::Option<crate::model::Precondition>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.current_document = v.into();
         self
     }
 
@@ -8044,30 +8044,6 @@ impl Write {
         })
     }
 
-    /// The value of [operation][crate::model::Write::operation]
-    /// if it holds a `Delete`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.operation.as_ref().and_then(|v| match v {
-            crate::model::write::Operation::Delete(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [operation][crate::model::Write::operation]
-    /// if it holds a `Transform`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn transform(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentTransform>> {
-        #[allow(unreachable_patterns)]
-        self.operation.as_ref().and_then(|v| match v {
-            crate::model::write::Operation::Transform(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [operation][crate::model::Write::operation]
     /// to hold a `Update`.
     ///
@@ -8082,6 +8058,17 @@ impl Write {
         self
     }
 
+    /// The value of [operation][crate::model::Write::operation]
+    /// if it holds a `Delete`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.operation.as_ref().and_then(|v| match v {
+            crate::model::write::Operation::Delete(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [operation][crate::model::Write::operation]
     /// to hold a `Delete`.
     ///
@@ -8091,6 +8078,19 @@ impl Write {
         self.operation =
             std::option::Option::Some(crate::model::write::Operation::Delete(v.into()));
         self
+    }
+
+    /// The value of [operation][crate::model::Write::operation]
+    /// if it holds a `Transform`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn transform(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentTransform>> {
+        #[allow(unreachable_patterns)]
+        self.operation.as_ref().and_then(|v| match v {
+            crate::model::write::Operation::Transform(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [operation][crate::model::Write::operation]
@@ -8275,71 +8275,6 @@ pub mod document_transform {
             })
         }
 
-        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// if it holds a `Increment`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn increment(&self) -> std::option::Option<&std::boxed::Box<crate::model::Value>> {
-            #[allow(unreachable_patterns)]
-            self.transform_type.as_ref().and_then(|v| match v {
-                crate::model::document_transform::field_transform::TransformType::Increment(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// if it holds a `Maximum`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn maximum(&self) -> std::option::Option<&std::boxed::Box<crate::model::Value>> {
-            #[allow(unreachable_patterns)]
-            self.transform_type.as_ref().and_then(|v| match v {
-                crate::model::document_transform::field_transform::TransformType::Maximum(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// if it holds a `Minimum`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn minimum(&self) -> std::option::Option<&std::boxed::Box<crate::model::Value>> {
-            #[allow(unreachable_patterns)]
-            self.transform_type.as_ref().and_then(|v| match v {
-                crate::model::document_transform::field_transform::TransformType::Minimum(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// if it holds a `AppendMissingElements`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn append_missing_elements(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::ArrayValue>> {
-            #[allow(unreachable_patterns)]
-            self.transform_type.as_ref().and_then(|v| match v {
-                crate::model::document_transform::field_transform::TransformType::AppendMissingElements(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// if it holds a `RemoveAllFromArray`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn remove_all_from_array(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::ArrayValue>> {
-            #[allow(unreachable_patterns)]
-            self.transform_type.as_ref().and_then(|v| match v {
-                crate::model::document_transform::field_transform::TransformType::RemoveAllFromArray(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// to hold a `SetToServerValue`.
         ///
@@ -8359,6 +8294,19 @@ pub mod document_transform {
             self
         }
 
+        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
+        /// if it holds a `Increment`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn increment(&self) -> std::option::Option<&std::boxed::Box<crate::model::Value>> {
+            #[allow(unreachable_patterns)]
+            self.transform_type.as_ref().and_then(|v| match v {
+                crate::model::document_transform::field_transform::TransformType::Increment(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// to hold a `Increment`.
         ///
@@ -8376,6 +8324,19 @@ pub mod document_transform {
             self
         }
 
+        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
+        /// if it holds a `Maximum`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn maximum(&self) -> std::option::Option<&std::boxed::Box<crate::model::Value>> {
+            #[allow(unreachable_patterns)]
+            self.transform_type.as_ref().and_then(|v| match v {
+                crate::model::document_transform::field_transform::TransformType::Maximum(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// to hold a `Maximum`.
         ///
@@ -8391,6 +8352,19 @@ pub mod document_transform {
             self
         }
 
+        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
+        /// if it holds a `Minimum`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn minimum(&self) -> std::option::Option<&std::boxed::Box<crate::model::Value>> {
+            #[allow(unreachable_patterns)]
+            self.transform_type.as_ref().and_then(|v| match v {
+                crate::model::document_transform::field_transform::TransformType::Minimum(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// to hold a `Minimum`.
         ///
@@ -8404,6 +8378,19 @@ pub mod document_transform {
                 crate::model::document_transform::field_transform::TransformType::Minimum(v.into()),
             );
             self
+        }
+
+        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
+        /// if it holds a `AppendMissingElements`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn append_missing_elements(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::ArrayValue>> {
+            #[allow(unreachable_patterns)]
+            self.transform_type.as_ref().and_then(|v| match v {
+                crate::model::document_transform::field_transform::TransformType::AppendMissingElements(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
@@ -8423,6 +8410,19 @@ pub mod document_transform {
                 )
             );
             self
+        }
+
+        /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
+        /// if it holds a `RemoveAllFromArray`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn remove_all_from_array(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::ArrayValue>> {
+            #[allow(unreachable_patterns)]
+            self.transform_type.as_ref().and_then(|v| match v {
+                crate::model::document_transform::field_transform::TransformType::RemoveAllFromArray(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
@@ -8886,15 +8886,6 @@ impl DocumentDelete {
         self
     }
 
-    /// Sets the value of [read_time][crate::model::DocumentDelete::read_time].
-    pub fn set_read_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.read_time = v.into();
-        self
-    }
-
     /// Sets the value of [removed_target_ids][crate::model::DocumentDelete::removed_target_ids].
     pub fn set_removed_target_ids<T, V>(mut self, v: T) -> Self
     where
@@ -8903,6 +8894,15 @@ impl DocumentDelete {
     {
         use std::iter::Iterator;
         self.removed_target_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [read_time][crate::model::DocumentDelete::read_time].
+    pub fn set_read_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.read_time = v.into();
         self
     }
 }
@@ -8963,15 +8963,6 @@ impl DocumentRemove {
         self
     }
 
-    /// Sets the value of [read_time][crate::model::DocumentRemove::read_time].
-    pub fn set_read_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.read_time = v.into();
-        self
-    }
-
     /// Sets the value of [removed_target_ids][crate::model::DocumentRemove::removed_target_ids].
     pub fn set_removed_target_ids<T, V>(mut self, v: T) -> Self
     where
@@ -8980,6 +8971,15 @@ impl DocumentRemove {
     {
         use std::iter::Iterator;
         self.removed_target_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [read_time][crate::model::DocumentRemove::read_time].
+    pub fn set_read_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.read_time = v.into();
         self
     }
 }

--- a/src/generated/api/apikeys/v2/src/model.rs
+++ b/src/generated/api/apikeys/v2/src/model.rs
@@ -183,12 +183,6 @@ impl ListKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [keys][crate::model::ListKeysResponse::keys].
     pub fn set_keys<T, V>(mut self, v: T) -> Self
     where
@@ -197,6 +191,12 @@ impl ListKeysResponse {
     {
         use std::iter::Iterator;
         self.keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -646,6 +646,18 @@ impl Key {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Key::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [restrictions][crate::model::Key::restrictions].
     pub fn set_restrictions<
         T: std::convert::Into<std::option::Option<crate::model::Restrictions>>,
@@ -660,18 +672,6 @@ impl Key {
     /// Sets the value of [etag][crate::model::Key::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Key::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -750,51 +750,6 @@ impl Restrictions {
         })
     }
 
-    /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// if it holds a `ServerKeyRestrictions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn server_key_restrictions(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ServerKeyRestrictions>> {
-        #[allow(unreachable_patterns)]
-        self.client_restrictions.as_ref().and_then(|v| match v {
-            crate::model::restrictions::ClientRestrictions::ServerKeyRestrictions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// if it holds a `AndroidKeyRestrictions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn android_key_restrictions(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AndroidKeyRestrictions>> {
-        #[allow(unreachable_patterns)]
-        self.client_restrictions.as_ref().and_then(|v| match v {
-            crate::model::restrictions::ClientRestrictions::AndroidKeyRestrictions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// if it holds a `IosKeyRestrictions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ios_key_restrictions(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IosKeyRestrictions>> {
-        #[allow(unreachable_patterns)]
-        self.client_restrictions.as_ref().and_then(|v| match v {
-            crate::model::restrictions::ClientRestrictions::IosKeyRestrictions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
     /// to hold a `BrowserKeyRestrictions`.
     ///
@@ -810,6 +765,21 @@ impl Restrictions {
             crate::model::restrictions::ClientRestrictions::BrowserKeyRestrictions(v.into()),
         );
         self
+    }
+
+    /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
+    /// if it holds a `ServerKeyRestrictions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn server_key_restrictions(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ServerKeyRestrictions>> {
+        #[allow(unreachable_patterns)]
+        self.client_restrictions.as_ref().and_then(|v| match v {
+            crate::model::restrictions::ClientRestrictions::ServerKeyRestrictions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
@@ -829,6 +799,21 @@ impl Restrictions {
         self
     }
 
+    /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
+    /// if it holds a `AndroidKeyRestrictions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn android_key_restrictions(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AndroidKeyRestrictions>> {
+        #[allow(unreachable_patterns)]
+        self.client_restrictions.as_ref().and_then(|v| match v {
+            crate::model::restrictions::ClientRestrictions::AndroidKeyRestrictions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
     /// to hold a `AndroidKeyRestrictions`.
     ///
@@ -844,6 +829,21 @@ impl Restrictions {
             crate::model::restrictions::ClientRestrictions::AndroidKeyRestrictions(v.into()),
         );
         self
+    }
+
+    /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
+    /// if it holds a `IosKeyRestrictions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ios_key_restrictions(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IosKeyRestrictions>> {
+        #[allow(unreachable_patterns)]
+        self.client_restrictions.as_ref().and_then(|v| match v {
+            crate::model::restrictions::ClientRestrictions::IosKeyRestrictions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]

--- a/src/generated/api/servicecontrol/v1/src/builder.rs
+++ b/src/generated/api/servicecontrol/v1/src/builder.rs
@@ -282,12 +282,6 @@ pub mod service_controller {
             self
         }
 
-        /// Sets the value of [service_config_id][crate::model::ReportRequest::service_config_id].
-        pub fn set_service_config_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.service_config_id = v.into();
-            self
-        }
-
         /// Sets the value of [operations][crate::model::ReportRequest::operations].
         pub fn set_operations<T, V>(mut self, v: T) -> Self
         where
@@ -296,6 +290,12 @@ pub mod service_controller {
         {
             use std::iter::Iterator;
             self.0.request.operations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [service_config_id][crate::model::ReportRequest::service_config_id].
+        pub fn set_service_config_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.service_config_id = v.into();
             self
         }
     }

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -564,36 +564,6 @@ impl Distribution {
         })
     }
 
-    /// The value of [bucket_option][crate::model::Distribution::bucket_option]
-    /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn exponential_buckets(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::distribution::ExponentialBuckets>> {
-        #[allow(unreachable_patterns)]
-        self.bucket_option.as_ref().and_then(|v| match v {
-            crate::model::distribution::BucketOption::ExponentialBuckets(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [bucket_option][crate::model::Distribution::bucket_option]
-    /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn explicit_buckets(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::distribution::ExplicitBuckets>> {
-        #[allow(unreachable_patterns)]
-        self.bucket_option.as_ref().and_then(|v| match v {
-            crate::model::distribution::BucketOption::ExplicitBuckets(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [bucket_option][crate::model::Distribution::bucket_option]
     /// to hold a `LinearBuckets`.
     ///
@@ -611,6 +581,21 @@ impl Distribution {
         self
     }
 
+    /// The value of [bucket_option][crate::model::Distribution::bucket_option]
+    /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn exponential_buckets(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::distribution::ExponentialBuckets>> {
+        #[allow(unreachable_patterns)]
+        self.bucket_option.as_ref().and_then(|v| match v {
+            crate::model::distribution::BucketOption::ExponentialBuckets(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [bucket_option][crate::model::Distribution::bucket_option]
     /// to hold a `ExponentialBuckets`.
     ///
@@ -626,6 +611,21 @@ impl Distribution {
             crate::model::distribution::BucketOption::ExponentialBuckets(v.into()),
         );
         self
+    }
+
+    /// The value of [bucket_option][crate::model::Distribution::bucket_option]
+    /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn explicit_buckets(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::distribution::ExplicitBuckets>> {
+        #[allow(unreachable_patterns)]
+        self.bucket_option.as_ref().and_then(|v| match v {
+            crate::model::distribution::BucketOption::ExplicitBuckets(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [bucket_option][crate::model::Distribution::bucket_option]
@@ -1174,6 +1174,18 @@ impl LogEntry {
         self
     }
 
+    /// Sets the value of [labels][crate::model::LogEntry::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [operation][crate::model::LogEntry::operation].
     pub fn set_operation<
         T: std::convert::Into<std::option::Option<crate::model::LogEntryOperation>>,
@@ -1193,18 +1205,6 @@ impl LogEntry {
         v: T,
     ) -> Self {
         self.source_location = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::LogEntry::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1233,28 +1233,6 @@ impl LogEntry {
         })
     }
 
-    /// The value of [payload][crate::model::LogEntry::payload]
-    /// if it holds a `TextPayload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text_payload(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.payload.as_ref().and_then(|v| match v {
-            crate::model::log_entry::Payload::TextPayload(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [payload][crate::model::LogEntry::payload]
-    /// if it holds a `StructPayload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn struct_payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
-        #[allow(unreachable_patterns)]
-        self.payload.as_ref().and_then(|v| match v {
-            crate::model::log_entry::Payload::StructPayload(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [payload][crate::model::LogEntry::payload]
     /// to hold a `ProtoPayload`.
     ///
@@ -1269,6 +1247,17 @@ impl LogEntry {
         self
     }
 
+    /// The value of [payload][crate::model::LogEntry::payload]
+    /// if it holds a `TextPayload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text_payload(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.payload.as_ref().and_then(|v| match v {
+            crate::model::log_entry::Payload::TextPayload(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [payload][crate::model::LogEntry::payload]
     /// to hold a `TextPayload`.
     ///
@@ -1278,6 +1267,17 @@ impl LogEntry {
         self.payload =
             std::option::Option::Some(crate::model::log_entry::Payload::TextPayload(v.into()));
         self
+    }
+
+    /// The value of [payload][crate::model::LogEntry::payload]
+    /// if it holds a `StructPayload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn struct_payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
+        #[allow(unreachable_patterns)]
+        self.payload.as_ref().and_then(|v| match v {
+            crate::model::log_entry::Payload::StructPayload(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [payload][crate::model::LogEntry::payload]
@@ -1498,6 +1498,18 @@ impl MetricValue {
         std::default::Default::default()
     }
 
+    /// Sets the value of [labels][crate::model::MetricValue::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::MetricValue::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1513,18 +1525,6 @@ impl MetricValue {
         v: T,
     ) -> Self {
         self.end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::MetricValue::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1553,52 +1553,6 @@ impl MetricValue {
         })
     }
 
-    /// The value of [value][crate::model::MetricValue::value]
-    /// if it holds a `Int64Value`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int64_value(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::metric_value::Value::Int64Value(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::MetricValue::value]
-    /// if it holds a `DoubleValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_value(&self) -> std::option::Option<&f64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::metric_value::Value::DoubleValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::MetricValue::value]
-    /// if it holds a `StringValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::metric_value::Value::StringValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::MetricValue::value]
-    /// if it holds a `DistributionValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn distribution_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::Distribution>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::metric_value::Value::DistributionValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::MetricValue::value]
     /// to hold a `BoolValue`.
     ///
@@ -1608,6 +1562,17 @@ impl MetricValue {
         self.value =
             std::option::Option::Some(crate::model::metric_value::Value::BoolValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::MetricValue::value]
+    /// if it holds a `Int64Value`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int64_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::metric_value::Value::Int64Value(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::MetricValue::value]
@@ -1621,6 +1586,17 @@ impl MetricValue {
         self
     }
 
+    /// The value of [value][crate::model::MetricValue::value]
+    /// if it holds a `DoubleValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_value(&self) -> std::option::Option<&f64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::metric_value::Value::DoubleValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::MetricValue::value]
     /// to hold a `DoubleValue`.
     ///
@@ -1632,6 +1608,17 @@ impl MetricValue {
         self
     }
 
+    /// The value of [value][crate::model::MetricValue::value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::metric_value::Value::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::MetricValue::value]
     /// to hold a `StringValue`.
     ///
@@ -1641,6 +1628,19 @@ impl MetricValue {
         self.value =
             std::option::Option::Some(crate::model::metric_value::Value::StringValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::MetricValue::value]
+    /// if it holds a `DistributionValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn distribution_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::Distribution>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::metric_value::Value::DistributionValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::MetricValue::value]
@@ -1881,12 +1881,15 @@ impl Operation {
         self
     }
 
-    /// Sets the value of [importance][crate::model::Operation::importance].
-    pub fn set_importance<T: std::convert::Into<crate::model::operation::Importance>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.importance = v.into();
+    /// Sets the value of [labels][crate::model::Operation::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1912,6 +1915,15 @@ impl Operation {
         self
     }
 
+    /// Sets the value of [importance][crate::model::Operation::importance].
+    pub fn set_importance<T: std::convert::Into<crate::model::operation::Importance>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.importance = v.into();
+        self
+    }
+
     /// Sets the value of [extensions][crate::model::Operation::extensions].
     pub fn set_extensions<T, V>(mut self, v: T) -> Self
     where
@@ -1920,18 +1932,6 @@ impl Operation {
     {
         use std::iter::Iterator;
         self.extensions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Operation::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2230,12 +2230,15 @@ impl QuotaOperation {
         self
     }
 
-    /// Sets the value of [quota_mode][crate::model::QuotaOperation::quota_mode].
-    pub fn set_quota_mode<T: std::convert::Into<crate::model::quota_operation::QuotaMode>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.quota_mode = v.into();
+    /// Sets the value of [labels][crate::model::QuotaOperation::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2250,15 +2253,12 @@ impl QuotaOperation {
         self
     }
 
-    /// Sets the value of [labels][crate::model::QuotaOperation::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [quota_mode][crate::model::QuotaOperation::quota_mode].
+    pub fn set_quota_mode<T: std::convert::Into<crate::model::quota_operation::QuotaMode>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.quota_mode = v.into();
         self
     }
 }
@@ -2498,15 +2498,6 @@ impl AllocateQuotaResponse {
         self
     }
 
-    /// Sets the value of [service_config_id][crate::model::AllocateQuotaResponse::service_config_id].
-    pub fn set_service_config_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_config_id = v.into();
-        self
-    }
-
     /// Sets the value of [allocate_errors][crate::model::AllocateQuotaResponse::allocate_errors].
     pub fn set_allocate_errors<T, V>(mut self, v: T) -> Self
     where
@@ -2526,6 +2517,15 @@ impl AllocateQuotaResponse {
     {
         use std::iter::Iterator;
         self.quota_metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service_config_id][crate::model::AllocateQuotaResponse::service_config_id].
+    pub fn set_service_config_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.service_config_id = v.into();
         self
     }
 }
@@ -2889,6 +2889,17 @@ impl CheckResponse {
         self
     }
 
+    /// Sets the value of [check_errors][crate::model::CheckResponse::check_errors].
+    pub fn set_check_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CheckError>,
+    {
+        use std::iter::Iterator;
+        self.check_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_config_id][crate::model::CheckResponse::service_config_id].
     pub fn set_service_config_id<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -2915,17 +2926,6 @@ impl CheckResponse {
         v: T,
     ) -> Self {
         self.check_info = v.into();
-        self
-    }
-
-    /// Sets the value of [check_errors][crate::model::CheckResponse::check_errors].
-    pub fn set_check_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CheckError>,
-    {
-        use std::iter::Iterator;
-        self.check_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2972,6 +2972,17 @@ pub mod check_response {
             std::default::Default::default()
         }
 
+        /// Sets the value of [unused_arguments][crate::model::check_response::CheckInfo::unused_arguments].
+        pub fn set_unused_arguments<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.unused_arguments = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [consumer_info][crate::model::check_response::CheckInfo::consumer_info].
         pub fn set_consumer_info<
             T: std::convert::Into<std::option::Option<crate::model::check_response::ConsumerInfo>>,
@@ -2986,17 +2997,6 @@ pub mod check_response {
         /// Sets the value of [api_key_uid][crate::model::check_response::CheckInfo::api_key_uid].
         pub fn set_api_key_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.api_key_uid = v.into();
-            self
-        }
-
-        /// Sets the value of [unused_arguments][crate::model::check_response::CheckInfo::unused_arguments].
-        pub fn set_unused_arguments<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.unused_arguments = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3286,15 +3286,6 @@ impl ReportRequest {
         self
     }
 
-    /// Sets the value of [service_config_id][crate::model::ReportRequest::service_config_id].
-    pub fn set_service_config_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_config_id = v.into();
-        self
-    }
-
     /// Sets the value of [operations][crate::model::ReportRequest::operations].
     pub fn set_operations<T, V>(mut self, v: T) -> Self
     where
@@ -3303,6 +3294,15 @@ impl ReportRequest {
     {
         use std::iter::Iterator;
         self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service_config_id][crate::model::ReportRequest::service_config_id].
+    pub fn set_service_config_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.service_config_id = v.into();
         self
     }
 }
@@ -3353,6 +3353,17 @@ impl ReportResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [report_errors][crate::model::ReportResponse::report_errors].
+    pub fn set_report_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::report_response::ReportError>,
+    {
+        use std::iter::Iterator;
+        self.report_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_config_id][crate::model::ReportResponse::service_config_id].
     pub fn set_service_config_id<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -3368,17 +3379,6 @@ impl ReportResponse {
         v: T,
     ) -> Self {
         self.service_rollout_id = v.into();
-        self
-    }
-
-    /// Sets the value of [report_errors][crate::model::ReportResponse::report_errors].
-    pub fn set_report_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::report_response::ReportError>,
-    {
-        use std::iter::Iterator;
-        self.report_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/api/servicecontrol/v2/src/builder.rs
+++ b/src/generated/api/servicecontrol/v2/src/builder.rs
@@ -122,12 +122,6 @@ pub mod service_controller {
             self
         }
 
-        /// Sets the value of [flags][crate::model::CheckRequest::flags].
-        pub fn set_flags<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.flags = v.into();
-            self
-        }
-
         /// Sets the value of [resources][crate::model::CheckRequest::resources].
         pub fn set_resources<T, V>(mut self, v: T) -> Self
         where
@@ -136,6 +130,12 @@ pub mod service_controller {
         {
             use std::iter::Iterator;
             self.0.request.resources = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [flags][crate::model::CheckRequest::flags].
+        pub fn set_flags<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.flags = v.into();
             self
         }
     }

--- a/src/generated/api/servicecontrol/v2/src/model.rs
+++ b/src/generated/api/servicecontrol/v2/src/model.rs
@@ -100,12 +100,6 @@ impl CheckRequest {
         self
     }
 
-    /// Sets the value of [flags][crate::model::CheckRequest::flags].
-    pub fn set_flags<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.flags = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::CheckRequest::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -114,6 +108,12 @@ impl CheckRequest {
     {
         use std::iter::Iterator;
         self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [flags][crate::model::CheckRequest::flags].
+    pub fn set_flags<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.flags = v.into();
         self
     }
 }

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -114,21 +114,6 @@ impl OperationMetadata {
         std::default::Default::default()
     }
 
-    /// Sets the value of [progress_percentage][crate::model::OperationMetadata::progress_percentage].
-    pub fn set_progress_percentage<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.progress_percentage = v.into();
-        self
-    }
-
-    /// Sets the value of [start_time][crate::model::OperationMetadata::start_time].
-    pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_time = v.into();
-        self
-    }
-
     /// Sets the value of [resource_names][crate::model::OperationMetadata::resource_names].
     pub fn set_resource_names<T, V>(mut self, v: T) -> Self
     where
@@ -148,6 +133,21 @@ impl OperationMetadata {
     {
         use std::iter::Iterator;
         self.steps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [progress_percentage][crate::model::OperationMetadata::progress_percentage].
+    pub fn set_progress_percentage<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.progress_percentage = v.into();
+        self
+    }
+
+    /// Sets the value of [start_time][crate::model::OperationMetadata::start_time].
+    pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.start_time = v.into();
         self
     }
 }
@@ -1014,21 +1014,6 @@ impl Rollout {
         })
     }
 
-    /// The value of [strategy][crate::model::Rollout::strategy]
-    /// if it holds a `DeleteServiceStrategy`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_service_strategy(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rollout::DeleteServiceStrategy>> {
-        #[allow(unreachable_patterns)]
-        self.strategy.as_ref().and_then(|v| match v {
-            crate::model::rollout::Strategy::DeleteServiceStrategy(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [strategy][crate::model::Rollout::strategy]
     /// to hold a `TrafficPercentStrategy`.
     ///
@@ -1044,6 +1029,21 @@ impl Rollout {
             crate::model::rollout::Strategy::TrafficPercentStrategy(v.into()),
         );
         self
+    }
+
+    /// The value of [strategy][crate::model::Rollout::strategy]
+    /// if it holds a `DeleteServiceStrategy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_service_strategy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rollout::DeleteServiceStrategy>> {
+        #[allow(unreachable_patterns)]
+        self.strategy.as_ref().and_then(|v| match v {
+            crate::model::rollout::Strategy::DeleteServiceStrategy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [strategy][crate::model::Rollout::strategy]
@@ -1446,12 +1446,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -1460,6 +1454,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1926,12 +1926,6 @@ impl ListServiceConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_configs][crate::model::ListServiceConfigsResponse::service_configs].
     pub fn set_service_configs<T, V>(mut self, v: T) -> Self
     where
@@ -1940,6 +1934,12 @@ impl ListServiceConfigsResponse {
     {
         use std::iter::Iterator;
         self.service_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2251,12 +2251,6 @@ impl ListServiceRolloutsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceRolloutsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rollouts][crate::model::ListServiceRolloutsResponse::rollouts].
     pub fn set_rollouts<T, V>(mut self, v: T) -> Self
     where
@@ -2265,6 +2259,12 @@ impl ListServiceRolloutsResponse {
     {
         use std::iter::Iterator;
         self.rollouts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceRolloutsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/api/serviceusage/v1/src/model.rs
+++ b/src/generated/api/serviceusage/v1/src/model.rs
@@ -184,6 +184,17 @@ impl ServiceConfig {
         self
     }
 
+    /// Sets the value of [apis][crate::model::ServiceConfig::apis].
+    pub fn set_apis<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Api>,
+    {
+        use std::iter::Iterator;
+        self.apis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [documentation][crate::model::ServiceConfig::documentation].
     pub fn set_documentation<
         T: std::convert::Into<std::option::Option<api::model::Documentation>>,
@@ -224,26 +235,6 @@ impl ServiceConfig {
         self
     }
 
-    /// Sets the value of [monitoring][crate::model::ServiceConfig::monitoring].
-    pub fn set_monitoring<T: std::convert::Into<std::option::Option<api::model::Monitoring>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.monitoring = v.into();
-        self
-    }
-
-    /// Sets the value of [apis][crate::model::ServiceConfig::apis].
-    pub fn set_apis<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Api>,
-    {
-        use std::iter::Iterator;
-        self.apis = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [endpoints][crate::model::ServiceConfig::endpoints].
     pub fn set_endpoints<T, V>(mut self, v: T) -> Self
     where
@@ -263,6 +254,15 @@ impl ServiceConfig {
     {
         use std::iter::Iterator;
         self.monitored_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [monitoring][crate::model::ServiceConfig::monitoring].
+    pub fn set_monitoring<T: std::convert::Into<std::option::Option<api::model::Monitoring>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.monitoring = v.into();
         self
     }
 }
@@ -765,12 +765,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -779,6 +773,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -241,6 +241,16 @@ impl JwtLocation {
         })
     }
 
+    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
+    /// to hold a `Header`.
+    ///
+    /// Note that all the setters affecting `r#in` are
+    /// mutually exclusive.
+    pub fn set_header<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Header(v.into()));
+        self
+    }
+
     /// The value of [r#in][crate::model::JwtLocation::r#in]
     /// if it holds a `Query`, `None` if the field is not set or
     /// holds a different branch.
@@ -252,6 +262,16 @@ impl JwtLocation {
         })
     }
 
+    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
+    /// to hold a `Query`.
+    ///
+    /// Note that all the setters affecting `r#in` are
+    /// mutually exclusive.
+    pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Query(v.into()));
+        self
+    }
+
     /// The value of [r#in][crate::model::JwtLocation::r#in]
     /// if it holds a `Cookie`, `None` if the field is not set or
     /// holds a different branch.
@@ -261,26 +281,6 @@ impl JwtLocation {
             crate::model::jwt_location::In::Cookie(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
-    /// to hold a `Header`.
-    ///
-    /// Note that all the setters affecting `r#in` are
-    /// mutually exclusive.
-    pub fn set_header<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Header(v.into()));
-        self
-    }
-
-    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
-    /// to hold a `Query`.
-    ///
-    /// Note that all the setters affecting `r#in` are
-    /// mutually exclusive.
-    pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Query(v.into()));
-        self
     }
 
     /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
@@ -844,6 +844,18 @@ impl BackendRule {
         })
     }
 
+    /// Sets the value of [authentication][crate::model::BackendRule::authentication]
+    /// to hold a `JwtAudience`.
+    ///
+    /// Note that all the setters affecting `authentication` are
+    /// mutually exclusive.
+    pub fn set_jwt_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.authentication = std::option::Option::Some(
+            crate::model::backend_rule::Authentication::JwtAudience(v.into()),
+        );
+        self
+    }
+
     /// The value of [authentication][crate::model::BackendRule::authentication]
     /// if it holds a `DisableAuth`, `None` if the field is not set or
     /// holds a different branch.
@@ -855,18 +867,6 @@ impl BackendRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication][crate::model::BackendRule::authentication]
-    /// to hold a `JwtAudience`.
-    ///
-    /// Note that all the setters affecting `authentication` are
-    /// mutually exclusive.
-    pub fn set_jwt_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication = std::option::Option::Some(
-            crate::model::backend_rule::Authentication::JwtAudience(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [authentication][crate::model::BackendRule::authentication]
@@ -1284,17 +1284,6 @@ impl CommonLanguageSettings {
         self
     }
 
-    /// Sets the value of [selective_gapic_generation][crate::model::CommonLanguageSettings::selective_gapic_generation].
-    pub fn set_selective_gapic_generation<
-        T: std::convert::Into<std::option::Option<crate::model::SelectiveGapicGeneration>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.selective_gapic_generation = v.into();
-        self
-    }
-
     /// Sets the value of [destinations][crate::model::CommonLanguageSettings::destinations].
     pub fn set_destinations<T, V>(mut self, v: T) -> Self
     where
@@ -1303,6 +1292,17 @@ impl CommonLanguageSettings {
     {
         use std::iter::Iterator;
         self.destinations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [selective_gapic_generation][crate::model::CommonLanguageSettings::selective_gapic_generation].
+    pub fn set_selective_gapic_generation<
+        T: std::convert::Into<std::option::Option<crate::model::SelectiveGapicGeneration>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.selective_gapic_generation = v.into();
         self
     }
 }
@@ -1559,6 +1559,17 @@ impl Publishing {
         std::default::Default::default()
     }
 
+    /// Sets the value of [method_settings][crate::model::Publishing::method_settings].
+    pub fn set_method_settings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MethodSettings>,
+    {
+        use std::iter::Iterator;
+        self.method_settings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [new_issue_uri][crate::model::Publishing::new_issue_uri].
     pub fn set_new_issue_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.new_issue_uri = v.into();
@@ -1586,6 +1597,17 @@ impl Publishing {
         self
     }
 
+    /// Sets the value of [codeowner_github_teams][crate::model::Publishing::codeowner_github_teams].
+    pub fn set_codeowner_github_teams<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.codeowner_github_teams = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [doc_tag_prefix][crate::model::Publishing::doc_tag_prefix].
     pub fn set_doc_tag_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.doc_tag_prefix = v.into();
@@ -1598,6 +1620,17 @@ impl Publishing {
         v: T,
     ) -> Self {
         self.organization = v.into();
+        self
+    }
+
+    /// Sets the value of [library_settings][crate::model::Publishing::library_settings].
+    pub fn set_library_settings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClientLibrarySettings>,
+    {
+        use std::iter::Iterator;
+        self.library_settings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1616,39 +1649,6 @@ impl Publishing {
         v: T,
     ) -> Self {
         self.rest_reference_documentation_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [method_settings][crate::model::Publishing::method_settings].
-    pub fn set_method_settings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MethodSettings>,
-    {
-        use std::iter::Iterator;
-        self.method_settings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [codeowner_github_teams][crate::model::Publishing::codeowner_github_teams].
-    pub fn set_codeowner_github_teams<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.codeowner_github_teams = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [library_settings][crate::model::Publishing::library_settings].
-    pub fn set_library_settings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClientLibrarySettings>,
-    {
-        use std::iter::Iterator;
-        self.library_settings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1715,17 +1715,6 @@ impl JavaSettings {
         self
     }
 
-    /// Sets the value of [common][crate::model::JavaSettings::common].
-    pub fn set_common<
-        T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.common = v.into();
-        self
-    }
-
     /// Sets the value of [service_class_names][crate::model::JavaSettings::service_class_names].
     pub fn set_service_class_names<T, K, V>(mut self, v: T) -> Self
     where
@@ -1735,6 +1724,17 @@ impl JavaSettings {
     {
         use std::iter::Iterator;
         self.service_class_names = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [common][crate::model::JavaSettings::common].
+    pub fn set_common<
+        T: std::convert::Into<std::option::Option<crate::model::CommonLanguageSettings>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.common = v.into();
         self
     }
 }
@@ -2051,6 +2051,30 @@ impl DotnetSettings {
         self
     }
 
+    /// Sets the value of [renamed_services][crate::model::DotnetSettings::renamed_services].
+    pub fn set_renamed_services<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.renamed_services = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [renamed_resources][crate::model::DotnetSettings::renamed_resources].
+    pub fn set_renamed_resources<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.renamed_resources = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [ignored_resources][crate::model::DotnetSettings::ignored_resources].
     pub fn set_ignored_resources<T, V>(mut self, v: T) -> Self
     where
@@ -2081,30 +2105,6 @@ impl DotnetSettings {
     {
         use std::iter::Iterator;
         self.handwritten_signatures = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [renamed_services][crate::model::DotnetSettings::renamed_services].
-    pub fn set_renamed_services<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.renamed_services = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [renamed_resources][crate::model::DotnetSettings::renamed_resources].
-    pub fn set_renamed_resources<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.renamed_resources = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2421,12 +2421,6 @@ impl SelectiveGapicGeneration {
         std::default::Default::default()
     }
 
-    /// Sets the value of [generate_omitted_as_internal][crate::model::SelectiveGapicGeneration::generate_omitted_as_internal].
-    pub fn set_generate_omitted_as_internal<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.generate_omitted_as_internal = v.into();
-        self
-    }
-
     /// Sets the value of [methods][crate::model::SelectiveGapicGeneration::methods].
     pub fn set_methods<T, V>(mut self, v: T) -> Self
     where
@@ -2435,6 +2429,12 @@ impl SelectiveGapicGeneration {
     {
         use std::iter::Iterator;
         self.methods = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [generate_omitted_as_internal][crate::model::SelectiveGapicGeneration::generate_omitted_as_internal].
+    pub fn set_generate_omitted_as_internal<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.generate_omitted_as_internal = v.into();
         self
     }
 }
@@ -3347,40 +3347,6 @@ pub mod distribution {
             })
         }
 
-        /// The value of [options][crate::model::distribution::BucketOptions::options]
-        /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn exponential_buckets(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::distribution::bucket_options::Exponential>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.options.as_ref().and_then(|v| match v {
-                crate::model::distribution::bucket_options::Options::ExponentialBuckets(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [options][crate::model::distribution::BucketOptions::options]
-        /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn explicit_buckets(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::distribution::bucket_options::Explicit>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.options.as_ref().and_then(|v| match v {
-                crate::model::distribution::bucket_options::Options::ExplicitBuckets(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
         /// to hold a `LinearBuckets`.
         ///
@@ -3396,6 +3362,23 @@ pub mod distribution {
                 crate::model::distribution::bucket_options::Options::LinearBuckets(v.into()),
             );
             self
+        }
+
+        /// The value of [options][crate::model::distribution::BucketOptions::options]
+        /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn exponential_buckets(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::distribution::bucket_options::Exponential>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.options.as_ref().and_then(|v| match v {
+                crate::model::distribution::bucket_options::Options::ExponentialBuckets(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
@@ -3415,6 +3398,23 @@ pub mod distribution {
                 crate::model::distribution::bucket_options::Options::ExponentialBuckets(v.into()),
             );
             self
+        }
+
+        /// The value of [options][crate::model::distribution::BucketOptions::options]
+        /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn explicit_buckets(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::distribution::bucket_options::Explicit>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.options.as_ref().and_then(|v| match v {
+                crate::model::distribution::bucket_options::Options::ExplicitBuckets(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
@@ -3800,6 +3800,28 @@ impl Documentation {
         self
     }
 
+    /// Sets the value of [pages][crate::model::Documentation::pages].
+    pub fn set_pages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Page>,
+    {
+        use std::iter::Iterator;
+        self.pages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::Documentation::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DocumentationRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [documentation_root_url][crate::model::Documentation::documentation_root_url].
     pub fn set_documentation_root_url<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -3821,28 +3843,6 @@ impl Documentation {
     /// Sets the value of [overview][crate::model::Documentation::overview].
     pub fn set_overview<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.overview = v.into();
-        self
-    }
-
-    /// Sets the value of [pages][crate::model::Documentation::pages].
-    pub fn set_pages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Page>,
-    {
-        use std::iter::Iterator;
-        self.pages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [rules][crate::model::Documentation::rules].
-    pub fn set_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DocumentationRule>,
-    {
-        use std::iter::Iterator;
-        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4055,6 +4055,17 @@ impl Endpoint {
         self
     }
 
+    /// Sets the value of [aliases][crate::model::Endpoint::aliases].
+    pub fn set_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.aliases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [target][crate::model::Endpoint::target].
     pub fn set_target<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target = v.into();
@@ -4064,17 +4075,6 @@ impl Endpoint {
     /// Sets the value of [allow_cors][crate::model::Endpoint::allow_cors].
     pub fn set_allow_cors<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_cors = v.into();
-        self
-    }
-
-    /// Sets the value of [aliases][crate::model::Endpoint::aliases].
-    pub fn set_aliases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.aliases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4381,15 +4381,6 @@ impl Http {
         std::default::Default::default()
     }
 
-    /// Sets the value of [fully_decode_reserved_expansion][crate::model::Http::fully_decode_reserved_expansion].
-    pub fn set_fully_decode_reserved_expansion<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.fully_decode_reserved_expansion = v.into();
-        self
-    }
-
     /// Sets the value of [rules][crate::model::Http::rules].
     pub fn set_rules<T, V>(mut self, v: T) -> Self
     where
@@ -4398,6 +4389,15 @@ impl Http {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [fully_decode_reserved_expansion][crate::model::Http::fully_decode_reserved_expansion].
+    pub fn set_fully_decode_reserved_expansion<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.fully_decode_reserved_expansion = v.into();
         self
     }
 }
@@ -4797,6 +4797,16 @@ impl HttpRule {
         })
     }
 
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Get`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_get<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Get(v.into()));
+        self
+    }
+
     /// The value of [pattern][crate::model::HttpRule::pattern]
     /// if it holds a `Put`, `None` if the field is not set or
     /// holds a different branch.
@@ -4806,6 +4816,16 @@ impl HttpRule {
             crate::model::http_rule::Pattern::Put(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Put`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_put<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Put(v.into()));
+        self
     }
 
     /// The value of [pattern][crate::model::HttpRule::pattern]
@@ -4819,6 +4839,16 @@ impl HttpRule {
         })
     }
 
+    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
+    /// to hold a `Post`.
+    ///
+    /// Note that all the setters affecting `pattern` are
+    /// mutually exclusive.
+    pub fn set_post<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Post(v.into()));
+        self
+    }
+
     /// The value of [pattern][crate::model::HttpRule::pattern]
     /// if it holds a `Delete`, `None` if the field is not set or
     /// holds a different branch.
@@ -4828,58 +4858,6 @@ impl HttpRule {
             crate::model::http_rule::Pattern::Delete(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [pattern][crate::model::HttpRule::pattern]
-    /// if it holds a `Patch`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn patch(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.pattern.as_ref().and_then(|v| match v {
-            crate::model::http_rule::Pattern::Patch(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [pattern][crate::model::HttpRule::pattern]
-    /// if it holds a `Custom`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom(&self) -> std::option::Option<&std::boxed::Box<crate::model::CustomHttpPattern>> {
-        #[allow(unreachable_patterns)]
-        self.pattern.as_ref().and_then(|v| match v {
-            crate::model::http_rule::Pattern::Custom(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Get`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_get<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Get(v.into()));
-        self
-    }
-
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Put`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_put<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Put(v.into()));
-        self
-    }
-
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Post`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_post<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Post(v.into()));
-        self
     }
 
     /// Sets the value of [pattern][crate::model::HttpRule::pattern]
@@ -4893,6 +4871,17 @@ impl HttpRule {
         self
     }
 
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Patch`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn patch(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Patch(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [pattern][crate::model::HttpRule::pattern]
     /// to hold a `Patch`.
     ///
@@ -4901,6 +4890,17 @@ impl HttpRule {
     pub fn set_patch<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Patch(v.into()));
         self
+    }
+
+    /// The value of [pattern][crate::model::HttpRule::pattern]
+    /// if it holds a `Custom`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom(&self) -> std::option::Option<&std::boxed::Box<crate::model::CustomHttpPattern>> {
+        #[allow(unreachable_patterns)]
+        self.pattern.as_ref().and_then(|v| match v {
+            crate::model::http_rule::Pattern::Custom(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [pattern][crate::model::HttpRule::pattern]
@@ -5346,6 +5346,17 @@ impl LogDescriptor {
         self
     }
 
+    /// Sets the value of [labels][crate::model::LogDescriptor::labels].
+    pub fn set_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LabelDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::LogDescriptor::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -5355,17 +5366,6 @@ impl LogDescriptor {
     /// Sets the value of [display_name][crate::model::LogDescriptor::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::LogDescriptor::labels].
-    pub fn set_labels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LabelDescriptor>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5749,6 +5749,17 @@ impl MetricDescriptor {
         self
     }
 
+    /// Sets the value of [labels][crate::model::MetricDescriptor::labels].
+    pub fn set_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LabelDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [metric_kind][crate::model::MetricDescriptor::metric_kind].
     pub fn set_metric_kind<T: std::convert::Into<crate::model::metric_descriptor::MetricKind>>(
         mut self,
@@ -5804,17 +5815,6 @@ impl MetricDescriptor {
         v: T,
     ) -> Self {
         self.launch_stage = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::MetricDescriptor::labels].
-    pub fn set_labels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LabelDescriptor>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6534,15 +6534,6 @@ impl MonitoredResourceDescriptor {
         self
     }
 
-    /// Sets the value of [launch_stage][crate::model::MonitoredResourceDescriptor::launch_stage].
-    pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.launch_stage = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::MonitoredResourceDescriptor::labels].
     pub fn set_labels<T, V>(mut self, v: T) -> Self
     where
@@ -6551,6 +6542,15 @@ impl MonitoredResourceDescriptor {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [launch_stage][crate::model::MonitoredResourceDescriptor::launch_stage].
+    pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.launch_stage = v.into();
         self
     }
 }
@@ -7344,12 +7344,6 @@ impl QuotaLimit {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::QuotaLimit::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
     /// Sets the value of [values][crate::model::QuotaLimit::values].
     pub fn set_values<T, K, V>(mut self, v: T) -> Self
     where
@@ -7359,6 +7353,12 @@ impl QuotaLimit {
     {
         use std::iter::Iterator;
         self.values = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::QuotaLimit::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 }
@@ -7536,6 +7536,17 @@ impl ResourceDescriptor {
         self
     }
 
+    /// Sets the value of [pattern][crate::model::ResourceDescriptor::pattern].
+    pub fn set_pattern<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.pattern = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [name_field][crate::model::ResourceDescriptor::name_field].
     pub fn set_name_field<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name_field = v.into();
@@ -7560,17 +7571,6 @@ impl ResourceDescriptor {
     /// Sets the value of [singular][crate::model::ResourceDescriptor::singular].
     pub fn set_singular<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.singular = v.into();
-        self
-    }
-
-    /// Sets the value of [pattern][crate::model::ResourceDescriptor::pattern].
-    pub fn set_pattern<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.pattern = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8724,6 +8724,39 @@ impl Service {
         self
     }
 
+    /// Sets the value of [apis][crate::model::Service::apis].
+    pub fn set_apis<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Api>,
+    {
+        use std::iter::Iterator;
+        self.apis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [types][crate::model::Service::types].
+    pub fn set_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Type>,
+    {
+        use std::iter::Iterator;
+        self.types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enums][crate::model::Service::enums].
+    pub fn set_enums<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Enum>,
+    {
+        use std::iter::Iterator;
+        self.enums = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [documentation][crate::model::Service::documentation].
     pub fn set_documentation<
         T: std::convert::Into<std::option::Option<crate::model::Documentation>>,
@@ -8791,12 +8824,56 @@ impl Service {
         self
     }
 
+    /// Sets the value of [endpoints][crate::model::Service::endpoints].
+    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Endpoint>,
+    {
+        use std::iter::Iterator;
+        self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [control][crate::model::Service::control].
     pub fn set_control<T: std::convert::Into<std::option::Option<crate::model::Control>>>(
         mut self,
         v: T,
     ) -> Self {
         self.control = v.into();
+        self
+    }
+
+    /// Sets the value of [logs][crate::model::Service::logs].
+    pub fn set_logs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LogDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.logs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metrics][crate::model::Service::metrics].
+    pub fn set_metrics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MetricDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [monitored_resources][crate::model::Service::monitored_resources].
+    pub fn set_monitored_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MonitoredResourceDescriptor>,
+    {
+        use std::iter::Iterator;
+        self.monitored_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8862,83 +8939,6 @@ impl Service {
         v: T,
     ) -> Self {
         self.config_version = v.into();
-        self
-    }
-
-    /// Sets the value of [apis][crate::model::Service::apis].
-    pub fn set_apis<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Api>,
-    {
-        use std::iter::Iterator;
-        self.apis = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [types][crate::model::Service::types].
-    pub fn set_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Type>,
-    {
-        use std::iter::Iterator;
-        self.types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [enums][crate::model::Service::enums].
-    pub fn set_enums<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Enum>,
-    {
-        use std::iter::Iterator;
-        self.enums = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [endpoints][crate::model::Service::endpoints].
-    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Endpoint>,
-    {
-        use std::iter::Iterator;
-        self.endpoints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [logs][crate::model::Service::logs].
-    pub fn set_logs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LogDescriptor>,
-    {
-        use std::iter::Iterator;
-        self.logs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [metrics][crate::model::Service::metrics].
-    pub fn set_metrics<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MetricDescriptor>,
-    {
-        use std::iter::Iterator;
-        self.metrics = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [monitored_resources][crate::model::Service::monitored_resources].
-    pub fn set_monitored_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MonitoredResourceDescriptor>,
-    {
-        use std::iter::Iterator;
-        self.monitored_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9220,15 +9220,6 @@ impl Usage {
         std::default::Default::default()
     }
 
-    /// Sets the value of [producer_notification_channel][crate::model::Usage::producer_notification_channel].
-    pub fn set_producer_notification_channel<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.producer_notification_channel = v.into();
-        self
-    }
-
     /// Sets the value of [requirements][crate::model::Usage::requirements].
     pub fn set_requirements<T, V>(mut self, v: T) -> Self
     where
@@ -9248,6 +9239,15 @@ impl Usage {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [producer_notification_channel][crate::model::Usage::producer_notification_channel].
+    pub fn set_producer_notification_channel<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.producer_notification_channel = v.into();
         self
     }
 }

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -433,30 +433,6 @@ impl UrlMap {
         })
     }
 
-    /// The value of [handler_type][crate::model::UrlMap::handler_type]
-    /// if it holds a `Script`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn script(&self) -> std::option::Option<&std::boxed::Box<crate::model::ScriptHandler>> {
-        #[allow(unreachable_patterns)]
-        self.handler_type.as_ref().and_then(|v| match v {
-            crate::model::url_map::HandlerType::Script(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [handler_type][crate::model::UrlMap::handler_type]
-    /// if it holds a `ApiEndpoint`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn api_endpoint(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ApiEndpointHandler>> {
-        #[allow(unreachable_patterns)]
-        self.handler_type.as_ref().and_then(|v| match v {
-            crate::model::url_map::HandlerType::ApiEndpoint(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [handler_type][crate::model::UrlMap::handler_type]
     /// to hold a `StaticFiles`.
     ///
@@ -473,6 +449,17 @@ impl UrlMap {
         self
     }
 
+    /// The value of [handler_type][crate::model::UrlMap::handler_type]
+    /// if it holds a `Script`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn script(&self) -> std::option::Option<&std::boxed::Box<crate::model::ScriptHandler>> {
+        #[allow(unreachable_patterns)]
+        self.handler_type.as_ref().and_then(|v| match v {
+            crate::model::url_map::HandlerType::Script(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [handler_type][crate::model::UrlMap::handler_type]
     /// to hold a `Script`.
     ///
@@ -485,6 +472,19 @@ impl UrlMap {
         self.handler_type =
             std::option::Option::Some(crate::model::url_map::HandlerType::Script(v.into()));
         self
+    }
+
+    /// The value of [handler_type][crate::model::UrlMap::handler_type]
+    /// if it holds a `ApiEndpoint`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn api_endpoint(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ApiEndpointHandler>> {
+        #[allow(unreachable_patterns)]
+        self.handler_type.as_ref().and_then(|v| match v {
+            crate::model::url_map::HandlerType::ApiEndpoint(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [handler_type][crate::model::UrlMap::handler_type]
@@ -754,6 +754,18 @@ impl StaticFilesHandler {
         self
     }
 
+    /// Sets the value of [http_headers][crate::model::StaticFilesHandler::http_headers].
+    pub fn set_http_headers<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.http_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [mime_type][crate::model::StaticFilesHandler::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
@@ -778,18 +790,6 @@ impl StaticFilesHandler {
     /// Sets the value of [application_readable][crate::model::StaticFilesHandler::application_readable].
     pub fn set_application_readable<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.application_readable = v.into();
-        self
-    }
-
-    /// Sets the value of [http_headers][crate::model::StaticFilesHandler::http_headers].
-    pub fn set_http_headers<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.http_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1458,12 +1458,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -1472,6 +1466,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1725,12 +1725,6 @@ impl ListVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [versions][crate::model::ListVersionsResponse::versions].
     pub fn set_versions<T, V>(mut self, v: T) -> Self
     where
@@ -1739,6 +1733,12 @@ impl ListVersionsResponse {
     {
         use std::iter::Iterator;
         self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2020,12 +2020,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -2034,6 +2028,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2264,12 +2264,6 @@ impl ListIngressRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIngressRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [ingress_rules][crate::model::ListIngressRulesResponse::ingress_rules].
     pub fn set_ingress_rules<T, V>(mut self, v: T) -> Self
     where
@@ -2278,6 +2272,12 @@ impl ListIngressRulesResponse {
     {
         use std::iter::Iterator;
         self.ingress_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIngressRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2642,12 +2642,6 @@ impl ListAuthorizedDomainsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAuthorizedDomainsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [domains][crate::model::ListAuthorizedDomainsResponse::domains].
     pub fn set_domains<T, V>(mut self, v: T) -> Self
     where
@@ -2656,6 +2650,12 @@ impl ListAuthorizedDomainsResponse {
     {
         use std::iter::Iterator;
         self.domains = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAuthorizedDomainsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2767,12 +2767,6 @@ impl ListAuthorizedCertificatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAuthorizedCertificatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificates][crate::model::ListAuthorizedCertificatesResponse::certificates].
     pub fn set_certificates<T, V>(mut self, v: T) -> Self
     where
@@ -2781,6 +2775,12 @@ impl ListAuthorizedCertificatesResponse {
     {
         use std::iter::Iterator;
         self.certificates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAuthorizedCertificatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3068,12 +3068,6 @@ impl ListDomainMappingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDomainMappingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [domain_mappings][crate::model::ListDomainMappingsResponse::domain_mappings].
     pub fn set_domain_mappings<T, V>(mut self, v: T) -> Self
     where
@@ -3082,6 +3076,12 @@ impl ListDomainMappingsResponse {
     {
         use std::iter::Iterator;
         self.domain_mappings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDomainMappingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3410,6 +3410,17 @@ impl Application {
         self
     }
 
+    /// Sets the value of [dispatch_rules][crate::model::Application::dispatch_rules].
+    pub fn set_dispatch_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::UrlDispatchRule>,
+    {
+        use std::iter::Iterator;
+        self.dispatch_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [auth_domain][crate::model::Application::auth_domain].
     pub fn set_auth_domain<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.auth_domain = v.into();
@@ -3503,17 +3514,6 @@ impl Application {
         v: T,
     ) -> Self {
         self.feature_settings = v.into();
-        self
-    }
-
-    /// Sets the value of [dispatch_rules][crate::model::Application::dispatch_rules].
-    pub fn set_dispatch_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::UrlDispatchRule>,
-    {
-        use std::iter::Iterator;
-        self.dispatch_rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4050,19 +4050,6 @@ impl AuditData {
         })
     }
 
-    /// The value of [method][crate::model::AuditData::method]
-    /// if it holds a `CreateVersion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_version(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateVersionMethod>> {
-        #[allow(unreachable_patterns)]
-        self.method.as_ref().and_then(|v| match v {
-            crate::model::audit_data::Method::CreateVersion(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [method][crate::model::AuditData::method]
     /// to hold a `UpdateService`.
     ///
@@ -4077,6 +4064,19 @@ impl AuditData {
         self.method =
             std::option::Option::Some(crate::model::audit_data::Method::UpdateService(v.into()));
         self
+    }
+
+    /// The value of [method][crate::model::AuditData::method]
+    /// if it holds a `CreateVersion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_version(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateVersionMethod>> {
+        #[allow(unreachable_patterns)]
+        self.method.as_ref().and_then(|v| match v {
+            crate::model::audit_data::Method::CreateVersion(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [method][crate::model::AuditData::method]
@@ -4304,6 +4304,17 @@ impl AuthorizedCertificate {
         self
     }
 
+    /// Sets the value of [domain_names][crate::model::AuthorizedCertificate::domain_names].
+    pub fn set_domain_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.domain_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [expire_time][crate::model::AuthorizedCertificate::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -4335,23 +4346,6 @@ impl AuthorizedCertificate {
         self
     }
 
-    /// Sets the value of [domain_mappings_count][crate::model::AuthorizedCertificate::domain_mappings_count].
-    pub fn set_domain_mappings_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.domain_mappings_count = v.into();
-        self
-    }
-
-    /// Sets the value of [domain_names][crate::model::AuthorizedCertificate::domain_names].
-    pub fn set_domain_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.domain_names = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [visible_domain_mappings][crate::model::AuthorizedCertificate::visible_domain_mappings].
     pub fn set_visible_domain_mappings<T, V>(mut self, v: T) -> Self
     where
@@ -4360,6 +4354,12 @@ impl AuthorizedCertificate {
     {
         use std::iter::Iterator;
         self.visible_domain_mappings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [domain_mappings_count][crate::model::AuthorizedCertificate::domain_mappings_count].
+    pub fn set_domain_mappings_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.domain_mappings_count = v.into();
         self
     }
 }
@@ -4512,6 +4512,18 @@ impl Deployment {
         std::default::Default::default()
     }
 
+    /// Sets the value of [files][crate::model::Deployment::files].
+    pub fn set_files<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::FileInfo>,
+    {
+        use std::iter::Iterator;
+        self.files = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [container][crate::model::Deployment::container].
     pub fn set_container<
         T: std::convert::Into<std::option::Option<crate::model::ContainerInfo>>,
@@ -4540,18 +4552,6 @@ impl Deployment {
         v: T,
     ) -> Self {
         self.cloud_build_options = v.into();
-        self
-    }
-
-    /// Sets the value of [files][crate::model::Deployment::files].
-    pub fn set_files<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::FileInfo>,
-    {
-        use std::iter::Iterator;
-        self.files = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6606,17 +6606,6 @@ impl Service {
         self
     }
 
-    /// Sets the value of [network_settings][crate::model::Service::network_settings].
-    pub fn set_network_settings<
-        T: std::convert::Into<std::option::Option<crate::model::NetworkSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.network_settings = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Service::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6626,6 +6615,17 @@ impl Service {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [network_settings][crate::model::Service::network_settings].
+    pub fn set_network_settings<
+        T: std::convert::Into<std::option::Option<crate::model::NetworkSettings>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.network_settings = v.into();
         self
     }
 }
@@ -7103,6 +7103,17 @@ impl Version {
         self
     }
 
+    /// Sets the value of [inbound_services][crate::model::Version::inbound_services].
+    pub fn set_inbound_services<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InboundServiceType>,
+    {
+        use std::iter::Iterator;
+        self.inbound_services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [instance_class][crate::model::Version::instance_class].
     pub fn set_instance_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance_class = v.into();
@@ -7115,6 +7126,17 @@ impl Version {
         v: T,
     ) -> Self {
         self.network = v.into();
+        self
+    }
+
+    /// Sets the value of [zones][crate::model::Version::zones].
+    pub fn set_zones<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.zones = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7154,6 +7176,18 @@ impl Version {
     /// Sets the value of [app_engine_apis][crate::model::Version::app_engine_apis].
     pub fn set_app_engine_apis<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.app_engine_apis = v.into();
+        self
+    }
+
+    /// Sets the value of [beta_settings][crate::model::Version::beta_settings].
+    pub fn set_beta_settings<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.beta_settings = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -7217,6 +7251,39 @@ impl Version {
         self
     }
 
+    /// Sets the value of [handlers][crate::model::Version::handlers].
+    pub fn set_handlers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::UrlMap>,
+    {
+        use std::iter::Iterator;
+        self.handlers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_handlers][crate::model::Version::error_handlers].
+    pub fn set_error_handlers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ErrorHandler>,
+    {
+        use std::iter::Iterator;
+        self.error_handlers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [libraries][crate::model::Version::libraries].
+    pub fn set_libraries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Library>,
+    {
+        use std::iter::Iterator;
+        self.libraries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [api_config][crate::model::Version::api_config].
     pub fn set_api_config<
         T: std::convert::Into<std::option::Option<crate::model::ApiConfigHandler>>,
@@ -7225,6 +7292,30 @@ impl Version {
         v: T,
     ) -> Self {
         self.api_config = v.into();
+        self
+    }
+
+    /// Sets the value of [env_variables][crate::model::Version::env_variables].
+    pub fn set_env_variables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.env_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [build_env_variables][crate::model::Version::build_env_variables].
+    pub fn set_build_env_variables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.build_env_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -7325,97 +7416,6 @@ impl Version {
         self
     }
 
-    /// Sets the value of [inbound_services][crate::model::Version::inbound_services].
-    pub fn set_inbound_services<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InboundServiceType>,
-    {
-        use std::iter::Iterator;
-        self.inbound_services = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [zones][crate::model::Version::zones].
-    pub fn set_zones<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.zones = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [handlers][crate::model::Version::handlers].
-    pub fn set_handlers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::UrlMap>,
-    {
-        use std::iter::Iterator;
-        self.handlers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [error_handlers][crate::model::Version::error_handlers].
-    pub fn set_error_handlers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ErrorHandler>,
-    {
-        use std::iter::Iterator;
-        self.error_handlers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [libraries][crate::model::Version::libraries].
-    pub fn set_libraries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Library>,
-    {
-        use std::iter::Iterator;
-        self.libraries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [beta_settings][crate::model::Version::beta_settings].
-    pub fn set_beta_settings<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.beta_settings = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [env_variables][crate::model::Version::env_variables].
-    pub fn set_env_variables<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.env_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [build_env_variables][crate::model::Version::build_env_variables].
-    pub fn set_build_env_variables<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.build_env_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [scaling][crate::model::Version::scaling].
     ///
     /// Note that all the setters affecting `scaling` are mutually
@@ -7443,32 +7443,6 @@ impl Version {
         })
     }
 
-    /// The value of [scaling][crate::model::Version::scaling]
-    /// if it holds a `BasicScaling`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn basic_scaling(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BasicScaling>> {
-        #[allow(unreachable_patterns)]
-        self.scaling.as_ref().and_then(|v| match v {
-            crate::model::version::Scaling::BasicScaling(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [scaling][crate::model::Version::scaling]
-    /// if it holds a `ManualScaling`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn manual_scaling(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ManualScaling>> {
-        #[allow(unreachable_patterns)]
-        self.scaling.as_ref().and_then(|v| match v {
-            crate::model::version::Scaling::ManualScaling(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [scaling][crate::model::Version::scaling]
     /// to hold a `AutomaticScaling`.
     ///
@@ -7485,6 +7459,19 @@ impl Version {
         self
     }
 
+    /// The value of [scaling][crate::model::Version::scaling]
+    /// if it holds a `BasicScaling`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn basic_scaling(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BasicScaling>> {
+        #[allow(unreachable_patterns)]
+        self.scaling.as_ref().and_then(|v| match v {
+            crate::model::version::Scaling::BasicScaling(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [scaling][crate::model::Version::scaling]
     /// to hold a `BasicScaling`.
     ///
@@ -7497,6 +7484,19 @@ impl Version {
         self.scaling =
             std::option::Option::Some(crate::model::version::Scaling::BasicScaling(v.into()));
         self
+    }
+
+    /// The value of [scaling][crate::model::Version::scaling]
+    /// if it holds a `ManualScaling`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn manual_scaling(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ManualScaling>> {
+        #[allow(unreachable_patterns)]
+        self.scaling.as_ref().and_then(|v| match v {
+            crate::model::version::Scaling::ManualScaling(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [scaling][crate::model::Version::scaling]
@@ -8410,6 +8410,17 @@ impl Network {
         std::default::Default::default()
     }
 
+    /// Sets the value of [forwarded_ports][crate::model::Network::forwarded_ports].
+    pub fn set_forwarded_ports<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.forwarded_ports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [instance_tag][crate::model::Network::instance_tag].
     pub fn set_instance_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.instance_tag = v.into();
@@ -8431,17 +8442,6 @@ impl Network {
     /// Sets the value of [session_affinity][crate::model::Network::session_affinity].
     pub fn set_session_affinity<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.session_affinity = v.into();
-        self
-    }
-
-    /// Sets the value of [forwarded_ports][crate::model::Network::forwarded_ports].
-    pub fn set_forwarded_ports<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.forwarded_ports = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8559,15 +8559,6 @@ impl Resources {
         self
     }
 
-    /// Sets the value of [kms_key_reference][crate::model::Resources::kms_key_reference].
-    pub fn set_kms_key_reference<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kms_key_reference = v.into();
-        self
-    }
-
     /// Sets the value of [volumes][crate::model::Resources::volumes].
     pub fn set_volumes<T, V>(mut self, v: T) -> Self
     where
@@ -8576,6 +8567,15 @@ impl Resources {
     {
         use std::iter::Iterator;
         self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [kms_key_reference][crate::model::Resources::kms_key_reference].
+    pub fn set_kms_key_reference<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.kms_key_reference = v.into();
         self
     }
 }

--- a/src/generated/apps/script/calendar/src/model.rs
+++ b/src/generated/apps/script/calendar/src/model.rs
@@ -80,6 +80,17 @@ impl CalendarAddOnManifest {
         self
     }
 
+    /// Sets the value of [conference_solution][crate::model::CalendarAddOnManifest::conference_solution].
+    pub fn set_conference_solution<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConferenceSolution>,
+    {
+        use std::iter::Iterator;
+        self.conference_solution = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_settings_url_function][crate::model::CalendarAddOnManifest::create_settings_url_function].
     pub fn set_create_settings_url_function<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -119,17 +130,6 @@ impl CalendarAddOnManifest {
         v: T,
     ) -> Self {
         self.current_event_access = v.into();
-        self
-    }
-
-    /// Sets the value of [conference_solution][crate::model::CalendarAddOnManifest::conference_solution].
-    pub fn set_conference_solution<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConferenceSolution>,
-    {
-        use std::iter::Iterator;
-        self.conference_solution = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -88,26 +88,6 @@ impl GmailAddOnManifest {
         self
     }
 
-    /// Sets the value of [compose_trigger][crate::model::GmailAddOnManifest::compose_trigger].
-    pub fn set_compose_trigger<
-        T: std::convert::Into<std::option::Option<crate::model::ComposeTrigger>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.compose_trigger = v.into();
-        self
-    }
-
-    /// Sets the value of [authorization_check_function][crate::model::GmailAddOnManifest::authorization_check_function].
-    pub fn set_authorization_check_function<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorization_check_function = v.into();
-        self
-    }
-
     /// Sets the value of [contextual_triggers][crate::model::GmailAddOnManifest::contextual_triggers].
     pub fn set_contextual_triggers<T, V>(mut self, v: T) -> Self
     where
@@ -127,6 +107,26 @@ impl GmailAddOnManifest {
     {
         use std::iter::Iterator;
         self.universal_actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [compose_trigger][crate::model::GmailAddOnManifest::compose_trigger].
+    pub fn set_compose_trigger<
+        T: std::convert::Into<std::option::Option<crate::model::ComposeTrigger>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.compose_trigger = v.into();
+        self
+    }
+
+    /// Sets the value of [authorization_check_function][crate::model::GmailAddOnManifest::authorization_check_function].
+    pub fn set_authorization_check_function<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.authorization_check_function = v.into();
         self
     }
 }
@@ -194,6 +194,18 @@ impl UniversalAction {
         })
     }
 
+    /// Sets the value of [action_type][crate::model::UniversalAction::action_type]
+    /// to hold a `OpenLink`.
+    ///
+    /// Note that all the setters affecting `action_type` are
+    /// mutually exclusive.
+    pub fn set_open_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.action_type = std::option::Option::Some(
+            crate::model::universal_action::ActionType::OpenLink(v.into()),
+        );
+        self
+    }
+
     /// The value of [action_type][crate::model::UniversalAction::action_type]
     /// if it holds a `RunFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -205,18 +217,6 @@ impl UniversalAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action_type][crate::model::UniversalAction::action_type]
-    /// to hold a `OpenLink`.
-    ///
-    /// Note that all the setters affecting `action_type` are
-    /// mutually exclusive.
-    pub fn set_open_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action_type = std::option::Option::Some(
-            crate::model::universal_action::ActionType::OpenLink(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [action_type][crate::model::UniversalAction::action_type]
@@ -281,15 +281,6 @@ impl ComposeTrigger {
         std::default::Default::default()
     }
 
-    /// Sets the value of [draft_access][crate::model::ComposeTrigger::draft_access].
-    pub fn set_draft_access<T: std::convert::Into<crate::model::compose_trigger::DraftAccess>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.draft_access = v.into();
-        self
-    }
-
     /// Sets the value of [actions][crate::model::ComposeTrigger::actions].
     pub fn set_actions<T, V>(mut self, v: T) -> Self
     where
@@ -298,6 +289,15 @@ impl ComposeTrigger {
     {
         use std::iter::Iterator;
         self.actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [draft_access][crate::model::ComposeTrigger::draft_access].
+    pub fn set_draft_access<T: std::convert::Into<crate::model::compose_trigger::DraftAccess>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.draft_access = v.into();
         self
     }
 }

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -405,6 +405,18 @@ impl UniversalActionExtensionPoint {
         })
     }
 
+    /// Sets the value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
+    /// to hold a `OpenLink`.
+    ///
+    /// Note that all the setters affecting `action_type` are
+    /// mutually exclusive.
+    pub fn set_open_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.action_type = std::option::Option::Some(
+            crate::model::universal_action_extension_point::ActionType::OpenLink(v.into()),
+        );
+        self
+    }
+
     /// The value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
     /// if it holds a `RunFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -416,18 +428,6 @@ impl UniversalActionExtensionPoint {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
-    /// to hold a `OpenLink`.
-    ///
-    /// Note that all the setters affecting `action_type` are
-    /// mutually exclusive.
-    pub fn set_open_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action_type = std::option::Option::Some(
-            crate::model::universal_action_extension_point::ActionType::OpenLink(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
@@ -578,17 +578,6 @@ impl CommonAddOnManifest {
         self
     }
 
-    /// Sets the value of [open_link_url_prefixes][crate::model::CommonAddOnManifest::open_link_url_prefixes].
-    pub fn set_open_link_url_prefixes<
-        T: std::convert::Into<std::option::Option<wkt::ListValue>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.open_link_url_prefixes = v.into();
-        self
-    }
-
     /// Sets the value of [universal_actions][crate::model::CommonAddOnManifest::universal_actions].
     pub fn set_universal_actions<T, V>(mut self, v: T) -> Self
     where
@@ -597,6 +586,17 @@ impl CommonAddOnManifest {
     {
         use std::iter::Iterator;
         self.universal_actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [open_link_url_prefixes][crate::model::CommonAddOnManifest::open_link_url_prefixes].
+    pub fn set_open_link_url_prefixes<
+        T: std::convert::Into<std::option::Option<wkt::ListValue>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.open_link_url_prefixes = v.into();
         self
     }
 }

--- a/src/generated/bigtable/admin/v2/src/builder.rs
+++ b/src/generated/bigtable/admin/v2/src/builder.rs
@@ -343,6 +343,17 @@ pub mod bigtable_instance_admin {
             self
         }
 
+        /// Sets the value of [labels][crate::model::Instance::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [create_time][crate::model::Instance::create_time].
         pub fn set_create_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
@@ -361,17 +372,6 @@ pub mod bigtable_instance_admin {
         /// Sets the value of [satisfies_pzi][crate::model::Instance::satisfies_pzi].
         pub fn set_satisfies_pzi<T: Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
             self.0.request.satisfies_pzi = v.into();
-            self
-        }
-
-        /// Sets the value of [labels][crate::model::Instance::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -3763,12 +3763,6 @@ pub mod bigtable_table_admin {
             self
         }
 
-        /// Sets the value of [ignore_warnings][crate::model::ModifyColumnFamiliesRequest::ignore_warnings].
-        pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.ignore_warnings = v.into();
-            self
-        }
-
         /// Sets the value of [modifications][crate::model::ModifyColumnFamiliesRequest::modifications].
         ///
         /// This is a **required** field for requests.
@@ -3779,6 +3773,12 @@ pub mod bigtable_table_admin {
         {
             use std::iter::Iterator;
             self.0.request.modifications = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [ignore_warnings][crate::model::ModifyColumnFamiliesRequest::ignore_warnings].
+        pub fn set_ignore_warnings<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.ignore_warnings = v.into();
             self
         }
     }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -220,12 +220,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -245,6 +239,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.failed_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -506,12 +506,6 @@ impl ListClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
     pub fn set_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -531,6 +525,12 @@ impl ListClustersResponse {
     {
         use std::iter::Iterator;
         self.failed_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1382,12 +1382,6 @@ impl ListAppProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAppProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [app_profiles][crate::model::ListAppProfilesResponse::app_profiles].
     pub fn set_app_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -1396,6 +1390,12 @@ impl ListAppProfilesResponse {
     {
         use std::iter::Iterator;
         self.app_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAppProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1678,12 +1678,6 @@ impl ListHotTabletsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHotTabletsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [hot_tablets][crate::model::ListHotTabletsResponse::hot_tablets].
     pub fn set_hot_tablets<T, V>(mut self, v: T) -> Self
     where
@@ -1692,6 +1686,12 @@ impl ListHotTabletsResponse {
     {
         use std::iter::Iterator;
         self.hot_tablets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHotTabletsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1955,12 +1955,6 @@ impl ListLogicalViewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLogicalViewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [logical_views][crate::model::ListLogicalViewsResponse::logical_views].
     pub fn set_logical_views<T, V>(mut self, v: T) -> Self
     where
@@ -1969,6 +1963,12 @@ impl ListLogicalViewsResponse {
     {
         use std::iter::Iterator;
         self.logical_views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLogicalViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2401,12 +2401,6 @@ impl ListMaterializedViewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMaterializedViewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [materialized_views][crate::model::ListMaterializedViewsResponse::materialized_views].
     pub fn set_materialized_views<T, V>(mut self, v: T) -> Self
     where
@@ -2415,6 +2409,12 @@ impl ListMaterializedViewsResponse {
     {
         use std::iter::Iterator;
         self.materialized_views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMaterializedViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3173,6 +3173,18 @@ impl DropRowRangeRequest {
         })
     }
 
+    /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
+    /// to hold a `RowKeyPrefix`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_row_key_prefix<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.target = std::option::Option::Some(
+            crate::model::drop_row_range_request::Target::RowKeyPrefix(v.into()),
+        );
+        self
+    }
+
     /// The value of [target][crate::model::DropRowRangeRequest::target]
     /// if it holds a `DeleteAllDataFromTable`, `None` if the field is not set or
     /// holds a different branch.
@@ -3184,18 +3196,6 @@ impl DropRowRangeRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
-    /// to hold a `RowKeyPrefix`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_row_key_prefix<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::drop_row_range_request::Target::RowKeyPrefix(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
@@ -3337,12 +3337,6 @@ impl ListTablesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTablesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tables][crate::model::ListTablesResponse::tables].
     pub fn set_tables<T, V>(mut self, v: T) -> Self
     where
@@ -3351,6 +3345,12 @@ impl ListTablesResponse {
     {
         use std::iter::Iterator;
         self.tables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTablesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3733,12 +3733,6 @@ impl ModifyColumnFamiliesRequest {
         self
     }
 
-    /// Sets the value of [ignore_warnings][crate::model::ModifyColumnFamiliesRequest::ignore_warnings].
-    pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.ignore_warnings = v.into();
-        self
-    }
-
     /// Sets the value of [modifications][crate::model::ModifyColumnFamiliesRequest::modifications].
     pub fn set_modifications<T, V>(mut self, v: T) -> Self
     where
@@ -3747,6 +3741,12 @@ impl ModifyColumnFamiliesRequest {
     {
         use std::iter::Iterator;
         self.modifications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ignore_warnings][crate::model::ModifyColumnFamiliesRequest::ignore_warnings].
+    pub fn set_ignore_warnings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.ignore_warnings = v.into();
         self
     }
 }
@@ -3838,32 +3838,6 @@ pub mod modify_column_families_request {
             })
         }
 
-        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
-        /// if it holds a `Update`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn update(&self) -> std::option::Option<&std::boxed::Box<crate::model::ColumnFamily>> {
-            #[allow(unreachable_patterns)]
-            self.r#mod.as_ref().and_then(|v| match v {
-                crate::model::modify_column_families_request::modification::Mod::Update(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
-        /// if it holds a `Drop`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn drop(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.r#mod.as_ref().and_then(|v| match v {
-                crate::model::modify_column_families_request::modification::Mod::Drop(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
         /// to hold a `Create`.
         ///
@@ -3879,6 +3853,19 @@ pub mod modify_column_families_request {
             self
         }
 
+        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// if it holds a `Update`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn update(&self) -> std::option::Option<&std::boxed::Box<crate::model::ColumnFamily>> {
+            #[allow(unreachable_patterns)]
+            self.r#mod.as_ref().and_then(|v| match v {
+                crate::model::modify_column_families_request::modification::Mod::Update(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
         /// to hold a `Update`.
         ///
@@ -3892,6 +3879,19 @@ pub mod modify_column_families_request {
                 crate::model::modify_column_families_request::modification::Mod::Update(v.into()),
             );
             self
+        }
+
+        /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
+        /// if it holds a `Drop`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn drop(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.r#mod.as_ref().and_then(|v| match v {
+                crate::model::modify_column_families_request::modification::Mod::Drop(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
@@ -4088,21 +4088,6 @@ impl CheckConsistencyRequest {
         })
     }
 
-    /// The value of [mode][crate::model::CheckConsistencyRequest::mode]
-    /// if it holds a `DataBoostReadLocalWrites`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_boost_read_local_writes(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataBoostReadLocalWrites>> {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::check_consistency_request::Mode::DataBoostReadLocalWrites(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
     /// to hold a `StandardReadRemoteWrites`.
     ///
@@ -4118,6 +4103,21 @@ impl CheckConsistencyRequest {
             crate::model::check_consistency_request::Mode::StandardReadRemoteWrites(v.into()),
         );
         self
+    }
+
+    /// The value of [mode][crate::model::CheckConsistencyRequest::mode]
+    /// if it holds a `DataBoostReadLocalWrites`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_boost_read_local_writes(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataBoostReadLocalWrites>> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::check_consistency_request::Mode::DataBoostReadLocalWrites(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
@@ -4481,12 +4481,6 @@ impl ListSnapshotsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [snapshots][crate::model::ListSnapshotsResponse::snapshots].
     pub fn set_snapshots<T, V>(mut self, v: T) -> Self
     where
@@ -4495,6 +4489,12 @@ impl ListSnapshotsResponse {
     {
         use std::iter::Iterator;
         self.snapshots = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5138,12 +5138,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -5152,6 +5146,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5569,12 +5569,6 @@ impl ListAuthorizedViewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAuthorizedViewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [authorized_views][crate::model::ListAuthorizedViewsResponse::authorized_views].
     pub fn set_authorized_views<T, V>(mut self, v: T) -> Self
     where
@@ -5583,6 +5577,12 @@ impl ListAuthorizedViewsResponse {
     {
         use std::iter::Iterator;
         self.authorized_views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAuthorizedViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5999,6 +5999,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Instance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -6023,18 +6035,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7106,22 +7106,6 @@ impl AppProfile {
         })
     }
 
-    /// The value of [routing_policy][crate::model::AppProfile::routing_policy]
-    /// if it holds a `SingleClusterRouting`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn single_cluster_routing(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::SingleClusterRouting>>
-    {
-        #[allow(unreachable_patterns)]
-        self.routing_policy.as_ref().and_then(|v| match v {
-            crate::model::app_profile::RoutingPolicy::SingleClusterRouting(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [routing_policy][crate::model::AppProfile::routing_policy]
     /// to hold a `MultiClusterRoutingUseAny`.
     ///
@@ -7137,6 +7121,22 @@ impl AppProfile {
             crate::model::app_profile::RoutingPolicy::MultiClusterRoutingUseAny(v.into()),
         );
         self
+    }
+
+    /// The value of [routing_policy][crate::model::AppProfile::routing_policy]
+    /// if it holds a `SingleClusterRouting`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn single_cluster_routing(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::SingleClusterRouting>>
+    {
+        #[allow(unreachable_patterns)]
+        self.routing_policy.as_ref().and_then(|v| match v {
+            crate::model::app_profile::RoutingPolicy::SingleClusterRouting(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [routing_policy][crate::model::AppProfile::routing_policy]
@@ -7182,37 +7182,6 @@ impl AppProfile {
         })
     }
 
-    /// The value of [isolation][crate::model::AppProfile::isolation]
-    /// if it holds a `StandardIsolation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn standard_isolation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::StandardIsolation>> {
-        #[allow(unreachable_patterns)]
-        self.isolation.as_ref().and_then(|v| match v {
-            crate::model::app_profile::Isolation::StandardIsolation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [isolation][crate::model::AppProfile::isolation]
-    /// if it holds a `DataBoostIsolationReadOnly`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_boost_isolation_read_only(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::DataBoostIsolationReadOnly>>
-    {
-        #[allow(unreachable_patterns)]
-        self.isolation.as_ref().and_then(|v| match v {
-            crate::model::app_profile::Isolation::DataBoostIsolationReadOnly(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [isolation][crate::model::AppProfile::isolation]
     /// to hold a `Priority`.
     ///
@@ -7226,6 +7195,21 @@ impl AppProfile {
         self.isolation =
             std::option::Option::Some(crate::model::app_profile::Isolation::Priority(v.into()));
         self
+    }
+
+    /// The value of [isolation][crate::model::AppProfile::isolation]
+    /// if it holds a `StandardIsolation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn standard_isolation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::StandardIsolation>> {
+        #[allow(unreachable_patterns)]
+        self.isolation.as_ref().and_then(|v| match v {
+            crate::model::app_profile::Isolation::StandardIsolation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [isolation][crate::model::AppProfile::isolation]
@@ -7243,6 +7227,22 @@ impl AppProfile {
             crate::model::app_profile::Isolation::StandardIsolation(v.into()),
         );
         self
+    }
+
+    /// The value of [isolation][crate::model::AppProfile::isolation]
+    /// if it holds a `DataBoostIsolationReadOnly`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_boost_isolation_read_only(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::app_profile::DataBoostIsolationReadOnly>>
+    {
+        #[allow(unreachable_patterns)]
+        self.isolation.as_ref().and_then(|v| match v {
+            crate::model::app_profile::Isolation::DataBoostIsolationReadOnly(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [isolation][crate::model::AppProfile::isolation]
@@ -8370,6 +8370,30 @@ impl Table {
         self
     }
 
+    /// Sets the value of [cluster_states][crate::model::Table::cluster_states].
+    pub fn set_cluster_states<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::table::ClusterState>,
+    {
+        use std::iter::Iterator;
+        self.cluster_states = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [column_families][crate::model::Table::column_families].
+    pub fn set_column_families<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ColumnFamily>,
+    {
+        use std::iter::Iterator;
+        self.column_families = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [granularity][crate::model::Table::granularity].
     pub fn set_granularity<T: std::convert::Into<crate::model::table::TimestampGranularity>>(
         mut self,
@@ -8415,30 +8439,6 @@ impl Table {
         v: T,
     ) -> Self {
         self.row_key_schema = v.into();
-        self
-    }
-
-    /// Sets the value of [cluster_states][crate::model::Table::cluster_states].
-    pub fn set_cluster_states<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::table::ClusterState>,
-    {
-        use std::iter::Iterator;
-        self.cluster_states = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [column_families][crate::model::Table::column_families].
-    pub fn set_column_families<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::ColumnFamily>,
-    {
-        use std::iter::Iterator;
-        self.column_families = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -9554,41 +9554,6 @@ impl GcRule {
         })
     }
 
-    /// The value of [rule][crate::model::GcRule::rule]
-    /// if it holds a `MaxAge`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn max_age(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.rule.as_ref().and_then(|v| match v {
-            crate::model::gc_rule::Rule::MaxAge(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule][crate::model::GcRule::rule]
-    /// if it holds a `Intersection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn intersection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::gc_rule::Intersection>> {
-        #[allow(unreachable_patterns)]
-        self.rule.as_ref().and_then(|v| match v {
-            crate::model::gc_rule::Rule::Intersection(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule][crate::model::GcRule::rule]
-    /// if it holds a `Union`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn union(&self) -> std::option::Option<&std::boxed::Box<crate::model::gc_rule::Union>> {
-        #[allow(unreachable_patterns)]
-        self.rule.as_ref().and_then(|v| match v {
-            crate::model::gc_rule::Rule::Union(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [rule][crate::model::GcRule::rule]
     /// to hold a `MaxNumVersions`.
     ///
@@ -9598,6 +9563,17 @@ impl GcRule {
         self.rule =
             std::option::Option::Some(crate::model::gc_rule::Rule::MaxNumVersions(v.into()));
         self
+    }
+
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `MaxAge`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn max_age(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::MaxAge(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule][crate::model::GcRule::rule]
@@ -9613,6 +9589,19 @@ impl GcRule {
         self
     }
 
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `Intersection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn intersection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::gc_rule::Intersection>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::Intersection(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rule][crate::model::GcRule::rule]
     /// to hold a `Intersection`.
     ///
@@ -9626,6 +9615,17 @@ impl GcRule {
     ) -> Self {
         self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::Intersection(v.into()));
         self
+    }
+
+    /// The value of [rule][crate::model::GcRule::rule]
+    /// if it holds a `Union`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn union(&self) -> std::option::Option<&std::boxed::Box<crate::model::gc_rule::Union>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::gc_rule::Rule::Union(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule][crate::model::GcRule::rule]
@@ -10823,139 +10823,6 @@ impl Type {
         })
     }
 
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `StringType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::String>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::StringType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `Int64Type`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int64_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Int64>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::Int64Type(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `Float32Type`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn float32_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Float32>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::Float32Type(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `Float64Type`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn float64_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Float64>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::Float64Type(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `BoolType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bool_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Bool>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::BoolType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `TimestampType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn timestamp_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::TimestampType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `DateType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn date_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Date>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::DateType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `AggregateType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aggregate_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Aggregate>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::AggregateType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `StructType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn struct_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Struct>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::StructType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `ArrayType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn array_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Array>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::ArrayType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Type::kind]
-    /// if it holds a `MapType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn map_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Map>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::r#type::Kind::MapType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `BytesType`.
     ///
@@ -10967,6 +10834,19 @@ impl Type {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::r#type::Kind::BytesType(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `StringType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::String>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::StringType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::Type::kind]
@@ -10982,6 +10862,17 @@ impl Type {
         self
     }
 
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `Int64Type`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int64_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Int64>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::Int64Type(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `Int64Type`.
     ///
@@ -10993,6 +10884,19 @@ impl Type {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::r#type::Kind::Int64Type(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `Float32Type`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn float32_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Float32>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::Float32Type(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::Type::kind]
@@ -11010,6 +10914,19 @@ impl Type {
         self
     }
 
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `Float64Type`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn float64_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Float64>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::Float64Type(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `Float64Type`.
     ///
@@ -11025,6 +10942,17 @@ impl Type {
         self
     }
 
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `BoolType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bool_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Bool>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::BoolType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `BoolType`.
     ///
@@ -11036,6 +10964,19 @@ impl Type {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::r#type::Kind::BoolType(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `TimestampType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn timestamp_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::TimestampType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::Type::kind]
@@ -11053,6 +10994,17 @@ impl Type {
         self
     }
 
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `DateType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn date_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Date>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::DateType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `DateType`.
     ///
@@ -11064,6 +11016,19 @@ impl Type {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::r#type::Kind::DateType(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `AggregateType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aggregate_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Aggregate>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::AggregateType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::Type::kind]
@@ -11081,6 +11046,19 @@ impl Type {
         self
     }
 
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `StructType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn struct_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Struct>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::StructType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `StructType`.
     ///
@@ -11094,6 +11072,17 @@ impl Type {
         self
     }
 
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `ArrayType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn array_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Array>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::ArrayType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Type::kind]
     /// to hold a `ArrayType`.
     ///
@@ -11105,6 +11094,17 @@ impl Type {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::r#type::Kind::ArrayType(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::Type::kind]
+    /// if it holds a `MapType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn map_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::r#type::Map>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::r#type::Kind::MapType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::Type::kind]
@@ -11388,23 +11388,6 @@ pub mod r#type {
                 })
             }
 
-            /// The value of [encoding][crate::model::r#type::string::Encoding::encoding]
-            /// if it holds a `Utf8Bytes`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn utf8_bytes(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.encoding.as_ref().and_then(|v| match v {
-                    crate::model::r#type::string::encoding::Encoding::Utf8Bytes(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [encoding][crate::model::r#type::string::Encoding::encoding]
             /// to hold a `Utf8Raw`.
             ///
@@ -11423,6 +11406,23 @@ pub mod r#type {
                     crate::model::r#type::string::encoding::Encoding::Utf8Raw(v.into()),
                 );
                 self
+            }
+
+            /// The value of [encoding][crate::model::r#type::string::Encoding::encoding]
+            /// if it holds a `Utf8Bytes`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn utf8_bytes(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::string::encoding::Encoding::Utf8Bytes(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [encoding][crate::model::r#type::string::Encoding::encoding]
@@ -11623,23 +11623,6 @@ pub mod r#type {
                 })
             }
 
-            /// The value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
-            /// if it holds a `OrderedCodeBytes`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn ordered_code_bytes(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::r#type::int_64::encoding::OrderedCodeBytes>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.encoding.as_ref().and_then(|v| match v {
-                    crate::model::r#type::int_64::encoding::Encoding::OrderedCodeBytes(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
             /// to hold a `BigEndianBytes`.
             ///
@@ -11657,6 +11640,23 @@ pub mod r#type {
                     crate::model::r#type::int_64::encoding::Encoding::BigEndianBytes(v.into()),
                 );
                 self
+            }
+
+            /// The value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
+            /// if it holds a `OrderedCodeBytes`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn ordered_code_bytes(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::int_64::encoding::OrderedCodeBytes>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::int_64::encoding::Encoding::OrderedCodeBytes(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
@@ -12040,17 +12040,6 @@ pub mod r#type {
             std::default::Default::default()
         }
 
-        /// Sets the value of [encoding][crate::model::r#type::Struct::encoding].
-        pub fn set_encoding<
-            T: std::convert::Into<std::option::Option<crate::model::r#type::r#struct::Encoding>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.encoding = v.into();
-            self
-        }
-
         /// Sets the value of [fields][crate::model::r#type::Struct::fields].
         pub fn set_fields<T, V>(mut self, v: T) -> Self
         where
@@ -12059,6 +12048,17 @@ pub mod r#type {
         {
             use std::iter::Iterator;
             self.fields = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [encoding][crate::model::r#type::Struct::encoding].
+        pub fn set_encoding<
+            T: std::convert::Into<std::option::Option<crate::model::r#type::r#struct::Encoding>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.encoding = v.into();
             self
         }
     }
@@ -12178,40 +12178,6 @@ pub mod r#type {
                 })
             }
 
-            /// The value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
-            /// if it holds a `DelimitedBytes`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn delimited_bytes(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::r#type::r#struct::encoding::DelimitedBytes>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.encoding.as_ref().and_then(|v| match v {
-                    crate::model::r#type::r#struct::encoding::Encoding::DelimitedBytes(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
-            /// if it holds a `OrderedCodeBytes`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn ordered_code_bytes(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::r#type::r#struct::encoding::OrderedCodeBytes>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.encoding.as_ref().and_then(|v| match v {
-                    crate::model::r#type::r#struct::encoding::Encoding::OrderedCodeBytes(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
             /// to hold a `Singleton`.
             ///
@@ -12231,6 +12197,23 @@ pub mod r#type {
                 self
             }
 
+            /// The value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
+            /// if it holds a `DelimitedBytes`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn delimited_bytes(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::r#struct::encoding::DelimitedBytes>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::r#struct::encoding::Encoding::DelimitedBytes(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
             /// to hold a `DelimitedBytes`.
             ///
@@ -12248,6 +12231,23 @@ pub mod r#type {
                     crate::model::r#type::r#struct::encoding::Encoding::DelimitedBytes(v.into()),
                 );
                 self
+            }
+
+            /// The value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
+            /// if it holds a `OrderedCodeBytes`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn ordered_code_bytes(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::r#type::r#struct::encoding::OrderedCodeBytes>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.encoding.as_ref().and_then(|v| match v {
+                    crate::model::r#type::r#struct::encoding::Encoding::OrderedCodeBytes(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
@@ -12617,49 +12617,6 @@ pub mod r#type {
             })
         }
 
-        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// if it holds a `HllppUniqueCount`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn hllpp_unique_count(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.aggregator.as_ref().and_then(|v| match v {
-                crate::model::r#type::aggregate::Aggregator::HllppUniqueCount(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// if it holds a `Max`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn max(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Max>> {
-            #[allow(unreachable_patterns)]
-            self.aggregator.as_ref().and_then(|v| match v {
-                crate::model::r#type::aggregate::Aggregator::Max(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// if it holds a `Min`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn min(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Min>> {
-            #[allow(unreachable_patterns)]
-            self.aggregator.as_ref().and_then(|v| match v {
-                crate::model::r#type::aggregate::Aggregator::Min(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
         /// to hold a `Sum`.
         ///
@@ -12675,6 +12632,23 @@ pub mod r#type {
                 crate::model::r#type::aggregate::Aggregator::Sum(v.into()),
             );
             self
+        }
+
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `HllppUniqueCount`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn hllpp_unique_count(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::HllppUniqueCount(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
@@ -12698,6 +12672,19 @@ pub mod r#type {
             self
         }
 
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `Max`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn max(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Max>> {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::Max(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
         /// to hold a `Max`.
         ///
@@ -12713,6 +12700,19 @@ pub mod r#type {
                 crate::model::r#type::aggregate::Aggregator::Max(v.into()),
             );
             self
+        }
+
+        /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
+        /// if it holds a `Min`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn min(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::r#type::aggregate::Min>> {
+            #[allow(unreachable_patterns)]
+            self.aggregator.as_ref().and_then(|v| match v {
+                crate::model::r#type::aggregate::Aggregator::Min(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -387,19 +387,6 @@ impl SignatureInfo {
         })
     }
 
-    /// The value of [verification_info][crate::model::SignatureInfo::verification_info]
-    /// if it holds a `CustomerKmsKeyVersion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn customer_kms_key_version(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.verification_info.as_ref().and_then(|v| match v {
-            crate::model::signature_info::VerificationInfo::CustomerKmsKeyVersion(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [verification_info][crate::model::SignatureInfo::verification_info]
     /// to hold a `GooglePublicKeyPem`.
     ///
@@ -413,6 +400,19 @@ impl SignatureInfo {
             crate::model::signature_info::VerificationInfo::GooglePublicKeyPem(v.into()),
         );
         self
+    }
+
+    /// The value of [verification_info][crate::model::SignatureInfo::verification_info]
+    /// if it holds a `CustomerKmsKeyVersion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn customer_kms_key_version(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.verification_info.as_ref().and_then(|v| match v {
+            crate::model::signature_info::VerificationInfo::CustomerKmsKeyVersion(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [verification_info][crate::model::SignatureInfo::verification_info]
@@ -768,17 +768,6 @@ impl ApprovalRequest {
         })
     }
 
-    /// The value of [decision][crate::model::ApprovalRequest::decision]
-    /// if it holds a `Dismiss`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dismiss(&self) -> std::option::Option<&std::boxed::Box<crate::model::DismissDecision>> {
-        #[allow(unreachable_patterns)]
-        self.decision.as_ref().and_then(|v| match v {
-            crate::model::approval_request::Decision::Dismiss(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [decision][crate::model::ApprovalRequest::decision]
     /// to hold a `Approve`.
     ///
@@ -791,6 +780,17 @@ impl ApprovalRequest {
         self.decision =
             std::option::Option::Some(crate::model::approval_request::Decision::Approve(v.into()));
         self
+    }
+
+    /// The value of [decision][crate::model::ApprovalRequest::decision]
+    /// if it holds a `Dismiss`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dismiss(&self) -> std::option::Option<&std::boxed::Box<crate::model::DismissDecision>> {
+        #[allow(unreachable_patterns)]
+        self.decision.as_ref().and_then(|v| match v {
+            crate::model::approval_request::Decision::Dismiss(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [decision][crate::model::ApprovalRequest::decision]
@@ -1018,6 +1018,28 @@ impl AccessApprovalSettings {
         self
     }
 
+    /// Sets the value of [notification_emails][crate::model::AccessApprovalSettings::notification_emails].
+    pub fn set_notification_emails<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.notification_emails = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enrolled_services][crate::model::AccessApprovalSettings::enrolled_services].
+    pub fn set_enrolled_services<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EnrolledService>,
+    {
+        use std::iter::Iterator;
+        self.enrolled_services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [enrolled_ancestor][crate::model::AccessApprovalSettings::enrolled_ancestor].
     pub fn set_enrolled_ancestor<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enrolled_ancestor = v.into();
@@ -1045,28 +1067,6 @@ impl AccessApprovalSettings {
     /// Sets the value of [invalid_key_version][crate::model::AccessApprovalSettings::invalid_key_version].
     pub fn set_invalid_key_version<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.invalid_key_version = v.into();
-        self
-    }
-
-    /// Sets the value of [notification_emails][crate::model::AccessApprovalSettings::notification_emails].
-    pub fn set_notification_emails<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.notification_emails = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [enrolled_services][crate::model::AccessApprovalSettings::enrolled_services].
-    pub fn set_enrolled_services<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EnrolledService>,
-    {
-        use std::iter::Iterator;
-        self.enrolled_services = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1220,12 +1220,6 @@ impl ListApprovalRequestsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListApprovalRequestsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [approval_requests][crate::model::ListApprovalRequestsResponse::approval_requests].
     pub fn set_approval_requests<T, V>(mut self, v: T) -> Self
     where
@@ -1234,6 +1228,12 @@ impl ListApprovalRequestsResponse {
     {
         use std::iter::Iterator;
         self.approval_requests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListApprovalRequestsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -83,6 +83,17 @@ impl Notification {
         self
     }
 
+    /// Sets the value of [messages][crate::model::Notification::messages].
+    pub fn set_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Message>,
+    {
+        use std::iter::Iterator;
+        self.messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Notification::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -98,17 +109,6 @@ impl Notification {
         v: T,
     ) -> Self {
         self.notification_type = v.into();
-        self
-    }
-
-    /// Sets the value of [messages][crate::model::Notification::messages].
-    pub fn set_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Message>,
-    {
-        use std::iter::Iterator;
-        self.messages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -248,6 +248,17 @@ impl Message {
         self
     }
 
+    /// Sets the value of [attachments][crate::model::Message::attachments].
+    pub fn set_attachments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Attachment>,
+    {
+        use std::iter::Iterator;
+        self.attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Message::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -263,17 +274,6 @@ impl Message {
         v: T,
     ) -> Self {
         self.localization_time = v.into();
-        self
-    }
-
-    /// Sets the value of [attachments][crate::model::Message::attachments].
-    pub fn set_attachments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Attachment>,
-    {
-        use std::iter::Iterator;
-        self.attachments = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -621,6 +621,17 @@ impl ListNotificationsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [notifications][crate::model::ListNotificationsResponse::notifications].
+    pub fn set_notifications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Notification>,
+    {
+        use std::iter::Iterator;
+        self.notifications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListNotificationsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -630,17 +641,6 @@ impl ListNotificationsResponse {
     /// Sets the value of [total_size][crate::model::ListNotificationsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [notifications][crate::model::ListNotificationsResponse::notifications].
-    pub fn set_notifications<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Notification>,
-    {
-        use std::iter::Iterator;
-        self.notifications = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -756,12 +756,6 @@ impl Settings {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Settings::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [notification_settings][crate::model::Settings::notification_settings].
     pub fn set_notification_settings<T, K, V>(mut self, v: T) -> Self
     where
@@ -771,6 +765,12 @@ impl Settings {
     {
         use std::iter::Iterator;
         self.notification_settings = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Settings::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -1324,6 +1324,17 @@ pub mod dataset_service {
             self
         }
 
+        /// Sets the value of [annotation_filters][crate::model::SearchDataItemsRequest::annotation_filters].
+        pub fn set_annotation_filters<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.annotation_filters = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [field_mask][crate::model::SearchDataItemsRequest::field_mask].
         pub fn set_field_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
             mut self,
@@ -1355,17 +1366,6 @@ pub mod dataset_service {
         /// Sets the value of [page_token][crate::model::SearchDataItemsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
-            self
-        }
-
-        /// Sets the value of [annotation_filters][crate::model::SearchDataItemsRequest::annotation_filters].
-        pub fn set_annotation_filters<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.annotation_filters = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -12489,6 +12489,19 @@ pub mod featurestore_service {
             self
         }
 
+        /// Sets the value of [feature_specs][crate::model::ImportFeatureValuesRequest::feature_specs].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_feature_specs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::import_feature_values_request::FeatureSpec>,
+        {
+            use std::iter::Iterator;
+            self.0.request.feature_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [disable_online_serving][crate::model::ImportFeatureValuesRequest::disable_online_serving].
         pub fn set_disable_online_serving<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.disable_online_serving = v.into();
@@ -12504,19 +12517,6 @@ pub mod featurestore_service {
         /// Sets the value of [disable_ingestion_analysis][crate::model::ImportFeatureValuesRequest::disable_ingestion_analysis].
         pub fn set_disable_ingestion_analysis<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.disable_ingestion_analysis = v.into();
-            self
-        }
-
-        /// Sets the value of [feature_specs][crate::model::ImportFeatureValuesRequest::feature_specs].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_feature_specs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::import_feature_values_request::FeatureSpec>,
-        {
-            use std::iter::Iterator;
-            self.0.request.feature_specs = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -12719,15 +12719,6 @@ pub mod featurestore_service {
             self
         }
 
-        /// Sets the value of [start_time][crate::model::BatchReadFeatureValuesRequest::start_time].
-        pub fn set_start_time<T: Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.start_time = v.into();
-            self
-        }
-
         /// Sets the value of [pass_through_fields][crate::model::BatchReadFeatureValuesRequest::pass_through_fields].
         pub fn set_pass_through_fields<T, V>(mut self, v: T) -> Self
         where
@@ -12751,6 +12742,15 @@ pub mod featurestore_service {
         {
             use std::iter::Iterator;
             self.0.request.entity_type_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [start_time][crate::model::BatchReadFeatureValuesRequest::start_time].
+        pub fn set_start_time<T: Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.start_time = v.into();
             self
         }
 
@@ -17604,15 +17604,6 @@ pub mod index_service {
             self
         }
 
-        /// Sets the value of [update_mask][crate::model::UpsertDatapointsRequest::update_mask].
-        pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.update_mask = v.into();
-            self
-        }
-
         /// Sets the value of [datapoints][crate::model::UpsertDatapointsRequest::datapoints].
         pub fn set_datapoints<T, V>(mut self, v: T) -> Self
         where
@@ -17621,6 +17612,15 @@ pub mod index_service {
         {
             use std::iter::Iterator;
             self.0.request.datapoints = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [update_mask][crate::model::UpsertDatapointsRequest::update_mask].
+        pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.update_mask = v.into();
             self
         }
     }
@@ -20294,6 +20294,19 @@ pub mod job_service {
             self
         }
 
+        /// Sets the value of [objectives][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::objectives].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_objectives<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_model_deployment_monitoring_stats_anomalies_request::StatsAnomaliesObjective>
+        {
+            use std::iter::Iterator;
+            self.0.request.objectives = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_size][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
@@ -20318,19 +20331,6 @@ pub mod job_service {
         /// Sets the value of [end_time][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::end_time].
         pub fn set_end_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
             self.0.request.end_time = v.into();
-            self
-        }
-
-        /// Sets the value of [objectives][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::objectives].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_objectives<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_model_deployment_monitoring_stats_anomalies_request::StatsAnomaliesObjective>
-        {
-            use std::iter::Iterator;
-            self.0.request.objectives = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -21482,26 +21482,6 @@ pub mod llm_utility_service {
             self
         }
 
-        /// Sets the value of [system_instruction][crate::model::CountTokensRequest::system_instruction].
-        pub fn set_system_instruction<T: Into<std::option::Option<crate::model::Content>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.system_instruction = v.into();
-            self
-        }
-
-        /// Sets the value of [generation_config][crate::model::CountTokensRequest::generation_config].
-        pub fn set_generation_config<
-            T: Into<std::option::Option<crate::model::GenerationConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.generation_config = v.into();
-            self
-        }
-
         /// Sets the value of [instances][crate::model::CountTokensRequest::instances].
         pub fn set_instances<T, V>(mut self, v: T) -> Self
         where
@@ -21524,6 +21504,15 @@ pub mod llm_utility_service {
             self
         }
 
+        /// Sets the value of [system_instruction][crate::model::CountTokensRequest::system_instruction].
+        pub fn set_system_instruction<T: Into<std::option::Option<crate::model::Content>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.system_instruction = v.into();
+            self
+        }
+
         /// Sets the value of [tools][crate::model::CountTokensRequest::tools].
         pub fn set_tools<T, V>(mut self, v: T) -> Self
         where
@@ -21532,6 +21521,17 @@ pub mod llm_utility_service {
         {
             use std::iter::Iterator;
             self.0.request.tools = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [generation_config][crate::model::CountTokensRequest::generation_config].
+        pub fn set_generation_config<
+            T: Into<std::option::Option<crate::model::GenerationConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.generation_config = v.into();
             self
         }
     }
@@ -21582,12 +21582,6 @@ pub mod llm_utility_service {
             self
         }
 
-        /// Sets the value of [model][crate::model::ComputeTokensRequest::model].
-        pub fn set_model<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.model = v.into();
-            self
-        }
-
         /// Sets the value of [instances][crate::model::ComputeTokensRequest::instances].
         pub fn set_instances<T, V>(mut self, v: T) -> Self
         where
@@ -21596,6 +21590,12 @@ pub mod llm_utility_service {
         {
             use std::iter::Iterator;
             self.0.request.instances = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [model][crate::model::ComputeTokensRequest::model].
+        pub fn set_model<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.model = v.into();
             self
         }
 
@@ -22311,12 +22311,6 @@ pub mod match_service {
             self
         }
 
-        /// Sets the value of [return_full_datapoint][crate::model::FindNeighborsRequest::return_full_datapoint].
-        pub fn set_return_full_datapoint<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.return_full_datapoint = v.into();
-            self
-        }
-
         /// Sets the value of [queries][crate::model::FindNeighborsRequest::queries].
         pub fn set_queries<T, V>(mut self, v: T) -> Self
         where
@@ -22325,6 +22319,12 @@ pub mod match_service {
         {
             use std::iter::Iterator;
             self.0.request.queries = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [return_full_datapoint][crate::model::FindNeighborsRequest::return_full_datapoint].
+        pub fn set_return_full_datapoint<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.return_full_datapoint = v.into();
             self
         }
     }
@@ -34607,12 +34607,6 @@ pub mod prediction_service {
             self
         }
 
-        /// Sets the value of [parameters][crate::model::PredictRequest::parameters].
-        pub fn set_parameters<T: Into<std::option::Option<wkt::Value>>>(mut self, v: T) -> Self {
-            self.0.request.parameters = v.into();
-            self
-        }
-
         /// Sets the value of [instances][crate::model::PredictRequest::instances].
         ///
         /// This is a **required** field for requests.
@@ -34623,6 +34617,12 @@ pub mod prediction_service {
         {
             use std::iter::Iterator;
             self.0.request.instances = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parameters][crate::model::PredictRequest::parameters].
+        pub fn set_parameters<T: Into<std::option::Option<wkt::Value>>>(mut self, v: T) -> Self {
+            self.0.request.parameters = v.into();
             self
         }
     }
@@ -34729,15 +34729,6 @@ pub mod prediction_service {
             self
         }
 
-        /// Sets the value of [parameters][crate::model::DirectPredictRequest::parameters].
-        pub fn set_parameters<T: Into<std::option::Option<crate::model::Tensor>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.parameters = v.into();
-            self
-        }
-
         /// Sets the value of [inputs][crate::model::DirectPredictRequest::inputs].
         pub fn set_inputs<T, V>(mut self, v: T) -> Self
         where
@@ -34746,6 +34737,15 @@ pub mod prediction_service {
         {
             use std::iter::Iterator;
             self.0.request.inputs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parameters][crate::model::DirectPredictRequest::parameters].
+        pub fn set_parameters<T: Into<std::option::Option<crate::model::Tensor>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.parameters = v.into();
             self
         }
     }
@@ -34858,6 +34858,19 @@ pub mod prediction_service {
             self
         }
 
+        /// Sets the value of [instances][crate::model::ExplainRequest::instances].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_instances<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<wkt::Value>,
+        {
+            use std::iter::Iterator;
+            self.0.request.instances = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [parameters][crate::model::ExplainRequest::parameters].
         pub fn set_parameters<T: Into<std::option::Option<wkt::Value>>>(mut self, v: T) -> Self {
             self.0.request.parameters = v.into();
@@ -34878,19 +34891,6 @@ pub mod prediction_service {
         /// Sets the value of [deployed_model_id][crate::model::ExplainRequest::deployed_model_id].
         pub fn set_deployed_model_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.deployed_model_id = v.into();
-            self
-        }
-
-        /// Sets the value of [instances][crate::model::ExplainRequest::instances].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_instances<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<wkt::Value>,
-        {
-            use std::iter::Iterator;
-            self.0.request.instances = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -34941,6 +34941,19 @@ pub mod prediction_service {
             self
         }
 
+        /// Sets the value of [contents][crate::model::GenerateContentRequest::contents].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_contents<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Content>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [system_instruction][crate::model::GenerateContentRequest::system_instruction].
         pub fn set_system_instruction<T: Into<std::option::Option<crate::model::Content>>>(
             mut self,
@@ -34956,6 +34969,17 @@ pub mod prediction_service {
             self
         }
 
+        /// Sets the value of [tools][crate::model::GenerateContentRequest::tools].
+        pub fn set_tools<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Tool>,
+        {
+            use std::iter::Iterator;
+            self.0.request.tools = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [tool_config][crate::model::GenerateContentRequest::tool_config].
         pub fn set_tool_config<T: Into<std::option::Option<crate::model::ToolConfig>>>(
             mut self,
@@ -34965,38 +34989,14 @@ pub mod prediction_service {
             self
         }
 
-        /// Sets the value of [generation_config][crate::model::GenerateContentRequest::generation_config].
-        pub fn set_generation_config<
-            T: Into<std::option::Option<crate::model::GenerationConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.generation_config = v.into();
-            self
-        }
-
-        /// Sets the value of [contents][crate::model::GenerateContentRequest::contents].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_contents<T, V>(mut self, v: T) -> Self
+        /// Sets the value of [labels][crate::model::GenerateContentRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
         where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::Content>,
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
         {
-            use std::iter::Iterator;
-            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [tools][crate::model::GenerateContentRequest::tools].
-        pub fn set_tools<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::Tool>,
-        {
-            use std::iter::Iterator;
-            self.0.request.tools = v.into_iter().map(|i| i.into()).collect();
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -35011,14 +35011,14 @@ pub mod prediction_service {
             self
         }
 
-        /// Sets the value of [labels][crate::model::GenerateContentRequest::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        /// Sets the value of [generation_config][crate::model::GenerateContentRequest::generation_config].
+        pub fn set_generation_config<
+            T: Into<std::option::Option<crate::model::GenerationConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.generation_config = v.into();
             self
         }
     }
@@ -43975,17 +43975,6 @@ pub mod vertex_rag_service {
             self
         }
 
-        /// Sets the value of [model][crate::model::AugmentPromptRequest::model].
-        pub fn set_model<
-            T: Into<std::option::Option<crate::model::augment_prompt_request::Model>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.model = v.into();
-            self
-        }
-
         /// Sets the value of [contents][crate::model::AugmentPromptRequest::contents].
         pub fn set_contents<T, V>(mut self, v: T) -> Self
         where
@@ -43994,6 +43983,17 @@ pub mod vertex_rag_service {
         {
             use std::iter::Iterator;
             self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [model][crate::model::AugmentPromptRequest::model].
+        pub fn set_model<
+            T: Into<std::option::Option<crate::model::augment_prompt_request::Model>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.model = v.into();
             self
         }
 
@@ -44085,17 +44085,6 @@ pub mod vertex_rag_service {
             self
         }
 
-        /// Sets the value of [parameters][crate::model::CorroborateContentRequest::parameters].
-        pub fn set_parameters<
-            T: Into<std::option::Option<crate::model::corroborate_content_request::Parameters>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.parameters = v.into();
-            self
-        }
-
         /// Sets the value of [facts][crate::model::CorroborateContentRequest::facts].
         pub fn set_facts<T, V>(mut self, v: T) -> Self
         where
@@ -44104,6 +44093,17 @@ pub mod vertex_rag_service {
         {
             use std::iter::Iterator;
             self.0.request.facts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parameters][crate::model::CorroborateContentRequest::parameters].
+        pub fn set_parameters<
+            T: Into<std::option::Option<crate::model::corroborate_content_request::Parameters>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.parameters = v.into();
             self
         }
     }

--- a/src/generated/cloud/aiplatform/v1/src/model.rs
+++ b/src/generated/cloud/aiplatform/v1/src/model.rs
@@ -534,6 +534,18 @@ impl Artifact {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Artifact::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Artifact::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -582,18 +594,6 @@ impl Artifact {
     /// Sets the value of [description][crate::model::Artifact::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Artifact::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1224,6 +1224,17 @@ impl BatchPredictionJob {
         self
     }
 
+    /// Sets the value of [partial_failures][crate::model::BatchPredictionJob::partial_failures].
+    pub fn set_partial_failures<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.partial_failures = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [resources_consumed][crate::model::BatchPredictionJob::resources_consumed].
     pub fn set_resources_consumed<
         T: std::convert::Into<std::option::Option<crate::model::ResourcesConsumed>>,
@@ -1282,6 +1293,18 @@ impl BatchPredictionJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::BatchPredictionJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [encryption_spec][crate::model::BatchPredictionJob::encryption_spec].
     pub fn set_encryption_spec<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
@@ -1308,29 +1331,6 @@ impl BatchPredictionJob {
     /// Sets the value of [satisfies_pzi][crate::model::BatchPredictionJob::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [partial_failures][crate::model::BatchPredictionJob::partial_failures].
-    pub fn set_partial_failures<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.partial_failures = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::BatchPredictionJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1423,21 +1423,6 @@ pub mod batch_prediction_job {
             })
         }
 
-        /// The value of [source][crate::model::batch_prediction_job::InputConfig::source]
-        /// if it holds a `BigquerySource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn bigquery_source(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::batch_prediction_job::input_config::Source::BigquerySource(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [source][crate::model::batch_prediction_job::InputConfig::source]
         /// to hold a `GcsSource`.
         ///
@@ -1451,6 +1436,21 @@ pub mod batch_prediction_job {
                 crate::model::batch_prediction_job::input_config::Source::GcsSource(v.into()),
             );
             self
+        }
+
+        /// The value of [source][crate::model::batch_prediction_job::InputConfig::source]
+        /// if it holds a `BigquerySource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn bigquery_source(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::batch_prediction_job::input_config::Source::BigquerySource(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source][crate::model::batch_prediction_job::InputConfig::source]
@@ -1754,19 +1754,6 @@ pub mod batch_prediction_job {
             })
         }
 
-        /// The value of [destination][crate::model::batch_prediction_job::OutputConfig::destination]
-        /// if it holds a `BigqueryDestination`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn bigquery_destination(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
-            #[allow(unreachable_patterns)]
-            self.destination.as_ref().and_then(|v| match v {
-                crate::model::batch_prediction_job::output_config::Destination::BigqueryDestination(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [destination][crate::model::batch_prediction_job::OutputConfig::destination]
         /// to hold a `GcsDestination`.
         ///
@@ -1784,6 +1771,19 @@ pub mod batch_prediction_job {
                 ),
             );
             self
+        }
+
+        /// The value of [destination][crate::model::batch_prediction_job::OutputConfig::destination]
+        /// if it holds a `BigqueryDestination`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn bigquery_destination(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
+            #[allow(unreachable_patterns)]
+            self.destination.as_ref().and_then(|v| match v {
+                crate::model::batch_prediction_job::output_config::Destination::BigqueryDestination(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [destination][crate::model::batch_prediction_job::OutputConfig::destination]
@@ -1952,17 +1952,6 @@ pub mod batch_prediction_job {
             })
         }
 
-        /// The value of [output_location][crate::model::batch_prediction_job::OutputInfo::output_location]
-        /// if it holds a `BigqueryOutputDataset`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn bigquery_output_dataset(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.output_location.as_ref().and_then(|v| match v {
-                crate::model::batch_prediction_job::output_info::OutputLocation::BigqueryOutputDataset(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [output_location][crate::model::batch_prediction_job::OutputInfo::output_location]
         /// to hold a `GcsOutputDirectory`.
         ///
@@ -1978,6 +1967,17 @@ pub mod batch_prediction_job {
                 ),
             );
             self
+        }
+
+        /// The value of [output_location][crate::model::batch_prediction_job::OutputInfo::output_location]
+        /// if it holds a `BigqueryOutputDataset`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn bigquery_output_dataset(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.output_location.as_ref().and_then(|v| match v {
+                crate::model::batch_prediction_job::output_info::OutputLocation::BigqueryOutputDataset(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [output_location][crate::model::batch_prediction_job::OutputInfo::output_location]
@@ -2127,6 +2127,28 @@ impl CachedContent {
         self
     }
 
+    /// Sets the value of [contents][crate::model::CachedContent::contents].
+    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Content>,
+    {
+        use std::iter::Iterator;
+        self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [tools][crate::model::CachedContent::tools].
+    pub fn set_tools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Tool>,
+    {
+        use std::iter::Iterator;
+        self.tools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [tool_config][crate::model::CachedContent::tool_config].
     pub fn set_tool_config<T: std::convert::Into<std::option::Option<crate::model::ToolConfig>>>(
         mut self,
@@ -2165,28 +2187,6 @@ impl CachedContent {
         self
     }
 
-    /// Sets the value of [contents][crate::model::CachedContent::contents].
-    pub fn set_contents<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Content>,
-    {
-        use std::iter::Iterator;
-        self.contents = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tools][crate::model::CachedContent::tools].
-    pub fn set_tools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Tool>,
-    {
-        use std::iter::Iterator;
-        self.tools = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [expiration][crate::model::CachedContent::expiration].
     ///
     /// Note that all the setters affecting `expiration` are mutually
@@ -2212,17 +2212,6 @@ impl CachedContent {
         })
     }
 
-    /// The value of [expiration][crate::model::CachedContent::expiration]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.expiration.as_ref().and_then(|v| match v {
-            crate::model::cached_content::Expiration::Ttl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [expiration][crate::model::CachedContent::expiration]
     /// to hold a `ExpireTime`.
     ///
@@ -2236,6 +2225,17 @@ impl CachedContent {
             crate::model::cached_content::Expiration::ExpireTime(v.into()),
         );
         self
+    }
+
+    /// The value of [expiration][crate::model::CachedContent::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::cached_content::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [expiration][crate::model::CachedContent::expiration]
@@ -2570,6 +2570,16 @@ impl Part {
         })
     }
 
+    /// Sets the value of [data][crate::model::Part::data]
+    /// to hold a `Text`.
+    ///
+    /// Note that all the setters affecting `data` are
+    /// mutually exclusive.
+    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.data = std::option::Option::Some(crate::model::part::Data::Text(v.into()));
+        self
+    }
+
     /// The value of [data][crate::model::Part::data]
     /// if it holds a `InlineData`, `None` if the field is not set or
     /// holds a different branch.
@@ -2579,79 +2589,6 @@ impl Part {
             crate::model::part::Data::InlineData(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [data][crate::model::Part::data]
-    /// if it holds a `FileData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn file_data(&self) -> std::option::Option<&std::boxed::Box<crate::model::FileData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::part::Data::FileData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::Part::data]
-    /// if it holds a `FunctionCall`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn function_call(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FunctionCall>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::part::Data::FunctionCall(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::Part::data]
-    /// if it holds a `FunctionResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn function_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FunctionResponse>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::part::Data::FunctionResponse(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::Part::data]
-    /// if it holds a `ExecutableCode`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn executable_code(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExecutableCode>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::part::Data::ExecutableCode(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::Part::data]
-    /// if it holds a `CodeExecutionResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn code_execution_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CodeExecutionResult>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::part::Data::CodeExecutionResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [data][crate::model::Part::data]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data = std::option::Option::Some(crate::model::part::Data::Text(v.into()));
-        self
     }
 
     /// Sets the value of [data][crate::model::Part::data]
@@ -2667,6 +2604,17 @@ impl Part {
         self
     }
 
+    /// The value of [data][crate::model::Part::data]
+    /// if it holds a `FileData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn file_data(&self) -> std::option::Option<&std::boxed::Box<crate::model::FileData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::part::Data::FileData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::Part::data]
     /// to hold a `FileData`.
     ///
@@ -2680,6 +2628,19 @@ impl Part {
         self
     }
 
+    /// The value of [data][crate::model::Part::data]
+    /// if it holds a `FunctionCall`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn function_call(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FunctionCall>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::part::Data::FunctionCall(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::Part::data]
     /// to hold a `FunctionCall`.
     ///
@@ -2691,6 +2652,19 @@ impl Part {
     ) -> Self {
         self.data = std::option::Option::Some(crate::model::part::Data::FunctionCall(v.into()));
         self
+    }
+
+    /// The value of [data][crate::model::Part::data]
+    /// if it holds a `FunctionResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn function_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FunctionResponse>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::part::Data::FunctionResponse(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::Part::data]
@@ -2708,6 +2682,19 @@ impl Part {
         self
     }
 
+    /// The value of [data][crate::model::Part::data]
+    /// if it holds a `ExecutableCode`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn executable_code(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExecutableCode>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::part::Data::ExecutableCode(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::Part::data]
     /// to hold a `ExecutableCode`.
     ///
@@ -2721,6 +2708,19 @@ impl Part {
     ) -> Self {
         self.data = std::option::Option::Some(crate::model::part::Data::ExecutableCode(v.into()));
         self
+    }
+
+    /// The value of [data][crate::model::Part::data]
+    /// if it holds a `CodeExecutionResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn code_execution_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CodeExecutionResult>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::part::Data::CodeExecutionResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::Part::data]
@@ -3183,6 +3183,17 @@ impl GenerationConfig {
         self
     }
 
+    /// Sets the value of [stop_sequences][crate::model::GenerationConfig::stop_sequences].
+    pub fn set_stop_sequences<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.stop_sequences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [response_logprobs][crate::model::GenerationConfig::response_logprobs].
     pub fn set_response_logprobs<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
@@ -3248,17 +3259,6 @@ impl GenerationConfig {
         v: T,
     ) -> Self {
         self.routing_config = v.into();
-        self
-    }
-
-    /// Sets the value of [stop_sequences][crate::model::GenerationConfig::stop_sequences].
-    pub fn set_stop_sequences<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.stop_sequences = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3333,23 +3333,6 @@ pub mod generation_config {
             })
         }
 
-        /// The value of [routing_config][crate::model::generation_config::RoutingConfig::routing_config]
-        /// if it holds a `ManualMode`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn manual_mode(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::generation_config::routing_config::ManualRoutingMode>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.routing_config.as_ref().and_then(|v| match v {
-                crate::model::generation_config::routing_config::RoutingConfig::ManualMode(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [routing_config][crate::model::generation_config::RoutingConfig::routing_config]
         /// to hold a `AutoMode`.
         ///
@@ -3369,6 +3352,23 @@ pub mod generation_config {
                 crate::model::generation_config::routing_config::RoutingConfig::AutoMode(v.into()),
             );
             self
+        }
+
+        /// The value of [routing_config][crate::model::generation_config::RoutingConfig::routing_config]
+        /// if it holds a `ManualMode`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn manual_mode(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::generation_config::routing_config::ManualRoutingMode>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.routing_config.as_ref().and_then(|v| match v {
+                crate::model::generation_config::routing_config::RoutingConfig::ManualMode(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [routing_config][crate::model::generation_config::RoutingConfig::routing_config]
@@ -4674,6 +4674,17 @@ impl Candidate {
         self
     }
 
+    /// Sets the value of [safety_ratings][crate::model::Candidate::safety_ratings].
+    pub fn set_safety_ratings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SafetyRating>,
+    {
+        use std::iter::Iterator;
+        self.safety_ratings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [finish_message][crate::model::Candidate::finish_message].
     pub fn set_finish_message<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
@@ -4702,17 +4713,6 @@ impl Candidate {
         v: T,
     ) -> Self {
         self.grounding_metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [safety_ratings][crate::model::Candidate::safety_ratings].
-    pub fn set_safety_ratings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SafetyRating>,
-    {
-        use std::iter::Iterator;
-        self.safety_ratings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5210,6 +5210,20 @@ impl GroundingChunk {
         })
     }
 
+    /// Sets the value of [chunk_type][crate::model::GroundingChunk::chunk_type]
+    /// to hold a `Web`.
+    ///
+    /// Note that all the setters affecting `chunk_type` are
+    /// mutually exclusive.
+    pub fn set_web<T: std::convert::Into<std::boxed::Box<crate::model::grounding_chunk::Web>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.chunk_type =
+            std::option::Option::Some(crate::model::grounding_chunk::ChunkType::Web(v.into()));
+        self
+    }
+
     /// The value of [chunk_type][crate::model::GroundingChunk::chunk_type]
     /// if it holds a `RetrievedContext`, `None` if the field is not set or
     /// holds a different branch.
@@ -5224,20 +5238,6 @@ impl GroundingChunk {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [chunk_type][crate::model::GroundingChunk::chunk_type]
-    /// to hold a `Web`.
-    ///
-    /// Note that all the setters affecting `chunk_type` are
-    /// mutually exclusive.
-    pub fn set_web<T: std::convert::Into<std::boxed::Box<crate::model::grounding_chunk::Web>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.chunk_type =
-            std::option::Option::Some(crate::model::grounding_chunk::ChunkType::Web(v.into()));
-        self
     }
 
     /// Sets the value of [chunk_type][crate::model::GroundingChunk::chunk_type]
@@ -5580,28 +5580,6 @@ impl GroundingMetadata {
         std::default::Default::default()
     }
 
-    /// Sets the value of [search_entry_point][crate::model::GroundingMetadata::search_entry_point].
-    pub fn set_search_entry_point<
-        T: std::convert::Into<std::option::Option<crate::model::SearchEntryPoint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.search_entry_point = v.into();
-        self
-    }
-
-    /// Sets the value of [retrieval_metadata][crate::model::GroundingMetadata::retrieval_metadata].
-    pub fn set_retrieval_metadata<
-        T: std::convert::Into<std::option::Option<crate::model::RetrievalMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.retrieval_metadata = v.into();
-        self
-    }
-
     /// Sets the value of [web_search_queries][crate::model::GroundingMetadata::web_search_queries].
     pub fn set_web_search_queries<T, V>(mut self, v: T) -> Self
     where
@@ -5610,6 +5588,17 @@ impl GroundingMetadata {
     {
         use std::iter::Iterator;
         self.web_search_queries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [search_entry_point][crate::model::GroundingMetadata::search_entry_point].
+    pub fn set_search_entry_point<
+        T: std::convert::Into<std::option::Option<crate::model::SearchEntryPoint>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.search_entry_point = v.into();
         self
     }
 
@@ -5632,6 +5621,17 @@ impl GroundingMetadata {
     {
         use std::iter::Iterator;
         self.grounding_supports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [retrieval_metadata][crate::model::GroundingMetadata::retrieval_metadata].
+    pub fn set_retrieval_metadata<
+        T: std::convert::Into<std::option::Option<crate::model::RetrievalMetadata>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.retrieval_metadata = v.into();
         self
     }
 }
@@ -5886,6 +5886,18 @@ impl Context {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Context::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Context::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5901,6 +5913,17 @@ impl Context {
         v: T,
     ) -> Self {
         self.update_time = v.into();
+        self
+    }
+
+    /// Sets the value of [parent_contexts][crate::model::Context::parent_contexts].
+    pub fn set_parent_contexts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.parent_contexts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5928,29 +5951,6 @@ impl Context {
     /// Sets the value of [description][crate::model::Context::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [parent_contexts][crate::model::Context::parent_contexts].
-    pub fn set_parent_contexts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.parent_contexts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Context::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6139,29 +6139,6 @@ impl CustomJob {
         self
     }
 
-    /// Sets the value of [encryption_spec][crate::model::CustomJob::encryption_spec].
-    pub fn set_encryption_spec<
-        T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [satisfies_pzs][crate::model::CustomJob::satisfies_pzs].
-    pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.satisfies_pzs = v.into();
-        self
-    }
-
-    /// Sets the value of [satisfies_pzi][crate::model::CustomJob::satisfies_pzi].
-    pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.satisfies_pzi = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::CustomJob::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6174,6 +6151,17 @@ impl CustomJob {
         self
     }
 
+    /// Sets the value of [encryption_spec][crate::model::CustomJob::encryption_spec].
+    pub fn set_encryption_spec<
+        T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.encryption_spec = v.into();
+        self
+    }
+
     /// Sets the value of [web_access_uris][crate::model::CustomJob::web_access_uris].
     pub fn set_web_access_uris<T, K, V>(mut self, v: T) -> Self
     where
@@ -6183,6 +6171,18 @@ impl CustomJob {
     {
         use std::iter::Iterator;
         self.web_access_uris = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [satisfies_pzs][crate::model::CustomJob::satisfies_pzs].
+    pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.satisfies_pzs = v.into();
+        self
+    }
+
+    /// Sets the value of [satisfies_pzi][crate::model::CustomJob::satisfies_pzi].
+    pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.satisfies_pzi = v.into();
         self
     }
 }
@@ -6380,6 +6380,17 @@ impl CustomJobSpec {
         self
     }
 
+    /// Sets the value of [worker_pool_specs][crate::model::CustomJobSpec::worker_pool_specs].
+    pub fn set_worker_pool_specs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::WorkerPoolSpec>,
+    {
+        use std::iter::Iterator;
+        self.worker_pool_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [scheduling][crate::model::CustomJobSpec::scheduling].
     pub fn set_scheduling<T: std::convert::Into<std::option::Option<crate::model::Scheduling>>>(
         mut self,
@@ -6398,6 +6409,17 @@ impl CustomJobSpec {
     /// Sets the value of [network][crate::model::CustomJobSpec::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
+        self
+    }
+
+    /// Sets the value of [reserved_ip_ranges][crate::model::CustomJobSpec::reserved_ip_ranges].
+    pub fn set_reserved_ip_ranges<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.reserved_ip_ranges = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6448,28 +6470,6 @@ impl CustomJobSpec {
     /// Sets the value of [experiment_run][crate::model::CustomJobSpec::experiment_run].
     pub fn set_experiment_run<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.experiment_run = v.into();
-        self
-    }
-
-    /// Sets the value of [worker_pool_specs][crate::model::CustomJobSpec::worker_pool_specs].
-    pub fn set_worker_pool_specs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::WorkerPoolSpec>,
-    {
-        use std::iter::Iterator;
-        self.worker_pool_specs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [reserved_ip_ranges][crate::model::CustomJobSpec::reserved_ip_ranges].
-    pub fn set_reserved_ip_ranges<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.reserved_ip_ranges = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6547,15 +6547,6 @@ impl WorkerPoolSpec {
         self
     }
 
-    /// Sets the value of [disk_spec][crate::model::WorkerPoolSpec::disk_spec].
-    pub fn set_disk_spec<T: std::convert::Into<std::option::Option<crate::model::DiskSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.disk_spec = v.into();
-        self
-    }
-
     /// Sets the value of [nfs_mounts][crate::model::WorkerPoolSpec::nfs_mounts].
     pub fn set_nfs_mounts<T, V>(mut self, v: T) -> Self
     where
@@ -6564,6 +6555,15 @@ impl WorkerPoolSpec {
     {
         use std::iter::Iterator;
         self.nfs_mounts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [disk_spec][crate::model::WorkerPoolSpec::disk_spec].
+    pub fn set_disk_spec<T: std::convert::Into<std::option::Option<crate::model::DiskSpec>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.disk_spec = v.into();
         self
     }
 
@@ -6594,21 +6594,6 @@ impl WorkerPoolSpec {
         })
     }
 
-    /// The value of [task][crate::model::WorkerPoolSpec::task]
-    /// if it holds a `PythonPackageSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn python_package_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PythonPackageSpec>> {
-        #[allow(unreachable_patterns)]
-        self.task.as_ref().and_then(|v| match v {
-            crate::model::worker_pool_spec::Task::PythonPackageSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [task][crate::model::WorkerPoolSpec::task]
     /// to hold a `ContainerSpec`.
     ///
@@ -6624,6 +6609,21 @@ impl WorkerPoolSpec {
             v.into(),
         ));
         self
+    }
+
+    /// The value of [task][crate::model::WorkerPoolSpec::task]
+    /// if it holds a `PythonPackageSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn python_package_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PythonPackageSpec>> {
+        #[allow(unreachable_patterns)]
+        self.task.as_ref().and_then(|v| match v {
+            crate::model::worker_pool_spec::Task::PythonPackageSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [task][crate::model::WorkerPoolSpec::task]
@@ -6807,12 +6807,6 @@ impl PythonPackageSpec {
         self
     }
 
-    /// Sets the value of [python_module][crate::model::PythonPackageSpec::python_module].
-    pub fn set_python_module<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.python_module = v.into();
-        self
-    }
-
     /// Sets the value of [package_uris][crate::model::PythonPackageSpec::package_uris].
     pub fn set_package_uris<T, V>(mut self, v: T) -> Self
     where
@@ -6821,6 +6815,12 @@ impl PythonPackageSpec {
     {
         use std::iter::Iterator;
         self.package_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [python_module][crate::model::PythonPackageSpec::python_module].
+    pub fn set_python_module<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.python_module = v.into();
         self
     }
 
@@ -7209,6 +7209,18 @@ impl DataItem {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataItem::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [payload][crate::model::DataItem::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<wkt::Value>>>(
         mut self,
@@ -7233,18 +7245,6 @@ impl DataItem {
     /// Sets the value of [satisfies_pzi][crate::model::DataItem::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DataItem::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7398,6 +7398,29 @@ impl DataLabelingJob {
         self
     }
 
+    /// Sets the value of [datasets][crate::model::DataLabelingJob::datasets].
+    pub fn set_datasets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [annotation_labels][crate::model::DataLabelingJob::annotation_labels].
+    pub fn set_annotation_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotation_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [labeler_count][crate::model::DataLabelingJob::labeler_count].
     pub fn set_labeler_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.labeler_count = v.into();
@@ -7476,6 +7499,29 @@ impl DataLabelingJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataLabelingJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [specialist_pools][crate::model::DataLabelingJob::specialist_pools].
+    pub fn set_specialist_pools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.specialist_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [encryption_spec][crate::model::DataLabelingJob::encryption_spec].
     pub fn set_encryption_spec<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
@@ -7495,52 +7541,6 @@ impl DataLabelingJob {
         v: T,
     ) -> Self {
         self.active_learning_config = v.into();
-        self
-    }
-
-    /// Sets the value of [datasets][crate::model::DataLabelingJob::datasets].
-    pub fn set_datasets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.datasets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [specialist_pools][crate::model::DataLabelingJob::specialist_pools].
-    pub fn set_specialist_pools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.specialist_pools = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotation_labels][crate::model::DataLabelingJob::annotation_labels].
-    pub fn set_annotation_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotation_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DataLabelingJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7639,6 +7639,18 @@ impl ActiveLearningConfig {
         })
     }
 
+    /// Sets the value of [human_labeling_budget][crate::model::ActiveLearningConfig::human_labeling_budget]
+    /// to hold a `MaxDataItemCount`.
+    ///
+    /// Note that all the setters affecting `human_labeling_budget` are
+    /// mutually exclusive.
+    pub fn set_max_data_item_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.human_labeling_budget = std::option::Option::Some(
+            crate::model::active_learning_config::HumanLabelingBudget::MaxDataItemCount(v.into()),
+        );
+        self
+    }
+
     /// The value of [human_labeling_budget][crate::model::ActiveLearningConfig::human_labeling_budget]
     /// if it holds a `MaxDataItemPercentage`, `None` if the field is not set or
     /// holds a different branch.
@@ -7650,18 +7662,6 @@ impl ActiveLearningConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [human_labeling_budget][crate::model::ActiveLearningConfig::human_labeling_budget]
-    /// to hold a `MaxDataItemCount`.
-    ///
-    /// Note that all the setters affecting `human_labeling_budget` are
-    /// mutually exclusive.
-    pub fn set_max_data_item_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.human_labeling_budget = std::option::Option::Some(
-            crate::model::active_learning_config::HumanLabelingBudget::MaxDataItemCount(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [human_labeling_budget][crate::model::ActiveLearningConfig::human_labeling_budget]
@@ -8233,6 +8233,29 @@ impl Dataset {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Dataset::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [saved_queries][crate::model::Dataset::saved_queries].
+    pub fn set_saved_queries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SavedQuery>,
+    {
+        use std::iter::Iterator;
+        self.saved_queries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [encryption_spec][crate::model::Dataset::encryption_spec].
     pub fn set_encryption_spec<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
@@ -8268,29 +8291,6 @@ impl Dataset {
     /// Sets the value of [satisfies_pzi][crate::model::Dataset::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [saved_queries][crate::model::Dataset::saved_queries].
-    pub fn set_saved_queries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SavedQuery>,
-    {
-        use std::iter::Iterator;
-        self.saved_queries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Dataset::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -8367,15 +8367,6 @@ impl ImportDataConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [import_schema_uri][crate::model::ImportDataConfig::import_schema_uri].
-    pub fn set_import_schema_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_schema_uri = v.into();
-        self
-    }
-
     /// Sets the value of [data_item_labels][crate::model::ImportDataConfig::data_item_labels].
     pub fn set_data_item_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -8397,6 +8388,15 @@ impl ImportDataConfig {
     {
         use std::iter::Iterator;
         self.annotation_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [import_schema_uri][crate::model::ImportDataConfig::import_schema_uri].
+    pub fn set_import_schema_uri<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.import_schema_uri = v.into();
         self
     }
 
@@ -8671,19 +8671,6 @@ impl ExportDataConfig {
         })
     }
 
-    /// The value of [split][crate::model::ExportDataConfig::split]
-    /// if it holds a `FilterSplit`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filter_split(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExportFilterSplit>> {
-        #[allow(unreachable_patterns)]
-        self.split.as_ref().and_then(|v| match v {
-            crate::model::export_data_config::Split::FilterSplit(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [split][crate::model::ExportDataConfig::split]
     /// to hold a `FractionSplit`.
     ///
@@ -8699,6 +8686,19 @@ impl ExportDataConfig {
             crate::model::export_data_config::Split::FractionSplit(v.into()),
         );
         self
+    }
+
+    /// The value of [split][crate::model::ExportDataConfig::split]
+    /// if it holds a `FilterSplit`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filter_split(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExportFilterSplit>> {
+        #[allow(unreachable_patterns)]
+        self.split.as_ref().and_then(|v| match v {
+            crate::model::export_data_config::Split::FilterSplit(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [split][crate::model::ExportDataConfig::split]
@@ -9459,12 +9459,6 @@ impl ListDatasetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [datasets][crate::model::ListDatasetsResponse::datasets].
     pub fn set_datasets<T, V>(mut self, v: T) -> Self
     where
@@ -9473,6 +9467,12 @@ impl ListDatasetsResponse {
     {
         use std::iter::Iterator;
         self.datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9754,17 +9754,6 @@ impl ExportDataResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [data_stats][crate::model::ExportDataResponse::data_stats].
-    pub fn set_data_stats<
-        T: std::convert::Into<std::option::Option<crate::model::model::DataStats>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_stats = v.into();
-        self
-    }
-
     /// Sets the value of [exported_files][crate::model::ExportDataResponse::exported_files].
     pub fn set_exported_files<T, V>(mut self, v: T) -> Self
     where
@@ -9773,6 +9762,17 @@ impl ExportDataResponse {
     {
         use std::iter::Iterator;
         self.exported_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_stats][crate::model::ExportDataResponse::data_stats].
+    pub fn set_data_stats<
+        T: std::convert::Into<std::option::Option<crate::model::model::DataStats>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data_stats = v.into();
         self
     }
 }
@@ -10157,12 +10157,6 @@ impl ListDatasetVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatasetVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [dataset_versions][crate::model::ListDatasetVersionsResponse::dataset_versions].
     pub fn set_dataset_versions<T, V>(mut self, v: T) -> Self
     where
@@ -10171,6 +10165,12 @@ impl ListDatasetVersionsResponse {
     {
         use std::iter::Iterator;
         self.dataset_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatasetVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10402,12 +10402,6 @@ impl ListDataItemsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataItemsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_items][crate::model::ListDataItemsResponse::data_items].
     pub fn set_data_items<T, V>(mut self, v: T) -> Self
     where
@@ -10416,6 +10410,12 @@ impl ListDataItemsResponse {
     {
         use std::iter::Iterator;
         self.data_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataItemsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10596,6 +10596,17 @@ impl SearchDataItemsRequest {
         self
     }
 
+    /// Sets the value of [annotation_filters][crate::model::SearchDataItemsRequest::annotation_filters].
+    pub fn set_annotation_filters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotation_filters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [field_mask][crate::model::SearchDataItemsRequest::field_mask].
     pub fn set_field_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
@@ -10630,17 +10641,6 @@ impl SearchDataItemsRequest {
         self
     }
 
-    /// Sets the value of [annotation_filters][crate::model::SearchDataItemsRequest::annotation_filters].
-    pub fn set_annotation_filters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotation_filters = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [order][crate::model::SearchDataItemsRequest::order].
     ///
     /// Note that all the setters affecting `order` are mutually
@@ -10668,6 +10668,21 @@ impl SearchDataItemsRequest {
         })
     }
 
+    /// Sets the value of [order][crate::model::SearchDataItemsRequest::order]
+    /// to hold a `OrderByDataItem`.
+    ///
+    /// Note that all the setters affecting `order` are
+    /// mutually exclusive.
+    pub fn set_order_by_data_item<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.order = std::option::Option::Some(
+            crate::model::search_data_items_request::Order::OrderByDataItem(v.into()),
+        );
+        self
+    }
+
     /// The value of [order][crate::model::SearchDataItemsRequest::order]
     /// if it holds a `OrderByAnnotation`, `None` if the field is not set or
     /// holds a different branch.
@@ -10683,21 +10698,6 @@ impl SearchDataItemsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [order][crate::model::SearchDataItemsRequest::order]
-    /// to hold a `OrderByDataItem`.
-    ///
-    /// Note that all the setters affecting `order` are
-    /// mutually exclusive.
-    pub fn set_order_by_data_item<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.order = std::option::Option::Some(
-            crate::model::search_data_items_request::Order::OrderByDataItem(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [order][crate::model::SearchDataItemsRequest::order]
@@ -10829,12 +10829,6 @@ impl SearchDataItemsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchDataItemsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_item_views][crate::model::SearchDataItemsResponse::data_item_views].
     pub fn set_data_item_views<T, V>(mut self, v: T) -> Self
     where
@@ -10843,6 +10837,12 @@ impl SearchDataItemsResponse {
     {
         use std::iter::Iterator;
         self.data_item_views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchDataItemsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10914,12 +10914,6 @@ impl DataItemView {
         self
     }
 
-    /// Sets the value of [has_truncated_annotations][crate::model::DataItemView::has_truncated_annotations].
-    pub fn set_has_truncated_annotations<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.has_truncated_annotations = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::DataItemView::annotations].
     pub fn set_annotations<T, V>(mut self, v: T) -> Self
     where
@@ -10928,6 +10922,12 @@ impl DataItemView {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [has_truncated_annotations][crate::model::DataItemView::has_truncated_annotations].
+    pub fn set_has_truncated_annotations<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.has_truncated_annotations = v.into();
         self
     }
 }
@@ -11061,12 +11061,6 @@ impl ListSavedQueriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSavedQueriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [saved_queries][crate::model::ListSavedQueriesResponse::saved_queries].
     pub fn set_saved_queries<T, V>(mut self, v: T) -> Self
     where
@@ -11075,6 +11069,12 @@ impl ListSavedQueriesResponse {
     {
         use std::iter::Iterator;
         self.saved_queries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSavedQueriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11316,12 +11316,6 @@ impl ListAnnotationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAnnotationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::ListAnnotationsResponse::annotations].
     pub fn set_annotations<T, V>(mut self, v: T) -> Self
     where
@@ -11330,6 +11324,12 @@ impl ListAnnotationsResponse {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAnnotationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11988,12 +11988,6 @@ impl ListDeploymentResourcePoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentResourcePoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployment_resource_pools][crate::model::ListDeploymentResourcePoolsResponse::deployment_resource_pools].
     pub fn set_deployment_resource_pools<T, V>(mut self, v: T) -> Self
     where
@@ -12002,6 +11996,12 @@ impl ListDeploymentResourcePoolsResponse {
     {
         use std::iter::Iterator;
         self.deployment_resource_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentResourcePoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -12270,24 +12270,6 @@ impl QueryDeployedModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::QueryDeployedModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [total_deployed_model_count][crate::model::QueryDeployedModelsResponse::total_deployed_model_count].
-    pub fn set_total_deployed_model_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.total_deployed_model_count = v.into();
-        self
-    }
-
-    /// Sets the value of [total_endpoint_count][crate::model::QueryDeployedModelsResponse::total_endpoint_count].
-    pub fn set_total_endpoint_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.total_endpoint_count = v.into();
-        self
-    }
-
     /// Sets the value of [deployed_models][crate::model::QueryDeployedModelsResponse::deployed_models].
     #[deprecated]
     pub fn set_deployed_models<T, V>(mut self, v: T) -> Self
@@ -12300,6 +12282,12 @@ impl QueryDeployedModelsResponse {
         self
     }
 
+    /// Sets the value of [next_page_token][crate::model::QueryDeployedModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
+        self
+    }
+
     /// Sets the value of [deployed_model_refs][crate::model::QueryDeployedModelsResponse::deployed_model_refs].
     pub fn set_deployed_model_refs<T, V>(mut self, v: T) -> Self
     where
@@ -12308,6 +12296,18 @@ impl QueryDeployedModelsResponse {
     {
         use std::iter::Iterator;
         self.deployed_model_refs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [total_deployed_model_count][crate::model::QueryDeployedModelsResponse::total_deployed_model_count].
+    pub fn set_total_deployed_model_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.total_deployed_model_count = v.into();
+        self
+    }
+
+    /// Sets the value of [total_endpoint_count][crate::model::QueryDeployedModelsResponse::total_endpoint_count].
+    pub fn set_total_endpoint_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.total_endpoint_count = v.into();
         self
     }
 }
@@ -12618,9 +12618,44 @@ impl Endpoint {
         self
     }
 
+    /// Sets the value of [deployed_models][crate::model::Endpoint::deployed_models].
+    pub fn set_deployed_models<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DeployedModel>,
+    {
+        use std::iter::Iterator;
+        self.deployed_models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [traffic_split][crate::model::Endpoint::traffic_split].
+    pub fn set_traffic_split<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.traffic_split = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Endpoint::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Endpoint::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -12732,41 +12767,6 @@ impl Endpoint {
     /// Sets the value of [satisfies_pzi][crate::model::Endpoint::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [deployed_models][crate::model::Endpoint::deployed_models].
-    pub fn set_deployed_models<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DeployedModel>,
-    {
-        use std::iter::Iterator;
-        self.deployed_models = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [traffic_split][crate::model::Endpoint::traffic_split].
-    pub fn set_traffic_split<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.traffic_split = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Endpoint::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -13042,17 +13042,6 @@ impl DeployedModel {
         self
     }
 
-    /// Sets the value of [speculative_decoding_spec][crate::model::DeployedModel::speculative_decoding_spec].
-    pub fn set_speculative_decoding_spec<
-        T: std::convert::Into<std::option::Option<crate::model::SpeculativeDecodingSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.speculative_decoding_spec = v.into();
-        self
-    }
-
     /// Sets the value of [system_labels][crate::model::DeployedModel::system_labels].
     pub fn set_system_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -13062,6 +13051,17 @@ impl DeployedModel {
     {
         use std::iter::Iterator;
         self.system_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [speculative_decoding_spec][crate::model::DeployedModel::speculative_decoding_spec].
+    pub fn set_speculative_decoding_spec<
+        T: std::convert::Into<std::option::Option<crate::model::SpeculativeDecodingSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.speculative_decoding_spec = v.into();
         self
     }
 
@@ -13094,34 +13094,6 @@ impl DeployedModel {
         })
     }
 
-    /// The value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
-    /// if it holds a `AutomaticResources`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn automatic_resources(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AutomaticResources>> {
-        #[allow(unreachable_patterns)]
-        self.prediction_resources.as_ref().and_then(|v| match v {
-            crate::model::deployed_model::PredictionResources::AutomaticResources(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
-    /// if it holds a `SharedResources`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn shared_resources(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.prediction_resources.as_ref().and_then(|v| match v {
-            crate::model::deployed_model::PredictionResources::SharedResources(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
     /// to hold a `DedicatedResources`.
     ///
@@ -13139,6 +13111,21 @@ impl DeployedModel {
         self
     }
 
+    /// The value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
+    /// if it holds a `AutomaticResources`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn automatic_resources(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AutomaticResources>> {
+        #[allow(unreachable_patterns)]
+        self.prediction_resources.as_ref().and_then(|v| match v {
+            crate::model::deployed_model::PredictionResources::AutomaticResources(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
     /// to hold a `AutomaticResources`.
     ///
@@ -13154,6 +13141,19 @@ impl DeployedModel {
             crate::model::deployed_model::PredictionResources::AutomaticResources(v.into()),
         );
         self
+    }
+
+    /// The value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
+    /// if it holds a `SharedResources`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn shared_resources(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.prediction_resources.as_ref().and_then(|v| match v {
+            crate::model::deployed_model::PredictionResources::SharedResources(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [prediction_resources][crate::model::DeployedModel::prediction_resources]
@@ -13593,23 +13593,6 @@ impl SpeculativeDecodingSpec {
         })
     }
 
-    /// The value of [speculation][crate::model::SpeculativeDecodingSpec::speculation]
-    /// if it holds a `NgramSpeculation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ngram_speculation(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::speculative_decoding_spec::NgramSpeculation>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.speculation.as_ref().and_then(|v| match v {
-            crate::model::speculative_decoding_spec::Speculation::NgramSpeculation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [speculation][crate::model::SpeculativeDecodingSpec::speculation]
     /// to hold a `DraftModelSpeculation`.
     ///
@@ -13627,6 +13610,23 @@ impl SpeculativeDecodingSpec {
             crate::model::speculative_decoding_spec::Speculation::DraftModelSpeculation(v.into()),
         );
         self
+    }
+
+    /// The value of [speculation][crate::model::SpeculativeDecodingSpec::speculation]
+    /// if it holds a `NgramSpeculation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ngram_speculation(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::speculative_decoding_spec::NgramSpeculation>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.speculation.as_ref().and_then(|v| match v {
+            crate::model::speculative_decoding_spec::Speculation::NgramSpeculation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [speculation][crate::model::SpeculativeDecodingSpec::speculation]
@@ -14101,12 +14101,6 @@ impl ListEndpointsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEndpointsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [endpoints][crate::model::ListEndpointsResponse::endpoints].
     pub fn set_endpoints<T, V>(mut self, v: T) -> Self
     where
@@ -14115,6 +14109,12 @@ impl ListEndpointsResponse {
     {
         use std::iter::Iterator;
         self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEndpointsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -14944,6 +14944,18 @@ impl EntityType {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EntityType::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::EntityType::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -14976,18 +14988,6 @@ impl EntityType {
     /// Sets the value of [satisfies_pzi][crate::model::EntityType::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::EntityType::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -15290,24 +15290,6 @@ impl EvaluatedAnnotation {
         self
     }
 
-    /// Sets the value of [data_item_payload][crate::model::EvaluatedAnnotation::data_item_payload].
-    pub fn set_data_item_payload<T: std::convert::Into<std::option::Option<wkt::Value>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_item_payload = v.into();
-        self
-    }
-
-    /// Sets the value of [evaluated_data_item_view_id][crate::model::EvaluatedAnnotation::evaluated_data_item_view_id].
-    pub fn set_evaluated_data_item_view_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.evaluated_data_item_view_id = v.into();
-        self
-    }
-
     /// Sets the value of [predictions][crate::model::EvaluatedAnnotation::predictions].
     pub fn set_predictions<T, V>(mut self, v: T) -> Self
     where
@@ -15327,6 +15309,24 @@ impl EvaluatedAnnotation {
     {
         use std::iter::Iterator;
         self.ground_truths = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_item_payload][crate::model::EvaluatedAnnotation::data_item_payload].
+    pub fn set_data_item_payload<T: std::convert::Into<std::option::Option<wkt::Value>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data_item_payload = v.into();
+        self
+    }
+
+    /// Sets the value of [evaluated_data_item_view_id][crate::model::EvaluatedAnnotation::evaluated_data_item_view_id].
+    pub fn set_evaluated_data_item_view_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.evaluated_data_item_view_id = v.into();
         self
     }
 
@@ -15614,6 +15614,17 @@ impl ErrorAnalysisAnnotation {
         std::default::Default::default()
     }
 
+    /// Sets the value of [attributed_items][crate::model::ErrorAnalysisAnnotation::attributed_items].
+    pub fn set_attributed_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::error_analysis_annotation::AttributedItem>,
+    {
+        use std::iter::Iterator;
+        self.attributed_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [query_type][crate::model::ErrorAnalysisAnnotation::query_type].
     pub fn set_query_type<
         T: std::convert::Into<crate::model::error_analysis_annotation::QueryType>,
@@ -15634,17 +15645,6 @@ impl ErrorAnalysisAnnotation {
     /// Sets the value of [outlier_threshold][crate::model::ErrorAnalysisAnnotation::outlier_threshold].
     pub fn set_outlier_threshold<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.outlier_threshold = v.into();
-        self
-    }
-
-    /// Sets the value of [attributed_items][crate::model::ErrorAnalysisAnnotation::attributed_items].
-    pub fn set_attributed_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::error_analysis_annotation::AttributedItem>,
-    {
-        use std::iter::Iterator;
-        self.attributed_items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -15924,348 +15924,6 @@ impl EvaluateInstancesRequest {
         })
     }
 
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `BleuInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bleu_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::BleuInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::BleuInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `RougeInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn rouge_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::RougeInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::RougeInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `FluencyInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fluency_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FluencyInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::FluencyInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `CoherenceInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn coherence_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CoherenceInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::CoherenceInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `SafetyInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn safety_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::SafetyInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::SafetyInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `GroundednessInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn groundedness_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GroundednessInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::GroundednessInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `FulfillmentInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fulfillment_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FulfillmentInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::FulfillmentInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `SummarizationQualityInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_quality_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationQualityInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::SummarizationQualityInput(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `PairwiseSummarizationQualityInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pairwise_summarization_quality_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseSummarizationQualityInput>>
-    {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::PairwiseSummarizationQualityInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `SummarizationHelpfulnessInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_helpfulness_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationHelpfulnessInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::SummarizationHelpfulnessInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `SummarizationVerbosityInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_verbosity_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationVerbosityInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::SummarizationVerbosityInput(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `QuestionAnsweringQualityInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_quality_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringQualityInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringQualityInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `PairwiseQuestionAnsweringQualityInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pairwise_question_answering_quality_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseQuestionAnsweringQualityInput>>
-    {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::PairwiseQuestionAnsweringQualityInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `QuestionAnsweringRelevanceInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_relevance_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringRelevanceInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringRelevanceInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `QuestionAnsweringHelpfulnessInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_helpfulness_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringHelpfulnessInput>>
-    {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringHelpfulnessInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `QuestionAnsweringCorrectnessInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_correctness_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringCorrectnessInput>>
-    {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringCorrectnessInput(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `PointwiseMetricInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pointwise_metric_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PointwiseMetricInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::PointwiseMetricInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `PairwiseMetricInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pairwise_metric_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseMetricInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::PairwiseMetricInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `ToolCallValidInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_call_valid_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolCallValidInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::ToolCallValidInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `ToolNameMatchInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_name_match_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolNameMatchInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::ToolNameMatchInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `ToolParameterKeyMatchInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_parameter_key_match_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKeyMatchInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::ToolParameterKeyMatchInput(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `ToolParameterKvMatchInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_parameter_kv_match_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKVMatchInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::ToolParameterKvMatchInput(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `CometInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn comet_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::CometInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::CometInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-    /// if it holds a `MetricxInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn metricx_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MetricxInput>> {
-        #[allow(unreachable_patterns)]
-        self.metric_inputs.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_request::MetricInputs::MetricxInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `ExactMatchInput`.
     ///
@@ -16283,6 +15941,19 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `BleuInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bleu_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::BleuInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::BleuInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `BleuInput`.
     ///
@@ -16296,6 +15967,19 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::BleuInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `RougeInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn rouge_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::RougeInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::RougeInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16313,6 +15997,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `FluencyInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fluency_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FluencyInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::FluencyInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `FluencyInput`.
     ///
@@ -16326,6 +16025,21 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::FluencyInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `CoherenceInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn coherence_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CoherenceInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::CoherenceInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16345,6 +16059,19 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `SafetyInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn safety_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::SafetyInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::SafetyInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `SafetyInput`.
     ///
@@ -16358,6 +16085,21 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::SafetyInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `GroundednessInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn groundedness_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GroundednessInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::GroundednessInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16377,6 +16119,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `FulfillmentInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fulfillment_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FulfillmentInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::FulfillmentInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `FulfillmentInput`.
     ///
@@ -16392,6 +16149,21 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::FulfillmentInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `SummarizationQualityInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_quality_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationQualityInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::SummarizationQualityInput(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16413,6 +16185,20 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `PairwiseSummarizationQualityInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pairwise_summarization_quality_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseSummarizationQualityInput>>
+    {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::PairwiseSummarizationQualityInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `PairwiseSummarizationQualityInput`.
     ///
@@ -16430,6 +16216,19 @@ impl EvaluateInstancesRequest {
             )
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `SummarizationHelpfulnessInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_helpfulness_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationHelpfulnessInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::SummarizationHelpfulnessInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16451,6 +16250,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `SummarizationVerbosityInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_verbosity_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationVerbosityInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::SummarizationVerbosityInput(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `SummarizationVerbosityInput`.
     ///
@@ -16468,6 +16282,19 @@ impl EvaluateInstancesRequest {
             ),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `QuestionAnsweringQualityInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_quality_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringQualityInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringQualityInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16489,6 +16316,20 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `PairwiseQuestionAnsweringQualityInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pairwise_question_answering_quality_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseQuestionAnsweringQualityInput>>
+    {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::PairwiseQuestionAnsweringQualityInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `PairwiseQuestionAnsweringQualityInput`.
     ///
@@ -16506,6 +16347,19 @@ impl EvaluateInstancesRequest {
             )
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `QuestionAnsweringRelevanceInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_relevance_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringRelevanceInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringRelevanceInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16527,6 +16381,20 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `QuestionAnsweringHelpfulnessInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_helpfulness_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringHelpfulnessInput>>
+    {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringHelpfulnessInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `QuestionAnsweringHelpfulnessInput`.
     ///
@@ -16544,6 +16412,20 @@ impl EvaluateInstancesRequest {
             )
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `QuestionAnsweringCorrectnessInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_correctness_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringCorrectnessInput>>
+    {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::QuestionAnsweringCorrectnessInput(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16565,6 +16447,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `PointwiseMetricInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pointwise_metric_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PointwiseMetricInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::PointwiseMetricInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `PointwiseMetricInput`.
     ///
@@ -16580,6 +16477,21 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::PointwiseMetricInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `PairwiseMetricInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pairwise_metric_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseMetricInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::PairwiseMetricInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16599,6 +16511,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `ToolCallValidInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_call_valid_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolCallValidInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::ToolCallValidInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `ToolCallValidInput`.
     ///
@@ -16616,6 +16543,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `ToolNameMatchInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_name_match_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolNameMatchInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::ToolNameMatchInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `ToolNameMatchInput`.
     ///
@@ -16631,6 +16573,21 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::ToolNameMatchInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `ToolParameterKeyMatchInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_parameter_key_match_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKeyMatchInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::ToolParameterKeyMatchInput(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16652,6 +16609,21 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `ToolParameterKvMatchInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_parameter_kv_match_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKVMatchInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::ToolParameterKvMatchInput(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `ToolParameterKvMatchInput`.
     ///
@@ -16671,6 +16643,19 @@ impl EvaluateInstancesRequest {
         self
     }
 
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `CometInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn comet_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::CometInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::CometInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
     /// to hold a `CometInput`.
     ///
@@ -16684,6 +16669,21 @@ impl EvaluateInstancesRequest {
             crate::model::evaluate_instances_request::MetricInputs::CometInput(v.into()),
         );
         self
+    }
+
+    /// The value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
+    /// if it holds a `MetricxInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn metricx_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MetricxInput>> {
+        #[allow(unreachable_patterns)]
+        self.metric_inputs.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_request::MetricInputs::MetricxInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
@@ -16845,344 +16845,6 @@ impl EvaluateInstancesResponse {
         })
     }
 
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `BleuResults`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bleu_results(&self) -> std::option::Option<&std::boxed::Box<crate::model::BleuResults>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::BleuResults(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `RougeResults`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn rouge_results(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RougeResults>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::RougeResults(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `FluencyResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fluency_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FluencyResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::FluencyResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `CoherenceResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn coherence_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CoherenceResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::CoherenceResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `SafetyResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn safety_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SafetyResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::SafetyResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `GroundednessResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn groundedness_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GroundednessResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::GroundednessResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `FulfillmentResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fulfillment_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FulfillmentResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::FulfillmentResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `SummarizationQualityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_quality_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationQualityResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::SummarizationQualityResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `PairwiseSummarizationQualityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pairwise_summarization_quality_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseSummarizationQualityResult>>
-    {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::PairwiseSummarizationQualityResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `SummarizationHelpfulnessResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_helpfulness_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationHelpfulnessResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::SummarizationHelpfulnessResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `SummarizationVerbosityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_verbosity_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationVerbosityResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::SummarizationVerbosityResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `QuestionAnsweringQualityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_quality_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringQualityResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringQualityResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `PairwiseQuestionAnsweringQualityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pairwise_question_answering_quality_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseQuestionAnsweringQualityResult>>
-    {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::PairwiseQuestionAnsweringQualityResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `QuestionAnsweringRelevanceResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_relevance_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringRelevanceResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringRelevanceResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `QuestionAnsweringHelpfulnessResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_helpfulness_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringHelpfulnessResult>>
-    {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringHelpfulnessResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `QuestionAnsweringCorrectnessResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn question_answering_correctness_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringCorrectnessResult>>
-    {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringCorrectnessResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `PointwiseMetricResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pointwise_metric_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PointwiseMetricResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::PointwiseMetricResult(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `PairwiseMetricResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pairwise_metric_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseMetricResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::PairwiseMetricResult(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `ToolCallValidResults`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_call_valid_results(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolCallValidResults>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::ToolCallValidResults(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `ToolNameMatchResults`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_name_match_results(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolNameMatchResults>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::ToolNameMatchResults(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `ToolParameterKeyMatchResults`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_parameter_key_match_results(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKeyMatchResults>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::ToolParameterKeyMatchResults(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `ToolParameterKvMatchResults`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tool_parameter_kv_match_results(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKVMatchResults>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::ToolParameterKvMatchResults(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `CometResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn comet_result(&self) -> std::option::Option<&std::boxed::Box<crate::model::CometResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::CometResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
-    /// if it holds a `MetricxResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn metricx_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MetricxResult>> {
-        #[allow(unreachable_patterns)]
-        self.evaluation_results.as_ref().and_then(|v| match v {
-            crate::model::evaluate_instances_response::EvaluationResults::MetricxResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `ExactMatchResults`.
     ///
@@ -17202,6 +16864,19 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `BleuResults`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bleu_results(&self) -> std::option::Option<&std::boxed::Box<crate::model::BleuResults>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::BleuResults(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `BleuResults`.
     ///
@@ -17217,6 +16892,21 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `RougeResults`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn rouge_results(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RougeResults>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::RougeResults(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `RougeResults`.
     ///
@@ -17230,6 +16920,21 @@ impl EvaluateInstancesResponse {
             crate::model::evaluate_instances_response::EvaluationResults::RougeResults(v.into()),
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `FluencyResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fluency_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FluencyResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::FluencyResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17249,6 +16954,21 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `CoherenceResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn coherence_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CoherenceResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::CoherenceResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `CoherenceResult`.
     ///
@@ -17266,6 +16986,21 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `SafetyResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn safety_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SafetyResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::SafetyResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `SafetyResult`.
     ///
@@ -17279,6 +17014,21 @@ impl EvaluateInstancesResponse {
             crate::model::evaluate_instances_response::EvaluationResults::SafetyResult(v.into()),
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `GroundednessResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn groundedness_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GroundednessResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::GroundednessResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17300,6 +17050,21 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `FulfillmentResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fulfillment_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FulfillmentResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::FulfillmentResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `FulfillmentResult`.
     ///
@@ -17317,6 +17082,19 @@ impl EvaluateInstancesResponse {
             ),
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `SummarizationQualityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_quality_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationQualityResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::SummarizationQualityResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17338,6 +17116,20 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `PairwiseSummarizationQualityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pairwise_summarization_quality_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseSummarizationQualityResult>>
+    {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::PairwiseSummarizationQualityResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `PairwiseSummarizationQualityResult`.
     ///
@@ -17355,6 +17147,19 @@ impl EvaluateInstancesResponse {
             )
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `SummarizationHelpfulnessResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_helpfulness_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationHelpfulnessResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::SummarizationHelpfulnessResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17376,6 +17181,19 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `SummarizationVerbosityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_verbosity_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationVerbosityResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::SummarizationVerbosityResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `SummarizationVerbosityResult`.
     ///
@@ -17393,6 +17211,19 @@ impl EvaluateInstancesResponse {
             )
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `QuestionAnsweringQualityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_quality_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringQualityResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringQualityResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17414,6 +17245,20 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `PairwiseQuestionAnsweringQualityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pairwise_question_answering_quality_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseQuestionAnsweringQualityResult>>
+    {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::PairwiseQuestionAnsweringQualityResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `PairwiseQuestionAnsweringQualityResult`.
     ///
@@ -17431,6 +17276,19 @@ impl EvaluateInstancesResponse {
             )
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `QuestionAnsweringRelevanceResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_relevance_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringRelevanceResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringRelevanceResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17452,6 +17310,20 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `QuestionAnsweringHelpfulnessResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_helpfulness_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringHelpfulnessResult>>
+    {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringHelpfulnessResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `QuestionAnsweringHelpfulnessResult`.
     ///
@@ -17469,6 +17341,20 @@ impl EvaluateInstancesResponse {
             )
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `QuestionAnsweringCorrectnessResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn question_answering_correctness_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QuestionAnsweringCorrectnessResult>>
+    {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::QuestionAnsweringCorrectnessResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17490,6 +17376,21 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `PointwiseMetricResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pointwise_metric_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PointwiseMetricResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::PointwiseMetricResult(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `PointwiseMetricResult`.
     ///
@@ -17507,6 +17408,21 @@ impl EvaluateInstancesResponse {
             ),
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `PairwiseMetricResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pairwise_metric_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PairwiseMetricResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::PairwiseMetricResult(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17528,6 +17444,21 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `ToolCallValidResults`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_call_valid_results(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolCallValidResults>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::ToolCallValidResults(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `ToolCallValidResults`.
     ///
@@ -17545,6 +17476,21 @@ impl EvaluateInstancesResponse {
             ),
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `ToolNameMatchResults`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_name_match_results(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolNameMatchResults>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::ToolNameMatchResults(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17566,6 +17512,19 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `ToolParameterKeyMatchResults`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_parameter_key_match_results(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKeyMatchResults>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::ToolParameterKeyMatchResults(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `ToolParameterKeyMatchResults`.
     ///
@@ -17583,6 +17542,19 @@ impl EvaluateInstancesResponse {
             )
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `ToolParameterKvMatchResults`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tool_parameter_kv_match_results(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ToolParameterKVMatchResults>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::ToolParameterKvMatchResults(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -17604,6 +17576,19 @@ impl EvaluateInstancesResponse {
         self
     }
 
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `CometResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn comet_result(&self) -> std::option::Option<&std::boxed::Box<crate::model::CometResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::CometResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
     /// to hold a `CometResult`.
     ///
@@ -17617,6 +17602,21 @@ impl EvaluateInstancesResponse {
             crate::model::evaluate_instances_response::EvaluationResults::CometResult(v.into()),
         );
         self
+    }
+
+    /// The value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
+    /// if it holds a `MetricxResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn metricx_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MetricxResult>> {
+        #[allow(unreachable_patterns)]
+        self.evaluation_results.as_ref().and_then(|v| match v {
+            crate::model::evaluate_instances_response::EvaluationResults::MetricxResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [evaluation_results][crate::model::EvaluateInstancesResponse::evaluation_results]
@@ -23843,6 +23843,18 @@ impl Execution {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Execution::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Execution::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -23885,18 +23897,6 @@ impl Execution {
     /// Sets the value of [description][crate::model::Execution::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Execution::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -24467,6 +24467,17 @@ impl Attribution {
         self
     }
 
+    /// Sets the value of [output_index][crate::model::Attribution::output_index].
+    pub fn set_output_index<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.output_index = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [output_display_name][crate::model::Attribution::output_display_name].
     pub fn set_output_display_name<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -24485,17 +24496,6 @@ impl Attribution {
     /// Sets the value of [output_name][crate::model::Attribution::output_name].
     pub fn set_output_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.output_name = v.into();
-        self
-    }
-
-    /// Sets the value of [output_index][crate::model::Attribution::output_index].
-    pub fn set_output_index<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.output_index = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -24733,49 +24733,6 @@ impl ExplanationParameters {
         })
     }
 
-    /// The value of [method][crate::model::ExplanationParameters::method]
-    /// if it holds a `IntegratedGradientsAttribution`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn integrated_gradients_attribution(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IntegratedGradientsAttribution>> {
-        #[allow(unreachable_patterns)]
-        self.method.as_ref().and_then(|v| match v {
-            crate::model::explanation_parameters::Method::IntegratedGradientsAttribution(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [method][crate::model::ExplanationParameters::method]
-    /// if it holds a `XraiAttribution`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn xrai_attribution(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::XraiAttribution>> {
-        #[allow(unreachable_patterns)]
-        self.method.as_ref().and_then(|v| match v {
-            crate::model::explanation_parameters::Method::XraiAttribution(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [method][crate::model::ExplanationParameters::method]
-    /// if it holds a `Examples`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn examples(&self) -> std::option::Option<&std::boxed::Box<crate::model::Examples>> {
-        #[allow(unreachable_patterns)]
-        self.method.as_ref().and_then(|v| match v {
-            crate::model::explanation_parameters::Method::Examples(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [method][crate::model::ExplanationParameters::method]
     /// to hold a `SampledShapleyAttribution`.
     ///
@@ -24791,6 +24748,21 @@ impl ExplanationParameters {
             crate::model::explanation_parameters::Method::SampledShapleyAttribution(v.into()),
         );
         self
+    }
+
+    /// The value of [method][crate::model::ExplanationParameters::method]
+    /// if it holds a `IntegratedGradientsAttribution`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn integrated_gradients_attribution(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IntegratedGradientsAttribution>> {
+        #[allow(unreachable_patterns)]
+        self.method.as_ref().and_then(|v| match v {
+            crate::model::explanation_parameters::Method::IntegratedGradientsAttribution(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [method][crate::model::ExplanationParameters::method]
@@ -24810,6 +24782,21 @@ impl ExplanationParameters {
         self
     }
 
+    /// The value of [method][crate::model::ExplanationParameters::method]
+    /// if it holds a `XraiAttribution`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn xrai_attribution(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::XraiAttribution>> {
+        #[allow(unreachable_patterns)]
+        self.method.as_ref().and_then(|v| match v {
+            crate::model::explanation_parameters::Method::XraiAttribution(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [method][crate::model::ExplanationParameters::method]
     /// to hold a `XraiAttribution`.
     ///
@@ -24825,6 +24812,19 @@ impl ExplanationParameters {
             crate::model::explanation_parameters::Method::XraiAttribution(v.into()),
         );
         self
+    }
+
+    /// The value of [method][crate::model::ExplanationParameters::method]
+    /// if it holds a `Examples`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn examples(&self) -> std::option::Option<&std::boxed::Box<crate::model::Examples>> {
+        #[allow(unreachable_patterns)]
+        self.method.as_ref().and_then(|v| match v {
+            crate::model::explanation_parameters::Method::Examples(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [method][crate::model::ExplanationParameters::method]
@@ -25276,6 +25276,18 @@ impl SmoothGradConfig {
         })
     }
 
+    /// Sets the value of [gradient_noise_sigma][crate::model::SmoothGradConfig::gradient_noise_sigma]
+    /// to hold a `NoiseSigma`.
+    ///
+    /// Note that all the setters affecting `gradient_noise_sigma` are
+    /// mutually exclusive.
+    pub fn set_noise_sigma<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.gradient_noise_sigma = std::option::Option::Some(
+            crate::model::smooth_grad_config::GradientNoiseSigma::NoiseSigma(v.into()),
+        );
+        self
+    }
+
     /// The value of [gradient_noise_sigma][crate::model::SmoothGradConfig::gradient_noise_sigma]
     /// if it holds a `FeatureNoiseSigma`, `None` if the field is not set or
     /// holds a different branch.
@@ -25289,18 +25301,6 @@ impl SmoothGradConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [gradient_noise_sigma][crate::model::SmoothGradConfig::gradient_noise_sigma]
-    /// to hold a `NoiseSigma`.
-    ///
-    /// Note that all the setters affecting `gradient_noise_sigma` are
-    /// mutually exclusive.
-    pub fn set_noise_sigma<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.gradient_noise_sigma = std::option::Option::Some(
-            crate::model::smooth_grad_config::GradientNoiseSigma::NoiseSigma(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [gradient_noise_sigma][crate::model::SmoothGradConfig::gradient_noise_sigma]
@@ -25745,17 +25745,6 @@ impl Examples {
         })
     }
 
-    /// The value of [config][crate::model::Examples::config]
-    /// if it holds a `Presets`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn presets(&self) -> std::option::Option<&std::boxed::Box<crate::model::Presets>> {
-        #[allow(unreachable_patterns)]
-        self.config.as_ref().and_then(|v| match v {
-            crate::model::examples::Config::Presets(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [config][crate::model::Examples::config]
     /// to hold a `NearestNeighborSearchConfig`.
     ///
@@ -25771,6 +25760,17 @@ impl Examples {
             crate::model::examples::Config::NearestNeighborSearchConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [config][crate::model::Examples::config]
+    /// if it holds a `Presets`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn presets(&self) -> std::option::Option<&std::boxed::Box<crate::model::Presets>> {
+        #[allow(unreachable_patterns)]
+        self.config.as_ref().and_then(|v| match v {
+            crate::model::examples::Config::Presets(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [config][crate::model::Examples::config]
@@ -26920,6 +26920,17 @@ impl ExamplesOverride {
         self
     }
 
+    /// Sets the value of [restrictions][crate::model::ExamplesOverride::restrictions].
+    pub fn set_restrictions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ExamplesRestrictionsNamespace>,
+    {
+        use std::iter::Iterator;
+        self.restrictions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [return_embeddings][crate::model::ExamplesOverride::return_embeddings].
     pub fn set_return_embeddings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.return_embeddings = v.into();
@@ -26932,17 +26943,6 @@ impl ExamplesOverride {
         v: T,
     ) -> Self {
         self.data_format = v.into();
-        self
-    }
-
-    /// Sets the value of [restrictions][crate::model::ExamplesOverride::restrictions].
-    pub fn set_restrictions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ExamplesRestrictionsNamespace>,
-    {
-        use std::iter::Iterator;
-        self.restrictions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -27256,24 +27256,6 @@ impl ExplanationMetadata {
         std::default::Default::default()
     }
 
-    /// Sets the value of [feature_attributions_schema_uri][crate::model::ExplanationMetadata::feature_attributions_schema_uri].
-    pub fn set_feature_attributions_schema_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.feature_attributions_schema_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [latent_space_source][crate::model::ExplanationMetadata::latent_space_source].
-    pub fn set_latent_space_source<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.latent_space_source = v.into();
-        self
-    }
-
     /// Sets the value of [inputs][crate::model::ExplanationMetadata::inputs].
     pub fn set_inputs<T, K, V>(mut self, v: T) -> Self
     where
@@ -27295,6 +27277,24 @@ impl ExplanationMetadata {
     {
         use std::iter::Iterator;
         self.outputs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [feature_attributions_schema_uri][crate::model::ExplanationMetadata::feature_attributions_schema_uri].
+    pub fn set_feature_attributions_schema_uri<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.feature_attributions_schema_uri = v.into();
+        self
+    }
+
+    /// Sets the value of [latent_space_source][crate::model::ExplanationMetadata::latent_space_source].
+    pub fn set_latent_space_source<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.latent_space_source = v.into();
         self
     }
 }
@@ -27474,6 +27474,17 @@ pub mod explanation_metadata {
             std::default::Default::default()
         }
 
+        /// Sets the value of [input_baselines][crate::model::explanation_metadata::InputMetadata::input_baselines].
+        pub fn set_input_baselines<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<wkt::Value>,
+        {
+            use std::iter::Iterator;
+            self.input_baselines = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [input_tensor_name][crate::model::explanation_metadata::InputMetadata::input_tensor_name].
         pub fn set_input_tensor_name<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -27533,12 +27544,34 @@ pub mod explanation_metadata {
             self
         }
 
+        /// Sets the value of [index_feature_mapping][crate::model::explanation_metadata::InputMetadata::index_feature_mapping].
+        pub fn set_index_feature_mapping<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.index_feature_mapping = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [encoded_tensor_name][crate::model::explanation_metadata::InputMetadata::encoded_tensor_name].
         pub fn set_encoded_tensor_name<T: std::convert::Into<std::string::String>>(
             mut self,
             v: T,
         ) -> Self {
             self.encoded_tensor_name = v.into();
+            self
+        }
+
+        /// Sets the value of [encoded_baselines][crate::model::explanation_metadata::InputMetadata::encoded_baselines].
+        pub fn set_encoded_baselines<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<wkt::Value>,
+        {
+            use std::iter::Iterator;
+            self.encoded_baselines = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -27560,39 +27593,6 @@ pub mod explanation_metadata {
         /// Sets the value of [group_name][crate::model::explanation_metadata::InputMetadata::group_name].
         pub fn set_group_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.group_name = v.into();
-            self
-        }
-
-        /// Sets the value of [input_baselines][crate::model::explanation_metadata::InputMetadata::input_baselines].
-        pub fn set_input_baselines<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<wkt::Value>,
-        {
-            use std::iter::Iterator;
-            self.input_baselines = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [index_feature_mapping][crate::model::explanation_metadata::InputMetadata::index_feature_mapping].
-        pub fn set_index_feature_mapping<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.index_feature_mapping = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [encoded_baselines][crate::model::explanation_metadata::InputMetadata::encoded_baselines].
-        pub fn set_encoded_baselines<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<wkt::Value>,
-        {
-            use std::iter::Iterator;
-            self.encoded_baselines = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -29161,17 +29161,6 @@ pub mod explanation_metadata {
             })
         }
 
-        /// The value of [display_name_mapping][crate::model::explanation_metadata::OutputMetadata::display_name_mapping]
-        /// if it holds a `DisplayNameMappingKey`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn display_name_mapping_key(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.display_name_mapping.as_ref().and_then(|v| match v {
-                crate::model::explanation_metadata::output_metadata::DisplayNameMapping::DisplayNameMappingKey(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [display_name_mapping][crate::model::explanation_metadata::OutputMetadata::display_name_mapping]
         /// to hold a `IndexDisplayNameMapping`.
         ///
@@ -29189,6 +29178,17 @@ pub mod explanation_metadata {
                 )
             );
             self
+        }
+
+        /// The value of [display_name_mapping][crate::model::explanation_metadata::OutputMetadata::display_name_mapping]
+        /// if it holds a `DisplayNameMappingKey`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn display_name_mapping_key(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.display_name_mapping.as_ref().and_then(|v| match v {
+                crate::model::explanation_metadata::output_metadata::DisplayNameMapping::DisplayNameMappingKey(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [display_name_mapping][crate::model::explanation_metadata::OutputMetadata::display_name_mapping]
@@ -29428,6 +29428,18 @@ impl Feature {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Feature::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Feature::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -29437,6 +29449,17 @@ impl Feature {
     /// Sets the value of [disable_monitoring][crate::model::Feature::disable_monitoring].
     pub fn set_disable_monitoring<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disable_monitoring = v.into();
+        self
+    }
+
+    /// Sets the value of [monitoring_stats_anomalies][crate::model::Feature::monitoring_stats_anomalies].
+    pub fn set_monitoring_stats_anomalies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::feature::MonitoringStatsAnomaly>,
+    {
+        use std::iter::Iterator;
+        self.monitoring_stats_anomalies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -29455,29 +29478,6 @@ impl Feature {
         v: T,
     ) -> Self {
         self.point_of_contact = v.into();
-        self
-    }
-
-    /// Sets the value of [monitoring_stats_anomalies][crate::model::Feature::monitoring_stats_anomalies].
-    pub fn set_monitoring_stats_anomalies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::feature::MonitoringStatsAnomaly>,
-    {
-        use std::iter::Iterator;
-        self.monitoring_stats_anomalies = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Feature::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -30000,12 +30000,6 @@ impl FeatureGroup {
         self
     }
 
-    /// Sets the value of [description][crate::model::FeatureGroup::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::FeatureGroup::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -30015,6 +30009,12 @@ impl FeatureGroup {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::FeatureGroup::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
         self
     }
 
@@ -30141,6 +30141,17 @@ pub mod feature_group {
             self
         }
 
+        /// Sets the value of [entity_id_columns][crate::model::feature_group::BigQuery::entity_id_columns].
+        pub fn set_entity_id_columns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.entity_id_columns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [static_data_source][crate::model::feature_group::BigQuery::static_data_source].
         pub fn set_static_data_source<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.static_data_source = v.into();
@@ -30163,17 +30174,6 @@ pub mod feature_group {
         /// Sets the value of [dense][crate::model::feature_group::BigQuery::dense].
         pub fn set_dense<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.dense = v.into();
-            self
-        }
-
-        /// Sets the value of [entity_id_columns][crate::model::feature_group::BigQuery::entity_id_columns].
-        pub fn set_entity_id_columns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.entity_id_columns = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -30506,6 +30506,18 @@ impl FeatureOnlineStore {
         self
     }
 
+    /// Sets the value of [labels][crate::model::FeatureOnlineStore::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::FeatureOnlineStore::state].
     pub fn set_state<T: std::convert::Into<crate::model::feature_online_store::State>>(
         mut self,
@@ -30551,18 +30563,6 @@ impl FeatureOnlineStore {
         self
     }
 
-    /// Sets the value of [labels][crate::model::FeatureOnlineStore::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [storage_type][crate::model::FeatureOnlineStore::storage_type].
     ///
     /// Note that all the setters affecting `storage_type` are mutually
@@ -30592,21 +30592,6 @@ impl FeatureOnlineStore {
         })
     }
 
-    /// The value of [storage_type][crate::model::FeatureOnlineStore::storage_type]
-    /// if it holds a `Optimized`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn optimized(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::feature_online_store::Optimized>> {
-        #[allow(unreachable_patterns)]
-        self.storage_type.as_ref().and_then(|v| match v {
-            crate::model::feature_online_store::StorageType::Optimized(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [storage_type][crate::model::FeatureOnlineStore::storage_type]
     /// to hold a `Bigtable`.
     ///
@@ -30622,6 +30607,21 @@ impl FeatureOnlineStore {
             crate::model::feature_online_store::StorageType::Bigtable(v.into()),
         );
         self
+    }
+
+    /// The value of [storage_type][crate::model::FeatureOnlineStore::storage_type]
+    /// if it holds a `Optimized`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn optimized(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::feature_online_store::Optimized>> {
+        #[allow(unreachable_patterns)]
+        self.storage_type.as_ref().and_then(|v| match v {
+            crate::model::feature_online_store::StorageType::Optimized(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [storage_type][crate::model::FeatureOnlineStore::storage_type]
@@ -31291,12 +31291,6 @@ impl ListFeatureOnlineStoresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeatureOnlineStoresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [feature_online_stores][crate::model::ListFeatureOnlineStoresResponse::feature_online_stores].
     pub fn set_feature_online_stores<T, V>(mut self, v: T) -> Self
     where
@@ -31305,6 +31299,12 @@ impl ListFeatureOnlineStoresResponse {
     {
         use std::iter::Iterator;
         self.feature_online_stores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeatureOnlineStoresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -31729,12 +31729,6 @@ impl ListFeatureViewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeatureViewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [feature_views][crate::model::ListFeatureViewsResponse::feature_views].
     pub fn set_feature_views<T, V>(mut self, v: T) -> Self
     where
@@ -31743,6 +31737,12 @@ impl ListFeatureViewsResponse {
     {
         use std::iter::Iterator;
         self.feature_views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeatureViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -32305,12 +32305,6 @@ impl ListFeatureViewSyncsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeatureViewSyncsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [feature_view_syncs][crate::model::ListFeatureViewSyncsResponse::feature_view_syncs].
     pub fn set_feature_view_syncs<T, V>(mut self, v: T) -> Self
     where
@@ -32319,6 +32313,12 @@ impl ListFeatureViewSyncsResponse {
     {
         use std::iter::Iterator;
         self.feature_view_syncs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeatureViewSyncsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -32390,6 +32390,17 @@ impl FeatureViewDataKey {
         })
     }
 
+    /// Sets the value of [key_oneof][crate::model::FeatureViewDataKey::key_oneof]
+    /// to hold a `Key`.
+    ///
+    /// Note that all the setters affecting `key_oneof` are
+    /// mutually exclusive.
+    pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.key_oneof =
+            std::option::Option::Some(crate::model::feature_view_data_key::KeyOneof::Key(v.into()));
+        self
+    }
+
     /// The value of [key_oneof][crate::model::FeatureViewDataKey::key_oneof]
     /// if it holds a `CompositeKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -32404,17 +32415,6 @@ impl FeatureViewDataKey {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [key_oneof][crate::model::FeatureViewDataKey::key_oneof]
-    /// to hold a `Key`.
-    ///
-    /// Note that all the setters affecting `key_oneof` are
-    /// mutually exclusive.
-    pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.key_oneof =
-            std::option::Option::Some(crate::model::feature_view_data_key::KeyOneof::Key(v.into()));
-        self
     }
 
     /// Sets the value of [key_oneof][crate::model::FeatureViewDataKey::key_oneof]
@@ -32646,19 +32646,6 @@ impl FetchFeatureValuesResponse {
         })
     }
 
-    /// The value of [format][crate::model::FetchFeatureValuesResponse::format]
-    /// if it holds a `ProtoStruct`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn proto_struct(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
-        #[allow(unreachable_patterns)]
-        self.format.as_ref().and_then(|v| match v {
-            crate::model::fetch_feature_values_response::Format::ProtoStruct(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [format][crate::model::FetchFeatureValuesResponse::format]
     /// to hold a `KeyValues`.
     ///
@@ -32678,6 +32665,19 @@ impl FetchFeatureValuesResponse {
             crate::model::fetch_feature_values_response::Format::KeyValues(v.into()),
         );
         self
+    }
+
+    /// The value of [format][crate::model::FetchFeatureValuesResponse::format]
+    /// if it holds a `ProtoStruct`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn proto_struct(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
+        #[allow(unreachable_patterns)]
+        self.format.as_ref().and_then(|v| match v {
+            crate::model::fetch_feature_values_response::Format::ProtoStruct(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [format][crate::model::FetchFeatureValuesResponse::format]
@@ -32917,26 +32917,6 @@ impl NearestNeighborQuery {
         self
     }
 
-    /// Sets the value of [per_crowding_attribute_neighbor_count][crate::model::NearestNeighborQuery::per_crowding_attribute_neighbor_count].
-    pub fn set_per_crowding_attribute_neighbor_count<T: std::convert::Into<i32>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.per_crowding_attribute_neighbor_count = v.into();
-        self
-    }
-
-    /// Sets the value of [parameters][crate::model::NearestNeighborQuery::parameters].
-    pub fn set_parameters<
-        T: std::convert::Into<std::option::Option<crate::model::nearest_neighbor_query::Parameters>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [string_filters][crate::model::NearestNeighborQuery::string_filters].
     pub fn set_string_filters<T, V>(mut self, v: T) -> Self
     where
@@ -32956,6 +32936,26 @@ impl NearestNeighborQuery {
     {
         use std::iter::Iterator;
         self.numeric_filters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [per_crowding_attribute_neighbor_count][crate::model::NearestNeighborQuery::per_crowding_attribute_neighbor_count].
+    pub fn set_per_crowding_attribute_neighbor_count<T: std::convert::Into<i32>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.per_crowding_attribute_neighbor_count = v.into();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::NearestNeighborQuery::parameters].
+    pub fn set_parameters<
+        T: std::convert::Into<std::option::Option<crate::model::nearest_neighbor_query::Parameters>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 
@@ -32986,6 +32986,18 @@ impl NearestNeighborQuery {
         })
     }
 
+    /// Sets the value of [instance][crate::model::NearestNeighborQuery::instance]
+    /// to hold a `EntityId`.
+    ///
+    /// Note that all the setters affecting `instance` are
+    /// mutually exclusive.
+    pub fn set_entity_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.instance = std::option::Option::Some(
+            crate::model::nearest_neighbor_query::Instance::EntityId(v.into()),
+        );
+        self
+    }
+
     /// The value of [instance][crate::model::NearestNeighborQuery::instance]
     /// if it holds a `Embedding`, `None` if the field is not set or
     /// holds a different branch.
@@ -33000,18 +33012,6 @@ impl NearestNeighborQuery {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [instance][crate::model::NearestNeighborQuery::instance]
-    /// to hold a `EntityId`.
-    ///
-    /// Note that all the setters affecting `instance` are
-    /// mutually exclusive.
-    pub fn set_entity_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.instance = std::option::Option::Some(
-            crate::model::nearest_neighbor_query::Instance::EntityId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [instance][crate::model::NearestNeighborQuery::instance]
@@ -33247,6 +33247,18 @@ pub mod nearest_neighbor_query {
             })
         }
 
+        /// Sets the value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
+        /// to hold a `ValueInt`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_value_int<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::nearest_neighbor_query::numeric_filter::Value::ValueInt(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
         /// if it holds a `ValueFloat`, `None` if the field is not set or
         /// holds a different branch.
@@ -33260,6 +33272,18 @@ pub mod nearest_neighbor_query {
             })
         }
 
+        /// Sets the value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
+        /// to hold a `ValueFloat`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_value_float<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::nearest_neighbor_query::numeric_filter::Value::ValueFloat(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
         /// if it holds a `ValueDouble`, `None` if the field is not set or
         /// holds a different branch.
@@ -33271,30 +33295,6 @@ pub mod nearest_neighbor_query {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
-        /// to hold a `ValueInt`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_value_int<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::nearest_neighbor_query::numeric_filter::Value::ValueInt(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
-        /// to hold a `ValueFloat`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_value_float<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::nearest_neighbor_query::numeric_filter::Value::ValueFloat(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::nearest_neighbor_query::NumericFilter::value]
@@ -34057,12 +34057,6 @@ impl ListFeatureGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeatureGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [feature_groups][crate::model::ListFeatureGroupsResponse::feature_groups].
     pub fn set_feature_groups<T, V>(mut self, v: T) -> Self
     where
@@ -34071,6 +34065,12 @@ impl ListFeatureGroupsResponse {
     {
         use std::iter::Iterator;
         self.feature_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeatureGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -34703,6 +34703,18 @@ impl FeatureView {
         self
     }
 
+    /// Sets the value of [labels][crate::model::FeatureView::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [sync_config][crate::model::FeatureView::sync_config].
     pub fn set_sync_config<
         T: std::convert::Into<std::option::Option<crate::model::feature_view::SyncConfig>>,
@@ -34768,18 +34780,6 @@ impl FeatureView {
         self
     }
 
-    /// Sets the value of [labels][crate::model::FeatureView::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [source][crate::model::FeatureView::source].
     ///
     /// Note that all the setters affecting `source` are mutually
@@ -34807,35 +34807,6 @@ impl FeatureView {
         })
     }
 
-    /// The value of [source][crate::model::FeatureView::source]
-    /// if it holds a `FeatureRegistrySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn feature_registry_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::feature_view::FeatureRegistrySource>>
-    {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::feature_view::Source::FeatureRegistrySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::FeatureView::source]
-    /// if it holds a `VertexRagSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertex_rag_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::feature_view::VertexRagSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::feature_view::Source::VertexRagSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::FeatureView::source]
     /// to hold a `BigQuerySource`.
     ///
@@ -34850,6 +34821,22 @@ impl FeatureView {
         self.source =
             std::option::Option::Some(crate::model::feature_view::Source::BigQuerySource(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::FeatureView::source]
+    /// if it holds a `FeatureRegistrySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn feature_registry_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::feature_view::FeatureRegistrySource>>
+    {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::feature_view::Source::FeatureRegistrySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::FeatureView::source]
@@ -34867,6 +34854,19 @@ impl FeatureView {
             crate::model::feature_view::Source::FeatureRegistrySource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::FeatureView::source]
+    /// if it holds a `VertexRagSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertex_rag_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::feature_view::VertexRagSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::feature_view::Source::VertexRagSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::FeatureView::source]
@@ -35067,6 +35067,17 @@ pub mod feature_view {
             self
         }
 
+        /// Sets the value of [filter_columns][crate::model::feature_view::IndexConfig::filter_columns].
+        pub fn set_filter_columns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.filter_columns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [crowding_column][crate::model::feature_view::IndexConfig::crowding_column].
         pub fn set_crowding_column<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -35093,17 +35104,6 @@ pub mod feature_view {
             v: T,
         ) -> Self {
             self.distance_measure_type = v.into();
-            self
-        }
-
-        /// Sets the value of [filter_columns][crate::model::feature_view::IndexConfig::filter_columns].
-        pub fn set_filter_columns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.filter_columns = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -35140,23 +35140,6 @@ pub mod feature_view {
             })
         }
 
-        /// The value of [algorithm_config][crate::model::feature_view::IndexConfig::algorithm_config]
-        /// if it holds a `BruteForceConfig`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn brute_force_config(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::feature_view::index_config::BruteForceConfig>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.algorithm_config.as_ref().and_then(|v| match v {
-                crate::model::feature_view::index_config::AlgorithmConfig::BruteForceConfig(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [algorithm_config][crate::model::feature_view::IndexConfig::algorithm_config]
         /// to hold a `TreeAhConfig`.
         ///
@@ -35174,6 +35157,23 @@ pub mod feature_view {
                 crate::model::feature_view::index_config::AlgorithmConfig::TreeAhConfig(v.into()),
             );
             self
+        }
+
+        /// The value of [algorithm_config][crate::model::feature_view::IndexConfig::algorithm_config]
+        /// if it holds a `BruteForceConfig`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn brute_force_config(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::feature_view::index_config::BruteForceConfig>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.algorithm_config.as_ref().and_then(|v| match v {
+                crate::model::feature_view::index_config::AlgorithmConfig::BruteForceConfig(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [algorithm_config][crate::model::feature_view::IndexConfig::algorithm_config]
@@ -35489,15 +35489,6 @@ pub mod feature_view {
             std::default::Default::default()
         }
 
-        /// Sets the value of [project_number][crate::model::feature_view::FeatureRegistrySource::project_number].
-        pub fn set_project_number<T: std::convert::Into<std::option::Option<i64>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.project_number = v.into();
-            self
-        }
-
         /// Sets the value of [feature_groups][crate::model::feature_view::FeatureRegistrySource::feature_groups].
         pub fn set_feature_groups<T, V>(mut self, v: T) -> Self
         where
@@ -35508,6 +35499,15 @@ pub mod feature_view {
         {
             use std::iter::Iterator;
             self.feature_groups = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [project_number][crate::model::feature_view::FeatureRegistrySource::project_number].
+        pub fn set_project_number<T: std::convert::Into<std::option::Option<i64>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.project_number = v.into();
             self
         }
     }
@@ -36140,6 +36140,18 @@ impl Featurestore {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Featurestore::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [online_serving_config][crate::model::Featurestore::online_serving_config].
     pub fn set_online_serving_config<
         T: std::convert::Into<std::option::Option<crate::model::featurestore::OnlineServingConfig>>,
@@ -36186,18 +36198,6 @@ impl Featurestore {
     /// Sets the value of [satisfies_pzi][crate::model::Featurestore::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Featurestore::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -37668,21 +37668,6 @@ pub mod read_feature_values_response {
                 })
             }
 
-            /// The value of [data][crate::model::read_feature_values_response::entity_view::Data::data]
-            /// if it holds a `Values`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn values(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::FeatureValueList>> {
-                #[allow(unreachable_patterns)]
-                self.data.as_ref().and_then(|v| match v {
-                    crate::model::read_feature_values_response::entity_view::data::Data::Values(
-                        v,
-                    ) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [data][crate::model::read_feature_values_response::entity_view::Data::data]
             /// to hold a `Value`.
             ///
@@ -37698,6 +37683,21 @@ pub mod read_feature_values_response {
                     ),
                 );
                 self
+            }
+
+            /// The value of [data][crate::model::read_feature_values_response::entity_view::Data::data]
+            /// if it holds a `Values`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn values(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::FeatureValueList>> {
+                #[allow(unreachable_patterns)]
+                self.data.as_ref().and_then(|v| match v {
+                    crate::model::read_feature_values_response::entity_view::data::Data::Values(
+                        v,
+                    ) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [data][crate::model::read_feature_values_response::entity_view::Data::data]
@@ -37794,17 +37794,6 @@ impl StreamingReadFeatureValuesRequest {
         self
     }
 
-    /// Sets the value of [feature_selector][crate::model::StreamingReadFeatureValuesRequest::feature_selector].
-    pub fn set_feature_selector<
-        T: std::convert::Into<std::option::Option<crate::model::FeatureSelector>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.feature_selector = v.into();
-        self
-    }
-
     /// Sets the value of [entity_ids][crate::model::StreamingReadFeatureValuesRequest::entity_ids].
     pub fn set_entity_ids<T, V>(mut self, v: T) -> Self
     where
@@ -37813,6 +37802,17 @@ impl StreamingReadFeatureValuesRequest {
     {
         use std::iter::Iterator;
         self.entity_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [feature_selector][crate::model::StreamingReadFeatureValuesRequest::feature_selector].
+    pub fn set_feature_selector<
+        T: std::convert::Into<std::option::Option<crate::model::FeatureSelector>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.feature_selector = v.into();
         self
     }
 }
@@ -37891,6 +37891,17 @@ impl FeatureValue {
         })
     }
 
+    /// Sets the value of [value][crate::model::FeatureValue::value]
+    /// to hold a `BoolValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::feature_value::Value::BoolValue(v.into()));
+        self
+    }
+
     /// The value of [value][crate::model::FeatureValue::value]
     /// if it holds a `DoubleValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -37900,6 +37911,17 @@ impl FeatureValue {
             crate::model::feature_value::Value::DoubleValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [value][crate::model::FeatureValue::value]
+    /// to hold a `DoubleValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::feature_value::Value::DoubleValue(v.into()));
+        self
     }
 
     /// The value of [value][crate::model::FeatureValue::value]
@@ -37913,6 +37935,17 @@ impl FeatureValue {
         })
     }
 
+    /// Sets the value of [value][crate::model::FeatureValue::value]
+    /// to hold a `Int64Value`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::feature_value::Value::Int64Value(v.into()));
+        self
+    }
+
     /// The value of [value][crate::model::FeatureValue::value]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -37922,6 +37955,17 @@ impl FeatureValue {
             crate::model::feature_value::Value::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [value][crate::model::FeatureValue::value]
+    /// to hold a `StringValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.value =
+            std::option::Option::Some(crate::model::feature_value::Value::StringValue(v.into()));
+        self
     }
 
     /// The value of [value][crate::model::FeatureValue::value]
@@ -37937,111 +37981,6 @@ impl FeatureValue {
         })
     }
 
-    /// The value of [value][crate::model::FeatureValue::value]
-    /// if it holds a `DoubleArrayValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_array_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DoubleArray>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::feature_value::Value::DoubleArrayValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::FeatureValue::value]
-    /// if it holds a `Int64ArrayValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int64_array_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::Int64Array>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::feature_value::Value::Int64ArrayValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::FeatureValue::value]
-    /// if it holds a `StringArrayValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_array_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StringArray>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::feature_value::Value::StringArrayValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::FeatureValue::value]
-    /// if it holds a `BytesValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bytes_value(&self) -> std::option::Option<&::bytes::Bytes> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::feature_value::Value::BytesValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::FeatureValue::value]
-    /// if it holds a `StructValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn struct_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::StructValue>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::feature_value::Value::StructValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [value][crate::model::FeatureValue::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::feature_value::Value::BoolValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [value][crate::model::FeatureValue::value]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::feature_value::Value::DoubleValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [value][crate::model::FeatureValue::value]
-    /// to hold a `Int64Value`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::feature_value::Value::Int64Value(v.into()));
-        self
-    }
-
-    /// Sets the value of [value][crate::model::FeatureValue::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::feature_value::Value::StringValue(v.into()));
-        self
-    }
-
     /// Sets the value of [value][crate::model::FeatureValue::value]
     /// to hold a `BoolArrayValue`.
     ///
@@ -38054,6 +37993,19 @@ impl FeatureValue {
         self.value =
             std::option::Option::Some(crate::model::feature_value::Value::BoolArrayValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::FeatureValue::value]
+    /// if it holds a `DoubleArrayValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_array_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DoubleArray>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::feature_value::Value::DoubleArrayValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::FeatureValue::value]
@@ -38073,6 +38025,19 @@ impl FeatureValue {
         self
     }
 
+    /// The value of [value][crate::model::FeatureValue::value]
+    /// if it holds a `Int64ArrayValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int64_array_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::Int64Array>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::feature_value::Value::Int64ArrayValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::FeatureValue::value]
     /// to hold a `Int64ArrayValue`.
     ///
@@ -38088,6 +38053,19 @@ impl FeatureValue {
             crate::model::feature_value::Value::Int64ArrayValue(v.into()),
         );
         self
+    }
+
+    /// The value of [value][crate::model::FeatureValue::value]
+    /// if it holds a `StringArrayValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_array_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StringArray>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::feature_value::Value::StringArrayValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::FeatureValue::value]
@@ -38107,6 +38085,17 @@ impl FeatureValue {
         self
     }
 
+    /// The value of [value][crate::model::FeatureValue::value]
+    /// if it holds a `BytesValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bytes_value(&self) -> std::option::Option<&::bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::feature_value::Value::BytesValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::FeatureValue::value]
     /// to hold a `BytesValue`.
     ///
@@ -38116,6 +38105,17 @@ impl FeatureValue {
         self.value =
             std::option::Option::Some(crate::model::feature_value::Value::BytesValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::FeatureValue::value]
+    /// if it holds a `StructValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn struct_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::StructValue>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::feature_value::Value::StructValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::FeatureValue::value]
@@ -38654,12 +38654,6 @@ impl ListFeaturestoresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeaturestoresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [featurestores][crate::model::ListFeaturestoresResponse::featurestores].
     pub fn set_featurestores<T, V>(mut self, v: T) -> Self
     where
@@ -38668,6 +38662,12 @@ impl ListFeaturestoresResponse {
     {
         use std::iter::Iterator;
         self.featurestores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeaturestoresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -38896,6 +38896,17 @@ impl ImportFeatureValuesRequest {
         self
     }
 
+    /// Sets the value of [feature_specs][crate::model::ImportFeatureValuesRequest::feature_specs].
+    pub fn set_feature_specs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::import_feature_values_request::FeatureSpec>,
+    {
+        use std::iter::Iterator;
+        self.feature_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [disable_online_serving][crate::model::ImportFeatureValuesRequest::disable_online_serving].
     pub fn set_disable_online_serving<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disable_online_serving = v.into();
@@ -38911,17 +38922,6 @@ impl ImportFeatureValuesRequest {
     /// Sets the value of [disable_ingestion_analysis][crate::model::ImportFeatureValuesRequest::disable_ingestion_analysis].
     pub fn set_disable_ingestion_analysis<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disable_ingestion_analysis = v.into();
-        self
-    }
-
-    /// Sets the value of [feature_specs][crate::model::ImportFeatureValuesRequest::feature_specs].
-    pub fn set_feature_specs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::import_feature_values_request::FeatureSpec>,
-    {
-        use std::iter::Iterator;
-        self.feature_specs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -38954,34 +38954,6 @@ impl ImportFeatureValuesRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportFeatureValuesRequest::source]
-    /// if it holds a `BigquerySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_feature_values_request::Source::BigquerySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportFeatureValuesRequest::source]
-    /// if it holds a `CsvSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn csv_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::CsvSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_feature_values_request::Source::CsvSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportFeatureValuesRequest::source]
     /// to hold a `AvroSource`.
     ///
@@ -38995,6 +38967,21 @@ impl ImportFeatureValuesRequest {
             crate::model::import_feature_values_request::Source::AvroSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportFeatureValuesRequest::source]
+    /// if it holds a `BigquerySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_feature_values_request::Source::BigquerySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportFeatureValuesRequest::source]
@@ -39012,6 +38999,19 @@ impl ImportFeatureValuesRequest {
             crate::model::import_feature_values_request::Source::BigquerySource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportFeatureValuesRequest::source]
+    /// if it holds a `CsvSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn csv_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::CsvSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_feature_values_request::Source::CsvSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportFeatureValuesRequest::source]
@@ -39058,19 +39058,6 @@ impl ImportFeatureValuesRequest {
         })
     }
 
-    /// The value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source]
-    /// if it holds a `FeatureTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn feature_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.feature_time_source.as_ref().and_then(|v| match v {
-            crate::model::import_feature_values_request::FeatureTimeSource::FeatureTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source]
     /// to hold a `FeatureTimeField`.
     ///
@@ -39086,6 +39073,19 @@ impl ImportFeatureValuesRequest {
             ),
         );
         self
+    }
+
+    /// The value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source]
+    /// if it holds a `FeatureTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn feature_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.feature_time_source.as_ref().and_then(|v| match v {
+            crate::model::import_feature_values_request::FeatureTimeSource::FeatureTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source]
@@ -39350,15 +39350,6 @@ impl BatchReadFeatureValuesRequest {
         self
     }
 
-    /// Sets the value of [start_time][crate::model::BatchReadFeatureValuesRequest::start_time].
-    pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_time = v.into();
-        self
-    }
-
     /// Sets the value of [pass_through_fields][crate::model::BatchReadFeatureValuesRequest::pass_through_fields].
     pub fn set_pass_through_fields<T, V>(mut self, v: T) -> Self
     where
@@ -39378,6 +39369,15 @@ impl BatchReadFeatureValuesRequest {
     {
         use std::iter::Iterator;
         self.entity_type_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [start_time][crate::model::BatchReadFeatureValuesRequest::start_time].
+    pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.start_time = v.into();
         self
     }
 
@@ -39412,21 +39412,6 @@ impl BatchReadFeatureValuesRequest {
         })
     }
 
-    /// The value of [read_option][crate::model::BatchReadFeatureValuesRequest::read_option]
-    /// if it holds a `BigqueryReadInstances`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_read_instances(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.read_option.as_ref().and_then(|v| match v {
-            crate::model::batch_read_feature_values_request::ReadOption::BigqueryReadInstances(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [read_option][crate::model::BatchReadFeatureValuesRequest::read_option]
     /// to hold a `CsvReadInstances`.
     ///
@@ -39442,6 +39427,21 @@ impl BatchReadFeatureValuesRequest {
             crate::model::batch_read_feature_values_request::ReadOption::CsvReadInstances(v.into()),
         );
         self
+    }
+
+    /// The value of [read_option][crate::model::BatchReadFeatureValuesRequest::read_option]
+    /// if it holds a `BigqueryReadInstances`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_read_instances(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.read_option.as_ref().and_then(|v| match v {
+            crate::model::batch_read_feature_values_request::ReadOption::BigqueryReadInstances(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [read_option][crate::model::BatchReadFeatureValuesRequest::read_option]
@@ -39738,23 +39738,6 @@ impl ExportFeatureValuesRequest {
         })
     }
 
-    /// The value of [mode][crate::model::ExportFeatureValuesRequest::mode]
-    /// if it holds a `FullExport`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn full_export(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::export_feature_values_request::FullExport>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::export_feature_values_request::Mode::FullExport(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::ExportFeatureValuesRequest::mode]
     /// to hold a `SnapshotExport`.
     ///
@@ -39772,6 +39755,23 @@ impl ExportFeatureValuesRequest {
             crate::model::export_feature_values_request::Mode::SnapshotExport(v.into()),
         );
         self
+    }
+
+    /// The value of [mode][crate::model::ExportFeatureValuesRequest::mode]
+    /// if it holds a `FullExport`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn full_export(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::export_feature_values_request::FullExport>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::export_feature_values_request::Mode::FullExport(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::ExportFeatureValuesRequest::mode]
@@ -40035,36 +40035,6 @@ impl FeatureValueDestination {
         })
     }
 
-    /// The value of [destination][crate::model::FeatureValueDestination::destination]
-    /// if it holds a `TfrecordDestination`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tfrecord_destination(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TFRecordDestination>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::feature_value_destination::Destination::TfrecordDestination(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [destination][crate::model::FeatureValueDestination::destination]
-    /// if it holds a `CsvDestination`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn csv_destination(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CsvDestination>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::feature_value_destination::Destination::CsvDestination(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::FeatureValueDestination::destination]
     /// to hold a `BigqueryDestination`.
     ///
@@ -40082,6 +40052,21 @@ impl FeatureValueDestination {
         self
     }
 
+    /// The value of [destination][crate::model::FeatureValueDestination::destination]
+    /// if it holds a `TfrecordDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tfrecord_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TFRecordDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::feature_value_destination::Destination::TfrecordDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [destination][crate::model::FeatureValueDestination::destination]
     /// to hold a `TfrecordDestination`.
     ///
@@ -40097,6 +40082,21 @@ impl FeatureValueDestination {
             crate::model::feature_value_destination::Destination::TfrecordDestination(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::FeatureValueDestination::destination]
+    /// if it holds a `CsvDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn csv_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CsvDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::feature_value_destination::Destination::CsvDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::FeatureValueDestination::destination]
@@ -40490,12 +40490,6 @@ impl ListEntityTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntityTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entity_types][crate::model::ListEntityTypesResponse::entity_types].
     pub fn set_entity_types<T, V>(mut self, v: T) -> Self
     where
@@ -40504,6 +40498,12 @@ impl ListEntityTypesResponse {
     {
         use std::iter::Iterator;
         self.entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntityTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -41075,12 +41075,6 @@ impl ListFeaturesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeaturesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [features][crate::model::ListFeaturesResponse::features].
     pub fn set_features<T, V>(mut self, v: T) -> Self
     where
@@ -41089,6 +41083,12 @@ impl ListFeaturesResponse {
     {
         use std::iter::Iterator;
         self.features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeaturesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -41295,12 +41295,6 @@ impl SearchFeaturesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchFeaturesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [features][crate::model::SearchFeaturesResponse::features].
     pub fn set_features<T, V>(mut self, v: T) -> Self
     where
@@ -41309,6 +41303,12 @@ impl SearchFeaturesResponse {
     {
         use std::iter::Iterator;
         self.features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchFeaturesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -41613,6 +41613,17 @@ impl ImportFeatureValuesOperationMetadata {
         self
     }
 
+    /// Sets the value of [source_uris][crate::model::ImportFeatureValuesOperationMetadata::source_uris].
+    pub fn set_source_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.source_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [invalid_row_count][crate::model::ImportFeatureValuesOperationMetadata::invalid_row_count].
     pub fn set_invalid_row_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.invalid_row_count = v.into();
@@ -41625,17 +41636,6 @@ impl ImportFeatureValuesOperationMetadata {
         v: T,
     ) -> Self {
         self.timestamp_outside_retention_rows_count = v.into();
-        self
-    }
-
-    /// Sets the value of [source_uris][crate::model::ImportFeatureValuesOperationMetadata::source_uris].
-    pub fn set_source_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.source_uris = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -41968,21 +41968,6 @@ impl DeleteFeatureValuesRequest {
         })
     }
 
-    /// The value of [delete_option][crate::model::DeleteFeatureValuesRequest::delete_option]
-    /// if it holds a `SelectTimeRangeAndFeature`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn select_time_range_and_feature(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::delete_feature_values_request::SelectTimeRangeAndFeature>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.delete_option.as_ref().and_then(|v| match v {
-            crate::model::delete_feature_values_request::DeleteOption::SelectTimeRangeAndFeature(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [delete_option][crate::model::DeleteFeatureValuesRequest::delete_option]
     /// to hold a `SelectEntity`.
     ///
@@ -42000,6 +41985,21 @@ impl DeleteFeatureValuesRequest {
             crate::model::delete_feature_values_request::DeleteOption::SelectEntity(v.into()),
         );
         self
+    }
+
+    /// The value of [delete_option][crate::model::DeleteFeatureValuesRequest::delete_option]
+    /// if it holds a `SelectTimeRangeAndFeature`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn select_time_range_and_feature(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::delete_feature_values_request::SelectTimeRangeAndFeature>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.delete_option.as_ref().and_then(|v| match v {
+            crate::model::delete_feature_values_request::DeleteOption::SelectTimeRangeAndFeature(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [delete_option][crate::model::DeleteFeatureValuesRequest::delete_option]
@@ -42230,23 +42230,6 @@ impl DeleteFeatureValuesResponse {
         })
     }
 
-    /// The value of [response][crate::model::DeleteFeatureValuesResponse::response]
-    /// if it holds a `SelectTimeRangeAndFeature`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn select_time_range_and_feature(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::delete_feature_values_response::SelectTimeRangeAndFeature>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::delete_feature_values_response::Response::SelectTimeRangeAndFeature(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response][crate::model::DeleteFeatureValuesResponse::response]
     /// to hold a `SelectEntity`.
     ///
@@ -42264,6 +42247,23 @@ impl DeleteFeatureValuesResponse {
             crate::model::delete_feature_values_response::Response::SelectEntity(v.into()),
         );
         self
+    }
+
+    /// The value of [response][crate::model::DeleteFeatureValuesResponse::response]
+    /// if it holds a `SelectTimeRangeAndFeature`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn select_time_range_and_feature(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::delete_feature_values_response::SelectTimeRangeAndFeature>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::delete_feature_values_response::Response::SelectTimeRangeAndFeature(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response][crate::model::DeleteFeatureValuesResponse::response]
@@ -42824,12 +42824,6 @@ impl ListCachedContentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCachedContentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cached_contents][crate::model::ListCachedContentsResponse::cached_contents].
     pub fn set_cached_contents<T, V>(mut self, v: T) -> Self
     where
@@ -42838,6 +42832,12 @@ impl ListCachedContentsResponse {
     {
         use std::iter::Iterator;
         self.cached_contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCachedContentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -43062,12 +43062,6 @@ impl ListTuningJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTuningJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tuning_jobs][crate::model::ListTuningJobsResponse::tuning_jobs].
     pub fn set_tuning_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -43076,6 +43070,12 @@ impl ListTuningJobsResponse {
     {
         use std::iter::Iterator;
         self.tuning_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTuningJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -43439,6 +43439,17 @@ impl HyperparameterTuningJob {
         self
     }
 
+    /// Sets the value of [trials][crate::model::HyperparameterTuningJob::trials].
+    pub fn set_trials<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Trial>,
+    {
+        use std::iter::Iterator;
+        self.trials = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::HyperparameterTuningJob::state].
     pub fn set_state<T: std::convert::Into<crate::model::JobState>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -43490,6 +43501,18 @@ impl HyperparameterTuningJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::HyperparameterTuningJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [encryption_spec][crate::model::HyperparameterTuningJob::encryption_spec].
     pub fn set_encryption_spec<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
@@ -43510,29 +43533,6 @@ impl HyperparameterTuningJob {
     /// Sets the value of [satisfies_pzi][crate::model::HyperparameterTuningJob::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [trials][crate::model::HyperparameterTuningJob::trials].
-    pub fn set_trials<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Trial>,
-    {
-        use std::iter::Iterator;
-        self.trials = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::HyperparameterTuningJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -43688,9 +43688,32 @@ impl Index {
         self
     }
 
+    /// Sets the value of [deployed_indexes][crate::model::Index::deployed_indexes].
+    pub fn set_deployed_indexes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DeployedIndexRef>,
+    {
+        use std::iter::Iterator;
+        self.deployed_indexes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Index::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Index::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -43752,29 +43775,6 @@ impl Index {
     /// Sets the value of [satisfies_pzi][crate::model::Index::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [deployed_indexes][crate::model::Index::deployed_indexes].
-    pub fn set_deployed_indexes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DeployedIndexRef>,
-    {
-        use std::iter::Iterator;
-        self.deployed_indexes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Index::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -43991,28 +43991,6 @@ impl IndexDatapoint {
         self
     }
 
-    /// Sets the value of [sparse_embedding][crate::model::IndexDatapoint::sparse_embedding].
-    pub fn set_sparse_embedding<
-        T: std::convert::Into<std::option::Option<crate::model::index_datapoint::SparseEmbedding>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sparse_embedding = v.into();
-        self
-    }
-
-    /// Sets the value of [crowding_tag][crate::model::IndexDatapoint::crowding_tag].
-    pub fn set_crowding_tag<
-        T: std::convert::Into<std::option::Option<crate::model::index_datapoint::CrowdingTag>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.crowding_tag = v.into();
-        self
-    }
-
     /// Sets the value of [feature_vector][crate::model::IndexDatapoint::feature_vector].
     pub fn set_feature_vector<T, V>(mut self, v: T) -> Self
     where
@@ -44021,6 +43999,17 @@ impl IndexDatapoint {
     {
         use std::iter::Iterator;
         self.feature_vector = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [sparse_embedding][crate::model::IndexDatapoint::sparse_embedding].
+    pub fn set_sparse_embedding<
+        T: std::convert::Into<std::option::Option<crate::model::index_datapoint::SparseEmbedding>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.sparse_embedding = v.into();
         self
     }
 
@@ -44043,6 +44032,17 @@ impl IndexDatapoint {
     {
         use std::iter::Iterator;
         self.numeric_restricts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [crowding_tag][crate::model::IndexDatapoint::crowding_tag].
+    pub fn set_crowding_tag<
+        T: std::convert::Into<std::option::Option<crate::model::index_datapoint::CrowdingTag>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.crowding_tag = v.into();
         self
     }
 }
@@ -44261,6 +44261,18 @@ pub mod index_datapoint {
             })
         }
 
+        /// Sets the value of [value][crate::model::index_datapoint::NumericRestriction::value]
+        /// to hold a `ValueInt`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_value_int<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::index_datapoint::numeric_restriction::Value::ValueInt(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::index_datapoint::NumericRestriction::value]
         /// if it holds a `ValueFloat`, `None` if the field is not set or
         /// holds a different branch.
@@ -44274,6 +44286,18 @@ pub mod index_datapoint {
             })
         }
 
+        /// Sets the value of [value][crate::model::index_datapoint::NumericRestriction::value]
+        /// to hold a `ValueFloat`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_value_float<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::index_datapoint::numeric_restriction::Value::ValueFloat(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::index_datapoint::NumericRestriction::value]
         /// if it holds a `ValueDouble`, `None` if the field is not set or
         /// holds a different branch.
@@ -44285,30 +44309,6 @@ pub mod index_datapoint {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::index_datapoint::NumericRestriction::value]
-        /// to hold a `ValueInt`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_value_int<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::index_datapoint::numeric_restriction::Value::ValueInt(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::index_datapoint::NumericRestriction::value]
-        /// to hold a `ValueFloat`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_value_float<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::index_datapoint::numeric_restriction::Value::ValueFloat(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::index_datapoint::NumericRestriction::value]
@@ -44786,9 +44786,32 @@ impl IndexEndpoint {
         self
     }
 
+    /// Sets the value of [deployed_indexes][crate::model::IndexEndpoint::deployed_indexes].
+    pub fn set_deployed_indexes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DeployedIndex>,
+    {
+        use std::iter::Iterator;
+        self.deployed_indexes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::IndexEndpoint::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::IndexEndpoint::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -44869,29 +44892,6 @@ impl IndexEndpoint {
     /// Sets the value of [satisfies_pzi][crate::model::IndexEndpoint::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [deployed_indexes][crate::model::IndexEndpoint::deployed_indexes].
-    pub fn set_deployed_indexes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DeployedIndex>,
-    {
-        use std::iter::Iterator;
-        self.deployed_indexes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::IndexEndpoint::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -45140,15 +45140,6 @@ impl DeployedIndex {
         self
     }
 
-    /// Sets the value of [deployment_group][crate::model::DeployedIndex::deployment_group].
-    pub fn set_deployment_group<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_group = v.into();
-        self
-    }
-
     /// Sets the value of [reserved_ip_ranges][crate::model::DeployedIndex::reserved_ip_ranges].
     pub fn set_reserved_ip_ranges<T, V>(mut self, v: T) -> Self
     where
@@ -45157,6 +45148,15 @@ impl DeployedIndex {
     {
         use std::iter::Iterator;
         self.reserved_ip_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [deployment_group][crate::model::DeployedIndex::deployment_group].
+    pub fn set_deployment_group<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.deployment_group = v.into();
         self
     }
 
@@ -45643,12 +45643,6 @@ impl ListIndexEndpointsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIndexEndpointsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [index_endpoints][crate::model::ListIndexEndpointsResponse::index_endpoints].
     pub fn set_index_endpoints<T, V>(mut self, v: T) -> Self
     where
@@ -45657,6 +45651,12 @@ impl ListIndexEndpointsResponse {
     {
         use std::iter::Iterator;
         self.index_endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIndexEndpointsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -46498,12 +46498,6 @@ impl ListIndexesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIndexesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [indexes][crate::model::ListIndexesResponse::indexes].
     pub fn set_indexes<T, V>(mut self, v: T) -> Self
     where
@@ -46512,6 +46506,12 @@ impl ListIndexesResponse {
     {
         use std::iter::Iterator;
         self.indexes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIndexesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -46743,15 +46743,6 @@ impl UpsertDatapointsRequest {
         self
     }
 
-    /// Sets the value of [update_mask][crate::model::UpsertDatapointsRequest::update_mask].
-    pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_mask = v.into();
-        self
-    }
-
     /// Sets the value of [datapoints][crate::model::UpsertDatapointsRequest::datapoints].
     pub fn set_datapoints<T, V>(mut self, v: T) -> Self
     where
@@ -46760,6 +46751,15 @@ impl UpsertDatapointsRequest {
     {
         use std::iter::Iterator;
         self.datapoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_mask][crate::model::UpsertDatapointsRequest::update_mask].
+    pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_mask = v.into();
         self
     }
 }
@@ -46917,12 +46917,6 @@ impl NearestNeighborSearchOperationMetadata {
         std::default::Default::default()
     }
 
-    /// Sets the value of [data_bytes_count][crate::model::NearestNeighborSearchOperationMetadata::data_bytes_count].
-    pub fn set_data_bytes_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.data_bytes_count = v.into();
-        self
-    }
-
     /// Sets the value of [content_validation_stats][crate::model::NearestNeighborSearchOperationMetadata::content_validation_stats].
     pub fn set_content_validation_stats<T, V>(mut self, v: T) -> Self
     where
@@ -46933,6 +46927,12 @@ impl NearestNeighborSearchOperationMetadata {
     {
         use std::iter::Iterator;
         self.content_validation_stats = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_bytes_count][crate::model::NearestNeighborSearchOperationMetadata::data_bytes_count].
+    pub fn set_data_bytes_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.data_bytes_count = v.into();
         self
     }
 }
@@ -47367,18 +47367,6 @@ pub mod nearest_neighbor_search_operation_metadata {
             self
         }
 
-        /// Sets the value of [valid_sparse_record_count][crate::model::nearest_neighbor_search_operation_metadata::ContentValidationStats::valid_sparse_record_count].
-        pub fn set_valid_sparse_record_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.valid_sparse_record_count = v.into();
-            self
-        }
-
-        /// Sets the value of [invalid_sparse_record_count][crate::model::nearest_neighbor_search_operation_metadata::ContentValidationStats::invalid_sparse_record_count].
-        pub fn set_invalid_sparse_record_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.invalid_sparse_record_count = v.into();
-            self
-        }
-
         /// Sets the value of [partial_errors][crate::model::nearest_neighbor_search_operation_metadata::ContentValidationStats::partial_errors].
         pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
         where
@@ -47389,6 +47377,18 @@ pub mod nearest_neighbor_search_operation_metadata {
         {
             use std::iter::Iterator;
             self.partial_errors = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [valid_sparse_record_count][crate::model::nearest_neighbor_search_operation_metadata::ContentValidationStats::valid_sparse_record_count].
+        pub fn set_valid_sparse_record_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.valid_sparse_record_count = v.into();
+            self
+        }
+
+        /// Sets the value of [invalid_sparse_record_count][crate::model::nearest_neighbor_search_operation_metadata::ContentValidationStats::invalid_sparse_record_count].
+        pub fn set_invalid_sparse_record_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.invalid_sparse_record_count = v.into();
             self
         }
     }
@@ -48199,17 +48199,6 @@ pub mod slack_source {
             std::default::Default::default()
         }
 
-        /// Sets the value of [api_key_config][crate::model::slack_source::SlackChannels::api_key_config].
-        pub fn set_api_key_config<
-            T: std::convert::Into<std::option::Option<crate::model::api_auth::ApiKeyConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.api_key_config = v.into();
-            self
-        }
-
         /// Sets the value of [channels][crate::model::slack_source::SlackChannels::channels].
         pub fn set_channels<T, V>(mut self, v: T) -> Self
         where
@@ -48218,6 +48207,17 @@ pub mod slack_source {
         {
             use std::iter::Iterator;
             self.channels = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [api_key_config][crate::model::slack_source::SlackChannels::api_key_config].
+        pub fn set_api_key_config<
+            T: std::convert::Into<std::option::Option<crate::model::api_auth::ApiKeyConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.api_key_config = v.into();
             self
         }
     }
@@ -48389,6 +48389,28 @@ pub mod jira_source {
             std::default::Default::default()
         }
 
+        /// Sets the value of [projects][crate::model::jira_source::JiraQueries::projects].
+        pub fn set_projects<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.projects = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [custom_queries][crate::model::jira_source::JiraQueries::custom_queries].
+        pub fn set_custom_queries<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.custom_queries = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [email][crate::model::jira_source::JiraQueries::email].
         pub fn set_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.email = v.into();
@@ -48409,28 +48431,6 @@ pub mod jira_source {
             v: T,
         ) -> Self {
             self.api_key_config = v.into();
-            self
-        }
-
-        /// Sets the value of [projects][crate::model::jira_source::JiraQueries::projects].
-        pub fn set_projects<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.projects = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [custom_queries][crate::model::jira_source::JiraQueries::custom_queries].
-        pub fn set_custom_queries<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.custom_queries = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -48607,17 +48607,6 @@ pub mod share_point_sources {
             })
         }
 
-        /// The value of [folder_source][crate::model::share_point_sources::SharePointSource::folder_source]
-        /// if it holds a `SharepointFolderId`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sharepoint_folder_id(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.folder_source.as_ref().and_then(|v| match v {
-                crate::model::share_point_sources::share_point_source::FolderSource::SharepointFolderId(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [folder_source][crate::model::share_point_sources::SharePointSource::folder_source]
         /// to hold a `SharepointFolderPath`.
         ///
@@ -48633,6 +48622,17 @@ pub mod share_point_sources {
                 )
             );
             self
+        }
+
+        /// The value of [folder_source][crate::model::share_point_sources::SharePointSource::folder_source]
+        /// if it holds a `SharepointFolderId`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sharepoint_folder_id(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.folder_source.as_ref().and_then(|v| match v {
+                crate::model::share_point_sources::share_point_source::FolderSource::SharepointFolderId(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [folder_source][crate::model::share_point_sources::SharePointSource::folder_source]
@@ -48683,19 +48683,6 @@ pub mod share_point_sources {
             })
         }
 
-        /// The value of [drive_source][crate::model::share_point_sources::SharePointSource::drive_source]
-        /// if it holds a `DriveId`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn drive_id(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.drive_source.as_ref().and_then(|v| match v {
-                crate::model::share_point_sources::share_point_source::DriveSource::DriveId(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [drive_source][crate::model::share_point_sources::SharePointSource::drive_source]
         /// to hold a `DriveName`.
         ///
@@ -48708,6 +48695,19 @@ pub mod share_point_sources {
                 ),
             );
             self
+        }
+
+        /// The value of [drive_source][crate::model::share_point_sources::SharePointSource::drive_source]
+        /// if it holds a `DriveId`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn drive_id(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.drive_source.as_ref().and_then(|v| match v {
+                crate::model::share_point_sources::share_point_source::DriveSource::DriveId(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [drive_source][crate::model::share_point_sources::SharePointSource::drive_source]
@@ -48998,12 +48998,6 @@ impl ListCustomJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCustomJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [custom_jobs][crate::model::ListCustomJobsResponse::custom_jobs].
     pub fn set_custom_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -49012,6 +49006,12 @@ impl ListCustomJobsResponse {
     {
         use std::iter::Iterator;
         self.custom_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCustomJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -49357,12 +49357,6 @@ impl ListDataLabelingJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataLabelingJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_labeling_jobs][crate::model::ListDataLabelingJobsResponse::data_labeling_jobs].
     pub fn set_data_labeling_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -49371,6 +49365,12 @@ impl ListDataLabelingJobsResponse {
     {
         use std::iter::Iterator;
         self.data_labeling_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataLabelingJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -49719,12 +49719,6 @@ impl ListHyperparameterTuningJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHyperparameterTuningJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [hyperparameter_tuning_jobs][crate::model::ListHyperparameterTuningJobsResponse::hyperparameter_tuning_jobs].
     pub fn set_hyperparameter_tuning_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -49733,6 +49727,12 @@ impl ListHyperparameterTuningJobsResponse {
     {
         use std::iter::Iterator;
         self.hyperparameter_tuning_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHyperparameterTuningJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -50077,12 +50077,6 @@ impl ListNasJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNasJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [nas_jobs][crate::model::ListNasJobsResponse::nas_jobs].
     pub fn set_nas_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -50091,6 +50085,12 @@ impl ListNasJobsResponse {
     {
         use std::iter::Iterator;
         self.nas_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNasJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -50338,12 +50338,6 @@ impl ListNasTrialDetailsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNasTrialDetailsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [nas_trial_details][crate::model::ListNasTrialDetailsResponse::nas_trial_details].
     pub fn set_nas_trial_details<T, V>(mut self, v: T) -> Self
     where
@@ -50352,6 +50346,12 @@ impl ListNasTrialDetailsResponse {
     {
         use std::iter::Iterator;
         self.nas_trial_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNasTrialDetailsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -50615,12 +50615,6 @@ impl ListBatchPredictionJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBatchPredictionJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [batch_prediction_jobs][crate::model::ListBatchPredictionJobsResponse::batch_prediction_jobs].
     pub fn set_batch_prediction_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -50629,6 +50623,12 @@ impl ListBatchPredictionJobsResponse {
     {
         use std::iter::Iterator;
         self.batch_prediction_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBatchPredictionJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -50884,6 +50884,17 @@ impl SearchModelDeploymentMonitoringStatsAnomaliesRequest {
         self
     }
 
+    /// Sets the value of [objectives][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::objectives].
+    pub fn set_objectives<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_model_deployment_monitoring_stats_anomalies_request::StatsAnomaliesObjective>
+    {
+        use std::iter::Iterator;
+        self.objectives = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -50911,17 +50922,6 @@ impl SearchModelDeploymentMonitoringStatsAnomaliesRequest {
         v: T,
     ) -> Self {
         self.end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [objectives][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest::objectives].
-    pub fn set_objectives<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_model_deployment_monitoring_stats_anomalies_request::StatsAnomaliesObjective>
-    {
-        use std::iter::Iterator;
-        self.objectives = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -51035,12 +51035,6 @@ impl SearchModelDeploymentMonitoringStatsAnomaliesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [monitoring_stats][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesResponse::monitoring_stats].
     pub fn set_monitoring_stats<T, V>(mut self, v: T) -> Self
     where
@@ -51049,6 +51043,12 @@ impl SearchModelDeploymentMonitoringStatsAnomaliesResponse {
     {
         use std::iter::Iterator;
         self.monitoring_stats = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchModelDeploymentMonitoringStatsAnomaliesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -51247,12 +51247,6 @@ impl ListModelDeploymentMonitoringJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelDeploymentMonitoringJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [model_deployment_monitoring_jobs][crate::model::ListModelDeploymentMonitoringJobsResponse::model_deployment_monitoring_jobs].
     pub fn set_model_deployment_monitoring_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -51261,6 +51255,12 @@ impl ListModelDeploymentMonitoringJobsResponse {
     {
         use std::iter::Iterator;
         self.model_deployment_monitoring_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelDeploymentMonitoringJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -51648,12 +51648,6 @@ impl ComputeTokensRequest {
         self
     }
 
-    /// Sets the value of [model][crate::model::ComputeTokensRequest::model].
-    pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.model = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ComputeTokensRequest::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -51662,6 +51656,12 @@ impl ComputeTokensRequest {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [model][crate::model::ComputeTokensRequest::model].
+    pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.model = v.into();
         self
     }
 
@@ -51715,12 +51715,6 @@ impl TokensInfo {
         std::default::Default::default()
     }
 
-    /// Sets the value of [role][crate::model::TokensInfo::role].
-    pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.role = v.into();
-        self
-    }
-
     /// Sets the value of [tokens][crate::model::TokensInfo::tokens].
     pub fn set_tokens<T, V>(mut self, v: T) -> Self
     where
@@ -51740,6 +51734,12 @@ impl TokensInfo {
     {
         use std::iter::Iterator;
         self.token_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [role][crate::model::TokensInfo::role].
+    pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.role = v.into();
         self
     }
 }
@@ -52059,12 +52059,6 @@ impl DedicatedResources {
         self
     }
 
-    /// Sets the value of [spot][crate::model::DedicatedResources::spot].
-    pub fn set_spot<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.spot = v.into();
-        self
-    }
-
     /// Sets the value of [autoscaling_metric_specs][crate::model::DedicatedResources::autoscaling_metric_specs].
     pub fn set_autoscaling_metric_specs<T, V>(mut self, v: T) -> Self
     where
@@ -52073,6 +52067,12 @@ impl DedicatedResources {
     {
         use std::iter::Iterator;
         self.autoscaling_metric_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [spot][crate::model::DedicatedResources::spot].
+    pub fn set_spot<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.spot = v.into();
         self
     }
 }
@@ -52643,12 +52643,6 @@ impl FindNeighborsRequest {
         self
     }
 
-    /// Sets the value of [return_full_datapoint][crate::model::FindNeighborsRequest::return_full_datapoint].
-    pub fn set_return_full_datapoint<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.return_full_datapoint = v.into();
-        self
-    }
-
     /// Sets the value of [queries][crate::model::FindNeighborsRequest::queries].
     pub fn set_queries<T, V>(mut self, v: T) -> Self
     where
@@ -52657,6 +52651,12 @@ impl FindNeighborsRequest {
     {
         use std::iter::Iterator;
         self.queries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [return_full_datapoint][crate::model::FindNeighborsRequest::return_full_datapoint].
+    pub fn set_return_full_datapoint<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.return_full_datapoint = v.into();
         self
     }
 }
@@ -53672,12 +53672,6 @@ impl ListMetadataStoresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMetadataStoresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [metadata_stores][crate::model::ListMetadataStoresResponse::metadata_stores].
     pub fn set_metadata_stores<T, V>(mut self, v: T) -> Self
     where
@@ -53686,6 +53680,12 @@ impl ListMetadataStoresResponse {
     {
         use std::iter::Iterator;
         self.metadata_stores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMetadataStoresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -54074,12 +54074,6 @@ impl ListArtifactsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListArtifactsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [artifacts][crate::model::ListArtifactsResponse::artifacts].
     pub fn set_artifacts<T, V>(mut self, v: T) -> Self
     where
@@ -54088,6 +54082,12 @@ impl ListArtifactsResponse {
     {
         use std::iter::Iterator;
         self.artifacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListArtifactsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -54675,12 +54675,6 @@ impl ListContextsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListContextsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [contexts][crate::model::ListContextsResponse::contexts].
     pub fn set_contexts<T, V>(mut self, v: T) -> Self
     where
@@ -54689,6 +54683,12 @@ impl ListContextsResponse {
     {
         use std::iter::Iterator;
         self.contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListContextsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -55597,12 +55597,6 @@ impl ListExecutionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [executions][crate::model::ListExecutionsResponse::executions].
     pub fn set_executions<T, V>(mut self, v: T) -> Self
     where
@@ -55611,6 +55605,12 @@ impl ListExecutionsResponse {
     {
         use std::iter::Iterator;
         self.executions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -56278,12 +56278,6 @@ impl ListMetadataSchemasResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMetadataSchemasResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [metadata_schemas][crate::model::ListMetadataSchemasResponse::metadata_schemas].
     pub fn set_metadata_schemas<T, V>(mut self, v: T) -> Self
     where
@@ -56292,6 +56286,12 @@ impl ListMetadataSchemasResponse {
     {
         use std::iter::Iterator;
         self.metadata_schemas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMetadataSchemasResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -56688,53 +56688,6 @@ impl MigratableResource {
         })
     }
 
-    /// The value of [resource][crate::model::MigratableResource::resource]
-    /// if it holds a `AutomlModel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn automl_model(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::migratable_resource::AutomlModel>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::migratable_resource::Resource::AutomlModel(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::MigratableResource::resource]
-    /// if it holds a `AutomlDataset`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn automl_dataset(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::migratable_resource::AutomlDataset>>
-    {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::migratable_resource::Resource::AutomlDataset(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::MigratableResource::resource]
-    /// if it holds a `DataLabelingDataset`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_labeling_dataset(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::migratable_resource::DataLabelingDataset>>
-    {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::migratable_resource::Resource::DataLabelingDataset(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [resource][crate::model::MigratableResource::resource]
     /// to hold a `MlEngineModelVersion`.
     ///
@@ -56754,6 +56707,21 @@ impl MigratableResource {
         self
     }
 
+    /// The value of [resource][crate::model::MigratableResource::resource]
+    /// if it holds a `AutomlModel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn automl_model(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::migratable_resource::AutomlModel>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::migratable_resource::Resource::AutomlModel(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [resource][crate::model::MigratableResource::resource]
     /// to hold a `AutomlModel`.
     ///
@@ -56771,6 +56739,22 @@ impl MigratableResource {
         self
     }
 
+    /// The value of [resource][crate::model::MigratableResource::resource]
+    /// if it holds a `AutomlDataset`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn automl_dataset(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::migratable_resource::AutomlDataset>>
+    {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::migratable_resource::Resource::AutomlDataset(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [resource][crate::model::MigratableResource::resource]
     /// to hold a `AutomlDataset`.
     ///
@@ -56786,6 +56770,22 @@ impl MigratableResource {
             crate::model::migratable_resource::Resource::AutomlDataset(v.into()),
         );
         self
+    }
+
+    /// The value of [resource][crate::model::MigratableResource::resource]
+    /// if it holds a `DataLabelingDataset`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_labeling_dataset(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::migratable_resource::DataLabelingDataset>>
+    {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::migratable_resource::Resource::DataLabelingDataset(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource][crate::model::MigratableResource::resource]
@@ -57238,12 +57238,6 @@ impl SearchMigratableResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchMigratableResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [migratable_resources][crate::model::SearchMigratableResourcesResponse::migratable_resources].
     pub fn set_migratable_resources<T, V>(mut self, v: T) -> Self
     where
@@ -57252,6 +57246,12 @@ impl SearchMigratableResourcesResponse {
     {
         use std::iter::Iterator;
         self.migratable_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchMigratableResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -57386,57 +57386,6 @@ impl MigrateResourceRequest {
         })
     }
 
-    /// The value of [request][crate::model::MigrateResourceRequest::request]
-    /// if it holds a `MigrateAutomlModelConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn migrate_automl_model_config(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::migrate_resource_request::MigrateAutomlModelConfig>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::migrate_resource_request::Request::MigrateAutomlModelConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::MigrateResourceRequest::request]
-    /// if it holds a `MigrateAutomlDatasetConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn migrate_automl_dataset_config(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::migrate_resource_request::MigrateAutomlDatasetConfig>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::migrate_resource_request::Request::MigrateAutomlDatasetConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::MigrateResourceRequest::request]
-    /// if it holds a `MigrateDataLabelingDatasetConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn migrate_data_labeling_dataset_config(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::migrate_resource_request::MigrateDataLabelingDatasetConfig>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::migrate_resource_request::Request::MigrateDataLabelingDatasetConfig(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [request][crate::model::MigrateResourceRequest::request]
     /// to hold a `MigrateMlEngineModelVersionConfig`.
     ///
@@ -57460,6 +57409,23 @@ impl MigrateResourceRequest {
         self
     }
 
+    /// The value of [request][crate::model::MigrateResourceRequest::request]
+    /// if it holds a `MigrateAutomlModelConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn migrate_automl_model_config(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::migrate_resource_request::MigrateAutomlModelConfig>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::migrate_resource_request::Request::MigrateAutomlModelConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::MigrateResourceRequest::request]
     /// to hold a `MigrateAutomlModelConfig`.
     ///
@@ -57479,6 +57445,23 @@ impl MigrateResourceRequest {
         self
     }
 
+    /// The value of [request][crate::model::MigrateResourceRequest::request]
+    /// if it holds a `MigrateAutomlDatasetConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn migrate_automl_dataset_config(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::migrate_resource_request::MigrateAutomlDatasetConfig>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::migrate_resource_request::Request::MigrateAutomlDatasetConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::MigrateResourceRequest::request]
     /// to hold a `MigrateAutomlDatasetConfig`.
     ///
@@ -57496,6 +57479,23 @@ impl MigrateResourceRequest {
             crate::model::migrate_resource_request::Request::MigrateAutomlDatasetConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::MigrateResourceRequest::request]
+    /// if it holds a `MigrateDataLabelingDatasetConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn migrate_data_labeling_dataset_config(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::migrate_resource_request::MigrateDataLabelingDatasetConfig>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::migrate_resource_request::Request::MigrateDataLabelingDatasetConfig(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::MigrateResourceRequest::request]
@@ -57971,6 +57971,18 @@ impl MigrateResourceResponse {
         })
     }
 
+    /// Sets the value of [migrated_resource][crate::model::MigrateResourceResponse::migrated_resource]
+    /// to hold a `Dataset`.
+    ///
+    /// Note that all the setters affecting `migrated_resource` are
+    /// mutually exclusive.
+    pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.migrated_resource = std::option::Option::Some(
+            crate::model::migrate_resource_response::MigratedResource::Dataset(v.into()),
+        );
+        self
+    }
+
     /// The value of [migrated_resource][crate::model::MigrateResourceResponse::migrated_resource]
     /// if it holds a `Model`, `None` if the field is not set or
     /// holds a different branch.
@@ -57982,18 +57994,6 @@ impl MigrateResourceResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [migrated_resource][crate::model::MigrateResourceResponse::migrated_resource]
-    /// to hold a `Dataset`.
-    ///
-    /// Note that all the setters affecting `migrated_resource` are
-    /// mutually exclusive.
-    pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.migrated_resource = std::option::Option::Some(
-            crate::model::migrate_resource_response::MigratedResource::Dataset(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [migrated_resource][crate::model::MigrateResourceResponse::migrated_resource]
@@ -58169,28 +58169,6 @@ pub mod batch_migrate_resources_operation_metadata {
             })
         }
 
-        /// The value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
-        /// if it holds a `Model`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn model(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.result.as_ref().and_then(|v| match v {
-                crate::model::batch_migrate_resources_operation_metadata::partial_result::Result::Model(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
-        /// if it holds a `Dataset`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn dataset(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.result.as_ref().and_then(|v| match v {
-                crate::model::batch_migrate_resources_operation_metadata::partial_result::Result::Dataset(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
         /// to hold a `Error`.
         ///
@@ -58208,6 +58186,17 @@ pub mod batch_migrate_resources_operation_metadata {
             self
         }
 
+        /// The value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
+        /// if it holds a `Model`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn model(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.result.as_ref().and_then(|v| match v {
+                crate::model::batch_migrate_resources_operation_metadata::partial_result::Result::Model(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
         /// to hold a `Model`.
         ///
@@ -58220,6 +58209,17 @@ pub mod batch_migrate_resources_operation_metadata {
                 )
             );
             self
+        }
+
+        /// The value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
+        /// if it holds a `Dataset`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn dataset(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.result.as_ref().and_then(|v| match v {
+                crate::model::batch_migrate_resources_operation_metadata::partial_result::Result::Dataset(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [result][crate::model::batch_migrate_resources_operation_metadata::PartialResult::result]
@@ -58671,6 +58671,17 @@ impl Model {
         self
     }
 
+    /// Sets the value of [version_aliases][crate::model::Model::version_aliases].
+    pub fn set_version_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.version_aliases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [version_create_time][crate::model::Model::version_create_time].
     pub fn set_version_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -58748,6 +58759,17 @@ impl Model {
         self
     }
 
+    /// Sets the value of [supported_export_formats][crate::model::Model::supported_export_formats].
+    pub fn set_supported_export_formats<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::model::ExportFormat>,
+    {
+        use std::iter::Iterator;
+        self.supported_export_formats = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [training_pipeline][crate::model::Model::training_pipeline].
     pub fn set_training_pipeline<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -58780,6 +58802,39 @@ impl Model {
         self
     }
 
+    /// Sets the value of [supported_deployment_resources_types][crate::model::Model::supported_deployment_resources_types].
+    pub fn set_supported_deployment_resources_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::model::DeploymentResourcesType>,
+    {
+        use std::iter::Iterator;
+        self.supported_deployment_resources_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [supported_input_storage_formats][crate::model::Model::supported_input_storage_formats].
+    pub fn set_supported_input_storage_formats<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.supported_input_storage_formats = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [supported_output_storage_formats][crate::model::Model::supported_output_storage_formats].
+    pub fn set_supported_output_storage_formats<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.supported_output_storage_formats = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Model::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -58798,6 +58853,17 @@ impl Model {
         self
     }
 
+    /// Sets the value of [deployed_models][crate::model::Model::deployed_models].
+    pub fn set_deployed_models<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DeployedModelRef>,
+    {
+        use std::iter::Iterator;
+        self.deployed_models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [explanation_spec][crate::model::Model::explanation_spec].
     pub fn set_explanation_spec<
         T: std::convert::Into<std::option::Option<crate::model::ExplanationSpec>>,
@@ -58812,6 +58878,18 @@ impl Model {
     /// Sets the value of [etag][crate::model::Model::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Model::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -58888,84 +58966,6 @@ impl Model {
     /// Sets the value of [satisfies_pzi][crate::model::Model::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [version_aliases][crate::model::Model::version_aliases].
-    pub fn set_version_aliases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.version_aliases = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [supported_export_formats][crate::model::Model::supported_export_formats].
-    pub fn set_supported_export_formats<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::model::ExportFormat>,
-    {
-        use std::iter::Iterator;
-        self.supported_export_formats = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [supported_deployment_resources_types][crate::model::Model::supported_deployment_resources_types].
-    pub fn set_supported_deployment_resources_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::model::DeploymentResourcesType>,
-    {
-        use std::iter::Iterator;
-        self.supported_deployment_resources_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [supported_input_storage_formats][crate::model::Model::supported_input_storage_formats].
-    pub fn set_supported_input_storage_formats<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.supported_input_storage_formats = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [supported_output_storage_formats][crate::model::Model::supported_output_storage_formats].
-    pub fn set_supported_output_storage_formats<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.supported_output_storage_formats = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [deployed_models][crate::model::Model::deployed_models].
-    pub fn set_deployed_models<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DeployedModelRef>,
-    {
-        use std::iter::Iterator;
-        self.deployed_models = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Model::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -59501,21 +59501,6 @@ pub mod model {
             })
         }
 
-        /// The value of [source][crate::model::model::BaseModelSource::source]
-        /// if it holds a `GenieSource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn genie_source(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::GenieSource>> {
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::model::base_model_source::Source::GenieSource(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [source][crate::model::model::BaseModelSource::source]
         /// to hold a `ModelGardenSource`.
         ///
@@ -59531,6 +59516,21 @@ pub mod model {
                 crate::model::model::base_model_source::Source::ModelGardenSource(v.into()),
             );
             self
+        }
+
+        /// The value of [source][crate::model::model::BaseModelSource::source]
+        /// if it holds a `GenieSource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn genie_source(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::GenieSource>> {
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::model::base_model_source::Source::GenieSource(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source][crate::model::model::BaseModelSource::source]
@@ -60393,60 +60393,6 @@ impl ModelContainerSpec {
         self
     }
 
-    /// Sets the value of [predict_route][crate::model::ModelContainerSpec::predict_route].
-    pub fn set_predict_route<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.predict_route = v.into();
-        self
-    }
-
-    /// Sets the value of [health_route][crate::model::ModelContainerSpec::health_route].
-    pub fn set_health_route<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.health_route = v.into();
-        self
-    }
-
-    /// Sets the value of [deployment_timeout][crate::model::ModelContainerSpec::deployment_timeout].
-    pub fn set_deployment_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_timeout = v.into();
-        self
-    }
-
-    /// Sets the value of [shared_memory_size_mb][crate::model::ModelContainerSpec::shared_memory_size_mb].
-    pub fn set_shared_memory_size_mb<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.shared_memory_size_mb = v.into();
-        self
-    }
-
-    /// Sets the value of [startup_probe][crate::model::ModelContainerSpec::startup_probe].
-    pub fn set_startup_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.startup_probe = v.into();
-        self
-    }
-
-    /// Sets the value of [health_probe][crate::model::ModelContainerSpec::health_probe].
-    pub fn set_health_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.health_probe = v.into();
-        self
-    }
-
-    /// Sets the value of [liveness_probe][crate::model::ModelContainerSpec::liveness_probe].
-    pub fn set_liveness_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.liveness_probe = v.into();
-        self
-    }
-
     /// Sets the value of [command][crate::model::ModelContainerSpec::command].
     pub fn set_command<T, V>(mut self, v: T) -> Self
     where
@@ -60491,6 +60437,18 @@ impl ModelContainerSpec {
         self
     }
 
+    /// Sets the value of [predict_route][crate::model::ModelContainerSpec::predict_route].
+    pub fn set_predict_route<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.predict_route = v.into();
+        self
+    }
+
+    /// Sets the value of [health_route][crate::model::ModelContainerSpec::health_route].
+    pub fn set_health_route<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.health_route = v.into();
+        self
+    }
+
     /// Sets the value of [grpc_ports][crate::model::ModelContainerSpec::grpc_ports].
     pub fn set_grpc_ports<T, V>(mut self, v: T) -> Self
     where
@@ -60499,6 +60457,48 @@ impl ModelContainerSpec {
     {
         use std::iter::Iterator;
         self.grpc_ports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [deployment_timeout][crate::model::ModelContainerSpec::deployment_timeout].
+    pub fn set_deployment_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.deployment_timeout = v.into();
+        self
+    }
+
+    /// Sets the value of [shared_memory_size_mb][crate::model::ModelContainerSpec::shared_memory_size_mb].
+    pub fn set_shared_memory_size_mb<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.shared_memory_size_mb = v.into();
+        self
+    }
+
+    /// Sets the value of [startup_probe][crate::model::ModelContainerSpec::startup_probe].
+    pub fn set_startup_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.startup_probe = v.into();
+        self
+    }
+
+    /// Sets the value of [health_probe][crate::model::ModelContainerSpec::health_probe].
+    pub fn set_health_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.health_probe = v.into();
+        self
+    }
+
+    /// Sets the value of [liveness_probe][crate::model::ModelContainerSpec::liveness_probe].
+    pub fn set_liveness_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.liveness_probe = v.into();
         self
     }
 }
@@ -60985,43 +60985,6 @@ impl Probe {
         })
     }
 
-    /// The value of [probe_type][crate::model::Probe::probe_type]
-    /// if it holds a `HttpGet`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn http_get(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::probe::HttpGetAction>> {
-        #[allow(unreachable_patterns)]
-        self.probe_type.as_ref().and_then(|v| match v {
-            crate::model::probe::ProbeType::HttpGet(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [probe_type][crate::model::Probe::probe_type]
-    /// if it holds a `Grpc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn grpc(&self) -> std::option::Option<&std::boxed::Box<crate::model::probe::GrpcAction>> {
-        #[allow(unreachable_patterns)]
-        self.probe_type.as_ref().and_then(|v| match v {
-            crate::model::probe::ProbeType::Grpc(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [probe_type][crate::model::Probe::probe_type]
-    /// if it holds a `TcpSocket`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tcp_socket(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::probe::TcpSocketAction>> {
-        #[allow(unreachable_patterns)]
-        self.probe_type.as_ref().and_then(|v| match v {
-            crate::model::probe::ProbeType::TcpSocket(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
     /// to hold a `Exec`.
     ///
@@ -61033,6 +60996,19 @@ impl Probe {
     ) -> Self {
         self.probe_type = std::option::Option::Some(crate::model::probe::ProbeType::Exec(v.into()));
         self
+    }
+
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `HttpGet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn http_get(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::probe::HttpGetAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::HttpGet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
@@ -61051,6 +61027,17 @@ impl Probe {
         self
     }
 
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `Grpc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn grpc(&self) -> std::option::Option<&std::boxed::Box<crate::model::probe::GrpcAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::Grpc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
     /// to hold a `Grpc`.
     ///
@@ -61062,6 +61049,19 @@ impl Probe {
     ) -> Self {
         self.probe_type = std::option::Option::Some(crate::model::probe::ProbeType::Grpc(v.into()));
         self
+    }
+
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `TcpSocket`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tcp_socket(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::probe::TcpSocketAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::TcpSocket(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
@@ -61718,6 +61718,18 @@ impl ModelDeploymentMonitoringJob {
         self
     }
 
+    /// Sets the value of [model_deployment_monitoring_objective_configs][crate::model::ModelDeploymentMonitoringJob::model_deployment_monitoring_objective_configs].
+    pub fn set_model_deployment_monitoring_objective_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ModelDeploymentMonitoringObjectiveConfig>,
+    {
+        use std::iter::Iterator;
+        self.model_deployment_monitoring_objective_configs =
+            v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [model_deployment_monitoring_schedule_config][crate::model::ModelDeploymentMonitoringJob::model_deployment_monitoring_schedule_config].
     pub fn set_model_deployment_monitoring_schedule_config<
         T: std::convert::Into<
@@ -61780,12 +61792,35 @@ impl ModelDeploymentMonitoringJob {
         self
     }
 
+    /// Sets the value of [bigquery_tables][crate::model::ModelDeploymentMonitoringJob::bigquery_tables].
+    pub fn set_bigquery_tables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ModelDeploymentMonitoringBigQueryTable>,
+    {
+        use std::iter::Iterator;
+        self.bigquery_tables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [log_ttl][crate::model::ModelDeploymentMonitoringJob::log_ttl].
     pub fn set_log_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
     ) -> Self {
         self.log_ttl = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::ModelDeploymentMonitoringJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -61865,41 +61900,6 @@ impl ModelDeploymentMonitoringJob {
     /// Sets the value of [satisfies_pzi][crate::model::ModelDeploymentMonitoringJob::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [model_deployment_monitoring_objective_configs][crate::model::ModelDeploymentMonitoringJob::model_deployment_monitoring_objective_configs].
-    pub fn set_model_deployment_monitoring_objective_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ModelDeploymentMonitoringObjectiveConfig>,
-    {
-        use std::iter::Iterator;
-        self.model_deployment_monitoring_objective_configs =
-            v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [bigquery_tables][crate::model::ModelDeploymentMonitoringJob::bigquery_tables].
-    pub fn set_bigquery_tables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ModelDeploymentMonitoringBigQueryTable>,
-    {
-        use std::iter::Iterator;
-        self.bigquery_tables = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ModelDeploymentMonitoringJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -62929,6 +62929,17 @@ impl ModelEvaluation {
         self
     }
 
+    /// Sets the value of [slice_dimensions][crate::model::ModelEvaluation::slice_dimensions].
+    pub fn set_slice_dimensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.slice_dimensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [data_item_schema_uri][crate::model::ModelEvaluation::data_item_schema_uri].
     pub fn set_data_item_schema_uri<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -62958,26 +62969,6 @@ impl ModelEvaluation {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::ModelEvaluation::metadata].
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Value>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [slice_dimensions][crate::model::ModelEvaluation::slice_dimensions].
-    pub fn set_slice_dimensions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.slice_dimensions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [explanation_specs][crate::model::ModelEvaluation::explanation_specs].
     pub fn set_explanation_specs<T, V>(mut self, v: T) -> Self
     where
@@ -62986,6 +62977,15 @@ impl ModelEvaluation {
     {
         use std::iter::Iterator;
         self.explanation_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::ModelEvaluation::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Value>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -63433,34 +63433,6 @@ pub mod model_evaluation_slice {
                     })
                 }
 
-                /// The value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
-                /// if it holds a `Range`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn range(
-                    &self,
-                ) -> std::option::Option<
-                    &std::boxed::Box<
-                        crate::model::model_evaluation_slice::slice::slice_spec::Range,
-                    >,
-                > {
-                    #[allow(unreachable_patterns)]
-                    self.kind.as_ref().and_then(|v| match v {
-                        crate::model::model_evaluation_slice::slice::slice_spec::slice_config::Kind::Range(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
-                /// The value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
-                /// if it holds a `AllValues`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn all_values(&self) -> std::option::Option<&std::boxed::Box<wkt::BoolValue>> {
-                    #[allow(unreachable_patterns)]
-                    self.kind.as_ref().and_then(|v| match v {
-                        crate::model::model_evaluation_slice::slice::slice_spec::slice_config::Kind::AllValues(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
                 /// to hold a `Value`.
                 ///
@@ -63484,6 +63456,23 @@ pub mod model_evaluation_slice {
                     self
                 }
 
+                /// The value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
+                /// if it holds a `Range`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn range(
+                    &self,
+                ) -> std::option::Option<
+                    &std::boxed::Box<
+                        crate::model::model_evaluation_slice::slice::slice_spec::Range,
+                    >,
+                > {
+                    #[allow(unreachable_patterns)]
+                    self.kind.as_ref().and_then(|v| match v {
+                        crate::model::model_evaluation_slice::slice::slice_spec::slice_config::Kind::Range(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
+                }
+
                 /// Sets the value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
                 /// to hold a `Range`.
                 ///
@@ -63505,6 +63494,17 @@ pub mod model_evaluation_slice {
                         )
                     );
                     self
+                }
+
+                /// The value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
+                /// if it holds a `AllValues`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn all_values(&self) -> std::option::Option<&std::boxed::Box<wkt::BoolValue>> {
+                    #[allow(unreachable_patterns)]
+                    self.kind.as_ref().and_then(|v| match v {
+                        crate::model::model_evaluation_slice::slice::slice_spec::slice_config::Kind::AllValues(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::SliceConfig::kind]
@@ -63654,17 +63654,6 @@ pub mod model_evaluation_slice {
                     })
                 }
 
-                /// The value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::Value::kind]
-                /// if it holds a `FloatValue`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn float_value(&self) -> std::option::Option<&f32> {
-                    #[allow(unreachable_patterns)]
-                    self.kind.as_ref().and_then(|v| match v {
-                        crate::model::model_evaluation_slice::slice::slice_spec::value::Kind::FloatValue(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::Value::kind]
                 /// to hold a `StringValue`.
                 ///
@@ -63680,6 +63669,17 @@ pub mod model_evaluation_slice {
                         )
                     );
                     self
+                }
+
+                /// The value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::Value::kind]
+                /// if it holds a `FloatValue`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn float_value(&self) -> std::option::Option<&f32> {
+                    #[allow(unreachable_patterns)]
+                    self.kind.as_ref().and_then(|v| match v {
+                        crate::model::model_evaluation_slice::slice::slice_spec::value::Kind::FloatValue(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [kind][crate::model::model_evaluation_slice::slice::slice_spec::Value::kind]
@@ -64012,30 +64012,6 @@ pub mod model_monitoring_objective_config {
             })
         }
 
-        /// The value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
-        /// if it holds a `GcsSource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-            #[allow(unreachable_patterns)]
-            self.data_source.as_ref().and_then(|v| match v {
-                crate::model::model_monitoring_objective_config::training_dataset::DataSource::GcsSource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
-        /// if it holds a `BigquerySource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn bigquery_source(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-            #[allow(unreachable_patterns)]
-            self.data_source.as_ref().and_then(|v| match v {
-                crate::model::model_monitoring_objective_config::training_dataset::DataSource::BigquerySource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
         /// to hold a `Dataset`.
         ///
@@ -64048,6 +64024,17 @@ pub mod model_monitoring_objective_config {
                 )
             );
             self
+        }
+
+        /// The value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
+        /// if it holds a `GcsSource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+            #[allow(unreachable_patterns)]
+            self.data_source.as_ref().and_then(|v| match v {
+                crate::model::model_monitoring_objective_config::training_dataset::DataSource::GcsSource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
@@ -64065,6 +64052,19 @@ pub mod model_monitoring_objective_config {
                 )
             );
             self
+        }
+
+        /// The value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
+        /// if it holds a `BigquerySource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn bigquery_source(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+            #[allow(unreachable_patterns)]
+            self.data_source.as_ref().and_then(|v| match v {
+                crate::model::model_monitoring_objective_config::training_dataset::DataSource::BigquerySource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [data_source][crate::model::model_monitoring_objective_config::TrainingDataset::data_source]
@@ -64155,17 +64155,6 @@ pub mod model_monitoring_objective_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [default_skew_threshold][crate::model::model_monitoring_objective_config::TrainingPredictionSkewDetectionConfig::default_skew_threshold].
-        pub fn set_default_skew_threshold<
-            T: std::convert::Into<std::option::Option<crate::model::ThresholdConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.default_skew_threshold = v.into();
-            self
-        }
-
         /// Sets the value of [skew_thresholds][crate::model::model_monitoring_objective_config::TrainingPredictionSkewDetectionConfig::skew_thresholds].
         pub fn set_skew_thresholds<T, K, V>(mut self, v: T) -> Self
         where
@@ -64188,6 +64177,17 @@ pub mod model_monitoring_objective_config {
             use std::iter::Iterator;
             self.attribution_score_skew_thresholds =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [default_skew_threshold][crate::model::model_monitoring_objective_config::TrainingPredictionSkewDetectionConfig::default_skew_threshold].
+        pub fn set_default_skew_threshold<
+            T: std::convert::Into<std::option::Option<crate::model::ThresholdConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.default_skew_threshold = v.into();
             self
         }
     }
@@ -64236,17 +64236,6 @@ pub mod model_monitoring_objective_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [default_drift_threshold][crate::model::model_monitoring_objective_config::PredictionDriftDetectionConfig::default_drift_threshold].
-        pub fn set_default_drift_threshold<
-            T: std::convert::Into<std::option::Option<crate::model::ThresholdConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.default_drift_threshold = v.into();
-            self
-        }
-
         /// Sets the value of [drift_thresholds][crate::model::model_monitoring_objective_config::PredictionDriftDetectionConfig::drift_thresholds].
         pub fn set_drift_thresholds<T, K, V>(mut self, v: T) -> Self
         where
@@ -64269,6 +64258,17 @@ pub mod model_monitoring_objective_config {
             use std::iter::Iterator;
             self.attribution_score_drift_thresholds =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [default_drift_threshold][crate::model::model_monitoring_objective_config::PredictionDriftDetectionConfig::default_drift_threshold].
+        pub fn set_default_drift_threshold<
+            T: std::convert::Into<std::option::Option<crate::model::ThresholdConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.default_drift_threshold = v.into();
             self
         }
     }
@@ -64395,20 +64395,6 @@ pub mod model_monitoring_objective_config {
                 })
             }
 
-            /// The value of [destination][crate::model::model_monitoring_objective_config::explanation_config::ExplanationBaseline::destination]
-            /// if it holds a `Bigquery`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn bigquery(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>>
-            {
-                #[allow(unreachable_patterns)]
-                self.destination.as_ref().and_then(|v| match v {
-                    crate::model::model_monitoring_objective_config::explanation_config::explanation_baseline::Destination::Bigquery(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [destination][crate::model::model_monitoring_objective_config::explanation_config::ExplanationBaseline::destination]
             /// to hold a `Gcs`.
             ///
@@ -64424,6 +64410,20 @@ pub mod model_monitoring_objective_config {
                     )
                 );
                 self
+            }
+
+            /// The value of [destination][crate::model::model_monitoring_objective_config::explanation_config::ExplanationBaseline::destination]
+            /// if it holds a `Bigquery`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn bigquery(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>>
+            {
+                #[allow(unreachable_patterns)]
+                self.destination.as_ref().and_then(|v| match v {
+                    crate::model::model_monitoring_objective_config::explanation_config::explanation_baseline::Destination::Bigquery(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [destination][crate::model::model_monitoring_objective_config::explanation_config::ExplanationBaseline::destination]
@@ -65363,12 +65363,6 @@ impl ListModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [models][crate::model::ListModelsResponse::models].
     pub fn set_models<T, V>(mut self, v: T) -> Self
     where
@@ -65377,6 +65371,12 @@ impl ListModelsResponse {
     {
         use std::iter::Iterator;
         self.models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -65554,12 +65554,6 @@ impl ListModelVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [models][crate::model::ListModelVersionsResponse::models].
     pub fn set_models<T, V>(mut self, v: T) -> Self
     where
@@ -65568,6 +65562,12 @@ impl ListModelVersionsResponse {
     {
         use std::iter::Iterator;
         self.models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -65757,12 +65757,6 @@ impl ListModelVersionCheckpointsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelVersionCheckpointsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [checkpoints][crate::model::ListModelVersionCheckpointsResponse::checkpoints].
     pub fn set_checkpoints<T, V>(mut self, v: T) -> Self
     where
@@ -65771,6 +65765,12 @@ impl ListModelVersionCheckpointsResponse {
     {
         use std::iter::Iterator;
         self.checkpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelVersionCheckpointsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -66536,6 +66536,18 @@ impl CopyModelRequest {
         })
     }
 
+    /// Sets the value of [destination_model][crate::model::CopyModelRequest::destination_model]
+    /// to hold a `ModelId`.
+    ///
+    /// Note that all the setters affecting `destination_model` are
+    /// mutually exclusive.
+    pub fn set_model_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.destination_model = std::option::Option::Some(
+            crate::model::copy_model_request::DestinationModel::ModelId(v.into()),
+        );
+        self
+    }
+
     /// The value of [destination_model][crate::model::CopyModelRequest::destination_model]
     /// if it holds a `ParentModel`, `None` if the field is not set or
     /// holds a different branch.
@@ -66547,18 +66559,6 @@ impl CopyModelRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination_model][crate::model::CopyModelRequest::destination_model]
-    /// to hold a `ModelId`.
-    ///
-    /// Note that all the setters affecting `destination_model` are
-    /// mutually exclusive.
-    pub fn set_model_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination_model = std::option::Option::Some(
-            crate::model::copy_model_request::DestinationModel::ModelId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [destination_model][crate::model::CopyModelRequest::destination_model]
@@ -67117,12 +67117,6 @@ impl ListModelEvaluationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelEvaluationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [model_evaluations][crate::model::ListModelEvaluationsResponse::model_evaluations].
     pub fn set_model_evaluations<T, V>(mut self, v: T) -> Self
     where
@@ -67131,6 +67125,12 @@ impl ListModelEvaluationsResponse {
     {
         use std::iter::Iterator;
         self.model_evaluations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelEvaluationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -67323,12 +67323,6 @@ impl ListModelEvaluationSlicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelEvaluationSlicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [model_evaluation_slices][crate::model::ListModelEvaluationSlicesResponse::model_evaluation_slices].
     pub fn set_model_evaluation_slices<T, V>(mut self, v: T) -> Self
     where
@@ -67337,6 +67331,12 @@ impl ListModelEvaluationSlicesResponse {
     {
         use std::iter::Iterator;
         self.model_evaluation_slices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelEvaluationSlicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -67539,6 +67539,18 @@ impl NasJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NasJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [encryption_spec][crate::model::NasJob::encryption_spec].
     pub fn set_encryption_spec<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
@@ -67569,18 +67581,6 @@ impl NasJob {
     /// Sets the value of [satisfies_pzi][crate::model::NasJob::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NasJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -69090,6 +69090,18 @@ impl NotebookExecutionJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NotebookExecutionJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [kernel_name][crate::model::NotebookExecutionJob::kernel_name].
     pub fn set_kernel_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kernel_name = v.into();
@@ -69104,18 +69116,6 @@ impl NotebookExecutionJob {
         v: T,
     ) -> Self {
         self.encryption_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NotebookExecutionJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -69152,40 +69152,6 @@ impl NotebookExecutionJob {
         })
     }
 
-    /// The value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
-    /// if it holds a `GcsNotebookSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_notebook_source(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::notebook_execution_job::GcsNotebookSource>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.notebook_source.as_ref().and_then(|v| match v {
-            crate::model::notebook_execution_job::NotebookSource::GcsNotebookSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
-    /// if it holds a `DirectNotebookSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn direct_notebook_source(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::notebook_execution_job::DirectNotebookSource>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.notebook_source.as_ref().and_then(|v| match v {
-            crate::model::notebook_execution_job::NotebookSource::DirectNotebookSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
     /// to hold a `DataformRepositorySource`.
     ///
@@ -69207,6 +69173,23 @@ impl NotebookExecutionJob {
         self
     }
 
+    /// The value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
+    /// if it holds a `GcsNotebookSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_notebook_source(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::notebook_execution_job::GcsNotebookSource>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.notebook_source.as_ref().and_then(|v| match v {
+            crate::model::notebook_execution_job::NotebookSource::GcsNotebookSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
     /// to hold a `GcsNotebookSource`.
     ///
@@ -69224,6 +69207,23 @@ impl NotebookExecutionJob {
             crate::model::notebook_execution_job::NotebookSource::GcsNotebookSource(v.into()),
         );
         self
+    }
+
+    /// The value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
+    /// if it holds a `DirectNotebookSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn direct_notebook_source(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::notebook_execution_job::DirectNotebookSource>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.notebook_source.as_ref().and_then(|v| match v {
+            crate::model::notebook_execution_job::NotebookSource::DirectNotebookSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [notebook_source][crate::model::NotebookExecutionJob::notebook_source]
@@ -69274,23 +69274,6 @@ impl NotebookExecutionJob {
         })
     }
 
-    /// The value of [environment_spec][crate::model::NotebookExecutionJob::environment_spec]
-    /// if it holds a `CustomEnvironmentSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_environment_spec(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::notebook_execution_job::CustomEnvironmentSpec>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.environment_spec.as_ref().and_then(|v| match v {
-            crate::model::notebook_execution_job::EnvironmentSpec::CustomEnvironmentSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [environment_spec][crate::model::NotebookExecutionJob::environment_spec]
     /// to hold a `NotebookRuntimeTemplateResourceName`.
     ///
@@ -69308,6 +69291,23 @@ impl NotebookExecutionJob {
             )
         );
         self
+    }
+
+    /// The value of [environment_spec][crate::model::NotebookExecutionJob::environment_spec]
+    /// if it holds a `CustomEnvironmentSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_environment_spec(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::notebook_execution_job::CustomEnvironmentSpec>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.environment_spec.as_ref().and_then(|v| match v {
+            crate::model::notebook_execution_job::EnvironmentSpec::CustomEnvironmentSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [environment_spec][crate::model::NotebookExecutionJob::environment_spec]
@@ -69399,6 +69399,18 @@ impl NotebookExecutionJob {
         })
     }
 
+    /// Sets the value of [execution_identity][crate::model::NotebookExecutionJob::execution_identity]
+    /// to hold a `ExecutionUser`.
+    ///
+    /// Note that all the setters affecting `execution_identity` are
+    /// mutually exclusive.
+    pub fn set_execution_user<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.execution_identity = std::option::Option::Some(
+            crate::model::notebook_execution_job::ExecutionIdentity::ExecutionUser(v.into()),
+        );
+        self
+    }
+
     /// The value of [execution_identity][crate::model::NotebookExecutionJob::execution_identity]
     /// if it holds a `ServiceAccount`, `None` if the field is not set or
     /// holds a different branch.
@@ -69410,18 +69422,6 @@ impl NotebookExecutionJob {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [execution_identity][crate::model::NotebookExecutionJob::execution_identity]
-    /// to hold a `ExecutionUser`.
-    ///
-    /// Note that all the setters affecting `execution_identity` are
-    /// mutually exclusive.
-    pub fn set_execution_user<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.execution_identity = std::option::Option::Some(
-            crate::model::notebook_execution_job::ExecutionIdentity::ExecutionUser(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [execution_identity][crate::model::NotebookExecutionJob::execution_identity]
@@ -70048,6 +70048,18 @@ impl NotebookRuntimeTemplate {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NotebookRuntimeTemplate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [idle_shutdown_config][crate::model::NotebookRuntimeTemplate::idle_shutdown_config].
     pub fn set_idle_shutdown_config<
         T: std::convert::Into<std::option::Option<crate::model::NotebookIdleShutdownConfig>>,
@@ -70108,6 +70120,17 @@ impl NotebookRuntimeTemplate {
         self
     }
 
+    /// Sets the value of [network_tags][crate::model::NotebookRuntimeTemplate::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [encryption_spec][crate::model::NotebookRuntimeTemplate::encryption_spec].
     pub fn set_encryption_spec<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
@@ -70127,29 +70150,6 @@ impl NotebookRuntimeTemplate {
         v: T,
     ) -> Self {
         self.software_config = v.into();
-        self
-    }
-
-    /// Sets the value of [network_tags][crate::model::NotebookRuntimeTemplate::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NotebookRuntimeTemplate::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -70414,6 +70414,18 @@ impl NotebookRuntime {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NotebookRuntime::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [expiration_time][crate::model::NotebookRuntime::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -70504,6 +70516,17 @@ impl NotebookRuntime {
         self
     }
 
+    /// Sets the value of [network_tags][crate::model::NotebookRuntime::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [software_config][crate::model::NotebookRuntime::software_config].
     pub fn set_software_config<
         T: std::convert::Into<std::option::Option<crate::model::NotebookSoftwareConfig>>,
@@ -70535,29 +70558,6 @@ impl NotebookRuntime {
     /// Sets the value of [satisfies_pzi][crate::model::NotebookRuntime::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [network_tags][crate::model::NotebookRuntime::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NotebookRuntime::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -71248,12 +71248,6 @@ impl ListNotebookRuntimeTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNotebookRuntimeTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [notebook_runtime_templates][crate::model::ListNotebookRuntimeTemplatesResponse::notebook_runtime_templates].
     pub fn set_notebook_runtime_templates<T, V>(mut self, v: T) -> Self
     where
@@ -71262,6 +71256,12 @@ impl ListNotebookRuntimeTemplatesResponse {
     {
         use std::iter::Iterator;
         self.notebook_runtime_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNotebookRuntimeTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -71750,12 +71750,6 @@ impl ListNotebookRuntimesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNotebookRuntimesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [notebook_runtimes][crate::model::ListNotebookRuntimesResponse::notebook_runtimes].
     pub fn set_notebook_runtimes<T, V>(mut self, v: T) -> Self
     where
@@ -71764,6 +71758,12 @@ impl ListNotebookRuntimesResponse {
     {
         use std::iter::Iterator;
         self.notebook_runtimes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNotebookRuntimesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -72509,12 +72509,6 @@ impl ListNotebookExecutionJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNotebookExecutionJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [notebook_execution_jobs][crate::model::ListNotebookExecutionJobsResponse::notebook_execution_jobs].
     pub fn set_notebook_execution_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -72523,6 +72517,12 @@ impl ListNotebookExecutionJobsResponse {
     {
         use std::iter::Iterator;
         self.notebook_execution_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNotebookExecutionJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -72839,17 +72839,6 @@ impl NotebookSoftwareConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [post_startup_script_config][crate::model::NotebookSoftwareConfig::post_startup_script_config].
-    pub fn set_post_startup_script_config<
-        T: std::convert::Into<std::option::Option<crate::model::PostStartupScriptConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.post_startup_script_config = v.into();
-        self
-    }
-
     /// Sets the value of [env][crate::model::NotebookSoftwareConfig::env].
     pub fn set_env<T, V>(mut self, v: T) -> Self
     where
@@ -72858,6 +72847,17 @@ impl NotebookSoftwareConfig {
     {
         use std::iter::Iterator;
         self.env = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [post_startup_script_config][crate::model::NotebookSoftwareConfig::post_startup_script_config].
+    pub fn set_post_startup_script_config<
+        T: std::convert::Into<std::option::Option<crate::model::PostStartupScriptConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.post_startup_script_config = v.into();
         self
     }
 }
@@ -73073,6 +73073,51 @@ impl Schema {
         self
     }
 
+    /// Sets the value of [r#enum][crate::model::Schema::enum].
+    pub fn set_enum<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.r#enum = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [properties][crate::model::Schema::properties].
+    pub fn set_properties<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::Schema>,
+    {
+        use std::iter::Iterator;
+        self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [property_ordering][crate::model::Schema::property_ordering].
+    pub fn set_property_ordering<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.property_ordering = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [required][crate::model::Schema::required].
+    pub fn set_required<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.required = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [min_properties][crate::model::Schema::min_properties].
     pub fn set_min_properties<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.min_properties = v.into();
@@ -73124,39 +73169,6 @@ impl Schema {
         self
     }
 
-    /// Sets the value of [r#enum][crate::model::Schema::enum].
-    pub fn set_enum<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.r#enum = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [property_ordering][crate::model::Schema::property_ordering].
-    pub fn set_property_ordering<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.property_ordering = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [required][crate::model::Schema::required].
-    pub fn set_required<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.required = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [any_of][crate::model::Schema::any_of].
     pub fn set_any_of<T, V>(mut self, v: T) -> Self
     where
@@ -73165,18 +73177,6 @@ impl Schema {
     {
         use std::iter::Iterator;
         self.any_of = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [properties][crate::model::Schema::properties].
-    pub fn set_properties<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::Schema>,
-    {
-        use std::iter::Iterator;
-        self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -73272,6 +73272,17 @@ impl GenericOperationMetadata {
         std::default::Default::default()
     }
 
+    /// Sets the value of [partial_failures][crate::model::GenericOperationMetadata::partial_failures].
+    pub fn set_partial_failures<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.partial_failures = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::GenericOperationMetadata::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -73287,17 +73298,6 @@ impl GenericOperationMetadata {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [partial_failures][crate::model::GenericOperationMetadata::partial_failures].
-    pub fn set_partial_failures<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.partial_failures = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -73554,6 +73554,17 @@ impl PersistentResource {
         self
     }
 
+    /// Sets the value of [resource_pools][crate::model::PersistentResource::resource_pools].
+    pub fn set_resource_pools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResourcePool>,
+    {
+        use std::iter::Iterator;
+        self.resource_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::PersistentResource::state].
     pub fn set_state<T: std::convert::Into<crate::model::persistent_resource::State>>(
         mut self,
@@ -73599,6 +73610,18 @@ impl PersistentResource {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PersistentResource::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [network][crate::model::PersistentResource::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
@@ -73638,17 +73661,6 @@ impl PersistentResource {
         self
     }
 
-    /// Sets the value of [resource_pools][crate::model::PersistentResource::resource_pools].
-    pub fn set_resource_pools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResourcePool>,
-    {
-        use std::iter::Iterator;
-        self.resource_pools = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [reserved_ip_ranges][crate::model::PersistentResource::reserved_ip_ranges].
     pub fn set_reserved_ip_ranges<T, V>(mut self, v: T) -> Self
     where
@@ -73657,18 +73669,6 @@ impl PersistentResource {
     {
         use std::iter::Iterator;
         self.reserved_ip_ranges = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::PersistentResource::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -74155,6 +74155,18 @@ impl RaySpec {
         self
     }
 
+    /// Sets the value of [resource_pool_images][crate::model::RaySpec::resource_pool_images].
+    pub fn set_resource_pool_images<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_pool_images = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [head_node_resource_pool_id][crate::model::RaySpec::head_node_resource_pool_id].
     pub fn set_head_node_resource_pool_id<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -74183,18 +74195,6 @@ impl RaySpec {
         v: T,
     ) -> Self {
         self.ray_logs_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_pool_images][crate::model::RaySpec::resource_pool_images].
-    pub fn set_resource_pool_images<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_pool_images = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -74747,12 +74747,6 @@ impl ListPersistentResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPersistentResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [persistent_resources][crate::model::ListPersistentResourcesResponse::persistent_resources].
     pub fn set_persistent_resources<T, V>(mut self, v: T) -> Self
     where
@@ -74761,6 +74755,12 @@ impl ListPersistentResourcesResponse {
     {
         use std::iter::Iterator;
         self.persistent_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPersistentResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -75156,6 +75156,18 @@ impl PipelineJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PipelineJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [runtime_config][crate::model::PipelineJob::runtime_config].
     pub fn set_runtime_config<
         T: std::convert::Into<std::option::Option<crate::model::pipeline_job::RuntimeConfig>>,
@@ -75190,6 +75202,17 @@ impl PipelineJob {
         self
     }
 
+    /// Sets the value of [reserved_ip_ranges][crate::model::PipelineJob::reserved_ip_ranges].
+    pub fn set_reserved_ip_ranges<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.reserved_ip_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [template_uri][crate::model::PipelineJob::template_uri].
     pub fn set_template_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.template_uri = v.into();
@@ -75216,29 +75239,6 @@ impl PipelineJob {
     /// Sets the value of [preflight_validations][crate::model::PipelineJob::preflight_validations].
     pub fn set_preflight_validations<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.preflight_validations = v.into();
-        self
-    }
-
-    /// Sets the value of [reserved_ip_ranges][crate::model::PipelineJob::reserved_ip_ranges].
-    pub fn set_reserved_ip_ranges<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.reserved_ip_ranges = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::PipelineJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -75326,24 +75326,6 @@ pub mod pipeline_job {
             std::default::Default::default()
         }
 
-        /// Sets the value of [gcs_output_directory][crate::model::pipeline_job::RuntimeConfig::gcs_output_directory].
-        pub fn set_gcs_output_directory<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.gcs_output_directory = v.into();
-            self
-        }
-
-        /// Sets the value of [failure_policy][crate::model::pipeline_job::RuntimeConfig::failure_policy].
-        pub fn set_failure_policy<T: std::convert::Into<crate::model::PipelineFailurePolicy>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.failure_policy = v.into();
-            self
-        }
-
         /// Sets the value of [parameters][crate::model::pipeline_job::RuntimeConfig::parameters].
         #[deprecated]
         pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
@@ -75357,6 +75339,15 @@ pub mod pipeline_job {
             self
         }
 
+        /// Sets the value of [gcs_output_directory][crate::model::pipeline_job::RuntimeConfig::gcs_output_directory].
+        pub fn set_gcs_output_directory<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.gcs_output_directory = v.into();
+            self
+        }
+
         /// Sets the value of [parameter_values][crate::model::pipeline_job::RuntimeConfig::parameter_values].
         pub fn set_parameter_values<T, K, V>(mut self, v: T) -> Self
         where
@@ -75366,6 +75357,15 @@ pub mod pipeline_job {
         {
             use std::iter::Iterator;
             self.parameter_values = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [failure_policy][crate::model::pipeline_job::RuntimeConfig::failure_policy].
+        pub fn set_failure_policy<T: std::convert::Into<crate::model::PipelineFailurePolicy>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.failure_policy = v.into();
             self
         }
 
@@ -76181,23 +76181,6 @@ impl PipelineTaskExecutorDetail {
         })
     }
 
-    /// The value of [details][crate::model::PipelineTaskExecutorDetail::details]
-    /// if it holds a `CustomJobDetail`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_job_detail(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::pipeline_task_executor_detail::CustomJobDetail>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::pipeline_task_executor_detail::Details::CustomJobDetail(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [details][crate::model::PipelineTaskExecutorDetail::details]
     /// to hold a `ContainerDetail`.
     ///
@@ -76215,6 +76198,23 @@ impl PipelineTaskExecutorDetail {
             crate::model::pipeline_task_executor_detail::Details::ContainerDetail(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::PipelineTaskExecutorDetail::details]
+    /// if it holds a `CustomJobDetail`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_job_detail(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::pipeline_task_executor_detail::CustomJobDetail>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::pipeline_task_executor_detail::Details::CustomJobDetail(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::PipelineTaskExecutorDetail::details]
@@ -76704,12 +76704,6 @@ impl ListTrainingPipelinesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTrainingPipelinesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [training_pipelines][crate::model::ListTrainingPipelinesResponse::training_pipelines].
     pub fn set_training_pipelines<T, V>(mut self, v: T) -> Self
     where
@@ -76718,6 +76712,12 @@ impl ListTrainingPipelinesResponse {
     {
         use std::iter::Iterator;
         self.training_pipelines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTrainingPipelinesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -77111,12 +77111,6 @@ impl ListPipelineJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPipelineJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [pipeline_jobs][crate::model::ListPipelineJobsResponse::pipeline_jobs].
     pub fn set_pipeline_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -77125,6 +77119,12 @@ impl ListPipelineJobsResponse {
     {
         use std::iter::Iterator;
         self.pipeline_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPipelineJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -77491,15 +77491,6 @@ impl PredictRequest {
         self
     }
 
-    /// Sets the value of [parameters][crate::model::PredictRequest::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<wkt::Value>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::PredictRequest::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -77508,6 +77499,15 @@ impl PredictRequest {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::PredictRequest::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<wkt::Value>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -77578,6 +77578,17 @@ impl PredictResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [predictions][crate::model::PredictResponse::predictions].
+    pub fn set_predictions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.predictions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [deployed_model_id][crate::model::PredictResponse::deployed_model_id].
     pub fn set_deployed_model_id<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -77617,17 +77628,6 @@ impl PredictResponse {
         v: T,
     ) -> Self {
         self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [predictions][crate::model::PredictResponse::predictions].
-    pub fn set_predictions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Value>,
-    {
-        use std::iter::Iterator;
-        self.predictions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -77803,15 +77803,6 @@ impl DirectPredictRequest {
         self
     }
 
-    /// Sets the value of [parameters][crate::model::DirectPredictRequest::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [inputs][crate::model::DirectPredictRequest::inputs].
     pub fn set_inputs<T, V>(mut self, v: T) -> Self
     where
@@ -77820,6 +77811,15 @@ impl DirectPredictRequest {
     {
         use std::iter::Iterator;
         self.inputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::DirectPredictRequest::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -77859,15 +77859,6 @@ impl DirectPredictResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parameters][crate::model::DirectPredictResponse::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [outputs][crate::model::DirectPredictResponse::outputs].
     pub fn set_outputs<T, V>(mut self, v: T) -> Self
     where
@@ -77876,6 +77867,15 @@ impl DirectPredictResponse {
     {
         use std::iter::Iterator;
         self.outputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::DirectPredictResponse::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -78038,15 +78038,6 @@ impl StreamDirectPredictRequest {
         self
     }
 
-    /// Sets the value of [parameters][crate::model::StreamDirectPredictRequest::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [inputs][crate::model::StreamDirectPredictRequest::inputs].
     pub fn set_inputs<T, V>(mut self, v: T) -> Self
     where
@@ -78055,6 +78046,15 @@ impl StreamDirectPredictRequest {
     {
         use std::iter::Iterator;
         self.inputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::StreamDirectPredictRequest::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -78092,15 +78092,6 @@ impl StreamDirectPredictResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parameters][crate::model::StreamDirectPredictResponse::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [outputs][crate::model::StreamDirectPredictResponse::outputs].
     pub fn set_outputs<T, V>(mut self, v: T) -> Self
     where
@@ -78109,6 +78100,15 @@ impl StreamDirectPredictResponse {
     {
         use std::iter::Iterator;
         self.outputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::StreamDirectPredictResponse::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -78281,15 +78281,6 @@ impl StreamingPredictRequest {
         self
     }
 
-    /// Sets the value of [parameters][crate::model::StreamingPredictRequest::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [inputs][crate::model::StreamingPredictRequest::inputs].
     pub fn set_inputs<T, V>(mut self, v: T) -> Self
     where
@@ -78298,6 +78289,15 @@ impl StreamingPredictRequest {
     {
         use std::iter::Iterator;
         self.inputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::StreamingPredictRequest::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -78335,15 +78335,6 @@ impl StreamingPredictResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parameters][crate::model::StreamingPredictResponse::parameters].
-    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parameters = v.into();
-        self
-    }
-
     /// Sets the value of [outputs][crate::model::StreamingPredictResponse::outputs].
     pub fn set_outputs<T, V>(mut self, v: T) -> Self
     where
@@ -78352,6 +78343,15 @@ impl StreamingPredictResponse {
     {
         use std::iter::Iterator;
         self.outputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::StreamingPredictResponse::parameters].
+    pub fn set_parameters<T: std::convert::Into<std::option::Option<crate::model::Tensor>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parameters = v.into();
         self
     }
 }
@@ -78562,6 +78562,17 @@ impl ExplainRequest {
         self
     }
 
+    /// Sets the value of [instances][crate::model::ExplainRequest::instances].
+    pub fn set_instances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [parameters][crate::model::ExplainRequest::parameters].
     pub fn set_parameters<T: std::convert::Into<std::option::Option<wkt::Value>>>(
         mut self,
@@ -78588,17 +78599,6 @@ impl ExplainRequest {
         v: T,
     ) -> Self {
         self.deployed_model_id = v.into();
-        self
-    }
-
-    /// Sets the value of [instances][crate::model::ExplainRequest::instances].
-    pub fn set_instances<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Value>,
-    {
-        use std::iter::Iterator;
-        self.instances = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -78654,15 +78654,6 @@ impl ExplainResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [deployed_model_id][crate::model::ExplainResponse::deployed_model_id].
-    pub fn set_deployed_model_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployed_model_id = v.into();
-        self
-    }
-
     /// Sets the value of [explanations][crate::model::ExplainResponse::explanations].
     pub fn set_explanations<T, V>(mut self, v: T) -> Self
     where
@@ -78671,6 +78662,15 @@ impl ExplainResponse {
     {
         use std::iter::Iterator;
         self.explanations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [deployed_model_id][crate::model::ExplainResponse::deployed_model_id].
+    pub fn set_deployed_model_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.deployed_model_id = v.into();
         self
     }
 
@@ -78763,28 +78763,6 @@ impl CountTokensRequest {
         self
     }
 
-    /// Sets the value of [system_instruction][crate::model::CountTokensRequest::system_instruction].
-    pub fn set_system_instruction<
-        T: std::convert::Into<std::option::Option<crate::model::Content>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_instruction = v.into();
-        self
-    }
-
-    /// Sets the value of [generation_config][crate::model::CountTokensRequest::generation_config].
-    pub fn set_generation_config<
-        T: std::convert::Into<std::option::Option<crate::model::GenerationConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.generation_config = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::CountTokensRequest::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -78807,6 +78785,17 @@ impl CountTokensRequest {
         self
     }
 
+    /// Sets the value of [system_instruction][crate::model::CountTokensRequest::system_instruction].
+    pub fn set_system_instruction<
+        T: std::convert::Into<std::option::Option<crate::model::Content>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.system_instruction = v.into();
+        self
+    }
+
     /// Sets the value of [tools][crate::model::CountTokensRequest::tools].
     pub fn set_tools<T, V>(mut self, v: T) -> Self
     where
@@ -78815,6 +78804,17 @@ impl CountTokensRequest {
     {
         use std::iter::Iterator;
         self.tools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [generation_config][crate::model::CountTokensRequest::generation_config].
+    pub fn set_generation_config<
+        T: std::convert::Into<std::option::Option<crate::model::GenerationConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.generation_config = v.into();
         self
     }
 }
@@ -78976,6 +78976,17 @@ impl GenerateContentRequest {
         self
     }
 
+    /// Sets the value of [contents][crate::model::GenerateContentRequest::contents].
+    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Content>,
+    {
+        use std::iter::Iterator;
+        self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [system_instruction][crate::model::GenerateContentRequest::system_instruction].
     pub fn set_system_instruction<
         T: std::convert::Into<std::option::Option<crate::model::Content>>,
@@ -78993,6 +79004,17 @@ impl GenerateContentRequest {
         self
     }
 
+    /// Sets the value of [tools][crate::model::GenerateContentRequest::tools].
+    pub fn set_tools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Tool>,
+    {
+        use std::iter::Iterator;
+        self.tools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [tool_config][crate::model::GenerateContentRequest::tool_config].
     pub fn set_tool_config<T: std::convert::Into<std::option::Option<crate::model::ToolConfig>>>(
         mut self,
@@ -79002,36 +79024,15 @@ impl GenerateContentRequest {
         self
     }
 
-    /// Sets the value of [generation_config][crate::model::GenerateContentRequest::generation_config].
-    pub fn set_generation_config<
-        T: std::convert::Into<std::option::Option<crate::model::GenerationConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.generation_config = v.into();
-        self
-    }
-
-    /// Sets the value of [contents][crate::model::GenerateContentRequest::contents].
-    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    /// Sets the value of [labels][crate::model::GenerateContentRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Content>,
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
     {
         use std::iter::Iterator;
-        self.contents = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tools][crate::model::GenerateContentRequest::tools].
-    pub fn set_tools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Tool>,
-    {
-        use std::iter::Iterator;
-        self.tools = v.into_iter().map(|i| i.into()).collect();
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -79046,15 +79047,14 @@ impl GenerateContentRequest {
         self
     }
 
-    /// Sets the value of [labels][crate::model::GenerateContentRequest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [generation_config][crate::model::GenerateContentRequest::generation_config].
+    pub fn set_generation_config<
+        T: std::convert::Into<std::option::Option<crate::model::GenerationConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.generation_config = v.into();
         self
     }
 }
@@ -79111,6 +79111,17 @@ impl GenerateContentResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [candidates][crate::model::GenerateContentResponse::candidates].
+    pub fn set_candidates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Candidate>,
+    {
+        use std::iter::Iterator;
+        self.candidates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [model_version][crate::model::GenerateContentResponse::model_version].
     pub fn set_model_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model_version = v.into();
@@ -79155,17 +79166,6 @@ impl GenerateContentResponse {
         v: T,
     ) -> Self {
         self.usage_metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [candidates][crate::model::GenerateContentResponse::candidates].
-    pub fn set_candidates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Candidate>,
-    {
-        use std::iter::Iterator;
-        self.candidates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -79224,15 +79224,6 @@ pub mod generate_content_response {
             self
         }
 
-        /// Sets the value of [block_reason_message][crate::model::generate_content_response::PromptFeedback::block_reason_message].
-        pub fn set_block_reason_message<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.block_reason_message = v.into();
-            self
-        }
-
         /// Sets the value of [safety_ratings][crate::model::generate_content_response::PromptFeedback::safety_ratings].
         pub fn set_safety_ratings<T, V>(mut self, v: T) -> Self
         where
@@ -79241,6 +79232,15 @@ pub mod generate_content_response {
         {
             use std::iter::Iterator;
             self.safety_ratings = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [block_reason_message][crate::model::generate_content_response::PromptFeedback::block_reason_message].
+        pub fn set_block_reason_message<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.block_reason_message = v.into();
             self
         }
     }
@@ -79625,6 +79625,17 @@ impl PublisherModel {
         self
     }
 
+    /// Sets the value of [frameworks][crate::model::PublisherModel::frameworks].
+    pub fn set_frameworks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.frameworks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [launch_stage][crate::model::PublisherModel::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<crate::model::publisher_model::LaunchStage>>(
         mut self,
@@ -79660,17 +79671,6 @@ impl PublisherModel {
         v: T,
     ) -> Self {
         self.predict_schemata = v.into();
-        self
-    }
-
-    /// Sets the value of [frameworks][crate::model::PublisherModel::frameworks].
-    pub fn set_frameworks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.frameworks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -79740,6 +79740,18 @@ pub mod publisher_model {
             })
         }
 
+        /// Sets the value of [reference][crate::model::publisher_model::ResourceReference::reference]
+        /// to hold a `Uri`.
+        ///
+        /// Note that all the setters affecting `reference` are
+        /// mutually exclusive.
+        pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.reference = std::option::Option::Some(
+                crate::model::publisher_model::resource_reference::Reference::Uri(v.into()),
+            );
+            self
+        }
+
         /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
         /// if it holds a `ResourceName`, `None` if the field is not set or
         /// holds a different branch.
@@ -79751,46 +79763,6 @@ pub mod publisher_model {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
-        /// if it holds a `UseCase`, `None` if the field is not set or
-        /// holds a different branch.
-        #[deprecated]
-        pub fn use_case(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.reference.as_ref().and_then(|v| match v {
-                crate::model::publisher_model::resource_reference::Reference::UseCase(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
-        /// if it holds a `Description`, `None` if the field is not set or
-        /// holds a different branch.
-        #[deprecated]
-        pub fn description(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.reference.as_ref().and_then(|v| match v {
-                crate::model::publisher_model::resource_reference::Reference::Description(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [reference][crate::model::publisher_model::ResourceReference::reference]
-        /// to hold a `Uri`.
-        ///
-        /// Note that all the setters affecting `reference` are
-        /// mutually exclusive.
-        pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.reference = std::option::Option::Some(
-                crate::model::publisher_model::resource_reference::Reference::Uri(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [reference][crate::model::publisher_model::ResourceReference::reference]
@@ -79810,6 +79782,20 @@ pub mod publisher_model {
             self
         }
 
+        /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
+        /// if it holds a `UseCase`, `None` if the field is not set or
+        /// holds a different branch.
+        #[deprecated]
+        pub fn use_case(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.reference.as_ref().and_then(|v| match v {
+                crate::model::publisher_model::resource_reference::Reference::UseCase(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [reference][crate::model::publisher_model::ResourceReference::reference]
         /// to hold a `UseCase`.
         ///
@@ -79821,6 +79807,20 @@ pub mod publisher_model {
                 crate::model::publisher_model::resource_reference::Reference::UseCase(v.into()),
             );
             self
+        }
+
+        /// The value of [reference][crate::model::publisher_model::ResourceReference::reference]
+        /// if it holds a `Description`, `None` if the field is not set or
+        /// holds a different branch.
+        #[deprecated]
+        pub fn description(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.reference.as_ref().and_then(|v| match v {
+                crate::model::publisher_model::resource_reference::Reference::Description(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [reference][crate::model::publisher_model::ResourceReference::reference]
@@ -80248,6 +80248,18 @@ pub mod publisher_model {
                 std::default::Default::default()
             }
 
+            /// Sets the value of [references][crate::model::publisher_model::call_to_action::RegionalResourceReferences::references].
+            pub fn set_references<T, K, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = (K, V)>,
+                K: std::convert::Into<std::string::String>,
+                V: std::convert::Into<crate::model::publisher_model::ResourceReference>,
+            {
+                use std::iter::Iterator;
+                self.references = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+                self
+            }
+
             /// Sets the value of [title][crate::model::publisher_model::call_to_action::RegionalResourceReferences::title].
             pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.title = v.into();
@@ -80286,18 +80298,6 @@ pub mod publisher_model {
                 self.resource_description = v.into();
                 self
             }
-
-            /// Sets the value of [references][crate::model::publisher_model::call_to_action::RegionalResourceReferences::references].
-            pub fn set_references<T, K, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = (K, V)>,
-                K: std::convert::Into<std::string::String>,
-                V: std::convert::Into<crate::model::publisher_model::ResourceReference>,
-            {
-                use std::iter::Iterator;
-                self.references = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-                self
-            }
         }
 
         #[cfg(feature = "model_garden_service")]
@@ -80332,12 +80332,6 @@ pub mod publisher_model {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [title][crate::model::publisher_model::call_to_action::ViewRestApi::title].
-            pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.title = v.into();
-                self
-            }
-
             /// Sets the value of [documentations][crate::model::publisher_model::call_to_action::ViewRestApi::documentations].
             pub fn set_documentations<T, V>(mut self, v: T) -> Self
             where
@@ -80346,6 +80340,12 @@ pub mod publisher_model {
             {
                 use std::iter::Iterator;
                 self.documentations = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [title][crate::model::publisher_model::call_to_action::ViewRestApi::title].
+            pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+                self.title = v.into();
                 self
             }
         }
@@ -80614,31 +80614,6 @@ pub mod publisher_model {
                 })
             }
 
-            /// The value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
-            /// if it holds a `AutomaticResources`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn automatic_resources(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::AutomaticResources>>
-            {
-                #[allow(unreachable_patterns)]
-                self.prediction_resources.as_ref().and_then(|v| match v {
-                    crate::model::publisher_model::call_to_action::deploy::PredictionResources::AutomaticResources(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
-            /// if it holds a `SharedResources`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn shared_resources(&self) -> std::option::Option<&std::string::String> {
-                #[allow(unreachable_patterns)]
-                self.prediction_resources.as_ref().and_then(|v| match v {
-                    crate::model::publisher_model::call_to_action::deploy::PredictionResources::SharedResources(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
             /// to hold a `DedicatedResources`.
             ///
@@ -80658,6 +80633,20 @@ pub mod publisher_model {
                 self
             }
 
+            /// The value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
+            /// if it holds a `AutomaticResources`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn automatic_resources(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::AutomaticResources>>
+            {
+                #[allow(unreachable_patterns)]
+                self.prediction_resources.as_ref().and_then(|v| match v {
+                    crate::model::publisher_model::call_to_action::deploy::PredictionResources::AutomaticResources(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
             /// to hold a `AutomaticResources`.
             ///
@@ -80675,6 +80664,17 @@ pub mod publisher_model {
                     )
                 );
                 self
+            }
+
+            /// The value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
+            /// if it holds a `SharedResources`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn shared_resources(&self) -> std::option::Option<&std::string::String> {
+                #[allow(unreachable_patterns)]
+                self.prediction_resources.as_ref().and_then(|v| match v {
+                    crate::model::publisher_model::call_to_action::deploy::PredictionResources::SharedResources(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [prediction_resources][crate::model::publisher_model::call_to_action::Deploy::prediction_resources]
@@ -80735,15 +80735,6 @@ pub mod publisher_model {
                     std::default::Default::default()
                 }
 
-                /// Sets the value of [sample_request][crate::model::publisher_model::call_to_action::deploy::DeployMetadata::sample_request].
-                pub fn set_sample_request<T: std::convert::Into<std::string::String>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.sample_request = v.into();
-                    self
-                }
-
                 /// Sets the value of [labels][crate::model::publisher_model::call_to_action::deploy::DeployMetadata::labels].
                 pub fn set_labels<T, K, V>(mut self, v: T) -> Self
                 where
@@ -80753,6 +80744,15 @@ pub mod publisher_model {
                 {
                     use std::iter::Iterator;
                     self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+                    self
+                }
+
+                /// Sets the value of [sample_request][crate::model::publisher_model::call_to_action::deploy::DeployMetadata::sample_request].
+                pub fn set_sample_request<T: std::convert::Into<std::string::String>>(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.sample_request = v.into();
                     self
                 }
             }
@@ -81364,12 +81364,6 @@ impl ReasoningEngineSpec {
         self
     }
 
-    /// Sets the value of [agent_framework][crate::model::ReasoningEngineSpec::agent_framework].
-    pub fn set_agent_framework<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent_framework = v.into();
-        self
-    }
-
     /// Sets the value of [class_methods][crate::model::ReasoningEngineSpec::class_methods].
     pub fn set_class_methods<T, V>(mut self, v: T) -> Self
     where
@@ -81378,6 +81372,12 @@ impl ReasoningEngineSpec {
     {
         use std::iter::Iterator;
         self.class_methods = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [agent_framework][crate::model::ReasoningEngineSpec::agent_framework].
+    pub fn set_agent_framework<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.agent_framework = v.into();
         self
     }
 }
@@ -82146,12 +82146,6 @@ impl ListReasoningEnginesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReasoningEnginesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [reasoning_engines][crate::model::ListReasoningEnginesResponse::reasoning_engines].
     pub fn set_reasoning_engines<T, V>(mut self, v: T) -> Self
     where
@@ -82160,6 +82154,12 @@ impl ListReasoningEnginesResponse {
     {
         use std::iter::Iterator;
         self.reasoning_engines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReasoningEnginesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -83043,22 +83043,6 @@ impl Schedule {
         })
     }
 
-    /// The value of [request][crate::model::Schedule::request]
-    /// if it holds a `CreateNotebookExecutionJobRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_notebook_execution_job_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateNotebookExecutionJobRequest>>
-    {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::schedule::Request::CreateNotebookExecutionJobRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [request][crate::model::Schedule::request]
     /// to hold a `CreatePipelineJobRequest`.
     ///
@@ -83074,6 +83058,22 @@ impl Schedule {
             crate::model::schedule::Request::CreatePipelineJobRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::Schedule::request]
+    /// if it holds a `CreateNotebookExecutionJobRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_notebook_execution_job_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateNotebookExecutionJobRequest>>
+    {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::schedule::Request::CreateNotebookExecutionJobRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::Schedule::request]
@@ -83610,12 +83610,6 @@ impl ListSchedulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSchedulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [schedules][crate::model::ListSchedulesResponse::schedules].
     pub fn set_schedules<T, V>(mut self, v: T) -> Self
     where
@@ -83624,6 +83618,12 @@ impl ListSchedulesResponse {
     {
         use std::iter::Iterator;
         self.schedules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSchedulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -83945,15 +83945,6 @@ impl PrivateServiceConnectConfig {
         self
     }
 
-    /// Sets the value of [service_attachment][crate::model::PrivateServiceConnectConfig::service_attachment].
-    pub fn set_service_attachment<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_attachment = v.into();
-        self
-    }
-
     /// Sets the value of [project_allowlist][crate::model::PrivateServiceConnectConfig::project_allowlist].
     pub fn set_project_allowlist<T, V>(mut self, v: T) -> Self
     where
@@ -83962,6 +83953,15 @@ impl PrivateServiceConnectConfig {
     {
         use std::iter::Iterator;
         self.project_allowlist = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service_attachment][crate::model::PrivateServiceConnectConfig::service_attachment].
+    pub fn set_service_attachment<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.service_attachment = v.into();
         self
     }
 }
@@ -84386,12 +84386,6 @@ impl ListSpecialistPoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSpecialistPoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [specialist_pools][crate::model::ListSpecialistPoolsResponse::specialist_pools].
     pub fn set_specialist_pools<T, V>(mut self, v: T) -> Self
     where
@@ -84400,6 +84394,12 @@ impl ListSpecialistPoolsResponse {
     {
         use std::iter::Iterator;
         self.specialist_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSpecialistPoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -84949,6 +84949,17 @@ impl Trial {
         self
     }
 
+    /// Sets the value of [parameters][crate::model::Trial::parameters].
+    pub fn set_parameters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::trial::Parameter>,
+    {
+        use std::iter::Iterator;
+        self.parameters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [final_measurement][crate::model::Trial::final_measurement].
     pub fn set_final_measurement<
         T: std::convert::Into<std::option::Option<crate::model::Measurement>>,
@@ -84957,6 +84968,17 @@ impl Trial {
         v: T,
     ) -> Self {
         self.final_measurement = v.into();
+        self
+    }
+
+    /// Sets the value of [measurements][crate::model::Trial::measurements].
+    pub fn set_measurements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Measurement>,
+    {
+        use std::iter::Iterator;
+        self.measurements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -84996,28 +85018,6 @@ impl Trial {
     /// Sets the value of [custom_job][crate::model::Trial::custom_job].
     pub fn set_custom_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.custom_job = v.into();
-        self
-    }
-
-    /// Sets the value of [parameters][crate::model::Trial::parameters].
-    pub fn set_parameters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::trial::Parameter>,
-    {
-        use std::iter::Iterator;
-        self.parameters = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [measurements][crate::model::Trial::measurements].
-    pub fn set_measurements<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Measurement>,
-    {
-        use std::iter::Iterator;
-        self.measurements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -85377,19 +85377,6 @@ impl StudyTimeConstraint {
         })
     }
 
-    /// The value of [constraint][crate::model::StudyTimeConstraint::constraint]
-    /// if it holds a `EndTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn end_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.constraint.as_ref().and_then(|v| match v {
-            crate::model::study_time_constraint::Constraint::EndTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [constraint][crate::model::StudyTimeConstraint::constraint]
     /// to hold a `MaxDuration`.
     ///
@@ -85403,6 +85390,19 @@ impl StudyTimeConstraint {
             crate::model::study_time_constraint::Constraint::MaxDuration(v.into()),
         );
         self
+    }
+
+    /// The value of [constraint][crate::model::StudyTimeConstraint::constraint]
+    /// if it holds a `EndTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn end_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.constraint.as_ref().and_then(|v| match v {
+            crate::model::study_time_constraint::Constraint::EndTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [constraint][crate::model::StudyTimeConstraint::constraint]
@@ -85491,6 +85491,28 @@ impl StudySpec {
         std::default::Default::default()
     }
 
+    /// Sets the value of [metrics][crate::model::StudySpec::metrics].
+    pub fn set_metrics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::study_spec::MetricSpec>,
+    {
+        use std::iter::Iterator;
+        self.metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::StudySpec::parameters].
+    pub fn set_parameters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::study_spec::ParameterSpec>,
+    {
+        use std::iter::Iterator;
+        self.parameters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [algorithm][crate::model::StudySpec::algorithm].
     pub fn set_algorithm<T: std::convert::Into<crate::model::study_spec::Algorithm>>(
         mut self,
@@ -85533,28 +85555,6 @@ impl StudySpec {
         self
     }
 
-    /// Sets the value of [metrics][crate::model::StudySpec::metrics].
-    pub fn set_metrics<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::study_spec::MetricSpec>,
-    {
-        use std::iter::Iterator;
-        self.metrics = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [parameters][crate::model::StudySpec::parameters].
-    pub fn set_parameters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::study_spec::ParameterSpec>,
-    {
-        use std::iter::Iterator;
-        self.parameters = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec].
     ///
     /// Note that all the setters affecting `automated_stopping_spec` are mutually
@@ -85586,38 +85586,6 @@ impl StudySpec {
         })
     }
 
-    /// The value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
-    /// if it holds a `MedianAutomatedStoppingSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn median_automated_stopping_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::MedianAutomatedStoppingSpec>>
-    {
-        #[allow(unreachable_patterns)]
-        self.automated_stopping_spec.as_ref().and_then(|v| match v {
-            crate::model::study_spec::AutomatedStoppingSpec::MedianAutomatedStoppingSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
-    /// if it holds a `ConvexAutomatedStoppingSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn convex_automated_stopping_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::ConvexAutomatedStoppingSpec>>
-    {
-        #[allow(unreachable_patterns)]
-        self.automated_stopping_spec.as_ref().and_then(|v| match v {
-            crate::model::study_spec::AutomatedStoppingSpec::ConvexAutomatedStoppingSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
     /// to hold a `DecayCurveStoppingSpec`.
     ///
@@ -85637,6 +85605,22 @@ impl StudySpec {
         self
     }
 
+    /// The value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
+    /// if it holds a `MedianAutomatedStoppingSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn median_automated_stopping_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::MedianAutomatedStoppingSpec>>
+    {
+        #[allow(unreachable_patterns)]
+        self.automated_stopping_spec.as_ref().and_then(|v| match v {
+            crate::model::study_spec::AutomatedStoppingSpec::MedianAutomatedStoppingSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
     /// to hold a `MedianAutomatedStoppingSpec`.
     ///
@@ -85652,6 +85636,22 @@ impl StudySpec {
             crate::model::study_spec::AutomatedStoppingSpec::MedianAutomatedStoppingSpec(v.into()),
         );
         self
+    }
+
+    /// The value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
+    /// if it holds a `ConvexAutomatedStoppingSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn convex_automated_stopping_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::ConvexAutomatedStoppingSpec>>
+    {
+        #[allow(unreachable_patterns)]
+        self.automated_stopping_spec.as_ref().and_then(|v| match v {
+            crate::model::study_spec::AutomatedStoppingSpec::ConvexAutomatedStoppingSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [automated_stopping_spec][crate::model::StudySpec::automated_stopping_spec]
@@ -86066,55 +86066,6 @@ pub mod study_spec {
             })
         }
 
-        /// The value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
-        /// if it holds a `IntegerValueSpec`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn integer_value_spec(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::study_spec::parameter_spec::IntegerValueSpec>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.parameter_value_spec.as_ref().and_then(|v| match v {
-                crate::model::study_spec::parameter_spec::ParameterValueSpec::IntegerValueSpec(
-                    v,
-                ) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
-        /// if it holds a `CategoricalValueSpec`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn categorical_value_spec(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::study_spec::parameter_spec::CategoricalValueSpec>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.parameter_value_spec.as_ref().and_then(|v| match v {
-                crate::model::study_spec::parameter_spec::ParameterValueSpec::CategoricalValueSpec(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
-        /// if it holds a `DiscreteValueSpec`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn discrete_value_spec(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::study_spec::parameter_spec::DiscreteValueSpec>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.parameter_value_spec.as_ref().and_then(|v| match v {
-                crate::model::study_spec::parameter_spec::ParameterValueSpec::DiscreteValueSpec(
-                    v,
-                ) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
         /// to hold a `DoubleValueSpec`.
         ///
@@ -86134,6 +86085,23 @@ pub mod study_spec {
                 ),
             );
             self
+        }
+
+        /// The value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
+        /// if it holds a `IntegerValueSpec`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn integer_value_spec(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::study_spec::parameter_spec::IntegerValueSpec>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.parameter_value_spec.as_ref().and_then(|v| match v {
+                crate::model::study_spec::parameter_spec::ParameterValueSpec::IntegerValueSpec(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
@@ -86157,6 +86125,21 @@ pub mod study_spec {
             self
         }
 
+        /// The value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
+        /// if it holds a `CategoricalValueSpec`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn categorical_value_spec(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::study_spec::parameter_spec::CategoricalValueSpec>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.parameter_value_spec.as_ref().and_then(|v| match v {
+                crate::model::study_spec::parameter_spec::ParameterValueSpec::CategoricalValueSpec(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
         /// to hold a `CategoricalValueSpec`.
         ///
@@ -86176,6 +86159,23 @@ pub mod study_spec {
                 ),
             );
             self
+        }
+
+        /// The value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
+        /// if it holds a `DiscreteValueSpec`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn discrete_value_spec(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::study_spec::parameter_spec::DiscreteValueSpec>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.parameter_value_spec.as_ref().and_then(|v| match v {
+                crate::model::study_spec::parameter_spec::ParameterValueSpec::DiscreteValueSpec(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [parameter_value_spec][crate::model::study_spec::ParameterSpec::parameter_value_spec]
@@ -86372,17 +86372,6 @@ pub mod study_spec {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [default_value][crate::model::study_spec::parameter_spec::CategoricalValueSpec::default_value].
-            pub fn set_default_value<
-                T: std::convert::Into<std::option::Option<std::string::String>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.default_value = v.into();
-                self
-            }
-
             /// Sets the value of [values][crate::model::study_spec::parameter_spec::CategoricalValueSpec::values].
             pub fn set_values<T, V>(mut self, v: T) -> Self
             where
@@ -86391,6 +86380,17 @@ pub mod study_spec {
             {
                 use std::iter::Iterator;
                 self.values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [default_value][crate::model::study_spec::parameter_spec::CategoricalValueSpec::default_value].
+            pub fn set_default_value<
+                T: std::convert::Into<std::option::Option<std::string::String>>,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.default_value = v.into();
                 self
             }
         }
@@ -86436,15 +86436,6 @@ pub mod study_spec {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [default_value][crate::model::study_spec::parameter_spec::DiscreteValueSpec::default_value].
-            pub fn set_default_value<T: std::convert::Into<std::option::Option<f64>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.default_value = v.into();
-                self
-            }
-
             /// Sets the value of [values][crate::model::study_spec::parameter_spec::DiscreteValueSpec::values].
             pub fn set_values<T, V>(mut self, v: T) -> Self
             where
@@ -86453,6 +86444,15 @@ pub mod study_spec {
             {
                 use std::iter::Iterator;
                 self.values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [default_value][crate::model::study_spec::parameter_spec::DiscreteValueSpec::default_value].
+            pub fn set_default_value<T: std::convert::Into<std::option::Option<f64>>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.default_value = v.into();
                 self
             }
         }
@@ -86527,28 +86527,6 @@ pub mod study_spec {
                 })
             }
 
-            /// The value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
-            /// if it holds a `ParentIntValues`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn parent_int_values(&self) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::parameter_spec::conditional_parameter_spec::IntValueCondition>>{
-                #[allow(unreachable_patterns)]
-                self.parent_value_condition.as_ref().and_then(|v| match v {
-                    crate::model::study_spec::parameter_spec::conditional_parameter_spec::ParentValueCondition::ParentIntValues(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
-            /// if it holds a `ParentCategoricalValues`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn parent_categorical_values(&self) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::parameter_spec::conditional_parameter_spec::CategoricalValueCondition>>{
-                #[allow(unreachable_patterns)]
-                self.parent_value_condition.as_ref().and_then(|v| match v {
-                    crate::model::study_spec::parameter_spec::conditional_parameter_spec::ParentValueCondition::ParentCategoricalValues(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
             /// to hold a `ParentDiscreteValues`.
             ///
@@ -86563,6 +86541,17 @@ pub mod study_spec {
                 self
             }
 
+            /// The value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
+            /// if it holds a `ParentIntValues`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn parent_int_values(&self) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::parameter_spec::conditional_parameter_spec::IntValueCondition>>{
+                #[allow(unreachable_patterns)]
+                self.parent_value_condition.as_ref().and_then(|v| match v {
+                    crate::model::study_spec::parameter_spec::conditional_parameter_spec::ParentValueCondition::ParentIntValues(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
             /// to hold a `ParentIntValues`.
             ///
@@ -86575,6 +86564,17 @@ pub mod study_spec {
                     )
                 );
                 self
+            }
+
+            /// The value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
+            /// if it holds a `ParentCategoricalValues`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn parent_categorical_values(&self) -> std::option::Option<&std::boxed::Box<crate::model::study_spec::parameter_spec::conditional_parameter_spec::CategoricalValueCondition>>{
+                #[allow(unreachable_patterns)]
+                self.parent_value_condition.as_ref().and_then(|v| match v {
+                    crate::model::study_spec::parameter_spec::conditional_parameter_spec::ParentValueCondition::ParentCategoricalValues(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [parent_value_condition][crate::model::study_spec::parameter_spec::ConditionalParameterSpec::parent_value_condition]
@@ -88054,6 +88054,18 @@ impl Tensorboard {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Tensorboard::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Tensorboard::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -88075,18 +88087,6 @@ impl Tensorboard {
     /// Sets the value of [satisfies_pzi][crate::model::Tensorboard::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Tensorboard::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -88237,30 +88237,6 @@ impl TimeSeriesDataPoint {
         })
     }
 
-    /// The value of [value][crate::model::TimeSeriesDataPoint::value]
-    /// if it holds a `Tensor`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tensor(&self) -> std::option::Option<&std::boxed::Box<crate::model::TensorboardTensor>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::time_series_data_point::Value::Tensor(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TimeSeriesDataPoint::value]
-    /// if it holds a `Blobs`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn blobs(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TensorboardBlobSequence>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::time_series_data_point::Value::Blobs(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::TimeSeriesDataPoint::value]
     /// to hold a `Scalar`.
     ///
@@ -88276,6 +88252,17 @@ impl TimeSeriesDataPoint {
         self
     }
 
+    /// The value of [value][crate::model::TimeSeriesDataPoint::value]
+    /// if it holds a `Tensor`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tensor(&self) -> std::option::Option<&std::boxed::Box<crate::model::TensorboardTensor>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::time_series_data_point::Value::Tensor(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::TimeSeriesDataPoint::value]
     /// to hold a `Tensor`.
     ///
@@ -88289,6 +88276,19 @@ impl TimeSeriesDataPoint {
             crate::model::time_series_data_point::Value::Tensor(v.into()),
         );
         self
+    }
+
+    /// The value of [value][crate::model::TimeSeriesDataPoint::value]
+    /// if it holds a `Blobs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn blobs(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TensorboardBlobSequence>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::time_series_data_point::Value::Blobs(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::TimeSeriesDataPoint::value]
@@ -88618,18 +88618,6 @@ impl TensorboardExperiment {
         self
     }
 
-    /// Sets the value of [etag][crate::model::TensorboardExperiment::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [source][crate::model::TensorboardExperiment::source].
-    pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::TensorboardExperiment::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -88639,6 +88627,18 @@ impl TensorboardExperiment {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::TensorboardExperiment::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [source][crate::model::TensorboardExperiment::source].
+    pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = v.into();
         self
     }
 }
@@ -88754,12 +88754,6 @@ impl TensorboardRun {
         self
     }
 
-    /// Sets the value of [etag][crate::model::TensorboardRun::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::TensorboardRun::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -88769,6 +88763,12 @@ impl TensorboardRun {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::TensorboardRun::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -89011,12 +89011,6 @@ impl ListTensorboardsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTensorboardsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tensorboards][crate::model::ListTensorboardsResponse::tensorboards].
     pub fn set_tensorboards<T, V>(mut self, v: T) -> Self
     where
@@ -89025,6 +89019,12 @@ impl ListTensorboardsResponse {
     {
         use std::iter::Iterator;
         self.tensorboards = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTensorboardsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -89663,12 +89663,6 @@ impl ListTensorboardExperimentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTensorboardExperimentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tensorboard_experiments][crate::model::ListTensorboardExperimentsResponse::tensorboard_experiments].
     pub fn set_tensorboard_experiments<T, V>(mut self, v: T) -> Self
     where
@@ -89677,6 +89671,12 @@ impl ListTensorboardExperimentsResponse {
     {
         use std::iter::Iterator;
         self.tensorboard_experiments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTensorboardExperimentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -90250,12 +90250,6 @@ impl ListTensorboardRunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTensorboardRunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tensorboard_runs][crate::model::ListTensorboardRunsResponse::tensorboard_runs].
     pub fn set_tensorboard_runs<T, V>(mut self, v: T) -> Self
     where
@@ -90264,6 +90258,12 @@ impl ListTensorboardRunsResponse {
     {
         use std::iter::Iterator;
         self.tensorboard_runs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTensorboardRunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -90745,12 +90745,6 @@ impl ListTensorboardTimeSeriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTensorboardTimeSeriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tensorboard_time_series][crate::model::ListTensorboardTimeSeriesResponse::tensorboard_time_series].
     pub fn set_tensorboard_time_series<T, V>(mut self, v: T) -> Self
     where
@@ -90759,6 +90753,12 @@ impl ListTensorboardTimeSeriesResponse {
     {
         use std::iter::Iterator;
         self.tensorboard_time_series = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTensorboardTimeSeriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -91404,12 +91404,6 @@ impl ExportTensorboardTimeSeriesDataResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ExportTensorboardTimeSeriesDataResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [time_series_data_points][crate::model::ExportTensorboardTimeSeriesDataResponse::time_series_data_points].
     pub fn set_time_series_data_points<T, V>(mut self, v: T) -> Self
     where
@@ -91418,6 +91412,12 @@ impl ExportTensorboardTimeSeriesDataResponse {
     {
         use std::iter::Iterator;
         self.time_series_data_points = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ExportTensorboardTimeSeriesDataResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -91964,6 +91964,17 @@ impl Tool {
         std::default::Default::default()
     }
 
+    /// Sets the value of [function_declarations][crate::model::Tool::function_declarations].
+    pub fn set_function_declarations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FunctionDeclaration>,
+    {
+        use std::iter::Iterator;
+        self.function_declarations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [retrieval][crate::model::Tool::retrieval].
     pub fn set_retrieval<T: std::convert::Into<std::option::Option<crate::model::Retrieval>>>(
         mut self,
@@ -92014,17 +92025,6 @@ impl Tool {
         v: T,
     ) -> Self {
         self.code_execution = v.into();
-        self
-    }
-
-    /// Sets the value of [function_declarations][crate::model::Tool::function_declarations].
-    pub fn set_function_declarations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FunctionDeclaration>,
-    {
-        use std::iter::Iterator;
-        self.function_declarations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -93003,19 +93003,6 @@ impl Retrieval {
         })
     }
 
-    /// The value of [source][crate::model::Retrieval::source]
-    /// if it holds a `VertexRagStore`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertex_rag_store(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexRagStore>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::retrieval::Source::VertexRagStore(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::Retrieval::source]
     /// to hold a `VertexAiSearch`.
     ///
@@ -93030,6 +93017,19 @@ impl Retrieval {
         self.source =
             std::option::Option::Some(crate::model::retrieval::Source::VertexAiSearch(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::Retrieval::source]
+    /// if it holds a `VertexRagStore`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertex_rag_store(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexRagStore>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::retrieval::Source::VertexRagStore(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::Retrieval::source]
@@ -93137,6 +93137,17 @@ impl VertexRagStore {
         std::default::Default::default()
     }
 
+    /// Sets the value of [rag_resources][crate::model::VertexRagStore::rag_resources].
+    pub fn set_rag_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::vertex_rag_store::RagResource>,
+    {
+        use std::iter::Iterator;
+        self.rag_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [similarity_top_k][crate::model::VertexRagStore::similarity_top_k].
     #[deprecated]
     pub fn set_similarity_top_k<T: std::convert::Into<std::option::Option<i32>>>(
@@ -93165,17 +93176,6 @@ impl VertexRagStore {
         v: T,
     ) -> Self {
         self.rag_retrieval_config = v.into();
-        self
-    }
-
-    /// Sets the value of [rag_resources][crate::model::VertexRagStore::rag_resources].
-    pub fn set_rag_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::vertex_rag_store::RagResource>,
-    {
-        use std::iter::Iterator;
-        self.rag_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -94155,17 +94155,6 @@ pub mod rag_retrieval_config {
             })
         }
 
-        /// The value of [vector_db_threshold][crate::model::rag_retrieval_config::Filter::vector_db_threshold]
-        /// if it holds a `VectorSimilarityThreshold`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn vector_similarity_threshold(&self) -> std::option::Option<&f64> {
-            #[allow(unreachable_patterns)]
-            self.vector_db_threshold.as_ref().and_then(|v| match v {
-                crate::model::rag_retrieval_config::filter::VectorDbThreshold::VectorSimilarityThreshold(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [vector_db_threshold][crate::model::rag_retrieval_config::Filter::vector_db_threshold]
         /// to hold a `VectorDistanceThreshold`.
         ///
@@ -94178,6 +94167,17 @@ pub mod rag_retrieval_config {
                 )
             );
             self
+        }
+
+        /// The value of [vector_db_threshold][crate::model::rag_retrieval_config::Filter::vector_db_threshold]
+        /// if it holds a `VectorSimilarityThreshold`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn vector_similarity_threshold(&self) -> std::option::Option<&f64> {
+            #[allow(unreachable_patterns)]
+            self.vector_db_threshold.as_ref().and_then(|v| match v {
+                crate::model::rag_retrieval_config::filter::VectorDbThreshold::VectorSimilarityThreshold(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [vector_db_threshold][crate::model::rag_retrieval_config::Filter::vector_db_threshold]
@@ -94304,23 +94304,6 @@ pub mod rag_retrieval_config {
             })
         }
 
-        /// The value of [ranking_config][crate::model::rag_retrieval_config::Ranking::ranking_config]
-        /// if it holds a `LlmRanker`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn llm_ranker(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::rag_retrieval_config::ranking::LlmRanker>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.ranking_config.as_ref().and_then(|v| match v {
-                crate::model::rag_retrieval_config::ranking::RankingConfig::LlmRanker(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [ranking_config][crate::model::rag_retrieval_config::Ranking::ranking_config]
         /// to hold a `RankService`.
         ///
@@ -94338,6 +94321,23 @@ pub mod rag_retrieval_config {
                 crate::model::rag_retrieval_config::ranking::RankingConfig::RankService(v.into()),
             );
             self
+        }
+
+        /// The value of [ranking_config][crate::model::rag_retrieval_config::Ranking::ranking_config]
+        /// if it holds a `LlmRanker`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn llm_ranker(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::rag_retrieval_config::ranking::LlmRanker>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.ranking_config.as_ref().and_then(|v| match v {
+                crate::model::rag_retrieval_config::ranking::RankingConfig::LlmRanker(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [ranking_config][crate::model::rag_retrieval_config::Ranking::ranking_config]
@@ -94798,17 +94798,6 @@ impl TrainingPipeline {
         self
     }
 
-    /// Sets the value of [encryption_spec][crate::model::TrainingPipeline::encryption_spec].
-    pub fn set_encryption_spec<
-        T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_spec = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::TrainingPipeline::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -94818,6 +94807,17 @@ impl TrainingPipeline {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [encryption_spec][crate::model::TrainingPipeline::encryption_spec].
+    pub fn set_encryption_spec<
+        T: std::convert::Into<std::option::Option<crate::model::EncryptionSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.encryption_spec = v.into();
         self
     }
 }
@@ -95028,62 +95028,6 @@ impl InputDataConfig {
         })
     }
 
-    /// The value of [split][crate::model::InputDataConfig::split]
-    /// if it holds a `FilterSplit`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filter_split(&self) -> std::option::Option<&std::boxed::Box<crate::model::FilterSplit>> {
-        #[allow(unreachable_patterns)]
-        self.split.as_ref().and_then(|v| match v {
-            crate::model::input_data_config::Split::FilterSplit(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [split][crate::model::InputDataConfig::split]
-    /// if it holds a `PredefinedSplit`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn predefined_split(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PredefinedSplit>> {
-        #[allow(unreachable_patterns)]
-        self.split.as_ref().and_then(|v| match v {
-            crate::model::input_data_config::Split::PredefinedSplit(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [split][crate::model::InputDataConfig::split]
-    /// if it holds a `TimestampSplit`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn timestamp_split(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TimestampSplit>> {
-        #[allow(unreachable_patterns)]
-        self.split.as_ref().and_then(|v| match v {
-            crate::model::input_data_config::Split::TimestampSplit(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [split][crate::model::InputDataConfig::split]
-    /// if it holds a `StratifiedSplit`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn stratified_split(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StratifiedSplit>> {
-        #[allow(unreachable_patterns)]
-        self.split.as_ref().and_then(|v| match v {
-            crate::model::input_data_config::Split::StratifiedSplit(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [split][crate::model::InputDataConfig::split]
     /// to hold a `FractionSplit`.
     ///
@@ -95101,6 +95045,17 @@ impl InputDataConfig {
         self
     }
 
+    /// The value of [split][crate::model::InputDataConfig::split]
+    /// if it holds a `FilterSplit`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filter_split(&self) -> std::option::Option<&std::boxed::Box<crate::model::FilterSplit>> {
+        #[allow(unreachable_patterns)]
+        self.split.as_ref().and_then(|v| match v {
+            crate::model::input_data_config::Split::FilterSplit(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [split][crate::model::InputDataConfig::split]
     /// to hold a `FilterSplit`.
     ///
@@ -95114,6 +95069,21 @@ impl InputDataConfig {
             crate::model::input_data_config::Split::FilterSplit(v.into()),
         );
         self
+    }
+
+    /// The value of [split][crate::model::InputDataConfig::split]
+    /// if it holds a `PredefinedSplit`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn predefined_split(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PredefinedSplit>> {
+        #[allow(unreachable_patterns)]
+        self.split.as_ref().and_then(|v| match v {
+            crate::model::input_data_config::Split::PredefinedSplit(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [split][crate::model::InputDataConfig::split]
@@ -95133,6 +95103,21 @@ impl InputDataConfig {
         self
     }
 
+    /// The value of [split][crate::model::InputDataConfig::split]
+    /// if it holds a `TimestampSplit`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn timestamp_split(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimestampSplit>> {
+        #[allow(unreachable_patterns)]
+        self.split.as_ref().and_then(|v| match v {
+            crate::model::input_data_config::Split::TimestampSplit(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [split][crate::model::InputDataConfig::split]
     /// to hold a `TimestampSplit`.
     ///
@@ -95148,6 +95133,21 @@ impl InputDataConfig {
             crate::model::input_data_config::Split::TimestampSplit(v.into()),
         );
         self
+    }
+
+    /// The value of [split][crate::model::InputDataConfig::split]
+    /// if it holds a `StratifiedSplit`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn stratified_split(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StratifiedSplit>> {
+        #[allow(unreachable_patterns)]
+        self.split.as_ref().and_then(|v| match v {
+            crate::model::input_data_config::Split::StratifiedSplit(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [split][crate::model::InputDataConfig::split]
@@ -95196,21 +95196,6 @@ impl InputDataConfig {
         })
     }
 
-    /// The value of [destination][crate::model::InputDataConfig::destination]
-    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_destination(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::input_data_config::Destination::BigqueryDestination(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::InputDataConfig::destination]
     /// to hold a `GcsDestination`.
     ///
@@ -95226,6 +95211,21 @@ impl InputDataConfig {
             crate::model::input_data_config::Destination::GcsDestination(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::InputDataConfig::destination]
+    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::input_data_config::Destination::BigqueryDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::InputDataConfig::destination]
@@ -95912,6 +95912,18 @@ impl TuningJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::TuningJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [experiment][crate::model::TuningJob::experiment].
     pub fn set_experiment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.experiment = v.into();
@@ -95952,18 +95964,6 @@ impl TuningJob {
     /// Sets the value of [service_account][crate::model::TuningJob::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::TuningJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -96455,12 +96455,6 @@ impl SupervisedTuningDataStats {
         self
     }
 
-    /// Sets the value of [total_truncated_example_count][crate::model::SupervisedTuningDataStats::total_truncated_example_count].
-    pub fn set_total_truncated_example_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.total_truncated_example_count = v.into();
-        self
-    }
-
     /// Sets the value of [user_dataset_examples][crate::model::SupervisedTuningDataStats::user_dataset_examples].
     pub fn set_user_dataset_examples<T, V>(mut self, v: T) -> Self
     where
@@ -96469,6 +96463,12 @@ impl SupervisedTuningDataStats {
     {
         use std::iter::Iterator;
         self.user_dataset_examples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [total_truncated_example_count][crate::model::SupervisedTuningDataStats::total_truncated_example_count].
+    pub fn set_total_truncated_example_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.total_truncated_example_count = v.into();
         self
     }
 
@@ -96923,6 +96923,18 @@ impl TunedModelRef {
         })
     }
 
+    /// Sets the value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
+    /// to hold a `TunedModel`.
+    ///
+    /// Note that all the setters affecting `tuned_model_ref` are
+    /// mutually exclusive.
+    pub fn set_tuned_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.tuned_model_ref = std::option::Option::Some(
+            crate::model::tuned_model_ref::TunedModelRef::TunedModel(v.into()),
+        );
+        self
+    }
+
     /// The value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
     /// if it holds a `TuningJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -96936,6 +96948,18 @@ impl TunedModelRef {
         })
     }
 
+    /// Sets the value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
+    /// to hold a `TuningJob`.
+    ///
+    /// Note that all the setters affecting `tuned_model_ref` are
+    /// mutually exclusive.
+    pub fn set_tuning_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.tuned_model_ref = std::option::Option::Some(
+            crate::model::tuned_model_ref::TunedModelRef::TuningJob(v.into()),
+        );
+        self
+    }
+
     /// The value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
     /// if it holds a `PipelineJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -96947,30 +96971,6 @@ impl TunedModelRef {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
-    /// to hold a `TunedModel`.
-    ///
-    /// Note that all the setters affecting `tuned_model_ref` are
-    /// mutually exclusive.
-    pub fn set_tuned_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.tuned_model_ref = std::option::Option::Some(
-            crate::model::tuned_model_ref::TunedModelRef::TunedModel(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
-    /// to hold a `TuningJob`.
-    ///
-    /// Note that all the setters affecting `tuned_model_ref` are
-    /// mutually exclusive.
-    pub fn set_tuning_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.tuned_model_ref = std::option::Option::Some(
-            crate::model::tuned_model_ref::TunedModelRef::TuningJob(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [tuned_model_ref][crate::model::TunedModelRef::tuned_model_ref]
@@ -97330,12 +97330,6 @@ impl Tensor {
         self
     }
 
-    /// Sets the value of [tensor_val][crate::model::Tensor::tensor_val].
-    pub fn set_tensor_val<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.tensor_val = v.into();
-        self
-    }
-
     /// Sets the value of [shape][crate::model::Tensor::shape].
     pub fn set_shape<T, V>(mut self, v: T) -> Self
     where
@@ -97466,6 +97460,12 @@ impl Tensor {
     {
         use std::iter::Iterator;
         self.struct_val = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [tensor_val][crate::model::Tensor::tensor_val].
+    pub fn set_tensor_val<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.tensor_val = v.into();
         self
     }
 }
@@ -97813,6 +97813,18 @@ impl UserActionReference {
         })
     }
 
+    /// Sets the value of [reference][crate::model::UserActionReference::reference]
+    /// to hold a `Operation`.
+    ///
+    /// Note that all the setters affecting `reference` are
+    /// mutually exclusive.
+    pub fn set_operation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.reference = std::option::Option::Some(
+            crate::model::user_action_reference::Reference::Operation(v.into()),
+        );
+        self
+    }
+
     /// The value of [reference][crate::model::UserActionReference::reference]
     /// if it holds a `DataLabelingJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -97824,18 +97836,6 @@ impl UserActionReference {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [reference][crate::model::UserActionReference::reference]
-    /// to hold a `Operation`.
-    ///
-    /// Note that all the setters affecting `reference` are
-    /// mutually exclusive.
-    pub fn set_operation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.reference = std::option::Option::Some(
-            crate::model::user_action_reference::Reference::Operation(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [reference][crate::model::UserActionReference::reference]
@@ -97928,6 +97928,16 @@ impl Value {
         })
     }
 
+    /// Sets the value of [value][crate::model::Value::value]
+    /// to hold a `IntValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.value = std::option::Option::Some(crate::model::value::Value::IntValue(v.into()));
+        self
+    }
+
     /// The value of [value][crate::model::Value::value]
     /// if it holds a `DoubleValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -97939,6 +97949,16 @@ impl Value {
         })
     }
 
+    /// Sets the value of [value][crate::model::Value::value]
+    /// to hold a `DoubleValue`.
+    ///
+    /// Note that all the setters affecting `value` are
+    /// mutually exclusive.
+    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.value = std::option::Option::Some(crate::model::value::Value::DoubleValue(v.into()));
+        self
+    }
+
     /// The value of [value][crate::model::Value::value]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -97948,26 +97968,6 @@ impl Value {
             crate::model::value::Value::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::Value::value]
-    /// to hold a `IntValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value = std::option::Option::Some(crate::model::value::Value::IntValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [value][crate::model::Value::value]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value = std::option::Option::Some(crate::model::value::Value::DoubleValue(v.into()));
-        self
     }
 
     /// Sets the value of [value][crate::model::Value::value]
@@ -98259,37 +98259,6 @@ impl RagVectorDbConfig {
         })
     }
 
-    /// The value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
-    /// if it holds a `Pinecone`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pinecone(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rag_vector_db_config::Pinecone>> {
-        #[allow(unreachable_patterns)]
-        self.vector_db.as_ref().and_then(|v| match v {
-            crate::model::rag_vector_db_config::VectorDb::Pinecone(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
-    /// if it holds a `VertexVectorSearch`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertex_vector_search(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rag_vector_db_config::VertexVectorSearch>>
-    {
-        #[allow(unreachable_patterns)]
-        self.vector_db.as_ref().and_then(|v| match v {
-            crate::model::rag_vector_db_config::VectorDb::VertexVectorSearch(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
     /// to hold a `RagManagedDb`.
     ///
@@ -98307,6 +98276,21 @@ impl RagVectorDbConfig {
         self
     }
 
+    /// The value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
+    /// if it holds a `Pinecone`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pinecone(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rag_vector_db_config::Pinecone>> {
+        #[allow(unreachable_patterns)]
+        self.vector_db.as_ref().and_then(|v| match v {
+            crate::model::rag_vector_db_config::VectorDb::Pinecone(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
     /// to hold a `Pinecone`.
     ///
@@ -98322,6 +98306,22 @@ impl RagVectorDbConfig {
             crate::model::rag_vector_db_config::VectorDb::Pinecone(v.into()),
         );
         self
+    }
+
+    /// The value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
+    /// if it holds a `VertexVectorSearch`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertex_vector_search(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rag_vector_db_config::VertexVectorSearch>>
+    {
+        #[allow(unreachable_patterns)]
+        self.vector_db.as_ref().and_then(|v| match v {
+            crate::model::rag_vector_db_config::VectorDb::VertexVectorSearch(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [vector_db][crate::model::RagVectorDbConfig::vector_db]
@@ -99045,21 +99045,6 @@ impl RagCorpus {
         })
     }
 
-    /// The value of [backend_config][crate::model::RagCorpus::backend_config]
-    /// if it holds a `VertexAiSearchConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertex_ai_search_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexAiSearchConfig>> {
-        #[allow(unreachable_patterns)]
-        self.backend_config.as_ref().and_then(|v| match v {
-            crate::model::rag_corpus::BackendConfig::VertexAiSearchConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [backend_config][crate::model::RagCorpus::backend_config]
     /// to hold a `VectorDbConfig`.
     ///
@@ -99075,6 +99060,21 @@ impl RagCorpus {
             crate::model::rag_corpus::BackendConfig::VectorDbConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [backend_config][crate::model::RagCorpus::backend_config]
+    /// if it holds a `VertexAiSearchConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertex_ai_search_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexAiSearchConfig>> {
+        #[allow(unreachable_patterns)]
+        self.backend_config.as_ref().and_then(|v| match v {
+            crate::model::rag_corpus::BackendConfig::VertexAiSearchConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [backend_config][crate::model::RagCorpus::backend_config]
@@ -99240,6 +99240,20 @@ impl RagFile {
         })
     }
 
+    /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
+    /// to hold a `GcsSource`.
+    ///
+    /// Note that all the setters affecting `rag_file_source` are
+    /// mutually exclusive.
+    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rag_file_source =
+            std::option::Option::Some(crate::model::rag_file::RagFileSource::GcsSource(v.into()));
+        self
+    }
+
     /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
     /// if it holds a `GoogleDriveSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -99253,72 +99267,6 @@ impl RagFile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
-    /// if it holds a `DirectUploadSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn direct_upload_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DirectUploadSource>> {
-        #[allow(unreachable_patterns)]
-        self.rag_file_source.as_ref().and_then(|v| match v {
-            crate::model::rag_file::RagFileSource::DirectUploadSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
-    /// if it holds a `SlackSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn slack_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::SlackSource>> {
-        #[allow(unreachable_patterns)]
-        self.rag_file_source.as_ref().and_then(|v| match v {
-            crate::model::rag_file::RagFileSource::SlackSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
-    /// if it holds a `JiraSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn jira_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::JiraSource>> {
-        #[allow(unreachable_patterns)]
-        self.rag_file_source.as_ref().and_then(|v| match v {
-            crate::model::rag_file::RagFileSource::JiraSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
-    /// if it holds a `SharePointSources`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn share_point_sources(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SharePointSources>> {
-        #[allow(unreachable_patterns)]
-        self.rag_file_source.as_ref().and_then(|v| match v {
-            crate::model::rag_file::RagFileSource::SharePointSources(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `rag_file_source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rag_file_source =
-            std::option::Option::Some(crate::model::rag_file::RagFileSource::GcsSource(v.into()));
-        self
     }
 
     /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
@@ -99338,6 +99286,21 @@ impl RagFile {
         self
     }
 
+    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
+    /// if it holds a `DirectUploadSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn direct_upload_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DirectUploadSource>> {
+        #[allow(unreachable_patterns)]
+        self.rag_file_source.as_ref().and_then(|v| match v {
+            crate::model::rag_file::RagFileSource::DirectUploadSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
     /// to hold a `DirectUploadSource`.
     ///
@@ -99355,6 +99318,17 @@ impl RagFile {
         self
     }
 
+    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
+    /// if it holds a `SlackSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn slack_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::SlackSource>> {
+        #[allow(unreachable_patterns)]
+        self.rag_file_source.as_ref().and_then(|v| match v {
+            crate::model::rag_file::RagFileSource::SlackSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
     /// to hold a `SlackSource`.
     ///
@@ -99369,6 +99343,17 @@ impl RagFile {
         self
     }
 
+    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
+    /// if it holds a `JiraSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn jira_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::JiraSource>> {
+        #[allow(unreachable_patterns)]
+        self.rag_file_source.as_ref().and_then(|v| match v {
+            crate::model::rag_file::RagFileSource::JiraSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
     /// to hold a `JiraSource`.
     ///
@@ -99381,6 +99366,21 @@ impl RagFile {
         self.rag_file_source =
             std::option::Option::Some(crate::model::rag_file::RagFileSource::JiraSource(v.into()));
         self
+    }
+
+    /// The value of [rag_file_source][crate::model::RagFile::rag_file_source]
+    /// if it holds a `SharePointSources`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn share_point_sources(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SharePointSources>> {
+        #[allow(unreachable_patterns)]
+        self.rag_file_source.as_ref().and_then(|v| match v {
+            crate::model::rag_file::RagFileSource::SharePointSources(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rag_file_source][crate::model::RagFile::rag_file_source]
@@ -100031,62 +100031,6 @@ impl ImportRagFilesConfig {
         })
     }
 
-    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
-    /// if it holds a `GoogleDriveSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn google_drive_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GoogleDriveSource>> {
-        #[allow(unreachable_patterns)]
-        self.import_source.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_config::ImportSource::GoogleDriveSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
-    /// if it holds a `SlackSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn slack_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::SlackSource>> {
-        #[allow(unreachable_patterns)]
-        self.import_source.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_config::ImportSource::SlackSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
-    /// if it holds a `JiraSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn jira_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::JiraSource>> {
-        #[allow(unreachable_patterns)]
-        self.import_source.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_config::ImportSource::JiraSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
-    /// if it holds a `SharePointSources`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn share_point_sources(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SharePointSources>> {
-        #[allow(unreachable_patterns)]
-        self.import_source.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_config::ImportSource::SharePointSources(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [import_source][crate::model::ImportRagFilesConfig::import_source]
     /// to hold a `GcsSource`.
     ///
@@ -100100,6 +100044,21 @@ impl ImportRagFilesConfig {
             crate::model::import_rag_files_config::ImportSource::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
+    /// if it holds a `GoogleDriveSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn google_drive_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GoogleDriveSource>> {
+        #[allow(unreachable_patterns)]
+        self.import_source.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_config::ImportSource::GoogleDriveSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [import_source][crate::model::ImportRagFilesConfig::import_source]
@@ -100119,6 +100078,19 @@ impl ImportRagFilesConfig {
         self
     }
 
+    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
+    /// if it holds a `SlackSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn slack_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::SlackSource>> {
+        #[allow(unreachable_patterns)]
+        self.import_source.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_config::ImportSource::SlackSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [import_source][crate::model::ImportRagFilesConfig::import_source]
     /// to hold a `SlackSource`.
     ///
@@ -100134,6 +100106,19 @@ impl ImportRagFilesConfig {
         self
     }
 
+    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
+    /// if it holds a `JiraSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn jira_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::JiraSource>> {
+        #[allow(unreachable_patterns)]
+        self.import_source.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_config::ImportSource::JiraSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [import_source][crate::model::ImportRagFilesConfig::import_source]
     /// to hold a `JiraSource`.
     ///
@@ -100147,6 +100132,21 @@ impl ImportRagFilesConfig {
             crate::model::import_rag_files_config::ImportSource::JiraSource(v.into()),
         );
         self
+    }
+
+    /// The value of [import_source][crate::model::ImportRagFilesConfig::import_source]
+    /// if it holds a `SharePointSources`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn share_point_sources(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SharePointSources>> {
+        #[allow(unreachable_patterns)]
+        self.import_source.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_config::ImportSource::SharePointSources(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [import_source][crate::model::ImportRagFilesConfig::import_source]
@@ -100198,20 +100198,6 @@ impl ImportRagFilesConfig {
         })
     }
 
-    /// The value of [partial_failure_sink][crate::model::ImportRagFilesConfig::partial_failure_sink]
-    /// if it holds a `PartialFailureBigquerySink`, `None` if the field is not set or
-    /// holds a different branch.
-    #[deprecated]
-    pub fn partial_failure_bigquery_sink(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
-        #[allow(unreachable_patterns)]
-        self.partial_failure_sink.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_config::PartialFailureSink::PartialFailureBigquerySink(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [partial_failure_sink][crate::model::ImportRagFilesConfig::partial_failure_sink]
     /// to hold a `PartialFailureGcsSink`.
     ///
@@ -100230,6 +100216,20 @@ impl ImportRagFilesConfig {
             ),
         );
         self
+    }
+
+    /// The value of [partial_failure_sink][crate::model::ImportRagFilesConfig::partial_failure_sink]
+    /// if it holds a `PartialFailureBigquerySink`, `None` if the field is not set or
+    /// holds a different branch.
+    #[deprecated]
+    pub fn partial_failure_bigquery_sink(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
+        #[allow(unreachable_patterns)]
+        self.partial_failure_sink.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_config::PartialFailureSink::PartialFailureBigquerySink(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [partial_failure_sink][crate::model::ImportRagFilesConfig::partial_failure_sink]
@@ -100283,21 +100283,6 @@ impl ImportRagFilesConfig {
         })
     }
 
-    /// The value of [import_result_sink][crate::model::ImportRagFilesConfig::import_result_sink]
-    /// if it holds a `ImportResultBigquerySink`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn import_result_bigquery_sink(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
-        #[allow(unreachable_patterns)]
-        self.import_result_sink.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_config::ImportResultSink::ImportResultBigquerySink(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [import_result_sink][crate::model::ImportRagFilesConfig::import_result_sink]
     /// to hold a `ImportResultGcsSink`.
     ///
@@ -100313,6 +100298,21 @@ impl ImportRagFilesConfig {
             crate::model::import_rag_files_config::ImportResultSink::ImportResultGcsSink(v.into()),
         );
         self
+    }
+
+    /// The value of [import_result_sink][crate::model::ImportRagFilesConfig::import_result_sink]
+    /// if it holds a `ImportResultBigquerySink`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn import_result_bigquery_sink(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
+        #[allow(unreachable_patterns)]
+        self.import_result_sink.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_config::ImportResultSink::ImportResultBigquerySink(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [import_result_sink][crate::model::ImportRagFilesConfig::import_result_sink]
@@ -100604,12 +100604,6 @@ impl ListRagCorporaResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRagCorporaResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rag_corpora][crate::model::ListRagCorporaResponse::rag_corpora].
     pub fn set_rag_corpora<T, V>(mut self, v: T) -> Self
     where
@@ -100618,6 +100612,12 @@ impl ListRagCorporaResponse {
     {
         use std::iter::Iterator;
         self.rag_corpora = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRagCorporaResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -100818,19 +100818,6 @@ impl UploadRagFileResponse {
         })
     }
 
-    /// The value of [result][crate::model::UploadRagFileResponse::result]
-    /// if it holds a `Error`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::upload_rag_file_response::Result::Error(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::UploadRagFileResponse::result]
     /// to hold a `RagFile`.
     ///
@@ -100844,6 +100831,19 @@ impl UploadRagFileResponse {
             crate::model::upload_rag_file_response::Result::RagFile(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::UploadRagFileResponse::result]
+    /// if it holds a `Error`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::upload_rag_file_response::Result::Error(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::UploadRagFileResponse::result]
@@ -101034,17 +101034,6 @@ impl ImportRagFilesResponse {
         })
     }
 
-    /// The value of [partial_failure_sink][crate::model::ImportRagFilesResponse::partial_failure_sink]
-    /// if it holds a `PartialFailuresBigqueryTable`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn partial_failures_bigquery_table(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.partial_failure_sink.as_ref().and_then(|v| match v {
-            crate::model::import_rag_files_response::PartialFailureSink::PartialFailuresBigqueryTable(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [partial_failure_sink][crate::model::ImportRagFilesResponse::partial_failure_sink]
     /// to hold a `PartialFailuresGcsPath`.
     ///
@@ -101060,6 +101049,17 @@ impl ImportRagFilesResponse {
             ),
         );
         self
+    }
+
+    /// The value of [partial_failure_sink][crate::model::ImportRagFilesResponse::partial_failure_sink]
+    /// if it holds a `PartialFailuresBigqueryTable`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn partial_failures_bigquery_table(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.partial_failure_sink.as_ref().and_then(|v| match v {
+            crate::model::import_rag_files_response::PartialFailureSink::PartialFailuresBigqueryTable(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [partial_failure_sink][crate::model::ImportRagFilesResponse::partial_failure_sink]
@@ -101248,12 +101248,6 @@ impl ListRagFilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRagFilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rag_files][crate::model::ListRagFilesResponse::rag_files].
     pub fn set_rag_files<T, V>(mut self, v: T) -> Self
     where
@@ -101262,6 +101256,12 @@ impl ListRagFilesResponse {
     {
         use std::iter::Iterator;
         self.rag_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRagFilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -101779,16 +101779,6 @@ pub mod retrieve_contexts_request {
             std::default::Default::default()
         }
 
-        /// Sets the value of [vector_distance_threshold][crate::model::retrieve_contexts_request::VertexRagStore::vector_distance_threshold].
-        #[deprecated]
-        pub fn set_vector_distance_threshold<T: std::convert::Into<std::option::Option<f64>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.vector_distance_threshold = v.into();
-            self
-        }
-
         /// Sets the value of [rag_resources][crate::model::retrieve_contexts_request::VertexRagStore::rag_resources].
         pub fn set_rag_resources<T, V>(mut self, v: T) -> Self
         where
@@ -101799,6 +101789,16 @@ pub mod retrieve_contexts_request {
         {
             use std::iter::Iterator;
             self.rag_resources = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [vector_distance_threshold][crate::model::retrieve_contexts_request::VertexRagStore::vector_distance_threshold].
+        #[deprecated]
+        pub fn set_vector_distance_threshold<T: std::convert::Into<std::option::Option<f64>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.vector_distance_threshold = v.into();
             self
         }
     }
@@ -102104,17 +102104,6 @@ impl AugmentPromptRequest {
         self
     }
 
-    /// Sets the value of [model][crate::model::AugmentPromptRequest::model].
-    pub fn set_model<
-        T: std::convert::Into<std::option::Option<crate::model::augment_prompt_request::Model>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model = v.into();
-        self
-    }
-
     /// Sets the value of [contents][crate::model::AugmentPromptRequest::contents].
     pub fn set_contents<T, V>(mut self, v: T) -> Self
     where
@@ -102123,6 +102112,17 @@ impl AugmentPromptRequest {
     {
         use std::iter::Iterator;
         self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [model][crate::model::AugmentPromptRequest::model].
+    pub fn set_model<
+        T: std::convert::Into<std::option::Option<crate::model::augment_prompt_request::Model>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.model = v.into();
         self
     }
 
@@ -102355,6 +102355,17 @@ impl CorroborateContentRequest {
         self
     }
 
+    /// Sets the value of [facts][crate::model::CorroborateContentRequest::facts].
+    pub fn set_facts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Fact>,
+    {
+        use std::iter::Iterator;
+        self.facts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [parameters][crate::model::CorroborateContentRequest::parameters].
     pub fn set_parameters<
         T: std::convert::Into<
@@ -102365,17 +102376,6 @@ impl CorroborateContentRequest {
         v: T,
     ) -> Self {
         self.parameters = v.into();
-        self
-    }
-
-    /// Sets the value of [facts][crate::model::CorroborateContentRequest::facts].
-    pub fn set_facts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Fact>,
-    {
-        use std::iter::Iterator;
-        self.facts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -102655,12 +102655,6 @@ impl Claim {
         self
     }
 
-    /// Sets the value of [score][crate::model::Claim::score].
-    pub fn set_score<T: std::convert::Into<std::option::Option<f32>>>(mut self, v: T) -> Self {
-        self.score = v.into();
-        self
-    }
-
     /// Sets the value of [fact_indexes][crate::model::Claim::fact_indexes].
     pub fn set_fact_indexes<T, V>(mut self, v: T) -> Self
     where
@@ -102669,6 +102663,12 @@ impl Claim {
     {
         use std::iter::Iterator;
         self.fact_indexes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [score][crate::model::Claim::score].
+    pub fn set_score<T: std::convert::Into<std::option::Option<f32>>>(mut self, v: T) -> Self {
+        self.score = v.into();
         self
     }
 }
@@ -102862,12 +102862,6 @@ impl ListStudiesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListStudiesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [studies][crate::model::ListStudiesResponse::studies].
     pub fn set_studies<T, V>(mut self, v: T) -> Self
     where
@@ -102876,6 +102870,12 @@ impl ListStudiesResponse {
     {
         use std::iter::Iterator;
         self.studies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListStudiesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -103139,6 +103139,17 @@ impl SuggestTrialsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [trials][crate::model::SuggestTrialsResponse::trials].
+    pub fn set_trials<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Trial>,
+    {
+        use std::iter::Iterator;
+        self.trials = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [study_state][crate::model::SuggestTrialsResponse::study_state].
     pub fn set_study_state<T: std::convert::Into<crate::model::study::State>>(
         mut self,
@@ -103163,17 +103174,6 @@ impl SuggestTrialsResponse {
         v: T,
     ) -> Self {
         self.end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [trials][crate::model::SuggestTrialsResponse::trials].
-    pub fn set_trials<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Trial>,
-    {
-        use std::iter::Iterator;
-        self.trials = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -103422,12 +103422,6 @@ impl ListTrialsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTrialsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [trials][crate::model::ListTrialsResponse::trials].
     pub fn set_trials<T, V>(mut self, v: T) -> Self
     where
@@ -103436,6 +103430,12 @@ impl ListTrialsResponse {
     {
         use std::iter::Iterator;
         self.trials = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTrialsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -1216,23 +1216,6 @@ impl AutomatedBackupPolicy {
         })
     }
 
-    /// The value of [retention][crate::model::AutomatedBackupPolicy::retention]
-    /// if it holds a `QuantityBasedRetention`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn quantity_based_retention(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::automated_backup_policy::QuantityBasedRetention>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.retention.as_ref().and_then(|v| match v {
-            crate::model::automated_backup_policy::Retention::QuantityBasedRetention(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [retention][crate::model::AutomatedBackupPolicy::retention]
     /// to hold a `TimeBasedRetention`.
     ///
@@ -1250,6 +1233,23 @@ impl AutomatedBackupPolicy {
             crate::model::automated_backup_policy::Retention::TimeBasedRetention(v.into()),
         );
         self
+    }
+
+    /// The value of [retention][crate::model::AutomatedBackupPolicy::retention]
+    /// if it holds a `QuantityBasedRetention`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn quantity_based_retention(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::automated_backup_policy::QuantityBasedRetention>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.retention.as_ref().and_then(|v| match v {
+            crate::model::automated_backup_policy::Retention::QuantityBasedRetention(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [retention][crate::model::AutomatedBackupPolicy::retention]
@@ -1575,17 +1575,6 @@ impl ContinuousBackupInfo {
         self
     }
 
-    /// Sets the value of [earliest_restorable_time][crate::model::ContinuousBackupInfo::earliest_restorable_time].
-    pub fn set_earliest_restorable_time<
-        T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.earliest_restorable_time = v.into();
-        self
-    }
-
     /// Sets the value of [schedule][crate::model::ContinuousBackupInfo::schedule].
     pub fn set_schedule<T, V>(mut self, v: T) -> Self
     where
@@ -1594,6 +1583,17 @@ impl ContinuousBackupInfo {
     {
         use std::iter::Iterator;
         self.schedule = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [earliest_restorable_time][crate::model::ContinuousBackupInfo::earliest_restorable_time].
+    pub fn set_earliest_restorable_time<
+        T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.earliest_restorable_time = v.into();
         self
     }
 }
@@ -2058,6 +2058,18 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Cluster::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Cluster::state].
     pub fn set_state<T: std::convert::Into<crate::model::cluster::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -2103,6 +2115,18 @@ impl Cluster {
     /// Sets the value of [etag][crate::model::Cluster::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Cluster::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2269,30 +2293,6 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Cluster::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Cluster::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [tags][crate::model::Cluster::tags].
     pub fn set_tags<T, K, V>(mut self, v: T) -> Self
     where
@@ -2330,19 +2330,6 @@ impl Cluster {
         })
     }
 
-    /// The value of [source][crate::model::Cluster::source]
-    /// if it holds a `MigrationSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn migration_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MigrationSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::cluster::Source::MigrationSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::Cluster::source]
     /// to hold a `BackupSource`.
     ///
@@ -2355,6 +2342,19 @@ impl Cluster {
         self.source =
             std::option::Option::Some(crate::model::cluster::Source::BackupSource(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::Cluster::source]
+    /// if it holds a `MigrationSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn migration_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MigrationSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::cluster::Source::MigrationSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::Cluster::source]
@@ -3176,6 +3176,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Instance::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -3219,6 +3231,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [database_flags][crate::model::Instance::database_flags].
+    pub fn set_database_flags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.database_flags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [writable_node][crate::model::Instance::writable_node].
     pub fn set_writable_node<
         T: std::convert::Into<std::option::Option<crate::model::instance::Node>>,
@@ -3227,6 +3251,17 @@ impl Instance {
         v: T,
     ) -> Self {
         self.writable_node = v.into();
+        self
+    }
+
+    /// Sets the value of [nodes][crate::model::Instance::nodes].
+    pub fn set_nodes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::instance::Node>,
+    {
+        use std::iter::Iterator;
+        self.nodes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3281,6 +3316,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Instance::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [client_connection_config][crate::model::Instance::client_connection_config].
     pub fn set_client_connection_config<
         T: std::convert::Into<std::option::Option<crate::model::instance::ClientConnectionConfig>>,
@@ -3320,17 +3367,6 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [nodes][crate::model::Instance::nodes].
-    pub fn set_nodes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::instance::Node>,
-    {
-        use std::iter::Iterator;
-        self.nodes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [outbound_public_ip_addresses][crate::model::Instance::outbound_public_ip_addresses].
     pub fn set_outbound_public_ip_addresses<T, V>(mut self, v: T) -> Self
     where
@@ -3339,42 +3375,6 @@ impl Instance {
     {
         use std::iter::Iterator;
         self.outbound_public_ip_addresses = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [database_flags][crate::model::Instance::database_flags].
-    pub fn set_database_flags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.database_flags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Instance::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3687,15 +3687,6 @@ pub mod instance {
             self
         }
 
-        /// Sets the value of [psc_dns_name][crate::model::instance::PscInstanceConfig::psc_dns_name].
-        pub fn set_psc_dns_name<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.psc_dns_name = v.into();
-            self
-        }
-
         /// Sets the value of [allowed_consumer_projects][crate::model::instance::PscInstanceConfig::allowed_consumer_projects].
         pub fn set_allowed_consumer_projects<T, V>(mut self, v: T) -> Self
         where
@@ -3704,6 +3695,15 @@ pub mod instance {
         {
             use std::iter::Iterator;
             self.allowed_consumer_projects = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [psc_dns_name][crate::model::instance::PscInstanceConfig::psc_dns_name].
+        pub fn set_psc_dns_name<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.psc_dns_name = v.into();
             self
         }
     }
@@ -3743,18 +3743,6 @@ pub mod instance {
             std::default::Default::default()
         }
 
-        /// Sets the value of [enable_public_ip][crate::model::instance::InstanceNetworkConfig::enable_public_ip].
-        pub fn set_enable_public_ip<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.enable_public_ip = v.into();
-            self
-        }
-
-        /// Sets the value of [enable_outbound_public_ip][crate::model::instance::InstanceNetworkConfig::enable_outbound_public_ip].
-        pub fn set_enable_outbound_public_ip<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.enable_outbound_public_ip = v.into();
-            self
-        }
-
         /// Sets the value of [authorized_external_networks][crate::model::instance::InstanceNetworkConfig::authorized_external_networks].
         pub fn set_authorized_external_networks<T, V>(mut self, v: T) -> Self
         where
@@ -3765,6 +3753,18 @@ pub mod instance {
         {
             use std::iter::Iterator;
             self.authorized_external_networks = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [enable_public_ip][crate::model::instance::InstanceNetworkConfig::enable_public_ip].
+        pub fn set_enable_public_ip<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.enable_public_ip = v.into();
+            self
+        }
+
+        /// Sets the value of [enable_outbound_public_ip][crate::model::instance::InstanceNetworkConfig::enable_outbound_public_ip].
+        pub fn set_enable_outbound_public_ip<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.enable_outbound_public_ip = v.into();
             self
         }
     }
@@ -4534,6 +4534,18 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Backup::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Backup::state].
     pub fn set_state<T: std::convert::Into<crate::model::backup::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -4598,6 +4610,18 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Backup::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [size_bytes][crate::model::Backup::size_bytes].
     pub fn set_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.size_bytes = v.into();
@@ -4636,30 +4660,6 @@ impl Backup {
         v: T,
     ) -> Self {
         self.database_version = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Backup::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Backup::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5114,12 +5114,6 @@ impl SupportedDatabaseFlag {
         self
     }
 
-    /// Sets the value of [requires_db_restart][crate::model::SupportedDatabaseFlag::requires_db_restart].
-    pub fn set_requires_db_restart<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.requires_db_restart = v.into();
-        self
-    }
-
     /// Sets the value of [supported_db_versions][crate::model::SupportedDatabaseFlag::supported_db_versions].
     pub fn set_supported_db_versions<T, V>(mut self, v: T) -> Self
     where
@@ -5128,6 +5122,12 @@ impl SupportedDatabaseFlag {
     {
         use std::iter::Iterator;
         self.supported_db_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [requires_db_restart][crate::model::SupportedDatabaseFlag::requires_db_restart].
+    pub fn set_requires_db_restart<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.requires_db_restart = v.into();
         self
     }
 
@@ -5164,23 +5164,6 @@ impl SupportedDatabaseFlag {
         })
     }
 
-    /// The value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
-    /// if it holds a `IntegerRestrictions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn integer_restrictions(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::supported_database_flag::IntegerRestrictions>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.restrictions.as_ref().and_then(|v| match v {
-            crate::model::supported_database_flag::Restrictions::IntegerRestrictions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
     /// to hold a `StringRestrictions`.
     ///
@@ -5198,6 +5181,23 @@ impl SupportedDatabaseFlag {
             crate::model::supported_database_flag::Restrictions::StringRestrictions(v.into()),
         );
         self
+    }
+
+    /// The value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
+    /// if it holds a `IntegerRestrictions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn integer_restrictions(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::supported_database_flag::IntegerRestrictions>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.restrictions.as_ref().and_then(|v| match v {
+            crate::model::supported_database_flag::Restrictions::IntegerRestrictions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
@@ -5532,6 +5532,17 @@ impl User {
         self
     }
 
+    /// Sets the value of [database_roles][crate::model::User::database_roles].
+    pub fn set_database_roles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.database_roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [user_type][crate::model::User::user_type].
     pub fn set_user_type<T: std::convert::Into<crate::model::user::UserType>>(
         mut self,
@@ -5544,17 +5555,6 @@ impl User {
     /// Sets the value of [keep_extra_roles][crate::model::User::keep_extra_roles].
     pub fn set_keep_extra_roles<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.keep_extra_roles = v.into();
-        self
-    }
-
-    /// Sets the value of [database_roles][crate::model::User::database_roles].
-    pub fn set_database_roles<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.database_roles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5865,12 +5865,6 @@ impl ListClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
     pub fn set_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -5879,6 +5873,12 @@ impl ListClustersResponse {
     {
         use std::iter::Iterator;
         self.clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6586,21 +6586,6 @@ impl RestoreClusterRequest {
         })
     }
 
-    /// The value of [source][crate::model::RestoreClusterRequest::source]
-    /// if it holds a `ContinuousBackupSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn continuous_backup_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ContinuousBackupSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::restore_cluster_request::Source::ContinuousBackupSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::RestoreClusterRequest::source]
     /// to hold a `BackupSource`.
     ///
@@ -6614,6 +6599,21 @@ impl RestoreClusterRequest {
             crate::model::restore_cluster_request::Source::BackupSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::RestoreClusterRequest::source]
+    /// if it holds a `ContinuousBackupSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn continuous_backup_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ContinuousBackupSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::restore_cluster_request::Source::ContinuousBackupSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::RestoreClusterRequest::source]
@@ -6765,12 +6765,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -6779,6 +6773,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8196,17 +8196,6 @@ impl ExecuteSqlResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [metadata][crate::model::ExecuteSqlResponse::metadata].
-    pub fn set_metadata<
-        T: std::convert::Into<std::option::Option<crate::model::ExecuteSqlMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [sql_results][crate::model::ExecuteSqlResponse::sql_results].
     pub fn set_sql_results<T, V>(mut self, v: T) -> Self
     where
@@ -8215,6 +8204,17 @@ impl ExecuteSqlResponse {
     {
         use std::iter::Iterator;
         self.sql_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::ExecuteSqlResponse::metadata].
+    pub fn set_metadata<
+        T: std::convert::Into<std::option::Option<crate::model::ExecuteSqlMetadata>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -8551,12 +8551,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -8565,6 +8559,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8977,12 +8977,6 @@ impl ListSupportedDatabaseFlagsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSupportedDatabaseFlagsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [supported_database_flags][crate::model::ListSupportedDatabaseFlagsResponse::supported_database_flags].
     pub fn set_supported_database_flags<T, V>(mut self, v: T) -> Self
     where
@@ -8991,6 +8985,12 @@ impl ListSupportedDatabaseFlagsResponse {
     {
         use std::iter::Iterator;
         self.supported_database_flags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSupportedDatabaseFlagsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9135,12 +9135,6 @@ impl GenerateClientCertificateResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [ca_cert][crate::model::GenerateClientCertificateResponse::ca_cert].
-    pub fn set_ca_cert<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.ca_cert = v.into();
-        self
-    }
-
     /// Sets the value of [pem_certificate_chain][crate::model::GenerateClientCertificateResponse::pem_certificate_chain].
     pub fn set_pem_certificate_chain<T, V>(mut self, v: T) -> Self
     where
@@ -9149,6 +9143,12 @@ impl GenerateClientCertificateResponse {
     {
         use std::iter::Iterator;
         self.pem_certificate_chain = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ca_cert][crate::model::GenerateClientCertificateResponse::ca_cert].
+    pub fn set_ca_cert<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.ca_cert = v.into();
         self
     }
 }
@@ -9485,12 +9485,6 @@ impl ListUsersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUsersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [users][crate::model::ListUsersResponse::users].
     pub fn set_users<T, V>(mut self, v: T) -> Self
     where
@@ -9499,6 +9493,12 @@ impl ListUsersResponse {
     {
         use std::iter::Iterator;
         self.users = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUsersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -9908,12 +9908,6 @@ impl ListDatabasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatabasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [databases][crate::model::ListDatabasesResponse::databases].
     pub fn set_databases<T, V>(mut self, v: T) -> Self
     where
@@ -9922,6 +9916,12 @@ impl ListDatabasesResponse {
     {
         use std::iter::Iterator;
         self.databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatabasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/apigateway/v1/src/model.rs
+++ b/src/generated/cloud/apigateway/v1/src/model.rs
@@ -104,6 +104,18 @@ impl Api {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Api::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::Api::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -119,18 +131,6 @@ impl Api {
     /// Sets the value of [state][crate::model::Api::state].
     pub fn set_state<T: std::convert::Into<crate::model::api::State>>(mut self, v: T) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Api::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -407,6 +407,18 @@ impl ApiConfig {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ApiConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::ApiConfig::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -470,18 +482,6 @@ impl ApiConfig {
     {
         use std::iter::Iterator;
         self.managed_service_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ApiConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -878,6 +878,18 @@ impl Gateway {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Gateway::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::Gateway::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -902,18 +914,6 @@ impl Gateway {
         v: T,
     ) -> Self {
         self.default_hostname = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Gateway::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1183,12 +1183,6 @@ impl ListGatewaysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGatewaysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [gateways][crate::model::ListGatewaysResponse::gateways].
     pub fn set_gateways<T, V>(mut self, v: T) -> Self
     where
@@ -1197,6 +1191,12 @@ impl ListGatewaysResponse {
     {
         use std::iter::Iterator;
         self.gateways = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGatewaysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1507,12 +1507,6 @@ impl ListApisResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListApisResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [apis][crate::model::ListApisResponse::apis].
     pub fn set_apis<T, V>(mut self, v: T) -> Self
     where
@@ -1521,6 +1515,12 @@ impl ListApisResponse {
     {
         use std::iter::Iterator;
         self.apis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListApisResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1831,12 +1831,6 @@ impl ListApiConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListApiConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [api_configs][crate::model::ListApiConfigsResponse::api_configs].
     pub fn set_api_configs<T, V>(mut self, v: T) -> Self
     where
@@ -1845,6 +1839,12 @@ impl ListApiConfigsResponse {
     {
         use std::iter::Iterator;
         self.api_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListApiConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -115,12 +115,6 @@ impl ListConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connections][crate::model::ListConnectionsResponse::connections].
     pub fn set_connections<T, V>(mut self, v: T) -> Self
     where
@@ -129,6 +123,12 @@ impl ListConnectionsResponse {
     {
         use std::iter::Iterator;
         self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -382,28 +382,6 @@ impl Payload {
         })
     }
 
-    /// The value of [kind][crate::model::Payload::kind]
-    /// if it holds a `StreamInfo`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn stream_info(&self) -> std::option::Option<&std::boxed::Box<crate::model::StreamInfo>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::payload::Kind::StreamInfo(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::Payload::kind]
-    /// if it holds a `Action`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn action(&self) -> std::option::Option<&crate::model::Action> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::payload::Kind::Action(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [kind][crate::model::Payload::kind]
     /// to hold a `HttpRequest`.
     ///
@@ -417,6 +395,17 @@ impl Payload {
         self
     }
 
+    /// The value of [kind][crate::model::Payload::kind]
+    /// if it holds a `StreamInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn stream_info(&self) -> std::option::Option<&std::boxed::Box<crate::model::StreamInfo>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::payload::Kind::StreamInfo(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::Payload::kind]
     /// to hold a `StreamInfo`.
     ///
@@ -428,6 +417,17 @@ impl Payload {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::payload::Kind::StreamInfo(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::Payload::kind]
+    /// if it holds a `Action`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn action(&self) -> std::option::Option<&crate::model::Action> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::payload::Kind::Action(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::Payload::kind]
@@ -661,12 +661,6 @@ impl HttpRequest {
         self
     }
 
-    /// Sets the value of [body][crate::model::HttpRequest::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::HttpRequest::headers].
     pub fn set_headers<T, V>(mut self, v: T) -> Self
     where
@@ -675,6 +669,12 @@ impl HttpRequest {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::HttpRequest::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 }
@@ -854,12 +854,6 @@ impl HttpResponse {
         self
     }
 
-    /// Sets the value of [content_length][crate::model::HttpResponse::content_length].
-    pub fn set_content_length<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.content_length = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::HttpResponse::headers].
     pub fn set_headers<T, V>(mut self, v: T) -> Self
     where
@@ -868,6 +862,12 @@ impl HttpResponse {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [content_length][crate::model::HttpResponse::content_length].
+    pub fn set_content_length<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.content_length = v.into();
         self
     }
 }

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -402,12 +402,6 @@ impl ListApisResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListApisResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [apis][crate::model::ListApisResponse::apis].
     pub fn set_apis<T, V>(mut self, v: T) -> Self
     where
@@ -416,6 +410,12 @@ impl ListApisResponse {
     {
         use std::iter::Iterator;
         self.apis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListApisResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -805,12 +805,6 @@ impl ListVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [versions][crate::model::ListVersionsResponse::versions].
     pub fn set_versions<T, V>(mut self, v: T) -> Self
     where
@@ -819,6 +813,12 @@ impl ListVersionsResponse {
     {
         use std::iter::Iterator;
         self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1185,12 +1185,6 @@ impl ListSpecsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSpecsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [specs][crate::model::ListSpecsResponse::specs].
     pub fn set_specs<T, V>(mut self, v: T) -> Self
     where
@@ -1199,6 +1193,12 @@ impl ListSpecsResponse {
     {
         use std::iter::Iterator;
         self.specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSpecsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1441,12 +1441,6 @@ impl ListApiOperationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListApiOperationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [api_operations][crate::model::ListApiOperationsResponse::api_operations].
     pub fn set_api_operations<T, V>(mut self, v: T) -> Self
     where
@@ -1455,6 +1449,12 @@ impl ListApiOperationsResponse {
     {
         use std::iter::Iterator;
         self.api_operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListApiOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1869,12 +1869,6 @@ impl ListDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::ListDeploymentsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -1883,6 +1877,12 @@ impl ListDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2246,12 +2246,6 @@ impl ListAttributesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAttributesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [attributes][crate::model::ListAttributesResponse::attributes].
     pub fn set_attributes<T, V>(mut self, v: T) -> Self
     where
@@ -2260,6 +2254,12 @@ impl ListAttributesResponse {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAttributesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2439,61 +2439,6 @@ impl ApiHubResource {
         })
     }
 
-    /// The value of [resource][crate::model::ApiHubResource::resource]
-    /// if it holds a `Operation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn operation(&self) -> std::option::Option<&std::boxed::Box<crate::model::ApiOperation>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::api_hub_resource::Resource::Operation(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::ApiHubResource::resource]
-    /// if it holds a `Deployment`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deployment(&self) -> std::option::Option<&std::boxed::Box<crate::model::Deployment>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::api_hub_resource::Resource::Deployment(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::ApiHubResource::resource]
-    /// if it holds a `Spec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::Spec>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::api_hub_resource::Resource::Spec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::ApiHubResource::resource]
-    /// if it holds a `Definition`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn definition(&self) -> std::option::Option<&std::boxed::Box<crate::model::Definition>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::api_hub_resource::Resource::Definition(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::ApiHubResource::resource]
-    /// if it holds a `Version`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn version(&self) -> std::option::Option<&std::boxed::Box<crate::model::Version>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::api_hub_resource::Resource::Version(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [resource][crate::model::ApiHubResource::resource]
     /// to hold a `Api`.
     ///
@@ -2506,6 +2451,17 @@ impl ApiHubResource {
         self.resource =
             std::option::Option::Some(crate::model::api_hub_resource::Resource::Api(v.into()));
         self
+    }
+
+    /// The value of [resource][crate::model::ApiHubResource::resource]
+    /// if it holds a `Operation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn operation(&self) -> std::option::Option<&std::boxed::Box<crate::model::ApiOperation>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::api_hub_resource::Resource::Operation(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource][crate::model::ApiHubResource::resource]
@@ -2523,6 +2479,17 @@ impl ApiHubResource {
         self
     }
 
+    /// The value of [resource][crate::model::ApiHubResource::resource]
+    /// if it holds a `Deployment`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deployment(&self) -> std::option::Option<&std::boxed::Box<crate::model::Deployment>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::api_hub_resource::Resource::Deployment(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [resource][crate::model::ApiHubResource::resource]
     /// to hold a `Deployment`.
     ///
@@ -2536,6 +2503,17 @@ impl ApiHubResource {
             crate::model::api_hub_resource::Resource::Deployment(v.into()),
         );
         self
+    }
+
+    /// The value of [resource][crate::model::ApiHubResource::resource]
+    /// if it holds a `Spec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::Spec>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::api_hub_resource::Resource::Spec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource][crate::model::ApiHubResource::resource]
@@ -2552,6 +2530,17 @@ impl ApiHubResource {
         self
     }
 
+    /// The value of [resource][crate::model::ApiHubResource::resource]
+    /// if it holds a `Definition`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn definition(&self) -> std::option::Option<&std::boxed::Box<crate::model::Definition>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::api_hub_resource::Resource::Definition(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [resource][crate::model::ApiHubResource::resource]
     /// to hold a `Definition`.
     ///
@@ -2565,6 +2554,17 @@ impl ApiHubResource {
             crate::model::api_hub_resource::Resource::Definition(v.into()),
         );
         self
+    }
+
+    /// The value of [resource][crate::model::ApiHubResource::resource]
+    /// if it holds a `Version`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn version(&self) -> std::option::Option<&std::boxed::Box<crate::model::Version>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::api_hub_resource::Resource::Version(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource][crate::model::ApiHubResource::resource]
@@ -2688,12 +2688,6 @@ impl SearchResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [search_results][crate::model::SearchResourcesResponse::search_results].
     pub fn set_search_results<T, V>(mut self, v: T) -> Self
     where
@@ -2702,6 +2696,12 @@ impl SearchResourcesResponse {
     {
         use std::iter::Iterator;
         self.search_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3056,12 +3056,6 @@ impl ListDependenciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDependenciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [dependencies][crate::model::ListDependenciesResponse::dependencies].
     pub fn set_dependencies<T, V>(mut self, v: T) -> Self
     where
@@ -3070,6 +3064,12 @@ impl ListDependenciesResponse {
     {
         use std::iter::Iterator;
         self.dependencies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDependenciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3388,12 +3388,6 @@ impl ListExternalApisResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExternalApisResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [external_apis][crate::model::ListExternalApisResponse::external_apis].
     pub fn set_external_apis<T, V>(mut self, v: T) -> Self
     where
@@ -3402,6 +3396,12 @@ impl ListExternalApisResponse {
     {
         use std::iter::Iterator;
         self.external_apis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExternalApisResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3586,6 +3586,17 @@ impl Api {
         self
     }
 
+    /// Sets the value of [versions][crate::model::Api::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Api::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -3646,6 +3657,18 @@ impl Api {
         self
     }
 
+    /// Sets the value of [attributes][crate::model::Api::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::AttributeValues>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [api_style][crate::model::Api::api_style].
     pub fn set_api_style<
         T: std::convert::Into<std::option::Option<crate::model::AttributeValues>>,
@@ -3663,29 +3686,6 @@ impl Api {
         v: T,
     ) -> Self {
         self.selected_version = v.into();
-        self
-    }
-
-    /// Sets the value of [versions][crate::model::Api::versions].
-    pub fn set_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.versions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [attributes][crate::model::Api::attributes].
-    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::AttributeValues>,
-    {
-        use std::iter::Iterator;
-        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3845,6 +3845,50 @@ impl Version {
         self
     }
 
+    /// Sets the value of [specs][crate::model::Version::specs].
+    pub fn set_specs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [api_operations][crate::model::Version::api_operations].
+    pub fn set_api_operations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.api_operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [definitions][crate::model::Version::definitions].
+    pub fn set_definitions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.definitions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [deployments][crate::model::Version::deployments].
+    pub fn set_deployments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Version::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -3896,59 +3940,6 @@ impl Version {
         self
     }
 
-    /// Sets the value of [selected_deployment][crate::model::Version::selected_deployment].
-    pub fn set_selected_deployment<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.selected_deployment = v.into();
-        self
-    }
-
-    /// Sets the value of [specs][crate::model::Version::specs].
-    pub fn set_specs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.specs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [api_operations][crate::model::Version::api_operations].
-    pub fn set_api_operations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.api_operations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [definitions][crate::model::Version::definitions].
-    pub fn set_definitions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.definitions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [deployments][crate::model::Version::deployments].
-    pub fn set_deployments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.deployments = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [attributes][crate::model::Version::attributes].
     pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
     where
@@ -3958,6 +3949,15 @@ impl Version {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [selected_deployment][crate::model::Version::selected_deployment].
+    pub fn set_selected_deployment<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.selected_deployment = v.into();
         self
     }
 }
@@ -4127,6 +4127,18 @@ impl Spec {
         self
     }
 
+    /// Sets the value of [attributes][crate::model::Spec::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::AttributeValues>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [documentation][crate::model::Spec::documentation].
     pub fn set_documentation<
         T: std::convert::Into<std::option::Option<crate::model::Documentation>>,
@@ -4144,18 +4156,6 @@ impl Spec {
         v: T,
     ) -> Self {
         self.parsing_mode = v.into();
-        self
-    }
-
-    /// Sets the value of [attributes][crate::model::Spec::attributes].
-    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::AttributeValues>,
-    {
-        use std::iter::Iterator;
-        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4462,6 +4462,28 @@ impl Deployment {
         self
     }
 
+    /// Sets the value of [endpoints][crate::model::Deployment::endpoints].
+    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [api_versions][crate::model::Deployment::api_versions].
+    pub fn set_api_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.api_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Deployment::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -4497,28 +4519,6 @@ impl Deployment {
         v: T,
     ) -> Self {
         self.environment = v.into();
-        self
-    }
-
-    /// Sets the value of [endpoints][crate::model::Deployment::endpoints].
-    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.endpoints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [api_versions][crate::model::Deployment::api_versions].
-    pub fn set_api_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.api_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5056,6 +5056,17 @@ impl Attribute {
         self
     }
 
+    /// Sets the value of [allowed_values][crate::model::Attribute::allowed_values].
+    pub fn set_allowed_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::attribute::AllowedValue>,
+    {
+        use std::iter::Iterator;
+        self.allowed_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cardinality][crate::model::Attribute::cardinality].
     pub fn set_cardinality<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.cardinality = v.into();
@@ -5083,17 +5094,6 @@ impl Attribute {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [allowed_values][crate::model::Attribute::allowed_values].
-    pub fn set_allowed_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::attribute::AllowedValue>,
-    {
-        use std::iter::Iterator;
-        self.allowed_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6569,34 +6569,6 @@ impl AttributeValues {
         })
     }
 
-    /// The value of [value][crate::model::AttributeValues::value]
-    /// if it holds a `StringValues`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_values(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::attribute_values::StringAttributeValues>>
-    {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::attribute_values::Value::StringValues(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::AttributeValues::value]
-    /// if it holds a `JsonValues`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn json_values(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::attribute_values::StringAttributeValues>>
-    {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::attribute_values::Value::JsonValues(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::AttributeValues::value]
     /// to hold a `EnumValues`.
     ///
@@ -6611,6 +6583,20 @@ impl AttributeValues {
         self.value =
             std::option::Option::Some(crate::model::attribute_values::Value::EnumValues(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::AttributeValues::value]
+    /// if it holds a `StringValues`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_values(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::attribute_values::StringAttributeValues>>
+    {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_values::Value::StringValues(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::AttributeValues::value]
@@ -6628,6 +6614,20 @@ impl AttributeValues {
             crate::model::attribute_values::Value::StringValues(v.into()),
         );
         self
+    }
+
+    /// The value of [value][crate::model::AttributeValues::value]
+    /// if it holds a `JsonValues`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn json_values(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::attribute_values::StringAttributeValues>>
+    {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_values::Value::JsonValues(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::AttributeValues::value]
@@ -7238,19 +7238,6 @@ impl DependencyEntityReference {
         })
     }
 
-    /// The value of [identifier][crate::model::DependencyEntityReference::identifier]
-    /// if it holds a `ExternalApiResourceName`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn external_api_resource_name(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::dependency_entity_reference::Identifier::ExternalApiResourceName(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [identifier][crate::model::DependencyEntityReference::identifier]
     /// to hold a `OperationResourceName`.
     ///
@@ -7264,6 +7251,19 @@ impl DependencyEntityReference {
             crate::model::dependency_entity_reference::Identifier::OperationResourceName(v.into()),
         );
         self
+    }
+
+    /// The value of [identifier][crate::model::DependencyEntityReference::identifier]
+    /// if it holds a `ExternalApiResourceName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn external_api_resource_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::dependency_entity_reference::Identifier::ExternalApiResourceName(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [identifier][crate::model::DependencyEntityReference::identifier]
@@ -7535,6 +7535,28 @@ impl LintResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [issues][crate::model::LintResponse::issues].
+    pub fn set_issues<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Issue>,
+    {
+        use std::iter::Iterator;
+        self.issues = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [summary][crate::model::LintResponse::summary].
+    pub fn set_summary<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::lint_response::SummaryEntry>,
+    {
+        use std::iter::Iterator;
+        self.summary = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::LintResponse::state].
     pub fn set_state<T: std::convert::Into<crate::model::LintState>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -7559,28 +7581,6 @@ impl LintResponse {
         v: T,
     ) -> Self {
         self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [issues][crate::model::LintResponse::issues].
-    pub fn set_issues<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Issue>,
-    {
-        use std::iter::Iterator;
-        self.issues = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [summary][crate::model::LintResponse::summary].
-    pub fn set_summary<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::lint_response::SummaryEntry>,
-    {
-        use std::iter::Iterator;
-        self.summary = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7679,6 +7679,17 @@ impl Issue {
         self
     }
 
+    /// Sets the value of [path][crate::model::Issue::path].
+    pub fn set_path<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.path = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [message][crate::model::Issue::message].
     pub fn set_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.message = v.into();
@@ -7697,17 +7708,6 @@ impl Issue {
         v: T,
     ) -> Self {
         self.range = v.into();
-        self
-    }
-
-    /// Sets the value of [path][crate::model::Issue::path].
-    pub fn set_path<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.path = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8013,12 +8013,6 @@ impl ApiHubInstance {
         self
     }
 
-    /// Sets the value of [description][crate::model::ApiHubInstance::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::ApiHubInstance::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -8028,6 +8022,12 @@ impl ApiHubInstance {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::ApiHubInstance::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
         self
     }
 }
@@ -8318,35 +8318,6 @@ impl ExternalApi {
         self
     }
 
-    /// Sets the value of [documentation][crate::model::ExternalApi::documentation].
-    pub fn set_documentation<
-        T: std::convert::Into<std::option::Option<crate::model::Documentation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.documentation = v.into();
-        self
-    }
-
-    /// Sets the value of [create_time][crate::model::ExternalApi::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [update_time][crate::model::ExternalApi::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [endpoints][crate::model::ExternalApi::endpoints].
     pub fn set_endpoints<T, V>(mut self, v: T) -> Self
     where
@@ -8369,6 +8340,17 @@ impl ExternalApi {
         self
     }
 
+    /// Sets the value of [documentation][crate::model::ExternalApi::documentation].
+    pub fn set_documentation<
+        T: std::convert::Into<std::option::Option<crate::model::Documentation>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.documentation = v.into();
+        self
+    }
+
     /// Sets the value of [attributes][crate::model::ExternalApi::attributes].
     pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
     where
@@ -8378,6 +8360,24 @@ impl ExternalApi {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::ExternalApi::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::ExternalApi::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -8622,12 +8622,6 @@ impl ListHostProjectRegistrationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHostProjectRegistrationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [host_project_registrations][crate::model::ListHostProjectRegistrationsResponse::host_project_registrations].
     pub fn set_host_project_registrations<T, V>(mut self, v: T) -> Self
     where
@@ -8636,6 +8630,12 @@ impl ListHostProjectRegistrationsResponse {
     {
         use std::iter::Iterator;
         self.host_project_registrations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHostProjectRegistrationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9734,12 +9734,6 @@ impl ListRuntimeProjectAttachmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRuntimeProjectAttachmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [runtime_project_attachments][crate::model::ListRuntimeProjectAttachmentsResponse::runtime_project_attachments].
     pub fn set_runtime_project_attachments<T, V>(mut self, v: T) -> Self
     where
@@ -9748,6 +9742,12 @@ impl ListRuntimeProjectAttachmentsResponse {
     {
         use std::iter::Iterator;
         self.runtime_project_attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRuntimeProjectAttachmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/apphub/v1/src/model.rs
+++ b/src/generated/cloud/apphub/v1/src/model.rs
@@ -207,12 +207,6 @@ impl ListServiceProjectAttachmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceProjectAttachmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_project_attachments][crate::model::ListServiceProjectAttachmentsResponse::service_project_attachments].
     pub fn set_service_project_attachments<T, V>(mut self, v: T) -> Self
     where
@@ -221,6 +215,12 @@ impl ListServiceProjectAttachmentsResponse {
     {
         use std::iter::Iterator;
         self.service_project_attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceProjectAttachmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -590,12 +590,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -604,6 +598,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -740,12 +740,6 @@ impl ListDiscoveredServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDiscoveredServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [discovered_services][crate::model::ListDiscoveredServicesResponse::discovered_services].
     pub fn set_discovered_services<T, V>(mut self, v: T) -> Self
     where
@@ -754,6 +748,12 @@ impl ListDiscoveredServicesResponse {
     {
         use std::iter::Iterator;
         self.discovered_services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDiscoveredServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1256,12 +1256,6 @@ impl ListApplicationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListApplicationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [applications][crate::model::ListApplicationsResponse::applications].
     pub fn set_applications<T, V>(mut self, v: T) -> Self
     where
@@ -1270,6 +1264,12 @@ impl ListApplicationsResponse {
     {
         use std::iter::Iterator;
         self.applications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListApplicationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1660,12 +1660,6 @@ impl ListWorkloadsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workloads][crate::model::ListWorkloadsResponse::workloads].
     pub fn set_workloads<T, V>(mut self, v: T) -> Self
     where
@@ -1674,6 +1668,12 @@ impl ListWorkloadsResponse {
     {
         use std::iter::Iterator;
         self.workloads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1810,12 +1810,6 @@ impl ListDiscoveredWorkloadsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDiscoveredWorkloadsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [discovered_workloads][crate::model::ListDiscoveredWorkloadsResponse::discovered_workloads].
     pub fn set_discovered_workloads<T, V>(mut self, v: T) -> Self
     where
@@ -1824,6 +1818,12 @@ impl ListDiscoveredWorkloadsResponse {
     {
         use std::iter::Iterator;
         self.discovered_workloads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDiscoveredWorkloadsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/asset/v1/src/builder.rs
+++ b/src/generated/cloud/asset/v1/src/builder.rs
@@ -154,6 +154,17 @@ pub mod asset_service {
             self
         }
 
+        /// Sets the value of [asset_types][crate::model::ExportAssetsRequest::asset_types].
+        pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [content_type][crate::model::ExportAssetsRequest::content_type].
         pub fn set_content_type<T: Into<crate::model::ContentType>>(mut self, v: T) -> Self {
             self.0.request.content_type = v.into();
@@ -168,17 +179,6 @@ pub mod asset_service {
             v: T,
         ) -> Self {
             self.0.request.output_config = v.into();
-            self
-        }
-
-        /// Sets the value of [asset_types][crate::model::ExportAssetsRequest::asset_types].
-        pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -261,6 +261,17 @@ pub mod asset_service {
             self
         }
 
+        /// Sets the value of [asset_types][crate::model::ListAssetsRequest::asset_types].
+        pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [content_type][crate::model::ListAssetsRequest::content_type].
         pub fn set_content_type<T: Into<crate::model::ContentType>>(mut self, v: T) -> Self {
             self.0.request.content_type = v.into();
@@ -276,17 +287,6 @@ pub mod asset_service {
         /// Sets the value of [page_token][crate::model::ListAssetsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
-            self
-        }
-
-        /// Sets the value of [asset_types][crate::model::ListAssetsRequest::asset_types].
-        pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -351,6 +351,17 @@ pub mod asset_service {
             self
         }
 
+        /// Sets the value of [asset_names][crate::model::BatchGetAssetsHistoryRequest::asset_names].
+        pub fn set_asset_names<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.asset_names = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [content_type][crate::model::BatchGetAssetsHistoryRequest::content_type].
         pub fn set_content_type<T: Into<crate::model::ContentType>>(mut self, v: T) -> Self {
             self.0.request.content_type = v.into();
@@ -363,17 +374,6 @@ pub mod asset_service {
             v: T,
         ) -> Self {
             self.0.request.read_time_window = v.into();
-            self
-        }
-
-        /// Sets the value of [asset_names][crate::model::BatchGetAssetsHistoryRequest::asset_names].
-        pub fn set_asset_names<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.asset_names = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -721,6 +721,17 @@ pub mod asset_service {
             self
         }
 
+        /// Sets the value of [asset_types][crate::model::SearchAllResourcesRequest::asset_types].
+        pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_size][crate::model::SearchAllResourcesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
@@ -742,17 +753,6 @@ pub mod asset_service {
         /// Sets the value of [read_mask][crate::model::SearchAllResourcesRequest::read_mask].
         pub fn set_read_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.read_mask = v.into();
-            self
-        }
-
-        /// Sets the value of [asset_types][crate::model::SearchAllResourcesRequest::asset_types].
-        pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -839,12 +839,6 @@ pub mod asset_service {
             self
         }
 
-        /// Sets the value of [order_by][crate::model::SearchAllIamPoliciesRequest::order_by].
-        pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.order_by = v.into();
-            self
-        }
-
         /// Sets the value of [asset_types][crate::model::SearchAllIamPoliciesRequest::asset_types].
         pub fn set_asset_types<T, V>(mut self, v: T) -> Self
         where
@@ -853,6 +847,12 @@ pub mod asset_service {
         {
             use std::iter::Iterator;
             self.0.request.asset_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [order_by][crate::model::SearchAllIamPoliciesRequest::order_by].
+        pub fn set_order_by<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.order_by = v.into();
             self
         }
     }

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -168,6 +168,17 @@ impl ExportAssetsRequest {
         self
     }
 
+    /// Sets the value of [asset_types][crate::model::ExportAssetsRequest::asset_types].
+    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.asset_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [content_type][crate::model::ExportAssetsRequest::content_type].
     pub fn set_content_type<T: std::convert::Into<crate::model::ContentType>>(
         mut self,
@@ -185,17 +196,6 @@ impl ExportAssetsRequest {
         v: T,
     ) -> Self {
         self.output_config = v.into();
-        self
-    }
-
-    /// Sets the value of [asset_types][crate::model::ExportAssetsRequest::asset_types].
-    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.asset_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -393,6 +393,17 @@ impl ListAssetsRequest {
         self
     }
 
+    /// Sets the value of [asset_types][crate::model::ListAssetsRequest::asset_types].
+    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.asset_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [content_type][crate::model::ListAssetsRequest::content_type].
     pub fn set_content_type<T: std::convert::Into<crate::model::ContentType>>(
         mut self,
@@ -411,17 +422,6 @@ impl ListAssetsRequest {
     /// Sets the value of [page_token][crate::model::ListAssetsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [asset_types][crate::model::ListAssetsRequest::asset_types].
-    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.asset_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -481,12 +481,6 @@ impl ListAssetsResponse {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assets][crate::model::ListAssetsResponse::assets].
     pub fn set_assets<T, V>(mut self, v: T) -> Self
     where
@@ -495,6 +489,12 @@ impl ListAssetsResponse {
     {
         use std::iter::Iterator;
         self.assets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -589,6 +589,17 @@ impl BatchGetAssetsHistoryRequest {
         self
     }
 
+    /// Sets the value of [asset_names][crate::model::BatchGetAssetsHistoryRequest::asset_names].
+    pub fn set_asset_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.asset_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [content_type][crate::model::BatchGetAssetsHistoryRequest::content_type].
     pub fn set_content_type<T: std::convert::Into<crate::model::ContentType>>(
         mut self,
@@ -606,17 +617,6 @@ impl BatchGetAssetsHistoryRequest {
         v: T,
     ) -> Self {
         self.read_time_window = v.into();
-        self
-    }
-
-    /// Sets the value of [asset_names][crate::model::BatchGetAssetsHistoryRequest::asset_names].
-    pub fn set_asset_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.asset_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -979,21 +979,6 @@ impl OutputConfig {
         })
     }
 
-    /// The value of [destination][crate::model::OutputConfig::destination]
-    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_destination(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::output_config::Destination::BigqueryDestination(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::OutputConfig::destination]
     /// to hold a `GcsDestination`.
     ///
@@ -1009,6 +994,21 @@ impl OutputConfig {
             crate::model::output_config::Destination::GcsDestination(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::OutputConfig::destination]
+    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestination>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::output_config::Destination::BigqueryDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::OutputConfig::destination]
@@ -1217,17 +1217,6 @@ impl GcsDestination {
         })
     }
 
-    /// The value of [object_uri][crate::model::GcsDestination::object_uri]
-    /// if it holds a `UriPrefix`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn uri_prefix(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.object_uri.as_ref().and_then(|v| match v {
-            crate::model::gcs_destination::ObjectUri::UriPrefix(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [object_uri][crate::model::GcsDestination::object_uri]
     /// to hold a `Uri`.
     ///
@@ -1237,6 +1226,17 @@ impl GcsDestination {
         self.object_uri =
             std::option::Option::Some(crate::model::gcs_destination::ObjectUri::Uri(v.into()));
         self
+    }
+
+    /// The value of [object_uri][crate::model::GcsDestination::object_uri]
+    /// if it holds a `UriPrefix`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn uri_prefix(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.object_uri.as_ref().and_then(|v| match v {
+            crate::model::gcs_destination::ObjectUri::UriPrefix(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [object_uri][crate::model::GcsDestination::object_uri]
@@ -1824,6 +1824,28 @@ impl Feed {
         self
     }
 
+    /// Sets the value of [asset_names][crate::model::Feed::asset_names].
+    pub fn set_asset_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.asset_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [asset_types][crate::model::Feed::asset_types].
+    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.asset_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [content_type][crate::model::Feed::content_type].
     pub fn set_content_type<T: std::convert::Into<crate::model::ContentType>>(
         mut self,
@@ -1850,28 +1872,6 @@ impl Feed {
         v: T,
     ) -> Self {
         self.condition = v.into();
-        self
-    }
-
-    /// Sets the value of [asset_names][crate::model::Feed::asset_names].
-    pub fn set_asset_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.asset_names = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [asset_types][crate::model::Feed::asset_types].
-    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.asset_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2104,6 +2104,17 @@ impl SearchAllResourcesRequest {
         self
     }
 
+    /// Sets the value of [asset_types][crate::model::SearchAllResourcesRequest::asset_types].
+    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.asset_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::SearchAllResourcesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -2128,17 +2139,6 @@ impl SearchAllResourcesRequest {
         v: T,
     ) -> Self {
         self.read_mask = v.into();
-        self
-    }
-
-    /// Sets the value of [asset_types][crate::model::SearchAllResourcesRequest::asset_types].
-    pub fn set_asset_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.asset_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2175,12 +2175,6 @@ impl SearchAllResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchAllResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::SearchAllResourcesResponse::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -2189,6 +2183,12 @@ impl SearchAllResourcesResponse {
     {
         use std::iter::Iterator;
         self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchAllResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2361,12 +2361,6 @@ impl SearchAllIamPoliciesRequest {
         self
     }
 
-    /// Sets the value of [order_by][crate::model::SearchAllIamPoliciesRequest::order_by].
-    pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.order_by = v.into();
-        self
-    }
-
     /// Sets the value of [asset_types][crate::model::SearchAllIamPoliciesRequest::asset_types].
     pub fn set_asset_types<T, V>(mut self, v: T) -> Self
     where
@@ -2375,6 +2369,12 @@ impl SearchAllIamPoliciesRequest {
     {
         use std::iter::Iterator;
         self.asset_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [order_by][crate::model::SearchAllIamPoliciesRequest::order_by].
+    pub fn set_order_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.order_by = v.into();
         self
     }
 }
@@ -2411,12 +2411,6 @@ impl SearchAllIamPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchAllIamPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::SearchAllIamPoliciesResponse::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -2425,6 +2419,12 @@ impl SearchAllIamPoliciesResponse {
     {
         use std::iter::Iterator;
         self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchAllIamPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3138,12 +3138,6 @@ impl AnalyzeIamPolicyResponse {
         self
     }
 
-    /// Sets the value of [fully_explored][crate::model::AnalyzeIamPolicyResponse::fully_explored].
-    pub fn set_fully_explored<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.fully_explored = v.into();
-        self
-    }
-
     /// Sets the value of [service_account_impersonation_analysis][crate::model::AnalyzeIamPolicyResponse::service_account_impersonation_analysis].
     pub fn set_service_account_impersonation_analysis<T, V>(mut self, v: T) -> Self
     where
@@ -3152,6 +3146,12 @@ impl AnalyzeIamPolicyResponse {
     {
         use std::iter::Iterator;
         self.service_account_impersonation_analysis = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [fully_explored][crate::model::AnalyzeIamPolicyResponse::fully_explored].
+    pub fn set_fully_explored<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.fully_explored = v.into();
         self
     }
 }
@@ -3217,12 +3217,6 @@ pub mod analyze_iam_policy_response {
             self
         }
 
-        /// Sets the value of [fully_explored][crate::model::analyze_iam_policy_response::IamPolicyAnalysis::fully_explored].
-        pub fn set_fully_explored<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.fully_explored = v.into();
-            self
-        }
-
         /// Sets the value of [analysis_results][crate::model::analyze_iam_policy_response::IamPolicyAnalysis::analysis_results].
         pub fn set_analysis_results<T, V>(mut self, v: T) -> Self
         where
@@ -3231,6 +3225,12 @@ pub mod analyze_iam_policy_response {
         {
             use std::iter::Iterator;
             self.analysis_results = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [fully_explored][crate::model::analyze_iam_policy_response::IamPolicyAnalysis::fully_explored].
+        pub fn set_fully_explored<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.fully_explored = v.into();
             self
         }
 
@@ -3306,23 +3306,6 @@ impl IamPolicyAnalysisOutputConfig {
         })
     }
 
-    /// The value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
-    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_destination(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::iam_policy_analysis_output_config::BigQueryDestination>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::iam_policy_analysis_output_config::Destination::BigqueryDestination(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
     /// to hold a `GcsDestination`.
     ///
@@ -3340,6 +3323,23 @@ impl IamPolicyAnalysisOutputConfig {
             crate::model::iam_policy_analysis_output_config::Destination::GcsDestination(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
+    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_destination(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::iam_policy_analysis_output_config::BigQueryDestination>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::iam_policy_analysis_output_config::Destination::BigqueryDestination(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
@@ -3871,17 +3871,6 @@ impl SavedQuery {
         self
     }
 
-    /// Sets the value of [content][crate::model::SavedQuery::content].
-    pub fn set_content<
-        T: std::convert::Into<std::option::Option<crate::model::saved_query::QueryContent>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::SavedQuery::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -3891,6 +3880,17 @@ impl SavedQuery {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [content][crate::model::SavedQuery::content].
+    pub fn set_content<
+        T: std::convert::Into<std::option::Option<crate::model::saved_query::QueryContent>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.content = v.into();
         self
     }
 }
@@ -4210,12 +4210,6 @@ impl ListSavedQueriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSavedQueriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [saved_queries][crate::model::ListSavedQueriesResponse::saved_queries].
     pub fn set_saved_queries<T, V>(mut self, v: T) -> Self
     where
@@ -4224,6 +4218,12 @@ impl ListSavedQueriesResponse {
     {
         use std::iter::Iterator;
         self.saved_queries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSavedQueriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4640,17 +4640,6 @@ impl MoveAnalysis {
         })
     }
 
-    /// The value of [result][crate::model::MoveAnalysis::result]
-    /// if it holds a `Error`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::move_analysis::Result::Error(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::MoveAnalysis::result]
     /// to hold a `Analysis`.
     ///
@@ -4665,6 +4654,17 @@ impl MoveAnalysis {
         self.result =
             std::option::Option::Some(crate::model::move_analysis::Result::Analysis(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::MoveAnalysis::result]
+    /// if it holds a `Error`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::move_analysis::Result::Error(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::MoveAnalysis::result]
@@ -5050,6 +5050,18 @@ impl QueryAssetsRequest {
         })
     }
 
+    /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
+    /// to hold a `Statement`.
+    ///
+    /// Note that all the setters affecting `query` are
+    /// mutually exclusive.
+    pub fn set_statement<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query = std::option::Option::Some(
+            crate::model::query_assets_request::Query::Statement(v.into()),
+        );
+        self
+    }
+
     /// The value of [query][crate::model::QueryAssetsRequest::query]
     /// if it holds a `JobReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -5061,18 +5073,6 @@ impl QueryAssetsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
-    /// to hold a `Statement`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_statement<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::query_assets_request::Query::Statement(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
@@ -5116,17 +5116,6 @@ impl QueryAssetsRequest {
         })
     }
 
-    /// The value of [time][crate::model::QueryAssetsRequest::time]
-    /// if it holds a `ReadTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.time.as_ref().and_then(|v| match v {
-            crate::model::query_assets_request::Time::ReadTime(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [time][crate::model::QueryAssetsRequest::time]
     /// to hold a `ReadTimeWindow`.
     ///
@@ -5142,6 +5131,17 @@ impl QueryAssetsRequest {
             crate::model::query_assets_request::Time::ReadTimeWindow(v.into()),
         );
         self
+    }
+
+    /// The value of [time][crate::model::QueryAssetsRequest::time]
+    /// if it holds a `ReadTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn read_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.time.as_ref().and_then(|v| match v {
+            crate::model::query_assets_request::Time::ReadTime(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [time][crate::model::QueryAssetsRequest::time]
@@ -5274,34 +5274,6 @@ impl QueryAssetsResponse {
         })
     }
 
-    /// The value of [response][crate::model::QueryAssetsResponse::response]
-    /// if it holds a `QueryResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn query_result(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryResult>> {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::query_assets_response::Response::QueryResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [response][crate::model::QueryAssetsResponse::response]
-    /// if it holds a `OutputConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn output_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::QueryAssetsOutputConfig>> {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::query_assets_response::Response::OutputConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response][crate::model::QueryAssetsResponse::response]
     /// to hold a `Error`.
     ///
@@ -5317,6 +5289,19 @@ impl QueryAssetsResponse {
         self
     }
 
+    /// The value of [response][crate::model::QueryAssetsResponse::response]
+    /// if it holds a `QueryResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn query_result(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryResult>> {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::query_assets_response::Response::QueryResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [response][crate::model::QueryAssetsResponse::response]
     /// to hold a `QueryResult`.
     ///
@@ -5330,6 +5315,21 @@ impl QueryAssetsResponse {
             crate::model::query_assets_response::Response::QueryResult(v.into()),
         );
         self
+    }
+
+    /// The value of [response][crate::model::QueryAssetsResponse::response]
+    /// if it holds a `OutputConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn output_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::QueryAssetsOutputConfig>> {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::query_assets_response::Response::OutputConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response][crate::model::QueryAssetsResponse::response]
@@ -5412,6 +5412,17 @@ impl QueryResult {
         std::default::Default::default()
     }
 
+    /// Sets the value of [rows][crate::model::QueryResult::rows].
+    pub fn set_rows<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Struct>,
+    {
+        use std::iter::Iterator;
+        self.rows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [schema][crate::model::QueryResult::schema].
     pub fn set_schema<T: std::convert::Into<std::option::Option<crate::model::TableSchema>>>(
         mut self,
@@ -5430,17 +5441,6 @@ impl QueryResult {
     /// Sets the value of [total_rows][crate::model::QueryResult::total_rows].
     pub fn set_total_rows<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.total_rows = v.into();
-        self
-    }
-
-    /// Sets the value of [rows][crate::model::QueryResult::rows].
-    pub fn set_rows<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Struct>,
-    {
-        use std::iter::Iterator;
-        self.rows = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5916,6 +5916,17 @@ impl AnalyzerOrgPolicy {
         self
     }
 
+    /// Sets the value of [rules][crate::model::AnalyzerOrgPolicy::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::analyzer_org_policy::Rule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [inherit_from_parent][crate::model::AnalyzerOrgPolicy::inherit_from_parent].
     pub fn set_inherit_from_parent<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.inherit_from_parent = v.into();
@@ -5925,17 +5936,6 @@ impl AnalyzerOrgPolicy {
     /// Sets the value of [reset][crate::model::AnalyzerOrgPolicy::reset].
     pub fn set_reset<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reset = v.into();
-        self
-    }
-
-    /// Sets the value of [rules][crate::model::AnalyzerOrgPolicy::rules].
-    pub fn set_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::analyzer_org_policy::Rule>,
-    {
-        use std::iter::Iterator;
-        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6050,45 +6050,6 @@ pub mod analyzer_org_policy {
             })
         }
 
-        /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// if it holds a `AllowAll`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn allow_all(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::analyzer_org_policy::rule::Kind::AllowAll(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// if it holds a `DenyAll`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn deny_all(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::analyzer_org_policy::rule::Kind::DenyAll(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// if it holds a `Enforce`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn enforce(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::analyzer_org_policy::rule::Kind::Enforce(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
         /// to hold a `Values`.
         ///
@@ -6108,6 +6069,19 @@ pub mod analyzer_org_policy {
             self
         }
 
+        /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
+        /// if it holds a `AllowAll`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn allow_all(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::analyzer_org_policy::rule::Kind::AllowAll(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
         /// to hold a `AllowAll`.
         ///
@@ -6120,6 +6094,19 @@ pub mod analyzer_org_policy {
             self
         }
 
+        /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
+        /// if it holds a `DenyAll`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn deny_all(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::analyzer_org_policy::rule::Kind::DenyAll(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
         /// to hold a `DenyAll`.
         ///
@@ -6130,6 +6117,19 @@ pub mod analyzer_org_policy {
                 crate::model::analyzer_org_policy::rule::Kind::DenyAll(v.into()),
             );
             self
+        }
+
+        /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
+        /// if it holds a `Enforce`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn enforce(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::analyzer_org_policy::rule::Kind::Enforce(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
@@ -6281,21 +6281,6 @@ impl AnalyzerOrgPolicyConstraint {
         })
     }
 
-    /// The value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
-    /// if it holds a `CustomConstraint`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_constraint(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::analyzer_org_policy_constraint::CustomConstraint>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.constraint_definition.as_ref().and_then(|v| match v {
-            crate::model::analyzer_org_policy_constraint::ConstraintDefinition::CustomConstraint(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
     /// to hold a `GoogleDefinedConstraint`.
     ///
@@ -6315,6 +6300,21 @@ impl AnalyzerOrgPolicyConstraint {
             )
         );
         self
+    }
+
+    /// The value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
+    /// if it holds a `CustomConstraint`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_constraint(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::analyzer_org_policy_constraint::CustomConstraint>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.constraint_definition.as_ref().and_then(|v| match v {
+            crate::model::analyzer_org_policy_constraint::ConstraintDefinition::CustomConstraint(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
@@ -6463,23 +6463,6 @@ pub mod analyzer_org_policy_constraint {
             })
         }
 
-        /// The value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
-        /// if it holds a `BooleanConstraint`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn boolean_constraint(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::analyzer_org_policy_constraint::constraint::BooleanConstraint,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.constraint_type.as_ref().and_then(|v| match v {
-                crate::model::analyzer_org_policy_constraint::constraint::ConstraintType::BooleanConstraint(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
         /// to hold a `ListConstraint`.
         ///
@@ -6501,6 +6484,23 @@ pub mod analyzer_org_policy_constraint {
                 )
             );
             self
+        }
+
+        /// The value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
+        /// if it holds a `BooleanConstraint`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn boolean_constraint(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::analyzer_org_policy_constraint::constraint::BooleanConstraint,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.constraint_type.as_ref().and_then(|v| match v {
+                crate::model::analyzer_org_policy_constraint::constraint::ConstraintType::BooleanConstraint(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
@@ -6836,6 +6836,30 @@ pub mod analyzer_org_policy_constraint {
             self
         }
 
+        /// Sets the value of [resource_types][crate::model::analyzer_org_policy_constraint::CustomConstraint::resource_types].
+        pub fn set_resource_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.resource_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [method_types][crate::model::analyzer_org_policy_constraint::CustomConstraint::method_types].
+        pub fn set_method_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                    crate::model::analyzer_org_policy_constraint::custom_constraint::MethodType,
+                >,
+        {
+            use std::iter::Iterator;
+            self.method_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [condition][crate::model::analyzer_org_policy_constraint::CustomConstraint::condition].
         pub fn set_condition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.condition = v.into();
@@ -6867,30 +6891,6 @@ pub mod analyzer_org_policy_constraint {
         /// Sets the value of [description][crate::model::analyzer_org_policy_constraint::CustomConstraint::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
-            self
-        }
-
-        /// Sets the value of [resource_types][crate::model::analyzer_org_policy_constraint::CustomConstraint::resource_types].
-        pub fn set_resource_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.resource_types = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [method_types][crate::model::analyzer_org_policy_constraint::CustomConstraint::method_types].
-        pub fn set_method_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<
-                    crate::model::analyzer_org_policy_constraint::custom_constraint::MethodType,
-                >,
-        {
-            use std::iter::Iterator;
-            self.method_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -7337,6 +7337,17 @@ impl AnalyzeOrgPoliciesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [org_policy_results][crate::model::AnalyzeOrgPoliciesResponse::org_policy_results].
+    pub fn set_org_policy_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::analyze_org_policies_response::OrgPolicyResult>,
+    {
+        use std::iter::Iterator;
+        self.org_policy_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [constraint][crate::model::AnalyzeOrgPoliciesResponse::constraint].
     pub fn set_constraint<
         T: std::convert::Into<std::option::Option<crate::model::AnalyzerOrgPolicyConstraint>>,
@@ -7351,17 +7362,6 @@ impl AnalyzeOrgPoliciesResponse {
     /// Sets the value of [next_page_token][crate::model::AnalyzeOrgPoliciesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [org_policy_results][crate::model::AnalyzeOrgPoliciesResponse::org_policy_results].
-    pub fn set_org_policy_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::analyze_org_policies_response::OrgPolicyResult>,
-    {
-        use std::iter::Iterator;
-        self.org_policy_results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7452,21 +7452,6 @@ pub mod analyze_org_policies_response {
             self
         }
 
-        /// Sets the value of [project][crate::model::analyze_org_policies_response::OrgPolicyResult::project].
-        pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.project = v.into();
-            self
-        }
-
-        /// Sets the value of [organization][crate::model::analyze_org_policies_response::OrgPolicyResult::organization].
-        pub fn set_organization<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.organization = v.into();
-            self
-        }
-
         /// Sets the value of [policy_bundle][crate::model::analyze_org_policies_response::OrgPolicyResult::policy_bundle].
         pub fn set_policy_bundle<T, V>(mut self, v: T) -> Self
         where
@@ -7478,6 +7463,12 @@ pub mod analyze_org_policies_response {
             self
         }
 
+        /// Sets the value of [project][crate::model::analyze_org_policies_response::OrgPolicyResult::project].
+        pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.project = v.into();
+            self
+        }
+
         /// Sets the value of [folders][crate::model::analyze_org_policies_response::OrgPolicyResult::folders].
         pub fn set_folders<T, V>(mut self, v: T) -> Self
         where
@@ -7486,6 +7477,15 @@ pub mod analyze_org_policies_response {
         {
             use std::iter::Iterator;
             self.folders = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [organization][crate::model::analyze_org_policies_response::OrgPolicyResult::organization].
+        pub fn set_organization<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.organization = v.into();
             self
         }
     }
@@ -7631,6 +7631,19 @@ impl AnalyzeOrgPolicyGovernedContainersResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [governed_containers][crate::model::AnalyzeOrgPolicyGovernedContainersResponse::governed_containers].
+    pub fn set_governed_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<
+                crate::model::analyze_org_policy_governed_containers_response::GovernedContainer,
+            >,
+    {
+        use std::iter::Iterator;
+        self.governed_containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [constraint][crate::model::AnalyzeOrgPolicyGovernedContainersResponse::constraint].
     pub fn set_constraint<
         T: std::convert::Into<std::option::Option<crate::model::AnalyzerOrgPolicyConstraint>>,
@@ -7645,19 +7658,6 @@ impl AnalyzeOrgPolicyGovernedContainersResponse {
     /// Sets the value of [next_page_token][crate::model::AnalyzeOrgPolicyGovernedContainersResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [governed_containers][crate::model::AnalyzeOrgPolicyGovernedContainersResponse::governed_containers].
-    pub fn set_governed_containers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<
-                crate::model::analyze_org_policy_governed_containers_response::GovernedContainer,
-            >,
-    {
-        use std::iter::Iterator;
-        self.governed_containers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7789,21 +7789,6 @@ pub mod analyze_org_policy_governed_containers_response {
             self
         }
 
-        /// Sets the value of [project][crate::model::analyze_org_policy_governed_containers_response::GovernedContainer::project].
-        pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.project = v.into();
-            self
-        }
-
-        /// Sets the value of [organization][crate::model::analyze_org_policy_governed_containers_response::GovernedContainer::organization].
-        pub fn set_organization<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.organization = v.into();
-            self
-        }
-
         /// Sets the value of [policy_bundle][crate::model::analyze_org_policy_governed_containers_response::GovernedContainer::policy_bundle].
         pub fn set_policy_bundle<T, V>(mut self, v: T) -> Self
         where
@@ -7815,6 +7800,12 @@ pub mod analyze_org_policy_governed_containers_response {
             self
         }
 
+        /// Sets the value of [project][crate::model::analyze_org_policy_governed_containers_response::GovernedContainer::project].
+        pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.project = v.into();
+            self
+        }
+
         /// Sets the value of [folders][crate::model::analyze_org_policy_governed_containers_response::GovernedContainer::folders].
         pub fn set_folders<T, V>(mut self, v: T) -> Self
         where
@@ -7823,6 +7814,15 @@ pub mod analyze_org_policy_governed_containers_response {
         {
             use std::iter::Iterator;
             self.folders = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [organization][crate::model::analyze_org_policy_governed_containers_response::GovernedContainer::organization].
+        pub fn set_organization<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.organization = v.into();
             self
         }
 
@@ -7995,6 +7995,19 @@ impl AnalyzeOrgPolicyGovernedAssetsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [governed_assets][crate::model::AnalyzeOrgPolicyGovernedAssetsResponse::governed_assets].
+    pub fn set_governed_assets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<
+                crate::model::analyze_org_policy_governed_assets_response::GovernedAsset,
+            >,
+    {
+        use std::iter::Iterator;
+        self.governed_assets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [constraint][crate::model::AnalyzeOrgPolicyGovernedAssetsResponse::constraint].
     pub fn set_constraint<
         T: std::convert::Into<std::option::Option<crate::model::AnalyzerOrgPolicyConstraint>>,
@@ -8009,19 +8022,6 @@ impl AnalyzeOrgPolicyGovernedAssetsResponse {
     /// Sets the value of [next_page_token][crate::model::AnalyzeOrgPolicyGovernedAssetsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [governed_assets][crate::model::AnalyzeOrgPolicyGovernedAssetsResponse::governed_assets].
-    pub fn set_governed_assets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<
-                crate::model::analyze_org_policy_governed_assets_response::GovernedAsset,
-            >,
-    {
-        use std::iter::Iterator;
-        self.governed_assets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8139,6 +8139,17 @@ pub mod analyze_org_policy_governed_assets_response {
             self
         }
 
+        /// Sets the value of [folders][crate::model::analyze_org_policy_governed_assets_response::GovernedResource::folders].
+        pub fn set_folders<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.folders = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [organization][crate::model::analyze_org_policy_governed_assets_response::GovernedResource::organization].
         pub fn set_organization<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -8151,17 +8162,6 @@ pub mod analyze_org_policy_governed_assets_response {
         /// Sets the value of [asset_type][crate::model::analyze_org_policy_governed_assets_response::GovernedResource::asset_type].
         pub fn set_asset_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.asset_type = v.into();
-            self
-        }
-
-        /// Sets the value of [folders][crate::model::analyze_org_policy_governed_assets_response::GovernedResource::folders].
-        pub fn set_folders<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.folders = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -8268,6 +8268,17 @@ pub mod analyze_org_policy_governed_assets_response {
             self
         }
 
+        /// Sets the value of [folders][crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy::folders].
+        pub fn set_folders<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.folders = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [organization][crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy::organization].
         pub fn set_organization<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -8280,17 +8291,6 @@ pub mod analyze_org_policy_governed_assets_response {
         /// Sets the value of [asset_type][crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy::asset_type].
         pub fn set_asset_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.asset_type = v.into();
-            self
-        }
-
-        /// Sets the value of [folders][crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy::folders].
-        pub fn set_folders<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.folders = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -8392,23 +8392,6 @@ pub mod analyze_org_policy_governed_assets_response {
             })
         }
 
-        /// The value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
-        /// if it holds a `GovernedIamPolicy`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn governed_iam_policy(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.governed_asset.as_ref().and_then(|v| match v {
-                crate::model::analyze_org_policy_governed_assets_response::governed_asset::GovernedAsset::GovernedIamPolicy(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
         /// to hold a `GovernedResource`.
         ///
@@ -8430,6 +8413,23 @@ pub mod analyze_org_policy_governed_assets_response {
                 )
             );
             self
+        }
+
+        /// The value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
+        /// if it holds a `GovernedIamPolicy`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn governed_iam_policy(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.governed_asset.as_ref().and_then(|v| match v {
+                crate::model::analyze_org_policy_governed_assets_response::governed_asset::GovernedAsset::GovernedIamPolicy(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
@@ -8916,6 +8916,17 @@ impl Asset {
         self
     }
 
+    /// Sets the value of [org_policy][crate::model::Asset::org_policy].
+    pub fn set_org_policy<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<orgpolicy_v1::model::Policy>,
+    {
+        use std::iter::Iterator;
+        self.org_policy = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [os_inventory][crate::model::Asset::os_inventory].
     pub fn set_os_inventory<
         T: std::convert::Into<std::option::Option<osconfig_v1::model::Inventory>>,
@@ -8947,17 +8958,6 @@ impl Asset {
         v: T,
     ) -> Self {
         self.related_asset = v.into();
-        self
-    }
-
-    /// Sets the value of [org_policy][crate::model::Asset::org_policy].
-    pub fn set_org_policy<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<orgpolicy_v1::model::Policy>,
-    {
-        use std::iter::Iterator;
-        self.org_policy = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -9001,37 +9001,6 @@ impl Asset {
         })
     }
 
-    /// The value of [access_context_policy][crate::model::Asset::access_context_policy]
-    /// if it holds a `AccessLevel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn access_level(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<accesscontextmanager_v1::model::AccessLevel>> {
-        #[allow(unreachable_patterns)]
-        self.access_context_policy.as_ref().and_then(|v| match v {
-            crate::model::asset::AccessContextPolicy::AccessLevel(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [access_context_policy][crate::model::Asset::access_context_policy]
-    /// if it holds a `ServicePerimeter`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn service_perimeter(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<accesscontextmanager_v1::model::ServicePerimeter>>
-    {
-        #[allow(unreachable_patterns)]
-        self.access_context_policy.as_ref().and_then(|v| match v {
-            crate::model::asset::AccessContextPolicy::ServicePerimeter(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [access_context_policy][crate::model::Asset::access_context_policy]
     /// to hold a `AccessPolicy`.
     ///
@@ -9049,6 +9018,21 @@ impl Asset {
         self
     }
 
+    /// The value of [access_context_policy][crate::model::Asset::access_context_policy]
+    /// if it holds a `AccessLevel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn access_level(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<accesscontextmanager_v1::model::AccessLevel>> {
+        #[allow(unreachable_patterns)]
+        self.access_context_policy.as_ref().and_then(|v| match v {
+            crate::model::asset::AccessContextPolicy::AccessLevel(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [access_context_policy][crate::model::Asset::access_context_policy]
     /// to hold a `AccessLevel`.
     ///
@@ -9064,6 +9048,22 @@ impl Asset {
             crate::model::asset::AccessContextPolicy::AccessLevel(v.into()),
         );
         self
+    }
+
+    /// The value of [access_context_policy][crate::model::Asset::access_context_policy]
+    /// if it holds a `ServicePerimeter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn service_perimeter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<accesscontextmanager_v1::model::ServicePerimeter>>
+    {
+        #[allow(unreachable_patterns)]
+        self.access_context_policy.as_ref().and_then(|v| match v {
+            crate::model::asset::AccessContextPolicy::ServicePerimeter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [access_context_policy][crate::model::Asset::access_context_policy]
@@ -9431,15 +9431,6 @@ impl RelatedAsset {
         self
     }
 
-    /// Sets the value of [relationship_type][crate::model::RelatedAsset::relationship_type].
-    pub fn set_relationship_type<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relationship_type = v.into();
-        self
-    }
-
     /// Sets the value of [ancestors][crate::model::RelatedAsset::ancestors].
     pub fn set_ancestors<T, V>(mut self, v: T) -> Self
     where
@@ -9448,6 +9439,15 @@ impl RelatedAsset {
     {
         use std::iter::Iterator;
         self.ancestors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relationship_type][crate::model::RelatedAsset::relationship_type].
+    pub fn set_relationship_type<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relationship_type = v.into();
         self
     }
 }
@@ -10017,6 +10017,17 @@ impl ResourceSearchResult {
         self
     }
 
+    /// Sets the value of [folders][crate::model::ResourceSearchResult::folders].
+    pub fn set_folders<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.folders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [organization][crate::model::ResourceSearchResult::organization].
     pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.organization = v.into();
@@ -10041,10 +10052,44 @@ impl ResourceSearchResult {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ResourceSearchResult::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [network_tags][crate::model::ResourceSearchResult::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [kms_key][crate::model::ResourceSearchResult::kms_key].
     #[deprecated]
     pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key = v.into();
+        self
+    }
+
+    /// Sets the value of [kms_keys][crate::model::ResourceSearchResult::kms_keys].
+    pub fn set_kms_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.kms_keys = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -10090,48 +10135,6 @@ impl ResourceSearchResult {
         self
     }
 
-    /// Sets the value of [parent_asset_type][crate::model::ResourceSearchResult::parent_asset_type].
-    pub fn set_parent_asset_type<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parent_asset_type = v.into();
-        self
-    }
-
-    /// Sets the value of [folders][crate::model::ResourceSearchResult::folders].
-    pub fn set_folders<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.folders = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [network_tags][crate::model::ResourceSearchResult::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [kms_keys][crate::model::ResourceSearchResult::kms_keys].
-    pub fn set_kms_keys<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.kms_keys = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [versioned_resources][crate::model::ResourceSearchResult::versioned_resources].
     pub fn set_versioned_resources<T, V>(mut self, v: T) -> Self
     where
@@ -10151,6 +10154,18 @@ impl ResourceSearchResult {
     {
         use std::iter::Iterator;
         self.attached_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relationships][crate::model::ResourceSearchResult::relationships].
+    pub fn set_relationships<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::RelatedResources>,
+    {
+        use std::iter::Iterator;
+        self.relationships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -10212,27 +10227,12 @@ impl ResourceSearchResult {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ResourceSearchResult::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [relationships][crate::model::ResourceSearchResult::relationships].
-    pub fn set_relationships<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::RelatedResources>,
-    {
-        use std::iter::Iterator;
-        self.relationships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [parent_asset_type][crate::model::ResourceSearchResult::parent_asset_type].
+    pub fn set_parent_asset_type<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parent_asset_type = v.into();
         self
     }
 
@@ -10569,6 +10569,17 @@ impl IamPolicySearchResult {
         self
     }
 
+    /// Sets the value of [folders][crate::model::IamPolicySearchResult::folders].
+    pub fn set_folders<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.folders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [organization][crate::model::IamPolicySearchResult::organization].
     pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.organization = v.into();
@@ -10594,17 +10605,6 @@ impl IamPolicySearchResult {
         v: T,
     ) -> Self {
         self.explanation = v.into();
-        self
-    }
-
-    /// Sets the value of [folders][crate::model::IamPolicySearchResult::folders].
-    pub fn set_folders<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.folders = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -11016,6 +11016,17 @@ impl IamPolicyAnalysisResult {
         self
     }
 
+    /// Sets the value of [access_control_lists][crate::model::IamPolicyAnalysisResult::access_control_lists].
+    pub fn set_access_control_lists<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::iam_policy_analysis_result::AccessControlList>,
+    {
+        use std::iter::Iterator;
+        self.access_control_lists = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [identity_list][crate::model::IamPolicyAnalysisResult::identity_list].
     pub fn set_identity_list<
         T: std::convert::Into<
@@ -11032,17 +11043,6 @@ impl IamPolicyAnalysisResult {
     /// Sets the value of [fully_explored][crate::model::IamPolicyAnalysisResult::fully_explored].
     pub fn set_fully_explored<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.fully_explored = v.into();
-        self
-    }
-
-    /// Sets the value of [access_control_lists][crate::model::IamPolicyAnalysisResult::access_control_lists].
-    pub fn set_access_control_lists<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::iam_policy_analysis_result::AccessControlList>,
-    {
-        use std::iter::Iterator;
-        self.access_control_lists = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -11174,6 +11174,18 @@ pub mod iam_policy_analysis_result {
             })
         }
 
+        /// Sets the value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
+        /// to hold a `Role`.
+        ///
+        /// Note that all the setters affecting `oneof_access` are
+        /// mutually exclusive.
+        pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.oneof_access = std::option::Option::Some(
+                crate::model::iam_policy_analysis_result::access::OneofAccess::Role(v.into()),
+            );
+            self
+        }
+
         /// The value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
         /// if it holds a `Permission`, `None` if the field is not set or
         /// holds a different branch.
@@ -11185,18 +11197,6 @@ pub mod iam_policy_analysis_result {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
-        /// to hold a `Role`.
-        ///
-        /// Note that all the setters affecting `oneof_access` are
-        /// mutually exclusive.
-        pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.oneof_access = std::option::Option::Some(
-                crate::model::iam_policy_analysis_result::access::OneofAccess::Role(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
@@ -11398,17 +11398,6 @@ pub mod iam_policy_analysis_result {
             std::default::Default::default()
         }
 
-        /// Sets the value of [condition_evaluation][crate::model::iam_policy_analysis_result::AccessControlList::condition_evaluation].
-        pub fn set_condition_evaluation<
-            T: std::convert::Into<std::option::Option<crate::model::ConditionEvaluation>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition_evaluation = v.into();
-            self
-        }
-
         /// Sets the value of [resources][crate::model::iam_policy_analysis_result::AccessControlList::resources].
         pub fn set_resources<T, V>(mut self, v: T) -> Self
         where
@@ -11439,6 +11428,17 @@ pub mod iam_policy_analysis_result {
         {
             use std::iter::Iterator;
             self.resource_edges = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [condition_evaluation][crate::model::iam_policy_analysis_result::AccessControlList::condition_evaluation].
+        pub fn set_condition_evaluation<
+            T: std::convert::Into<std::option::Option<crate::model::ConditionEvaluation>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.condition_evaluation = v.into();
             self
         }
     }

--- a/src/generated/cloud/assuredworkloads/v1/src/model.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/model.rs
@@ -312,12 +312,6 @@ impl ListWorkloadsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workloads][crate::model::ListWorkloadsResponse::workloads].
     pub fn set_workloads<T, V>(mut self, v: T) -> Self
     where
@@ -326,6 +320,12 @@ impl ListWorkloadsResponse {
     {
         use std::iter::Iterator;
         self.workloads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -477,6 +477,17 @@ impl Workload {
         self
     }
 
+    /// Sets the value of [resources][crate::model::Workload::resources].
+    pub fn set_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::workload::ResourceInfo>,
+    {
+        use std::iter::Iterator;
+        self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [compliance_regime][crate::model::Workload::compliance_regime].
     pub fn set_compliance_regime<
         T: std::convert::Into<crate::model::workload::ComplianceRegime>,
@@ -509,6 +520,18 @@ impl Workload {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Workload::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [provisioned_resources_parent][crate::model::Workload::provisioned_resources_parent].
     pub fn set_provisioned_resources_parent<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -527,6 +550,17 @@ impl Workload {
         v: T,
     ) -> Self {
         self.kms_settings = v.into();
+        self
+    }
+
+    /// Sets the value of [resource_settings][crate::model::Workload::resource_settings].
+    pub fn set_resource_settings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::workload::ResourceSettings>,
+    {
+        use std::iter::Iterator;
+        self.resource_settings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -558,37 +592,6 @@ impl Workload {
         self
     }
 
-    /// Sets the value of [partner][crate::model::Workload::partner].
-    pub fn set_partner<T: std::convert::Into<crate::model::workload::Partner>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.partner = v.into();
-        self
-    }
-
-    /// Sets the value of [resources][crate::model::Workload::resources].
-    pub fn set_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::workload::ResourceInfo>,
-    {
-        use std::iter::Iterator;
-        self.resources = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [resource_settings][crate::model::Workload::resource_settings].
-    pub fn set_resource_settings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::workload::ResourceSettings>,
-    {
-        use std::iter::Iterator;
-        self.resource_settings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [compliant_but_disallowed_services][crate::model::Workload::compliant_but_disallowed_services].
     pub fn set_compliant_but_disallowed_services<T, V>(mut self, v: T) -> Self
     where
@@ -600,15 +603,12 @@ impl Workload {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Workload::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [partner][crate::model::Workload::partner].
+    pub fn set_partner<T: std::convert::Into<crate::model::workload::Partner>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.partner = v.into();
         self
     }
 }
@@ -2306,12 +2306,6 @@ impl ListViolationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListViolationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [violations][crate::model::ListViolationsResponse::violations].
     pub fn set_violations<T, V>(mut self, v: T) -> Self
     where
@@ -2320,6 +2314,12 @@ impl ListViolationsResponse {
     {
         use std::iter::Iterator;
         self.violations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListViolationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2631,17 +2631,6 @@ pub mod violation {
             self
         }
 
-        /// Sets the value of [remediation_type][crate::model::violation::Remediation::remediation_type].
-        pub fn set_remediation_type<
-            T: std::convert::Into<crate::model::violation::remediation::RemediationType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.remediation_type = v.into();
-            self
-        }
-
         /// Sets the value of [compliant_values][crate::model::violation::Remediation::compliant_values].
         pub fn set_compliant_values<T, V>(mut self, v: T) -> Self
         where
@@ -2650,6 +2639,17 @@ pub mod violation {
         {
             use std::iter::Iterator;
             self.compliant_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [remediation_type][crate::model::violation::Remediation::remediation_type].
+        pub fn set_remediation_type<
+            T: std::convert::Into<crate::model::violation::remediation::RemediationType>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.remediation_type = v.into();
             self
         }
     }

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -460,6 +460,18 @@ impl ManagementServer {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ManagementServer::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::ManagementServer::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -518,6 +530,17 @@ impl ManagementServer {
         self
     }
 
+    /// Sets the value of [networks][crate::model::ManagementServer::networks].
+    pub fn set_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkConfig>,
+    {
+        use std::iter::Iterator;
+        self.networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::ManagementServer::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -544,6 +567,17 @@ impl ManagementServer {
         self
     }
 
+    /// Sets the value of [ba_proxy_uri][crate::model::ManagementServer::ba_proxy_uri].
+    pub fn set_ba_proxy_uri<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ba_proxy_uri = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [satisfies_pzs][crate::model::ManagementServer::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(
         mut self,
@@ -556,40 +590,6 @@ impl ManagementServer {
     /// Sets the value of [satisfies_pzi][crate::model::ManagementServer::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [networks][crate::model::ManagementServer::networks].
-    pub fn set_networks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkConfig>,
-    {
-        use std::iter::Iterator;
-        self.networks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [ba_proxy_uri][crate::model::ManagementServer::ba_proxy_uri].
-    pub fn set_ba_proxy_uri<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.ba_proxy_uri = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ManagementServer::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1019,12 +1019,6 @@ impl ListManagementServersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListManagementServersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [management_servers][crate::model::ListManagementServersResponse::management_servers].
     pub fn set_management_servers<T, V>(mut self, v: T) -> Self
     where
@@ -1033,6 +1027,12 @@ impl ListManagementServersResponse {
     {
         use std::iter::Iterator;
         self.management_servers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListManagementServersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1576,6 +1576,18 @@ impl BackupPlan {
         self
     }
 
+    /// Sets the value of [labels][crate::model::BackupPlan::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::BackupPlan::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1591,6 +1603,17 @@ impl BackupPlan {
         v: T,
     ) -> Self {
         self.update_time = v.into();
+        self
+    }
+
+    /// Sets the value of [backup_rules][crate::model::BackupPlan::backup_rules].
+    pub fn set_backup_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BackupRule>,
+    {
+        use std::iter::Iterator;
+        self.backup_rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1627,29 +1650,6 @@ impl BackupPlan {
         v: T,
     ) -> Self {
         self.backup_vault_service_account = v.into();
-        self
-    }
-
-    /// Sets the value of [backup_rules][crate::model::BackupPlan::backup_rules].
-    pub fn set_backup_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BackupRule>,
-    {
-        use std::iter::Iterator;
-        self.backup_rules = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::BackupPlan::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2036,34 +2036,6 @@ impl StandardSchedule {
         self
     }
 
-    /// Sets the value of [week_day_of_month][crate::model::StandardSchedule::week_day_of_month].
-    pub fn set_week_day_of_month<
-        T: std::convert::Into<std::option::Option<crate::model::WeekDayOfMonth>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.week_day_of_month = v.into();
-        self
-    }
-
-    /// Sets the value of [backup_window][crate::model::StandardSchedule::backup_window].
-    pub fn set_backup_window<
-        T: std::convert::Into<std::option::Option<crate::model::BackupWindow>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_window = v.into();
-        self
-    }
-
-    /// Sets the value of [time_zone][crate::model::StandardSchedule::time_zone].
-    pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.time_zone = v.into();
-        self
-    }
-
     /// Sets the value of [days_of_week][crate::model::StandardSchedule::days_of_week].
     pub fn set_days_of_week<T, V>(mut self, v: T) -> Self
     where
@@ -2086,6 +2058,17 @@ impl StandardSchedule {
         self
     }
 
+    /// Sets the value of [week_day_of_month][crate::model::StandardSchedule::week_day_of_month].
+    pub fn set_week_day_of_month<
+        T: std::convert::Into<std::option::Option<crate::model::WeekDayOfMonth>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.week_day_of_month = v.into();
+        self
+    }
+
     /// Sets the value of [months][crate::model::StandardSchedule::months].
     pub fn set_months<T, V>(mut self, v: T) -> Self
     where
@@ -2094,6 +2077,23 @@ impl StandardSchedule {
     {
         use std::iter::Iterator;
         self.months = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [backup_window][crate::model::StandardSchedule::backup_window].
+    pub fn set_backup_window<
+        T: std::convert::Into<std::option::Option<crate::model::BackupWindow>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.backup_window = v.into();
+        self
+    }
+
+    /// Sets the value of [time_zone][crate::model::StandardSchedule::time_zone].
+    pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.time_zone = v.into();
         self
     }
 }
@@ -2733,12 +2733,6 @@ impl ListBackupPlansResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupPlansResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_plans][crate::model::ListBackupPlansResponse::backup_plans].
     pub fn set_backup_plans<T, V>(mut self, v: T) -> Self
     where
@@ -2747,6 +2741,12 @@ impl ListBackupPlansResponse {
     {
         use std::iter::Iterator;
         self.backup_plans = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupPlansResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2982,12 +2982,6 @@ impl BackupPlanAssociation {
         self
     }
 
-    /// Sets the value of [data_source][crate::model::BackupPlanAssociation::data_source].
-    pub fn set_data_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data_source = v.into();
-        self
-    }
-
     /// Sets the value of [rules_config_info][crate::model::BackupPlanAssociation::rules_config_info].
     pub fn set_rules_config_info<T, V>(mut self, v: T) -> Self
     where
@@ -2996,6 +2990,12 @@ impl BackupPlanAssociation {
     {
         use std::iter::Iterator;
         self.rules_config_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_source][crate::model::BackupPlanAssociation::data_source].
+    pub fn set_data_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.data_source = v.into();
         self
     }
 }
@@ -3573,12 +3573,6 @@ impl ListBackupPlanAssociationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupPlanAssociationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_plan_associations][crate::model::ListBackupPlanAssociationsResponse::backup_plan_associations].
     pub fn set_backup_plan_associations<T, V>(mut self, v: T) -> Self
     where
@@ -3587,6 +3581,12 @@ impl ListBackupPlanAssociationsResponse {
     {
         use std::iter::Iterator;
         self.backup_plan_associations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupPlanAssociationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3885,6 +3885,18 @@ impl BackupVault {
         self
     }
 
+    /// Sets the value of [labels][crate::model::BackupVault::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::BackupVault::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -3971,29 +3983,6 @@ impl BackupVault {
         self
     }
 
-    /// Sets the value of [access_restriction][crate::model::BackupVault::access_restriction].
-    pub fn set_access_restriction<
-        T: std::convert::Into<crate::model::backup_vault::AccessRestriction>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.access_restriction = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::BackupVault::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::BackupVault::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -4003,6 +3992,17 @@ impl BackupVault {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [access_restriction][crate::model::BackupVault::access_restriction].
+    pub fn set_access_restriction<
+        T: std::convert::Into<crate::model::backup_vault::AccessRestriction>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.access_restriction = v.into();
         self
     }
 }
@@ -4399,6 +4399,18 @@ impl DataSource {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataSource::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::DataSource::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -4464,18 +4476,6 @@ impl DataSource {
         self
     }
 
-    /// Sets the value of [labels][crate::model::DataSource::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [source_resource][crate::model::DataSource::source_resource].
     ///
     /// Note that all the setters affecting `source_resource` are mutually
@@ -4505,22 +4505,6 @@ impl DataSource {
         })
     }
 
-    /// The value of [source_resource][crate::model::DataSource::source_resource]
-    /// if it holds a `DataSourceBackupApplianceApplication`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_source_backup_appliance_application(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataSourceBackupApplianceApplication>>
-    {
-        #[allow(unreachable_patterns)]
-        self.source_resource.as_ref().and_then(|v| match v {
-            crate::model::data_source::SourceResource::DataSourceBackupApplianceApplication(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_resource][crate::model::DataSource::source_resource]
     /// to hold a `DataSourceGcpResource`.
     ///
@@ -4536,6 +4520,22 @@ impl DataSource {
             crate::model::data_source::SourceResource::DataSourceGcpResource(v.into()),
         );
         self
+    }
+
+    /// The value of [source_resource][crate::model::DataSource::source_resource]
+    /// if it holds a `DataSourceBackupApplianceApplication`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_source_backup_appliance_application(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataSourceBackupApplianceApplication>>
+    {
+        #[allow(unreachable_patterns)]
+        self.source_resource.as_ref().and_then(|v| match v {
+            crate::model::data_source::SourceResource::DataSourceBackupApplianceApplication(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_resource][crate::model::DataSource::source_resource]
@@ -4825,21 +4825,6 @@ impl BackupConfigInfo {
         })
     }
 
-    /// The value of [backup_config][crate::model::BackupConfigInfo::backup_config]
-    /// if it holds a `BackupApplianceBackupConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn backup_appliance_backup_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupApplianceBackupConfig>> {
-        #[allow(unreachable_patterns)]
-        self.backup_config.as_ref().and_then(|v| match v {
-            crate::model::backup_config_info::BackupConfig::BackupApplianceBackupConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [backup_config][crate::model::BackupConfigInfo::backup_config]
     /// to hold a `GcpBackupConfig`.
     ///
@@ -4855,6 +4840,21 @@ impl BackupConfigInfo {
             crate::model::backup_config_info::BackupConfig::GcpBackupConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [backup_config][crate::model::BackupConfigInfo::backup_config]
+    /// if it holds a `BackupApplianceBackupConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn backup_appliance_backup_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupApplianceBackupConfig>> {
+        #[allow(unreachable_patterns)]
+        self.backup_config.as_ref().and_then(|v| match v {
+            crate::model::backup_config_info::BackupConfig::BackupApplianceBackupConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [backup_config][crate::model::BackupConfigInfo::backup_config]
@@ -5576,6 +5576,18 @@ impl BackupApplianceLockInfo {
         })
     }
 
+    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
+    /// to hold a `JobName`.
+    ///
+    /// Note that all the setters affecting `lock_source` are
+    /// mutually exclusive.
+    pub fn set_job_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.lock_source = std::option::Option::Some(
+            crate::model::backup_appliance_lock_info::LockSource::JobName(v.into()),
+        );
+        self
+    }
+
     /// The value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
     /// if it holds a `BackupImage`, `None` if the field is not set or
     /// holds a different branch.
@@ -5589,6 +5601,18 @@ impl BackupApplianceLockInfo {
         })
     }
 
+    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
+    /// to hold a `BackupImage`.
+    ///
+    /// Note that all the setters affecting `lock_source` are
+    /// mutually exclusive.
+    pub fn set_backup_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.lock_source = std::option::Option::Some(
+            crate::model::backup_appliance_lock_info::LockSource::BackupImage(v.into()),
+        );
+        self
+    }
+
     /// The value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
     /// if it holds a `SlaId`, `None` if the field is not set or
     /// holds a different branch.
@@ -5600,30 +5624,6 @@ impl BackupApplianceLockInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
-    /// to hold a `JobName`.
-    ///
-    /// Note that all the setters affecting `lock_source` are
-    /// mutually exclusive.
-    pub fn set_job_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.lock_source = std::option::Option::Some(
-            crate::model::backup_appliance_lock_info::LockSource::JobName(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
-    /// to hold a `BackupImage`.
-    ///
-    /// Note that all the setters affecting `lock_source` are
-    /// mutually exclusive.
-    pub fn set_backup_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.lock_source = std::option::Option::Some(
-            crate::model::backup_appliance_lock_info::LockSource::BackupImage(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
@@ -5727,21 +5727,6 @@ impl BackupLock {
         })
     }
 
-    /// The value of [client_lock_info][crate::model::BackupLock::client_lock_info]
-    /// if it holds a `ServiceLockInfo`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn service_lock_info(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ServiceLockInfo>> {
-        #[allow(unreachable_patterns)]
-        self.client_lock_info.as_ref().and_then(|v| match v {
-            crate::model::backup_lock::ClientLockInfo::ServiceLockInfo(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [client_lock_info][crate::model::BackupLock::client_lock_info]
     /// to hold a `BackupApplianceLockInfo`.
     ///
@@ -5757,6 +5742,21 @@ impl BackupLock {
             crate::model::backup_lock::ClientLockInfo::BackupApplianceLockInfo(v.into()),
         );
         self
+    }
+
+    /// The value of [client_lock_info][crate::model::BackupLock::client_lock_info]
+    /// if it holds a `ServiceLockInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn service_lock_info(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ServiceLockInfo>> {
+        #[allow(unreachable_patterns)]
+        self.client_lock_info.as_ref().and_then(|v| match v {
+            crate::model::backup_lock::ClientLockInfo::ServiceLockInfo(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [client_lock_info][crate::model::BackupLock::client_lock_info]
@@ -5921,6 +5921,18 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Backup::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [enforced_retention_end_time][crate::model::Backup::enforced_retention_end_time].
     pub fn set_enforced_retention_end_time<
         T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
@@ -5965,21 +5977,6 @@ impl Backup {
         self
     }
 
-    /// Sets the value of [backup_type][crate::model::Backup::backup_type].
-    pub fn set_backup_type<T: std::convert::Into<crate::model::backup::BackupType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_type = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_size_bytes][crate::model::Backup::resource_size_bytes].
-    pub fn set_resource_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.resource_size_bytes = v.into();
-        self
-    }
-
     /// Sets the value of [service_locks][crate::model::Backup::service_locks].
     pub fn set_service_locks<T, V>(mut self, v: T) -> Self
     where
@@ -6002,15 +5999,18 @@ impl Backup {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Backup::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [backup_type][crate::model::Backup::backup_type].
+    pub fn set_backup_type<T: std::convert::Into<crate::model::backup::BackupType>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.backup_type = v.into();
+        self
+    }
+
+    /// Sets the value of [resource_size_bytes][crate::model::Backup::resource_size_bytes].
+    pub fn set_resource_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.resource_size_bytes = v.into();
         self
     }
 
@@ -6043,21 +6043,6 @@ impl Backup {
         })
     }
 
-    /// The value of [backup_properties][crate::model::Backup::backup_properties]
-    /// if it holds a `BackupApplianceBackupProperties`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn backup_appliance_backup_properties(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupApplianceBackupProperties>> {
-        #[allow(unreachable_patterns)]
-        self.backup_properties.as_ref().and_then(|v| match v {
-            crate::model::backup::BackupProperties::BackupApplianceBackupProperties(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [backup_properties][crate::model::Backup::backup_properties]
     /// to hold a `ComputeInstanceBackupProperties`.
     ///
@@ -6073,6 +6058,21 @@ impl Backup {
             crate::model::backup::BackupProperties::ComputeInstanceBackupProperties(v.into()),
         );
         self
+    }
+
+    /// The value of [backup_properties][crate::model::Backup::backup_properties]
+    /// if it holds a `BackupApplianceBackupProperties`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn backup_appliance_backup_properties(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BackupApplianceBackupProperties>> {
+        #[allow(unreachable_patterns)]
+        self.backup_properties.as_ref().and_then(|v| match v {
+            crate::model::backup::BackupProperties::BackupApplianceBackupProperties(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [backup_properties][crate::model::Backup::backup_properties]
@@ -6714,12 +6714,6 @@ impl ListBackupVaultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupVaultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_vaults][crate::model::ListBackupVaultsResponse::backup_vaults].
     pub fn set_backup_vaults<T, V>(mut self, v: T) -> Self
     where
@@ -6728,6 +6722,12 @@ impl ListBackupVaultsResponse {
     {
         use std::iter::Iterator;
         self.backup_vaults = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupVaultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6875,12 +6875,6 @@ impl FetchUsableBackupVaultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchUsableBackupVaultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_vaults][crate::model::FetchUsableBackupVaultsResponse::backup_vaults].
     pub fn set_backup_vaults<T, V>(mut self, v: T) -> Self
     where
@@ -6889,6 +6883,12 @@ impl FetchUsableBackupVaultsResponse {
     {
         use std::iter::Iterator;
         self.backup_vaults = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchUsableBackupVaultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7287,12 +7287,6 @@ impl ListDataSourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataSourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_sources][crate::model::ListDataSourcesResponse::data_sources].
     pub fn set_data_sources<T, V>(mut self, v: T) -> Self
     where
@@ -7301,6 +7295,12 @@ impl ListDataSourcesResponse {
     {
         use std::iter::Iterator;
         self.data_sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataSourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7575,12 +7575,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -7589,6 +7583,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8380,6 +8380,28 @@ impl ComputeInstanceBackupProperties {
         self
     }
 
+    /// Sets the value of [network_interface][crate::model::ComputeInstanceBackupProperties::network_interface].
+    pub fn set_network_interface<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkInterface>,
+    {
+        use std::iter::Iterator;
+        self.network_interface = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [disk][crate::model::ComputeInstanceBackupProperties::disk].
+    pub fn set_disk<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AttachedDisk>,
+    {
+        use std::iter::Iterator;
+        self.disk = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [metadata][crate::model::ComputeInstanceBackupProperties::metadata].
     pub fn set_metadata<T: std::convert::Into<std::option::Option<crate::model::Metadata>>>(
         mut self,
@@ -8389,12 +8411,34 @@ impl ComputeInstanceBackupProperties {
         self
     }
 
+    /// Sets the value of [service_account][crate::model::ComputeInstanceBackupProperties::service_account].
+    pub fn set_service_account<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ServiceAccount>,
+    {
+        use std::iter::Iterator;
+        self.service_account = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [scheduling][crate::model::ComputeInstanceBackupProperties::scheduling].
     pub fn set_scheduling<T: std::convert::Into<std::option::Option<crate::model::Scheduling>>>(
         mut self,
         v: T,
     ) -> Self {
         self.scheduling = v.into();
+        self
+    }
+
+    /// Sets the value of [guest_accelerator][crate::model::ComputeInstanceBackupProperties::guest_accelerator].
+    pub fn set_guest_accelerator<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AcceleratorConfig>,
+    {
+        use std::iter::Iterator;
+        self.guest_accelerator = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8424,50 +8468,6 @@ impl ComputeInstanceBackupProperties {
         v: T,
     ) -> Self {
         self.source_instance = v.into();
-        self
-    }
-
-    /// Sets the value of [network_interface][crate::model::ComputeInstanceBackupProperties::network_interface].
-    pub fn set_network_interface<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkInterface>,
-    {
-        use std::iter::Iterator;
-        self.network_interface = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [disk][crate::model::ComputeInstanceBackupProperties::disk].
-    pub fn set_disk<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AttachedDisk>,
-    {
-        use std::iter::Iterator;
-        self.disk = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [service_account][crate::model::ComputeInstanceBackupProperties::service_account].
-    pub fn set_service_account<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ServiceAccount>,
-    {
-        use std::iter::Iterator;
-        self.service_account = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [guest_accelerator][crate::model::ComputeInstanceBackupProperties::guest_accelerator].
-    pub fn set_guest_accelerator<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AcceleratorConfig>,
-    {
-        use std::iter::Iterator;
-        self.guest_accelerator = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8685,6 +8685,17 @@ impl ComputeInstanceRestoreProperties {
         self
     }
 
+    /// Sets the value of [disks][crate::model::ComputeInstanceRestoreProperties::disks].
+    pub fn set_disks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AttachedDisk>,
+    {
+        use std::iter::Iterator;
+        self.disks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [display_device][crate::model::ComputeInstanceRestoreProperties::display_device].
     pub fn set_display_device<
         T: std::convert::Into<std::option::Option<crate::model::DisplayDevice>>,
@@ -8693,6 +8704,17 @@ impl ComputeInstanceRestoreProperties {
         v: T,
     ) -> Self {
         self.display_device = v.into();
+        self
+    }
+
+    /// Sets the value of [guest_accelerators][crate::model::ComputeInstanceRestoreProperties::guest_accelerators].
+    pub fn set_guest_accelerators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AcceleratorConfig>,
+    {
+        use std::iter::Iterator;
+        self.guest_accelerators = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8727,6 +8749,18 @@ impl ComputeInstanceRestoreProperties {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ComputeInstanceRestoreProperties::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [machine_type][crate::model::ComputeInstanceRestoreProperties::machine_type].
     pub fn set_machine_type<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
@@ -8751,6 +8785,17 @@ impl ComputeInstanceRestoreProperties {
         v: T,
     ) -> Self {
         self.min_cpu_platform = v.into();
+        self
+    }
+
+    /// Sets the value of [network_interfaces][crate::model::ComputeInstanceRestoreProperties::network_interfaces].
+    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkInterface>,
+    {
+        use std::iter::Iterator;
+        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8791,57 +8836,6 @@ impl ComputeInstanceRestoreProperties {
         self
     }
 
-    /// Sets the value of [scheduling][crate::model::ComputeInstanceRestoreProperties::scheduling].
-    pub fn set_scheduling<T: std::convert::Into<std::option::Option<crate::model::Scheduling>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scheduling = v.into();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::ComputeInstanceRestoreProperties::tags].
-    pub fn set_tags<T: std::convert::Into<std::option::Option<crate::model::Tags>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tags = v.into();
-        self
-    }
-
-    /// Sets the value of [disks][crate::model::ComputeInstanceRestoreProperties::disks].
-    pub fn set_disks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AttachedDisk>,
-    {
-        use std::iter::Iterator;
-        self.disks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [guest_accelerators][crate::model::ComputeInstanceRestoreProperties::guest_accelerators].
-    pub fn set_guest_accelerators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AcceleratorConfig>,
-    {
-        use std::iter::Iterator;
-        self.guest_accelerators = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [network_interfaces][crate::model::ComputeInstanceRestoreProperties::network_interfaces].
-    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkInterface>,
-    {
-        use std::iter::Iterator;
-        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [resource_policies][crate::model::ComputeInstanceRestoreProperties::resource_policies].
     pub fn set_resource_policies<T, V>(mut self, v: T) -> Self
     where
@@ -8850,6 +8844,15 @@ impl ComputeInstanceRestoreProperties {
     {
         use std::iter::Iterator;
         self.resource_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [scheduling][crate::model::ComputeInstanceRestoreProperties::scheduling].
+    pub fn set_scheduling<T: std::convert::Into<std::option::Option<crate::model::Scheduling>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.scheduling = v.into();
         self
     }
 
@@ -8864,15 +8867,12 @@ impl ComputeInstanceRestoreProperties {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ComputeInstanceRestoreProperties::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [tags][crate::model::ComputeInstanceRestoreProperties::tags].
+    pub fn set_tags<T: std::convert::Into<std::option::Option<crate::model::Tags>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.tags = v.into();
         self
     }
 }
@@ -9423,6 +9423,17 @@ impl CustomerEncryptionKey {
         })
     }
 
+    /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
+    /// to hold a `RawKey`.
+    ///
+    /// Note that all the setters affecting `key` are
+    /// mutually exclusive.
+    pub fn set_raw_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.key =
+            std::option::Option::Some(crate::model::customer_encryption_key::Key::RawKey(v.into()));
+        self
+    }
+
     /// The value of [key][crate::model::CustomerEncryptionKey::key]
     /// if it holds a `RsaEncryptedKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -9434,30 +9445,6 @@ impl CustomerEncryptionKey {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [key][crate::model::CustomerEncryptionKey::key]
-    /// if it holds a `KmsKeyName`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn kms_key_name(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.key.as_ref().and_then(|v| match v {
-            crate::model::customer_encryption_key::Key::KmsKeyName(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
-    /// to hold a `RawKey`.
-    ///
-    /// Note that all the setters affecting `key` are
-    /// mutually exclusive.
-    pub fn set_raw_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.key =
-            std::option::Option::Some(crate::model::customer_encryption_key::Key::RawKey(v.into()));
-        self
     }
 
     /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
@@ -9473,6 +9460,19 @@ impl CustomerEncryptionKey {
             crate::model::customer_encryption_key::Key::RsaEncryptedKey(v.into()),
         );
         self
+    }
+
+    /// The value of [key][crate::model::CustomerEncryptionKey::key]
+    /// if it holds a `KmsKeyName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn kms_key_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.key.as_ref().and_then(|v| match v {
+            crate::model::customer_encryption_key::Key::KmsKeyName(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
@@ -9752,6 +9752,39 @@ impl NetworkInterface {
         self
     }
 
+    /// Sets the value of [access_configs][crate::model::NetworkInterface::access_configs].
+    pub fn set_access_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AccessConfig>,
+    {
+        use std::iter::Iterator;
+        self.access_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ipv6_access_configs][crate::model::NetworkInterface::ipv6_access_configs].
+    pub fn set_ipv6_access_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AccessConfig>,
+    {
+        use std::iter::Iterator;
+        self.ipv6_access_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [alias_ip_ranges][crate::model::NetworkInterface::alias_ip_ranges].
+    pub fn set_alias_ip_ranges<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AliasIpRange>,
+    {
+        use std::iter::Iterator;
+        self.alias_ip_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [stack_type][crate::model::NetworkInterface::stack_type].
     pub fn set_stack_type<
         T: std::convert::Into<std::option::Option<crate::model::network_interface::StackType>>,
@@ -9802,39 +9835,6 @@ impl NetworkInterface {
         v: T,
     ) -> Self {
         self.network_attachment = v.into();
-        self
-    }
-
-    /// Sets the value of [access_configs][crate::model::NetworkInterface::access_configs].
-    pub fn set_access_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AccessConfig>,
-    {
-        use std::iter::Iterator;
-        self.access_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [ipv6_access_configs][crate::model::NetworkInterface::ipv6_access_configs].
-    pub fn set_ipv6_access_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AccessConfig>,
-    {
-        use std::iter::Iterator;
-        self.ipv6_access_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [alias_ip_ranges][crate::model::NetworkInterface::alias_ip_ranges].
-    pub fn set_alias_ip_ranges<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AliasIpRange>,
-    {
-        use std::iter::Iterator;
-        self.alias_ip_ranges = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -11222,6 +11222,17 @@ impl Scheduling {
         self
     }
 
+    /// Sets the value of [node_affinities][crate::model::Scheduling::node_affinities].
+    pub fn set_node_affinities<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::scheduling::NodeAffinity>,
+    {
+        use std::iter::Iterator;
+        self.node_affinities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [min_node_cpus][crate::model::Scheduling::min_node_cpus].
     pub fn set_min_node_cpus<T: std::convert::Into<std::option::Option<i32>>>(
         mut self,
@@ -11263,17 +11274,6 @@ impl Scheduling {
         v: T,
     ) -> Self {
         self.local_ssd_recovery_timeout = v.into();
-        self
-    }
-
-    /// Sets the value of [node_affinities][crate::model::Scheduling::node_affinities].
-    pub fn set_node_affinities<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::scheduling::NodeAffinity>,
-    {
-        use std::iter::Iterator;
-        self.node_affinities = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -12214,6 +12214,17 @@ impl AttachedDisk {
         self
     }
 
+    /// Sets the value of [license][crate::model::AttachedDisk::license].
+    pub fn set_license<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.license = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [disk_interface][crate::model::AttachedDisk::disk_interface].
     pub fn set_disk_interface<
         T: std::convert::Into<std::option::Option<crate::model::attached_disk::DiskInterface>>,
@@ -12222,6 +12233,17 @@ impl AttachedDisk {
         v: T,
     ) -> Self {
         self.disk_interface = v.into();
+        self
+    }
+
+    /// Sets the value of [guest_os_feature][crate::model::AttachedDisk::guest_os_feature].
+    pub fn set_guest_os_feature<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::GuestOsFeature>,
+    {
+        use std::iter::Iterator;
+        self.guest_os_feature = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -12273,28 +12295,6 @@ impl AttachedDisk {
         v: T,
     ) -> Self {
         self.r#type = v.into();
-        self
-    }
-
-    /// Sets the value of [license][crate::model::AttachedDisk::license].
-    pub fn set_license<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.license = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [guest_os_feature][crate::model::AttachedDisk::guest_os_feature].
-    pub fn set_guest_os_feature<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::GuestOsFeature>,
-    {
-        use std::iter::Iterator;
-        self.guest_os_feature = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -316,57 +316,15 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [interactive_serial_console_enabled][crate::model::Instance::interactive_serial_console_enabled].
-    pub fn set_interactive_serial_console_enabled<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.interactive_serial_console_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [os_image][crate::model::Instance::os_image].
-    pub fn set_os_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.os_image = v.into();
-        self
-    }
-
-    /// Sets the value of [pod][crate::model::Instance::pod].
-    pub fn set_pod<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pod = v.into();
-        self
-    }
-
-    /// Sets the value of [network_template][crate::model::Instance::network_template].
-    pub fn set_network_template<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.network_template = v.into();
-        self
-    }
-
-    /// Sets the value of [login_info][crate::model::Instance::login_info].
-    pub fn set_login_info<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.login_info = v.into();
-        self
-    }
-
-    /// Sets the value of [workload_profile][crate::model::Instance::workload_profile].
-    pub fn set_workload_profile<T: std::convert::Into<crate::model::WorkloadProfile>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.workload_profile = v.into();
-        self
-    }
-
-    /// Sets the value of [firmware_version][crate::model::Instance::firmware_version].
-    pub fn set_firmware_version<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firmware_version = v.into();
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -403,6 +361,36 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [interactive_serial_console_enabled][crate::model::Instance::interactive_serial_console_enabled].
+    pub fn set_interactive_serial_console_enabled<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.interactive_serial_console_enabled = v.into();
+        self
+    }
+
+    /// Sets the value of [os_image][crate::model::Instance::os_image].
+    pub fn set_os_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.os_image = v.into();
+        self
+    }
+
+    /// Sets the value of [pod][crate::model::Instance::pod].
+    pub fn set_pod<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pod = v.into();
+        self
+    }
+
+    /// Sets the value of [network_template][crate::model::Instance::network_template].
+    pub fn set_network_template<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.network_template = v.into();
+        self
+    }
+
     /// Sets the value of [logical_interfaces][crate::model::Instance::logical_interfaces].
     pub fn set_logical_interfaces<T, V>(mut self, v: T) -> Self
     where
@@ -414,15 +402,27 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [login_info][crate::model::Instance::login_info].
+    pub fn set_login_info<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.login_info = v.into();
+        self
+    }
+
+    /// Sets the value of [workload_profile][crate::model::Instance::workload_profile].
+    pub fn set_workload_profile<T: std::convert::Into<crate::model::WorkloadProfile>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.workload_profile = v.into();
+        self
+    }
+
+    /// Sets the value of [firmware_version][crate::model::Instance::firmware_version].
+    pub fn set_firmware_version<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.firmware_version = v.into();
         self
     }
 }
@@ -728,12 +728,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -742,6 +736,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2134,12 +2134,6 @@ impl ListLunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [luns][crate::model::ListLunsResponse::luns].
     pub fn set_luns<T, V>(mut self, v: T) -> Self
     where
@@ -2148,6 +2142,12 @@ impl ListLunsResponse {
     {
         use std::iter::Iterator;
         self.luns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2323,6 +2323,17 @@ impl Network {
         self
     }
 
+    /// Sets the value of [mac_address][crate::model::Network::mac_address].
+    pub fn set_mac_address<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.mac_address = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Network::state].
     pub fn set_state<T: std::convert::Into<crate::model::network::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -2350,38 +2361,21 @@ impl Network {
         self
     }
 
-    /// Sets the value of [services_cidr][crate::model::Network::services_cidr].
-    pub fn set_services_cidr<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.services_cidr = v.into();
-        self
-    }
-
-    /// Sets the value of [pod][crate::model::Network::pod].
-    pub fn set_pod<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pod = v.into();
-        self
-    }
-
-    /// Sets the value of [jumbo_frames_enabled][crate::model::Network::jumbo_frames_enabled].
-    pub fn set_jumbo_frames_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.jumbo_frames_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [gateway_ip][crate::model::Network::gateway_ip].
-    pub fn set_gateway_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.gateway_ip = v.into();
-        self
-    }
-
-    /// Sets the value of [mac_address][crate::model::Network::mac_address].
-    pub fn set_mac_address<T, V>(mut self, v: T) -> Self
+    /// Sets the value of [labels][crate::model::Network::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
-        T: std::iter::IntoIterator<Item = V>,
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
         V: std::convert::Into<std::string::String>,
     {
         use std::iter::Iterator;
-        self.mac_address = v.into_iter().map(|i| i.into()).collect();
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [services_cidr][crate::model::Network::services_cidr].
+    pub fn set_services_cidr<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.services_cidr = v.into();
         self
     }
 
@@ -2396,6 +2390,12 @@ impl Network {
         self
     }
 
+    /// Sets the value of [pod][crate::model::Network::pod].
+    pub fn set_pod<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.pod = v.into();
+        self
+    }
+
     /// Sets the value of [mount_points][crate::model::Network::mount_points].
     pub fn set_mount_points<T, V>(mut self, v: T) -> Self
     where
@@ -2407,15 +2407,15 @@ impl Network {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Network::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [jumbo_frames_enabled][crate::model::Network::jumbo_frames_enabled].
+    pub fn set_jumbo_frames_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.jumbo_frames_enabled = v.into();
+        self
+    }
+
+    /// Sets the value of [gateway_ip][crate::model::Network::gateway_ip].
+    pub fn set_gateway_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.gateway_ip = v.into();
         self
     }
 }
@@ -3147,6 +3147,17 @@ impl LogicalInterface {
         std::default::Default::default()
     }
 
+    /// Sets the value of [logical_network_interfaces][crate::model::LogicalInterface::logical_network_interfaces].
+    pub fn set_logical_network_interfaces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::logical_interface::LogicalNetworkInterface>,
+    {
+        use std::iter::Iterator;
+        self.logical_network_interfaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [name][crate::model::LogicalInterface::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
@@ -3157,17 +3168,6 @@ impl LogicalInterface {
     #[deprecated]
     pub fn set_interface_index<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.interface_index = v.into();
-        self
-    }
-
-    /// Sets the value of [logical_network_interfaces][crate::model::LogicalInterface::logical_network_interfaces].
-    pub fn set_logical_network_interfaces<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::logical_interface::LogicalNetworkInterface>,
-    {
-        use std::iter::Iterator;
-        self.logical_network_interfaces = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3381,12 +3381,6 @@ impl ListNetworksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNetworksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [networks][crate::model::ListNetworksResponse::networks].
     pub fn set_networks<T, V>(mut self, v: T) -> Self
     where
@@ -3395,6 +3389,12 @@ impl ListNetworksResponse {
     {
         use std::iter::Iterator;
         self.networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNetworksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3796,21 +3796,6 @@ impl NfsShare {
         self
     }
 
-    /// Sets the value of [requested_size_gib][crate::model::NfsShare::requested_size_gib].
-    pub fn set_requested_size_gib<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.requested_size_gib = v.into();
-        self
-    }
-
-    /// Sets the value of [storage_type][crate::model::NfsShare::storage_type].
-    pub fn set_storage_type<T: std::convert::Into<crate::model::nfs_share::StorageType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.storage_type = v.into();
-        self
-    }
-
     /// Sets the value of [allowed_clients][crate::model::NfsShare::allowed_clients].
     pub fn set_allowed_clients<T, V>(mut self, v: T) -> Self
     where
@@ -3831,6 +3816,21 @@ impl NfsShare {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [requested_size_gib][crate::model::NfsShare::requested_size_gib].
+    pub fn set_requested_size_gib<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.requested_size_gib = v.into();
+        self
+    }
+
+    /// Sets the value of [storage_type][crate::model::NfsShare::storage_type].
+    pub fn set_storage_type<T: std::convert::Into<crate::model::nfs_share::StorageType>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.storage_type = v.into();
         self
     }
 }
@@ -4493,12 +4493,6 @@ impl ListNfsSharesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNfsSharesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [nfs_shares][crate::model::ListNfsSharesResponse::nfs_shares].
     pub fn set_nfs_shares<T, V>(mut self, v: T) -> Self
     where
@@ -4507,6 +4501,12 @@ impl ListNfsSharesResponse {
     {
         use std::iter::Iterator;
         self.nfs_shares = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNfsSharesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4879,12 +4879,6 @@ impl ListOSImagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOSImagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [os_images][crate::model::ListOSImagesResponse::os_images].
     pub fn set_os_images<T, V>(mut self, v: T) -> Self
     where
@@ -4893,6 +4887,12 @@ impl ListOSImagesResponse {
     {
         use std::iter::Iterator;
         self.os_images = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOSImagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4998,6 +4998,39 @@ impl ProvisioningConfig {
         self
     }
 
+    /// Sets the value of [instances][crate::model::ProvisioningConfig::instances].
+    pub fn set_instances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InstanceConfig>,
+    {
+        use std::iter::Iterator;
+        self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [networks][crate::model::ProvisioningConfig::networks].
+    pub fn set_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkConfig>,
+    {
+        use std::iter::Iterator;
+        self.networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::ProvisioningConfig::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::VolumeConfig>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [ticket_id][crate::model::ProvisioningConfig::ticket_id].
     pub fn set_ticket_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.ticket_id = v.into();
@@ -5068,39 +5101,6 @@ impl ProvisioningConfig {
     /// Sets the value of [custom_id][crate::model::ProvisioningConfig::custom_id].
     pub fn set_custom_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.custom_id = v.into();
-        self
-    }
-
-    /// Sets the value of [instances][crate::model::ProvisioningConfig::instances].
-    pub fn set_instances<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InstanceConfig>,
-    {
-        use std::iter::Iterator;
-        self.instances = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [networks][crate::model::ProvisioningConfig::networks].
-    pub fn set_networks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkConfig>,
-    {
-        use std::iter::Iterator;
-        self.networks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [volumes][crate::model::ProvisioningConfig::volumes].
-    pub fn set_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::VolumeConfig>,
-    {
-        use std::iter::Iterator;
-        self.volumes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5531,6 +5531,18 @@ impl ProvisioningQuota {
         })
     }
 
+    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
+    /// to hold a `ServerCount`.
+    ///
+    /// Note that all the setters affecting `availability` are
+    /// mutually exclusive.
+    pub fn set_server_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.availability = std::option::Option::Some(
+            crate::model::provisioning_quota::Availability::ServerCount(v.into()),
+        );
+        self
+    }
+
     /// The value of [availability][crate::model::ProvisioningQuota::availability]
     /// if it holds a `NetworkBandwidth`, `None` if the field is not set or
     /// holds a different branch.
@@ -5544,6 +5556,18 @@ impl ProvisioningQuota {
         })
     }
 
+    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
+    /// to hold a `NetworkBandwidth`.
+    ///
+    /// Note that all the setters affecting `availability` are
+    /// mutually exclusive.
+    pub fn set_network_bandwidth<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.availability = std::option::Option::Some(
+            crate::model::provisioning_quota::Availability::NetworkBandwidth(v.into()),
+        );
+        self
+    }
+
     /// The value of [availability][crate::model::ProvisioningQuota::availability]
     /// if it holds a `StorageGib`, `None` if the field is not set or
     /// holds a different branch.
@@ -5555,30 +5579,6 @@ impl ProvisioningQuota {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
-    /// to hold a `ServerCount`.
-    ///
-    /// Note that all the setters affecting `availability` are
-    /// mutually exclusive.
-    pub fn set_server_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.availability = std::option::Option::Some(
-            crate::model::provisioning_quota::Availability::ServerCount(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
-    /// to hold a `NetworkBandwidth`.
-    ///
-    /// Note that all the setters affecting `availability` are
-    /// mutually exclusive.
-    pub fn set_network_bandwidth<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.availability = std::option::Option::Some(
-            crate::model::provisioning_quota::Availability::NetworkBandwidth(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
@@ -5846,12 +5846,6 @@ impl ListProvisioningQuotasResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProvisioningQuotasResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [provisioning_quotas][crate::model::ListProvisioningQuotasResponse::provisioning_quotas].
     pub fn set_provisioning_quotas<T, V>(mut self, v: T) -> Self
     where
@@ -5860,6 +5854,12 @@ impl ListProvisioningQuotasResponse {
     {
         use std::iter::Iterator;
         self.provisioning_quotas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProvisioningQuotasResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6381,27 +6381,6 @@ impl VolumeConfig {
         self
     }
 
-    /// Sets the value of [user_note][crate::model::VolumeConfig::user_note].
-    pub fn set_user_note<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.user_note = v.into();
-        self
-    }
-
-    /// Sets the value of [gcp_service][crate::model::VolumeConfig::gcp_service].
-    pub fn set_gcp_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.gcp_service = v.into();
-        self
-    }
-
-    /// Sets the value of [performance_tier][crate::model::VolumeConfig::performance_tier].
-    pub fn set_performance_tier<T: std::convert::Into<crate::model::VolumePerformanceTier>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.performance_tier = v.into();
-        self
-    }
-
     /// Sets the value of [lun_ranges][crate::model::VolumeConfig::lun_ranges].
     pub fn set_lun_ranges<T, V>(mut self, v: T) -> Self
     where
@@ -6432,6 +6411,27 @@ impl VolumeConfig {
     {
         use std::iter::Iterator;
         self.nfs_exports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [user_note][crate::model::VolumeConfig::user_note].
+    pub fn set_user_note<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.user_note = v.into();
+        self
+    }
+
+    /// Sets the value of [gcp_service][crate::model::VolumeConfig::gcp_service].
+    pub fn set_gcp_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.gcp_service = v.into();
+        self
+    }
+
+    /// Sets the value of [performance_tier][crate::model::VolumeConfig::performance_tier].
+    pub fn set_performance_tier<T: std::convert::Into<crate::model::VolumePerformanceTier>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.performance_tier = v.into();
         self
     }
 }
@@ -6593,6 +6593,18 @@ pub mod volume_config {
             })
         }
 
+        /// Sets the value of [client][crate::model::volume_config::NfsExport::client]
+        /// to hold a `MachineId`.
+        ///
+        /// Note that all the setters affecting `client` are
+        /// mutually exclusive.
+        pub fn set_machine_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.client = std::option::Option::Some(
+                crate::model::volume_config::nfs_export::Client::MachineId(v.into()),
+            );
+            self
+        }
+
         /// The value of [client][crate::model::volume_config::NfsExport::client]
         /// if it holds a `Cidr`, `None` if the field is not set or
         /// holds a different branch.
@@ -6604,18 +6616,6 @@ pub mod volume_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [client][crate::model::volume_config::NfsExport::client]
-        /// to hold a `MachineId`.
-        ///
-        /// Note that all the setters affecting `client` are
-        /// mutually exclusive.
-        pub fn set_machine_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.client = std::option::Option::Some(
-                crate::model::volume_config::nfs_export::Client::MachineId(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [client][crate::model::volume_config::NfsExport::client]
@@ -7146,6 +7146,17 @@ impl NetworkConfig {
         self
     }
 
+    /// Sets the value of [vlan_attachments][crate::model::NetworkConfig::vlan_attachments].
+    pub fn set_vlan_attachments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::network_config::IntakeVlanAttachment>,
+    {
+        use std::iter::Iterator;
+        self.vlan_attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cidr][crate::model::NetworkConfig::cidr].
     pub fn set_cidr<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cidr = v.into();
@@ -7182,17 +7193,6 @@ impl NetworkConfig {
     /// Sets the value of [jumbo_frames_enabled][crate::model::NetworkConfig::jumbo_frames_enabled].
     pub fn set_jumbo_frames_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.jumbo_frames_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [vlan_attachments][crate::model::NetworkConfig::vlan_attachments].
-    pub fn set_vlan_attachments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::network_config::IntakeVlanAttachment>,
-    {
-        use std::iter::Iterator;
-        self.vlan_attachments = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8023,12 +8023,6 @@ impl ListSSHKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSSHKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [ssh_keys][crate::model::ListSSHKeysResponse::ssh_keys].
     pub fn set_ssh_keys<T, V>(mut self, v: T) -> Self
     where
@@ -8037,6 +8031,12 @@ impl ListSSHKeysResponse {
     {
         use std::iter::Iterator;
         self.ssh_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSSHKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8373,6 +8373,18 @@ impl Volume {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Volume::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [snapshot_enabled][crate::model::Volume::snapshot_enabled].
     pub fn set_snapshot_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.snapshot_enabled = v.into();
@@ -8433,12 +8445,6 @@ impl Volume {
         self
     }
 
-    /// Sets the value of [attached][crate::model::Volume::attached].
-    pub fn set_attached<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.attached = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::Volume::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -8450,15 +8456,9 @@ impl Volume {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Volume::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [attached][crate::model::Volume::attached].
+    pub fn set_attached<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.attached = v.into();
         self
     }
 }
@@ -9368,12 +9368,6 @@ impl ListVolumesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVolumesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [volumes][crate::model::ListVolumesResponse::volumes].
     pub fn set_volumes<T, V>(mut self, v: T) -> Self
     where
@@ -9382,6 +9376,12 @@ impl ListVolumesResponse {
     {
         use std::iter::Iterator;
         self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVolumesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -9927,12 +9927,6 @@ impl ListVolumeSnapshotsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVolumeSnapshotsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [volume_snapshots][crate::model::ListVolumeSnapshotsResponse::volume_snapshots].
     pub fn set_volume_snapshots<T, V>(mut self, v: T) -> Self
     where
@@ -9941,6 +9935,12 @@ impl ListVolumeSnapshotsResponse {
     {
         use std::iter::Iterator;
         self.volume_snapshots = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVolumeSnapshotsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/model.rs
@@ -144,12 +144,6 @@ impl ListAppConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAppConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [app_connections][crate::model::ListAppConnectionsResponse::app_connections].
     pub fn set_app_connections<T, V>(mut self, v: T) -> Self
     where
@@ -158,6 +152,12 @@ impl ListAppConnectionsResponse {
     {
         use std::iter::Iterator;
         self.app_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAppConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -594,12 +594,6 @@ impl ResolveAppConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ResolveAppConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [app_connection_details][crate::model::ResolveAppConnectionsResponse::app_connection_details].
     pub fn set_app_connection_details<T, V>(mut self, v: T) -> Self
     where
@@ -608,6 +602,12 @@ impl ResolveAppConnectionsResponse {
     {
         use std::iter::Iterator;
         self.app_connection_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ResolveAppConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -793,6 +793,18 @@ impl AppConnection {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AppConnection::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::AppConnection::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -825,6 +837,17 @@ impl AppConnection {
         self
     }
 
+    /// Sets the value of [connectors][crate::model::AppConnection::connectors].
+    pub fn set_connectors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.connectors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::AppConnection::state].
     pub fn set_state<T: std::convert::Into<crate::model::app_connection::State>>(
         mut self,
@@ -842,29 +865,6 @@ impl AppConnection {
         v: T,
     ) -> Self {
         self.gateway = v.into();
-        self
-    }
-
-    /// Sets the value of [connectors][crate::model::AppConnection::connectors].
-    pub fn set_connectors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.connectors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AppConnection::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -394,12 +394,6 @@ impl ListAppConnectorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAppConnectorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [app_connectors][crate::model::ListAppConnectorsResponse::app_connectors].
     pub fn set_app_connectors<T, V>(mut self, v: T) -> Self
     where
@@ -408,6 +402,12 @@ impl ListAppConnectorsResponse {
     {
         use std::iter::Iterator;
         self.app_connectors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAppConnectorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -891,6 +891,18 @@ impl AppConnector {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AppConnector::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::AppConnector::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -931,18 +943,6 @@ impl AppConnector {
         v: T,
     ) -> Self {
         self.resource_info = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AppConnector::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/model.rs
@@ -144,12 +144,6 @@ impl ListAppGatewaysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAppGatewaysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [app_gateways][crate::model::ListAppGatewaysResponse::app_gateways].
     pub fn set_app_gateways<T, V>(mut self, v: T) -> Self
     where
@@ -158,6 +152,12 @@ impl ListAppGatewaysResponse {
     {
         use std::iter::Iterator;
         self.app_gateways = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAppGatewaysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -472,6 +472,18 @@ impl AppGateway {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AppGateway::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::AppGateway::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -508,15 +520,6 @@ impl AppGateway {
         self
     }
 
-    /// Sets the value of [host_type][crate::model::AppGateway::host_type].
-    pub fn set_host_type<T: std::convert::Into<crate::model::app_gateway::HostType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.host_type = v.into();
-        self
-    }
-
     /// Sets the value of [allocated_connections][crate::model::AppGateway::allocated_connections].
     pub fn set_allocated_connections<T, V>(mut self, v: T) -> Self
     where
@@ -528,15 +531,12 @@ impl AppGateway {
         self
     }
 
-    /// Sets the value of [labels][crate::model::AppGateway::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [host_type][crate::model::AppGateway::host_type].
+    pub fn set_host_type<T: std::convert::Into<crate::model::app_gateway::HostType>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.host_type = v.into();
         self
     }
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -889,12 +889,6 @@ impl ListClientConnectorServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClientConnectorServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [client_connector_services][crate::model::ListClientConnectorServicesResponse::client_connector_services].
     pub fn set_client_connector_services<T, V>(mut self, v: T) -> Self
     where
@@ -903,6 +897,12 @@ impl ListClientConnectorServicesResponse {
     {
         use std::iter::Iterator;
         self.client_connector_services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClientConnectorServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/model.rs
@@ -396,12 +396,6 @@ impl ListClientGatewaysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClientGatewaysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [client_gateways][crate::model::ListClientGatewaysResponse::client_gateways].
     pub fn set_client_gateways<T, V>(mut self, v: T) -> Self
     where
@@ -410,6 +404,12 @@ impl ListClientGatewaysResponse {
     {
         use std::iter::Iterator;
         self.client_gateways = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClientGatewaysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -242,23 +242,6 @@ impl SharingEnvironmentConfig {
         })
     }
 
-    /// The value of [environment][crate::model::SharingEnvironmentConfig::environment]
-    /// if it holds a `DcrExchangeConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dcr_exchange_config(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::sharing_environment_config::DcrExchangeConfig>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.environment.as_ref().and_then(|v| match v {
-            crate::model::sharing_environment_config::Environment::DcrExchangeConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [environment][crate::model::SharingEnvironmentConfig::environment]
     /// to hold a `DefaultExchangeConfig`.
     ///
@@ -276,6 +259,23 @@ impl SharingEnvironmentConfig {
             crate::model::sharing_environment_config::Environment::DefaultExchangeConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [environment][crate::model::SharingEnvironmentConfig::environment]
+    /// if it holds a `DcrExchangeConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dcr_exchange_config(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::sharing_environment_config::DcrExchangeConfig>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.environment.as_ref().and_then(|v| match v {
+            crate::model::sharing_environment_config::Environment::DcrExchangeConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [environment][crate::model::SharingEnvironmentConfig::environment]
@@ -606,12 +606,6 @@ impl DestinationDataset {
         self
     }
 
-    /// Sets the value of [location][crate::model::DestinationDataset::location].
-    pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.location = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::DestinationDataset::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -621,6 +615,12 @@ impl DestinationDataset {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [location][crate::model::DestinationDataset::location].
+    pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.location = v.into();
         self
     }
 }
@@ -820,6 +820,17 @@ impl Listing {
         self
     }
 
+    /// Sets the value of [categories][crate::model::Listing::categories].
+    pub fn set_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::listing::Category>,
+    {
+        use std::iter::Iterator;
+        self.categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [publisher][crate::model::Listing::publisher].
     pub fn set_publisher<T: std::convert::Into<std::option::Option<crate::model::Publisher>>>(
         mut self,
@@ -877,17 +888,6 @@ impl Listing {
         self
     }
 
-    /// Sets the value of [categories][crate::model::Listing::categories].
-    pub fn set_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::listing::Category>,
-    {
-        use std::iter::Iterator;
-        self.categories = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [source][crate::model::Listing::source].
     ///
     /// Note that all the setters affecting `source` are mutually
@@ -913,19 +913,6 @@ impl Listing {
         })
     }
 
-    /// The value of [source][crate::model::Listing::source]
-    /// if it holds a `PubsubTopic`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pubsub_topic(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::listing::PubSubTopicSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::listing::Source::PubsubTopic(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::Listing::source]
     /// to hold a `BigqueryDataset`.
     ///
@@ -940,6 +927,19 @@ impl Listing {
         self.source =
             std::option::Option::Some(crate::model::listing::Source::BigqueryDataset(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::Listing::source]
+    /// if it holds a `PubsubTopic`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pubsub_topic(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::listing::PubSubTopicSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::listing::Source::PubsubTopic(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::Listing::source]
@@ -1015,6 +1015,19 @@ pub mod listing {
             self
         }
 
+        /// Sets the value of [selected_resources][crate::model::listing::BigQueryDatasetSource::selected_resources].
+        pub fn set_selected_resources<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                    crate::model::listing::big_query_dataset_source::SelectedResource,
+                >,
+        {
+            use std::iter::Iterator;
+            self.selected_resources = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [restricted_export_policy][crate::model::listing::BigQueryDatasetSource::restricted_export_policy].
         pub fn set_restricted_export_policy<
             T: std::convert::Into<
@@ -1027,19 +1040,6 @@ pub mod listing {
             v: T,
         ) -> Self {
             self.restricted_export_policy = v.into();
-            self
-        }
-
-        /// Sets the value of [selected_resources][crate::model::listing::BigQueryDatasetSource::selected_resources].
-        pub fn set_selected_resources<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<
-                    crate::model::listing::big_query_dataset_source::SelectedResource,
-                >,
-        {
-            use std::iter::Iterator;
-            self.selected_resources = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1811,12 +1811,35 @@ impl Subscription {
         self
     }
 
+    /// Sets the value of [linked_dataset_map][crate::model::Subscription::linked_dataset_map].
+    pub fn set_linked_dataset_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::subscription::LinkedResource>,
+    {
+        use std::iter::Iterator;
+        self.linked_dataset_map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [subscriber_contact][crate::model::Subscription::subscriber_contact].
     pub fn set_subscriber_contact<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.subscriber_contact = v.into();
+        self
+    }
+
+    /// Sets the value of [linked_resources][crate::model::Subscription::linked_resources].
+    pub fn set_linked_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::subscription::LinkedResource>,
+    {
+        use std::iter::Iterator;
+        self.linked_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1837,29 +1860,6 @@ impl Subscription {
         v: T,
     ) -> Self {
         self.log_linked_dataset_query_user_email = v.into();
-        self
-    }
-
-    /// Sets the value of [linked_resources][crate::model::Subscription::linked_resources].
-    pub fn set_linked_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::subscription::LinkedResource>,
-    {
-        use std::iter::Iterator;
-        self.linked_resources = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [linked_dataset_map][crate::model::Subscription::linked_dataset_map].
-    pub fn set_linked_dataset_map<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::subscription::LinkedResource>,
-    {
-        use std::iter::Iterator;
-        self.linked_dataset_map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1888,6 +1888,17 @@ impl Subscription {
         })
     }
 
+    /// Sets the value of [resource_name][crate::model::Subscription::resource_name]
+    /// to hold a `Listing`.
+    ///
+    /// Note that all the setters affecting `resource_name` are
+    /// mutually exclusive.
+    pub fn set_listing<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.resource_name =
+            std::option::Option::Some(crate::model::subscription::ResourceName::Listing(v.into()));
+        self
+    }
+
     /// The value of [resource_name][crate::model::Subscription::resource_name]
     /// if it holds a `DataExchange`, `None` if the field is not set or
     /// holds a different branch.
@@ -1899,17 +1910,6 @@ impl Subscription {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource_name][crate::model::Subscription::resource_name]
-    /// to hold a `Listing`.
-    ///
-    /// Note that all the setters affecting `resource_name` are
-    /// mutually exclusive.
-    pub fn set_listing<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.resource_name =
-            std::option::Option::Some(crate::model::subscription::ResourceName::Listing(v.into()));
-        self
     }
 
     /// Sets the value of [resource_name][crate::model::Subscription::resource_name]
@@ -1993,17 +1993,6 @@ pub mod subscription {
             })
         }
 
-        /// The value of [reference][crate::model::subscription::LinkedResource::reference]
-        /// if it holds a `LinkedPubsubSubscription`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn linked_pubsub_subscription(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.reference.as_ref().and_then(|v| match v {
-                crate::model::subscription::linked_resource::Reference::LinkedPubsubSubscription(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [reference][crate::model::subscription::LinkedResource::reference]
         /// to hold a `LinkedDataset`.
         ///
@@ -2017,6 +2006,17 @@ pub mod subscription {
                 crate::model::subscription::linked_resource::Reference::LinkedDataset(v.into()),
             );
             self
+        }
+
+        /// The value of [reference][crate::model::subscription::LinkedResource::reference]
+        /// if it holds a `LinkedPubsubSubscription`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn linked_pubsub_subscription(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.reference.as_ref().and_then(|v| match v {
+                crate::model::subscription::linked_resource::Reference::LinkedPubsubSubscription(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [reference][crate::model::subscription::LinkedResource::reference]
@@ -2293,12 +2293,6 @@ impl ListDataExchangesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataExchangesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_exchanges][crate::model::ListDataExchangesResponse::data_exchanges].
     pub fn set_data_exchanges<T, V>(mut self, v: T) -> Self
     where
@@ -2307,6 +2301,12 @@ impl ListDataExchangesResponse {
     {
         use std::iter::Iterator;
         self.data_exchanges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataExchangesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2411,12 +2411,6 @@ impl ListOrgDataExchangesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOrgDataExchangesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_exchanges][crate::model::ListOrgDataExchangesResponse::data_exchanges].
     pub fn set_data_exchanges<T, V>(mut self, v: T) -> Self
     where
@@ -2425,6 +2419,12 @@ impl ListOrgDataExchangesResponse {
     {
         use std::iter::Iterator;
         self.data_exchanges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOrgDataExchangesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2708,12 +2708,6 @@ impl ListListingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListListingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [listings][crate::model::ListListingsResponse::listings].
     pub fn set_listings<T, V>(mut self, v: T) -> Self
     where
@@ -2722,6 +2716,12 @@ impl ListListingsResponse {
     {
         use std::iter::Iterator;
         self.listings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListListingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2981,21 +2981,6 @@ impl SubscribeListingRequest {
         })
     }
 
-    /// The value of [destination][crate::model::SubscribeListingRequest::destination]
-    /// if it holds a `DestinationPubsubSubscription`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn destination_pubsub_subscription(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DestinationPubSubSubscription>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::subscribe_listing_request::Destination::DestinationPubsubSubscription(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::SubscribeListingRequest::destination]
     /// to hold a `DestinationDataset`.
     ///
@@ -3011,6 +2996,21 @@ impl SubscribeListingRequest {
             crate::model::subscribe_listing_request::Destination::DestinationDataset(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::SubscribeListingRequest::destination]
+    /// if it holds a `DestinationPubsubSubscription`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn destination_pubsub_subscription(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DestinationPubSubSubscription>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::subscribe_listing_request::Destination::DestinationPubsubSubscription(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::SubscribeListingRequest::destination]
@@ -3417,12 +3417,6 @@ impl ListSubscriptionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSubscriptionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [subscriptions][crate::model::ListSubscriptionsResponse::subscriptions].
     pub fn set_subscriptions<T, V>(mut self, v: T) -> Self
     where
@@ -3431,6 +3425,12 @@ impl ListSubscriptionsResponse {
     {
         use std::iter::Iterator;
         self.subscriptions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSubscriptionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3544,12 +3544,6 @@ impl ListSharedResourceSubscriptionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSharedResourceSubscriptionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [shared_resource_subscriptions][crate::model::ListSharedResourceSubscriptionsResponse::shared_resource_subscriptions].
     pub fn set_shared_resource_subscriptions<T, V>(mut self, v: T) -> Self
     where
@@ -3558,6 +3552,12 @@ impl ListSharedResourceSubscriptionsResponse {
     {
         use std::iter::Iterator;
         self.shared_resource_subscriptions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSharedResourceSubscriptionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3993,6 +3993,18 @@ impl PubSubSubscription {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PubSubSubscription::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [enable_message_ordering][crate::model::PubSubSubscription::enable_message_ordering].
     pub fn set_enable_message_ordering<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_message_ordering = v.into();
@@ -4058,18 +4070,6 @@ impl PubSubSubscription {
     {
         use std::iter::Iterator;
         self.message_transforms = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::PubSubSubscription::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4399,19 +4399,6 @@ impl PushConfig {
         })
     }
 
-    /// The value of [wrapper][crate::model::PushConfig::wrapper]
-    /// if it holds a `NoWrapper`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn no_wrapper(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::push_config::NoWrapper>> {
-        #[allow(unreachable_patterns)]
-        self.wrapper.as_ref().and_then(|v| match v {
-            crate::model::push_config::Wrapper::NoWrapper(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [wrapper][crate::model::PushConfig::wrapper]
     /// to hold a `PubsubWrapper`.
     ///
@@ -4426,6 +4413,19 @@ impl PushConfig {
         self.wrapper =
             std::option::Option::Some(crate::model::push_config::Wrapper::PubsubWrapper(v.into()));
         self
+    }
+
+    /// The value of [wrapper][crate::model::PushConfig::wrapper]
+    /// if it holds a `NoWrapper`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn no_wrapper(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::push_config::NoWrapper>> {
+        #[allow(unreachable_patterns)]
+        self.wrapper.as_ref().and_then(|v| match v {
+            crate::model::push_config::Wrapper::NoWrapper(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [wrapper][crate::model::PushConfig::wrapper]
@@ -4866,21 +4866,6 @@ impl CloudStorageConfig {
         })
     }
 
-    /// The value of [output_format][crate::model::CloudStorageConfig::output_format]
-    /// if it holds a `AvroConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn avro_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::cloud_storage_config::AvroConfig>> {
-        #[allow(unreachable_patterns)]
-        self.output_format.as_ref().and_then(|v| match v {
-            crate::model::cloud_storage_config::OutputFormat::AvroConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [output_format][crate::model::CloudStorageConfig::output_format]
     /// to hold a `TextConfig`.
     ///
@@ -4896,6 +4881,21 @@ impl CloudStorageConfig {
             crate::model::cloud_storage_config::OutputFormat::TextConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [output_format][crate::model::CloudStorageConfig::output_format]
+    /// if it holds a `AvroConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn avro_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::cloud_storage_config::AvroConfig>> {
+        #[allow(unreachable_patterns)]
+        self.output_format.as_ref().and_then(|v| match v {
+            crate::model::cloud_storage_config::OutputFormat::AvroConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [output_format][crate::model::CloudStorageConfig::output_format]

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -451,80 +451,6 @@ impl Connection {
         })
     }
 
-    /// The value of [properties][crate::model::Connection::properties]
-    /// if it holds a `Aws`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsProperties>> {
-        #[allow(unreachable_patterns)]
-        self.properties.as_ref().and_then(|v| match v {
-            crate::model::connection::Properties::Aws(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [properties][crate::model::Connection::properties]
-    /// if it holds a `Azure`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn azure(&self) -> std::option::Option<&std::boxed::Box<crate::model::AzureProperties>> {
-        #[allow(unreachable_patterns)]
-        self.properties.as_ref().and_then(|v| match v {
-            crate::model::connection::Properties::Azure(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [properties][crate::model::Connection::properties]
-    /// if it holds a `CloudSpanner`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_spanner(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSpannerProperties>> {
-        #[allow(unreachable_patterns)]
-        self.properties.as_ref().and_then(|v| match v {
-            crate::model::connection::Properties::CloudSpanner(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [properties][crate::model::Connection::properties]
-    /// if it holds a `CloudResource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_resource(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudResourceProperties>> {
-        #[allow(unreachable_patterns)]
-        self.properties.as_ref().and_then(|v| match v {
-            crate::model::connection::Properties::CloudResource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [properties][crate::model::Connection::properties]
-    /// if it holds a `Spark`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkProperties>> {
-        #[allow(unreachable_patterns)]
-        self.properties.as_ref().and_then(|v| match v {
-            crate::model::connection::Properties::Spark(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [properties][crate::model::Connection::properties]
-    /// if it holds a `SalesforceDataCloud`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn salesforce_data_cloud(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceDataCloudProperties>> {
-        #[allow(unreachable_patterns)]
-        self.properties.as_ref().and_then(|v| match v {
-            crate::model::connection::Properties::SalesforceDataCloud(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [properties][crate::model::Connection::properties]
     /// to hold a `CloudSql`.
     ///
@@ -541,6 +467,17 @@ impl Connection {
         self
     }
 
+    /// The value of [properties][crate::model::Connection::properties]
+    /// if it holds a `Aws`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsProperties>> {
+        #[allow(unreachable_patterns)]
+        self.properties.as_ref().and_then(|v| match v {
+            crate::model::connection::Properties::Aws(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [properties][crate::model::Connection::properties]
     /// to hold a `Aws`.
     ///
@@ -553,6 +490,17 @@ impl Connection {
         self.properties =
             std::option::Option::Some(crate::model::connection::Properties::Aws(v.into()));
         self
+    }
+
+    /// The value of [properties][crate::model::Connection::properties]
+    /// if it holds a `Azure`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn azure(&self) -> std::option::Option<&std::boxed::Box<crate::model::AzureProperties>> {
+        #[allow(unreachable_patterns)]
+        self.properties.as_ref().and_then(|v| match v {
+            crate::model::connection::Properties::Azure(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [properties][crate::model::Connection::properties]
@@ -569,6 +517,19 @@ impl Connection {
         self
     }
 
+    /// The value of [properties][crate::model::Connection::properties]
+    /// if it holds a `CloudSpanner`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_spanner(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSpannerProperties>> {
+        #[allow(unreachable_patterns)]
+        self.properties.as_ref().and_then(|v| match v {
+            crate::model::connection::Properties::CloudSpanner(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [properties][crate::model::Connection::properties]
     /// to hold a `CloudSpanner`.
     ///
@@ -583,6 +544,19 @@ impl Connection {
         self.properties =
             std::option::Option::Some(crate::model::connection::Properties::CloudSpanner(v.into()));
         self
+    }
+
+    /// The value of [properties][crate::model::Connection::properties]
+    /// if it holds a `CloudResource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_resource(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudResourceProperties>> {
+        #[allow(unreachable_patterns)]
+        self.properties.as_ref().and_then(|v| match v {
+            crate::model::connection::Properties::CloudResource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [properties][crate::model::Connection::properties]
@@ -602,6 +576,17 @@ impl Connection {
         self
     }
 
+    /// The value of [properties][crate::model::Connection::properties]
+    /// if it holds a `Spark`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkProperties>> {
+        #[allow(unreachable_patterns)]
+        self.properties.as_ref().and_then(|v| match v {
+            crate::model::connection::Properties::Spark(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [properties][crate::model::Connection::properties]
     /// to hold a `Spark`.
     ///
@@ -614,6 +599,21 @@ impl Connection {
         self.properties =
             std::option::Option::Some(crate::model::connection::Properties::Spark(v.into()));
         self
+    }
+
+    /// The value of [properties][crate::model::Connection::properties]
+    /// if it holds a `SalesforceDataCloud`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn salesforce_data_cloud(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceDataCloudProperties>> {
+        #[allow(unreachable_patterns)]
+        self.properties.as_ref().and_then(|v| match v {
+            crate::model::connection::Properties::SalesforceDataCloud(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [properties][crate::model::Connection::properties]
@@ -1092,21 +1092,6 @@ impl AwsProperties {
         })
     }
 
-    /// The value of [authentication_method][crate::model::AwsProperties::authentication_method]
-    /// if it holds a `AccessRole`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn access_role(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsAccessRole>> {
-        #[allow(unreachable_patterns)]
-        self.authentication_method.as_ref().and_then(|v| match v {
-            crate::model::aws_properties::AuthenticationMethod::AccessRole(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [authentication_method][crate::model::AwsProperties::authentication_method]
     /// to hold a `CrossAccountRole`.
     ///
@@ -1123,6 +1108,21 @@ impl AwsProperties {
             crate::model::aws_properties::AuthenticationMethod::CrossAccountRole(v.into()),
         );
         self
+    }
+
+    /// The value of [authentication_method][crate::model::AwsProperties::authentication_method]
+    /// if it holds a `AccessRole`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn access_role(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsAccessRole>> {
+        #[allow(unreachable_patterns)]
+        self.authentication_method.as_ref().and_then(|v| match v {
+            crate::model::aws_properties::AuthenticationMethod::AccessRole(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [authentication_method][crate::model::AwsProperties::authentication_method]

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -343,12 +343,6 @@ impl ListDataPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_policies][crate::model::ListDataPoliciesResponse::data_policies].
     pub fn set_data_policies<T, V>(mut self, v: T) -> Self
     where
@@ -357,6 +351,12 @@ impl ListDataPoliciesResponse {
     {
         use std::iter::Iterator;
         self.data_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -740,19 +740,6 @@ impl DataMaskingPolicy {
         })
     }
 
-    /// The value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]
-    /// if it holds a `Routine`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn routine(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.masking_expression.as_ref().and_then(|v| match v {
-            crate::model::data_masking_policy::MaskingExpression::Routine(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]
     /// to hold a `PredefinedExpression`.
     ///
@@ -768,6 +755,19 @@ impl DataMaskingPolicy {
             crate::model::data_masking_policy::MaskingExpression::PredefinedExpression(v.into()),
         );
         self
+    }
+
+    /// The value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]
+    /// if it holds a `Routine`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn routine(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.masking_expression.as_ref().and_then(|v| match v {
+            crate::model::data_masking_policy::MaskingExpression::Routine(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -509,6 +509,17 @@ pub mod data_transfer_service {
             self
         }
 
+        /// Sets the value of [data_source_ids][crate::model::ListTransferConfigsRequest::data_source_ids].
+        pub fn set_data_source_ids<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.data_source_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_token][crate::model::ListTransferConfigsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
@@ -518,17 +529,6 @@ pub mod data_transfer_service {
         /// Sets the value of [page_size][crate::model::ListTransferConfigsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
-            self
-        }
-
-        /// Sets the value of [data_source_ids][crate::model::ListTransferConfigsRequest::data_source_ids].
-        pub fn set_data_source_ids<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.data_source_ids = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -857,6 +857,17 @@ pub mod data_transfer_service {
             self
         }
 
+        /// Sets the value of [states][crate::model::ListTransferRunsRequest::states].
+        pub fn set_states<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::TransferState>,
+        {
+            use std::iter::Iterator;
+            self.0.request.states = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_token][crate::model::ListTransferRunsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
@@ -875,17 +886,6 @@ pub mod data_transfer_service {
             v: T,
         ) -> Self {
             self.0.request.run_attempt = v.into();
-            self
-        }
-
-        /// Sets the value of [states][crate::model::ListTransferRunsRequest::states].
-        pub fn set_states<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::TransferState>,
-        {
-            use std::iter::Iterator;
-            self.0.request.states = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -161,6 +161,17 @@ impl DataSourceParameter {
         self
     }
 
+    /// Sets the value of [allowed_values][crate::model::DataSourceParameter::allowed_values].
+    pub fn set_allowed_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.allowed_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [min_value][crate::model::DataSourceParameter::min_value].
     pub fn set_min_value<T: std::convert::Into<std::option::Option<wkt::DoubleValue>>>(
         mut self,
@@ -176,6 +187,17 @@ impl DataSourceParameter {
         v: T,
     ) -> Self {
         self.max_value = v.into();
+        self
+    }
+
+    /// Sets the value of [fields][crate::model::DataSourceParameter::fields].
+    pub fn set_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataSourceParameter>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -212,28 +234,6 @@ impl DataSourceParameter {
     /// Sets the value of [deprecated][crate::model::DataSourceParameter::deprecated].
     pub fn set_deprecated<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.deprecated = v.into();
-        self
-    }
-
-    /// Sets the value of [allowed_values][crate::model::DataSourceParameter::allowed_values].
-    pub fn set_allowed_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.allowed_values = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [fields][crate::model::DataSourceParameter::fields].
-    pub fn set_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataSourceParameter>,
-    {
-        use std::iter::Iterator;
-        self.fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -548,6 +548,17 @@ impl DataSource {
         self
     }
 
+    /// Sets the value of [scopes][crate::model::DataSource::scopes].
+    pub fn set_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [transfer_type][crate::model::DataSource::transfer_type].
     #[deprecated]
     pub fn set_transfer_type<T: std::convert::Into<crate::model::TransferType>>(
@@ -583,6 +594,17 @@ impl DataSource {
     /// Sets the value of [supports_custom_schedule][crate::model::DataSource::supports_custom_schedule].
     pub fn set_supports_custom_schedule<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.supports_custom_schedule = v.into();
+        self
+    }
+
+    /// Sets the value of [parameters][crate::model::DataSource::parameters].
+    pub fn set_parameters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataSourceParameter>,
+    {
+        use std::iter::Iterator;
+        self.parameters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -637,28 +659,6 @@ impl DataSource {
         v: T,
     ) -> Self {
         self.minimum_schedule_interval = v.into();
-        self
-    }
-
-    /// Sets the value of [scopes][crate::model::DataSource::scopes].
-    pub fn set_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.scopes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [parameters][crate::model::DataSource::parameters].
-    pub fn set_parameters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataSourceParameter>,
-    {
-        use std::iter::Iterator;
-        self.parameters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1072,12 +1072,6 @@ impl ListDataSourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataSourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_sources][crate::model::ListDataSourcesResponse::data_sources].
     pub fn set_data_sources<T, V>(mut self, v: T) -> Self
     where
@@ -1086,6 +1080,12 @@ impl ListDataSourcesResponse {
     {
         use std::iter::Iterator;
         self.data_sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataSourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1555,6 +1555,17 @@ impl ListTransferConfigsRequest {
         self
     }
 
+    /// Sets the value of [data_source_ids][crate::model::ListTransferConfigsRequest::data_source_ids].
+    pub fn set_data_source_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.data_source_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_token][crate::model::ListTransferConfigsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
@@ -1564,17 +1575,6 @@ impl ListTransferConfigsRequest {
     /// Sets the value of [page_size][crate::model::ListTransferConfigsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
-        self
-    }
-
-    /// Sets the value of [data_source_ids][crate::model::ListTransferConfigsRequest::data_source_ids].
-    pub fn set_data_source_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.data_source_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1611,12 +1611,6 @@ impl ListTransferConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTransferConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [transfer_configs][crate::model::ListTransferConfigsResponse::transfer_configs].
     pub fn set_transfer_configs<T, V>(mut self, v: T) -> Self
     where
@@ -1625,6 +1619,12 @@ impl ListTransferConfigsResponse {
     {
         use std::iter::Iterator;
         self.transfer_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTransferConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1696,6 +1696,17 @@ impl ListTransferRunsRequest {
         self
     }
 
+    /// Sets the value of [states][crate::model::ListTransferRunsRequest::states].
+    pub fn set_states<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TransferState>,
+    {
+        use std::iter::Iterator;
+        self.states = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_token][crate::model::ListTransferRunsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
@@ -1716,17 +1727,6 @@ impl ListTransferRunsRequest {
         v: T,
     ) -> Self {
         self.run_attempt = v.into();
-        self
-    }
-
-    /// Sets the value of [states][crate::model::ListTransferRunsRequest::states].
-    pub fn set_states<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TransferState>,
-    {
-        use std::iter::Iterator;
-        self.states = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1894,12 +1894,6 @@ impl ListTransferRunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTransferRunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [transfer_runs][crate::model::ListTransferRunsResponse::transfer_runs].
     pub fn set_transfer_runs<T, V>(mut self, v: T) -> Self
     where
@@ -1908,6 +1902,12 @@ impl ListTransferRunsResponse {
     {
         use std::iter::Iterator;
         self.transfer_runs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTransferRunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2032,12 +2032,6 @@ impl ListTransferLogsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTransferLogsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [transfer_messages][crate::model::ListTransferLogsResponse::transfer_messages].
     pub fn set_transfer_messages<T, V>(mut self, v: T) -> Self
     where
@@ -2046,6 +2040,12 @@ impl ListTransferLogsResponse {
     {
         use std::iter::Iterator;
         self.transfer_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTransferLogsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2305,19 +2305,6 @@ impl StartManualTransferRunsRequest {
         })
     }
 
-    /// The value of [time][crate::model::StartManualTransferRunsRequest::time]
-    /// if it holds a `RequestedRunTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn requested_run_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-        #[allow(unreachable_patterns)]
-        self.time.as_ref().and_then(|v| match v {
-            crate::model::start_manual_transfer_runs_request::Time::RequestedRunTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [time][crate::model::StartManualTransferRunsRequest::time]
     /// to hold a `RequestedTimeRange`.
     ///
@@ -2335,6 +2322,19 @@ impl StartManualTransferRunsRequest {
             crate::model::start_manual_transfer_runs_request::Time::RequestedTimeRange(v.into()),
         );
         self
+    }
+
+    /// The value of [time][crate::model::StartManualTransferRunsRequest::time]
+    /// if it holds a `RequestedRunTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn requested_run_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+        #[allow(unreachable_patterns)]
+        self.time.as_ref().and_then(|v| match v {
+            crate::model::start_manual_transfer_runs_request::Time::RequestedRunTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [time][crate::model::StartManualTransferRunsRequest::time]
@@ -2729,36 +2729,6 @@ impl ScheduleOptionsV2 {
         })
     }
 
-    /// The value of [schedule][crate::model::ScheduleOptionsV2::schedule]
-    /// if it holds a `ManualSchedule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn manual_schedule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ManualSchedule>> {
-        #[allow(unreachable_patterns)]
-        self.schedule.as_ref().and_then(|v| match v {
-            crate::model::schedule_options_v_2::Schedule::ManualSchedule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [schedule][crate::model::ScheduleOptionsV2::schedule]
-    /// if it holds a `EventDrivenSchedule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn event_driven_schedule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::EventDrivenSchedule>> {
-        #[allow(unreachable_patterns)]
-        self.schedule.as_ref().and_then(|v| match v {
-            crate::model::schedule_options_v_2::Schedule::EventDrivenSchedule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [schedule][crate::model::ScheduleOptionsV2::schedule]
     /// to hold a `TimeBasedSchedule`.
     ///
@@ -2776,6 +2746,21 @@ impl ScheduleOptionsV2 {
         self
     }
 
+    /// The value of [schedule][crate::model::ScheduleOptionsV2::schedule]
+    /// if it holds a `ManualSchedule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn manual_schedule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ManualSchedule>> {
+        #[allow(unreachable_patterns)]
+        self.schedule.as_ref().and_then(|v| match v {
+            crate::model::schedule_options_v_2::Schedule::ManualSchedule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [schedule][crate::model::ScheduleOptionsV2::schedule]
     /// to hold a `ManualSchedule`.
     ///
@@ -2791,6 +2776,21 @@ impl ScheduleOptionsV2 {
             crate::model::schedule_options_v_2::Schedule::ManualSchedule(v.into()),
         );
         self
+    }
+
+    /// The value of [schedule][crate::model::ScheduleOptionsV2::schedule]
+    /// if it holds a `EventDrivenSchedule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn event_driven_schedule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::EventDrivenSchedule>> {
+        #[allow(unreachable_patterns)]
+        self.schedule.as_ref().and_then(|v| match v {
+            crate::model::schedule_options_v_2::Schedule::EventDrivenSchedule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schedule][crate::model::ScheduleOptionsV2::schedule]

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -89,6 +89,18 @@ impl MigrationWorkflow {
         self
     }
 
+    /// Sets the value of [tasks][crate::model::MigrationWorkflow::tasks].
+    pub fn set_tasks<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::MigrationTask>,
+    {
+        use std::iter::Iterator;
+        self.tasks = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::MigrationWorkflow::state].
     pub fn set_state<T: std::convert::Into<crate::model::migration_workflow::State>>(
         mut self,
@@ -113,18 +125,6 @@ impl MigrationWorkflow {
         v: T,
     ) -> Self {
         self.last_update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [tasks][crate::model::MigrationWorkflow::tasks].
-    pub fn set_tasks<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::MigrationTask>,
-    {
-        use std::iter::Iterator;
-        self.tasks = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -422,9 +422,31 @@ impl MigrationTask {
         self
     }
 
+    /// Sets the value of [resource_error_details][crate::model::MigrationTask::resource_error_details].
+    pub fn set_resource_error_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResourceErrorDetail>,
+    {
+        use std::iter::Iterator;
+        self.resource_error_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [resource_error_count][crate::model::MigrationTask::resource_error_count].
     pub fn set_resource_error_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.resource_error_count = v.into();
+        self
+    }
+
+    /// Sets the value of [metrics][crate::model::MigrationTask::metrics].
+    pub fn set_metrics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TimeSeries>,
+    {
+        use std::iter::Iterator;
+        self.metrics = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -448,28 +470,6 @@ impl MigrationTask {
     /// Sets the value of [total_resource_error_count][crate::model::MigrationTask::total_resource_error_count].
     pub fn set_total_resource_error_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_resource_error_count = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_error_details][crate::model::MigrationTask::resource_error_details].
-    pub fn set_resource_error_details<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResourceErrorDetail>,
-    {
-        use std::iter::Iterator;
-        self.resource_error_details = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [metrics][crate::model::MigrationTask::metrics].
-    pub fn set_metrics<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TimeSeries>,
-    {
-        use std::iter::Iterator;
-        self.metrics = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -502,21 +502,6 @@ impl MigrationTask {
         })
     }
 
-    /// The value of [task_details][crate::model::MigrationTask::task_details]
-    /// if it holds a `TranslationDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn translation_details(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TranslationDetails>> {
-        #[allow(unreachable_patterns)]
-        self.task_details.as_ref().and_then(|v| match v {
-            crate::model::migration_task::TaskDetails::TranslationDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [task_details][crate::model::MigrationTask::task_details]
     /// to hold a `TranslationConfigDetails`.
     ///
@@ -532,6 +517,21 @@ impl MigrationTask {
             crate::model::migration_task::TaskDetails::TranslationConfigDetails(v.into()),
         );
         self
+    }
+
+    /// The value of [task_details][crate::model::MigrationTask::task_details]
+    /// if it holds a `TranslationDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn translation_details(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TranslationDetails>> {
+        #[allow(unreachable_patterns)]
+        self.task_details.as_ref().and_then(|v| match v {
+            crate::model::migration_task::TaskDetails::TranslationDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [task_details][crate::model::MigrationTask::task_details]
@@ -843,6 +843,17 @@ impl MigrationSubtask {
         self
     }
 
+    /// Sets the value of [resource_error_details][crate::model::MigrationSubtask::resource_error_details].
+    pub fn set_resource_error_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResourceErrorDetail>,
+    {
+        use std::iter::Iterator;
+        self.resource_error_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [resource_error_count][crate::model::MigrationSubtask::resource_error_count].
     pub fn set_resource_error_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.resource_error_count = v.into();
@@ -864,17 +875,6 @@ impl MigrationSubtask {
         v: T,
     ) -> Self {
         self.last_update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_error_details][crate::model::MigrationSubtask::resource_error_details].
-    pub fn set_resource_error_details<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResourceErrorDetail>,
-    {
-        use std::iter::Iterator;
-        self.resource_error_details = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1243,12 +1243,6 @@ impl ResourceErrorDetail {
         self
     }
 
-    /// Sets the value of [error_count][crate::model::ResourceErrorDetail::error_count].
-    pub fn set_error_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.error_count = v.into();
-        self
-    }
-
     /// Sets the value of [error_details][crate::model::ResourceErrorDetail::error_details].
     pub fn set_error_details<T, V>(mut self, v: T) -> Self
     where
@@ -1257,6 +1251,12 @@ impl ResourceErrorDetail {
     {
         use std::iter::Iterator;
         self.error_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_count][crate::model::ResourceErrorDetail::error_count].
+    pub fn set_error_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.error_count = v.into();
         self
     }
 }
@@ -1597,52 +1597,6 @@ impl TypedValue {
         })
     }
 
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `Int64Value`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int64_value(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::Int64Value(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `DoubleValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_value(&self) -> std::option::Option<&f64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::DoubleValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `StringValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::StringValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `DistributionValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn distribution_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<api::model::Distribution>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::DistributionValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::TypedValue::value]
     /// to hold a `BoolValue`.
     ///
@@ -1652,6 +1606,17 @@ impl TypedValue {
         self.value =
             std::option::Option::Some(crate::model::typed_value::Value::BoolValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `Int64Value`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int64_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::Int64Value(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::TypedValue::value]
@@ -1665,6 +1630,17 @@ impl TypedValue {
         self
     }
 
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `DoubleValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_value(&self) -> std::option::Option<&f64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::DoubleValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::TypedValue::value]
     /// to hold a `DoubleValue`.
     ///
@@ -1676,6 +1652,17 @@ impl TypedValue {
         self
     }
 
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::TypedValue::value]
     /// to hold a `StringValue`.
     ///
@@ -1685,6 +1672,19 @@ impl TypedValue {
         self.value =
             std::option::Option::Some(crate::model::typed_value::Value::StringValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `DistributionValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn distribution_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<api::model::Distribution>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::DistributionValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::TypedValue::value]
@@ -1925,12 +1925,6 @@ impl ListMigrationWorkflowsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMigrationWorkflowsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [migration_workflows][crate::model::ListMigrationWorkflowsResponse::migration_workflows].
     pub fn set_migration_workflows<T, V>(mut self, v: T) -> Self
     where
@@ -1939,6 +1933,12 @@ impl ListMigrationWorkflowsResponse {
     {
         use std::iter::Iterator;
         self.migration_workflows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMigrationWorkflowsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2182,12 +2182,6 @@ impl ListMigrationSubtasksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMigrationSubtasksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [migration_subtasks][crate::model::ListMigrationSubtasksResponse::migration_subtasks].
     pub fn set_migration_subtasks<T, V>(mut self, v: T) -> Self
     where
@@ -2196,6 +2190,12 @@ impl ListMigrationSubtasksResponse {
     {
         use std::iter::Iterator;
         self.migration_subtasks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMigrationSubtasksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2536,222 +2536,6 @@ impl Dialect {
         })
     }
 
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `HiveqlDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn hiveql_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::HiveQLDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::HiveqlDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `RedshiftDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redshift_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RedshiftDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::RedshiftDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `TeradataDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn teradata_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TeradataDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::TeradataDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `OracleDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oracle_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OracleDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::OracleDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `SparksqlDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sparksql_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSQLDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::SparksqlDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `SnowflakeDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn snowflake_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SnowflakeDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::SnowflakeDialect(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `NetezzaDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn netezza_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::NetezzaDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::NetezzaDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `AzureSynapseDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn azure_synapse_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureSynapseDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::AzureSynapseDialect(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `VerticaDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertica_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VerticaDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::VerticaDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `SqlServerDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_server_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SQLServerDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::SqlServerDialect(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `PostgresqlDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::PostgresqlDialect(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `PrestoDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn presto_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PrestoDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::PrestoDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `MysqlDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mysql_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MySQLDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::MysqlDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `Db2Dialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn db2_dialect(&self) -> std::option::Option<&std::boxed::Box<crate::model::DB2Dialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::Db2Dialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `SqliteDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sqlite_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SQLiteDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::SqliteDialect(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// if it holds a `GreenplumDialect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn greenplum_dialect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GreenplumDialect>> {
-        #[allow(unreachable_patterns)]
-        self.dialect_value.as_ref().and_then(|v| match v {
-            crate::model::dialect::DialectValue::GreenplumDialect(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `BigqueryDialect`.
     ///
@@ -2769,6 +2553,19 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `HiveqlDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn hiveql_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HiveQLDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::HiveqlDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `HiveqlDialect`.
     ///
@@ -2783,6 +2580,19 @@ impl Dialect {
         self.dialect_value =
             std::option::Option::Some(crate::model::dialect::DialectValue::HiveqlDialect(v.into()));
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `RedshiftDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redshift_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RedshiftDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::RedshiftDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2802,6 +2612,19 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `TeradataDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn teradata_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TeradataDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::TeradataDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `TeradataDialect`.
     ///
@@ -2819,6 +2642,19 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `OracleDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oracle_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OracleDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::OracleDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `OracleDialect`.
     ///
@@ -2833,6 +2669,19 @@ impl Dialect {
         self.dialect_value =
             std::option::Option::Some(crate::model::dialect::DialectValue::OracleDialect(v.into()));
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `SparksqlDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sparksql_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSQLDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::SparksqlDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2852,6 +2701,21 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `SnowflakeDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn snowflake_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SnowflakeDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::SnowflakeDialect(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `SnowflakeDialect`.
     ///
@@ -2867,6 +2731,19 @@ impl Dialect {
             crate::model::dialect::DialectValue::SnowflakeDialect(v.into()),
         );
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `NetezzaDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn netezza_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::NetezzaDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::NetezzaDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2886,6 +2763,21 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `AzureSynapseDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn azure_synapse_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureSynapseDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::AzureSynapseDialect(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `AzureSynapseDialect`.
     ///
@@ -2901,6 +2793,19 @@ impl Dialect {
             crate::model::dialect::DialectValue::AzureSynapseDialect(v.into()),
         );
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `VerticaDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertica_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VerticaDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::VerticaDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2920,6 +2825,21 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `SqlServerDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_server_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SQLServerDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::SqlServerDialect(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `SqlServerDialect`.
     ///
@@ -2935,6 +2855,21 @@ impl Dialect {
             crate::model::dialect::DialectValue::SqlServerDialect(v.into()),
         );
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `PostgresqlDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::PostgresqlDialect(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2954,6 +2889,19 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `PrestoDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn presto_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PrestoDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::PrestoDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `PrestoDialect`.
     ///
@@ -2970,6 +2918,19 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `MysqlDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mysql_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MySQLDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::MysqlDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `MysqlDialect`.
     ///
@@ -2982,6 +2943,17 @@ impl Dialect {
         self.dialect_value =
             std::option::Option::Some(crate::model::dialect::DialectValue::MysqlDialect(v.into()));
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `Db2Dialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn db2_dialect(&self) -> std::option::Option<&std::boxed::Box<crate::model::DB2Dialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::Db2Dialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2998,6 +2970,19 @@ impl Dialect {
         self
     }
 
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `SqliteDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sqlite_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SQLiteDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::SqliteDialect(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
     /// to hold a `SqliteDialect`.
     ///
@@ -3012,6 +2997,21 @@ impl Dialect {
         self.dialect_value =
             std::option::Option::Some(crate::model::dialect::DialectValue::SqliteDialect(v.into()));
         self
+    }
+
+    /// The value of [dialect_value][crate::model::Dialect::dialect_value]
+    /// if it holds a `GreenplumDialect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn greenplum_dialect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GreenplumDialect>> {
+        #[allow(unreachable_patterns)]
+        self.dialect_value.as_ref().and_then(|v| match v {
+            crate::model::dialect::DialectValue::GreenplumDialect(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -4059,15 +4059,6 @@ impl SourceEnv {
         self
     }
 
-    /// Sets the value of [metadata_store_dataset][crate::model::SourceEnv::metadata_store_dataset].
-    pub fn set_metadata_store_dataset<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata_store_dataset = v.into();
-        self
-    }
-
     /// Sets the value of [schema_search_path][crate::model::SourceEnv::schema_search_path].
     pub fn set_schema_search_path<T, V>(mut self, v: T) -> Self
     where
@@ -4076,6 +4067,15 @@ impl SourceEnv {
     {
         use std::iter::Iterator;
         self.schema_search_path = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata_store_dataset][crate::model::SourceEnv::metadata_store_dataset].
+    pub fn set_metadata_store_dataset<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata_store_dataset = v.into();
         self
     }
 }
@@ -4127,6 +4127,17 @@ impl TranslationDetails {
         std::default::Default::default()
     }
 
+    /// Sets the value of [source_target_mapping][crate::model::TranslationDetails::source_target_mapping].
+    pub fn set_source_target_mapping<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SourceTargetMapping>,
+    {
+        use std::iter::Iterator;
+        self.source_target_mapping = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [target_base_uri][crate::model::TranslationDetails::target_base_uri].
     pub fn set_target_base_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.target_base_uri = v.into();
@@ -4141,17 +4152,6 @@ impl TranslationDetails {
         v: T,
     ) -> Self {
         self.source_environment = v.into();
-        self
-    }
-
-    /// Sets the value of [source_target_mapping][crate::model::TranslationDetails::source_target_mapping].
-    pub fn set_source_target_mapping<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SourceTargetMapping>,
-    {
-        use std::iter::Iterator;
-        self.source_target_mapping = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4286,17 +4286,6 @@ impl SourceSpec {
         })
     }
 
-    /// The value of [source][crate::model::SourceSpec::source]
-    /// if it holds a `Literal`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn literal(&self) -> std::option::Option<&std::boxed::Box<crate::model::Literal>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::source_spec::Source::Literal(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::SourceSpec::source]
     /// to hold a `BaseUri`.
     ///
@@ -4306,6 +4295,17 @@ impl SourceSpec {
         self.source =
             std::option::Option::Some(crate::model::source_spec::Source::BaseUri(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::SourceSpec::source]
+    /// if it holds a `Literal`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn literal(&self) -> std::option::Option<&std::boxed::Box<crate::model::Literal>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source_spec::Source::Literal(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::SourceSpec::source]
@@ -4434,17 +4434,6 @@ impl Literal {
         })
     }
 
-    /// The value of [literal_data][crate::model::Literal::literal_data]
-    /// if it holds a `LiteralBytes`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn literal_bytes(&self) -> std::option::Option<&::bytes::Bytes> {
-        #[allow(unreachable_patterns)]
-        self.literal_data.as_ref().and_then(|v| match v {
-            crate::model::literal::LiteralData::LiteralBytes(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [literal_data][crate::model::Literal::literal_data]
     /// to hold a `LiteralString`.
     ///
@@ -4454,6 +4443,17 @@ impl Literal {
         self.literal_data =
             std::option::Option::Some(crate::model::literal::LiteralData::LiteralString(v.into()));
         self
+    }
+
+    /// The value of [literal_data][crate::model::Literal::literal_data]
+    /// if it holds a `LiteralBytes`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn literal_bytes(&self) -> std::option::Option<&::bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.literal_data.as_ref().and_then(|v| match v {
+            crate::model::literal::LiteralData::LiteralBytes(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [literal_data][crate::model::Literal::literal_data]
@@ -4534,15 +4534,6 @@ impl SourceEnvironment {
         self
     }
 
-    /// Sets the value of [metadata_store_dataset][crate::model::SourceEnvironment::metadata_store_dataset].
-    pub fn set_metadata_store_dataset<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata_store_dataset = v.into();
-        self
-    }
-
     /// Sets the value of [schema_search_path][crate::model::SourceEnvironment::schema_search_path].
     pub fn set_schema_search_path<T, V>(mut self, v: T) -> Self
     where
@@ -4551,6 +4542,15 @@ impl SourceEnvironment {
     {
         use std::iter::Iterator;
         self.schema_search_path = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata_store_dataset][crate::model::SourceEnvironment::metadata_store_dataset].
+    pub fn set_metadata_store_dataset<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata_store_dataset = v.into();
         self
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/model.rs
@@ -1061,12 +1061,6 @@ impl ListReservationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReservationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [reservations][crate::model::ListReservationsResponse::reservations].
     pub fn set_reservations<T, V>(mut self, v: T) -> Self
     where
@@ -1075,6 +1069,12 @@ impl ListReservationsResponse {
     {
         use std::iter::Iterator;
         self.reservations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReservationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1422,12 +1422,6 @@ impl ListCapacityCommitmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCapacityCommitmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [capacity_commitments][crate::model::ListCapacityCommitmentsResponse::capacity_commitments].
     pub fn set_capacity_commitments<T, V>(mut self, v: T) -> Self
     where
@@ -1436,6 +1430,12 @@ impl ListCapacityCommitmentsResponse {
     {
         use std::iter::Iterator;
         self.capacity_commitments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCapacityCommitmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2291,12 +2291,6 @@ impl ListAssignmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAssignmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assignments][crate::model::ListAssignmentsResponse::assignments].
     pub fn set_assignments<T, V>(mut self, v: T) -> Self
     where
@@ -2305,6 +2299,12 @@ impl ListAssignmentsResponse {
     {
         use std::iter::Iterator;
         self.assignments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAssignmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2544,12 +2544,6 @@ impl SearchAssignmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchAssignmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assignments][crate::model::SearchAssignmentsResponse::assignments].
     pub fn set_assignments<T, V>(mut self, v: T) -> Self
     where
@@ -2558,6 +2552,12 @@ impl SearchAssignmentsResponse {
     {
         use std::iter::Iterator;
         self.assignments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchAssignmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2609,12 +2609,6 @@ impl SearchAllAssignmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchAllAssignmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assignments][crate::model::SearchAllAssignmentsResponse::assignments].
     pub fn set_assignments<T, V>(mut self, v: T) -> Self
     where
@@ -2623,6 +2617,12 @@ impl SearchAllAssignmentsResponse {
     {
         use std::iter::Iterator;
         self.assignments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchAllAssignmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -1928,12 +1928,6 @@ pub mod row_access_policy_service {
             self
         }
 
-        /// Sets the value of [force][crate::model::BatchDeleteRowAccessPoliciesRequest::force].
-        pub fn set_force<T: Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
-            self.0.request.force = v.into();
-            self
-        }
-
         /// Sets the value of [policy_ids][crate::model::BatchDeleteRowAccessPoliciesRequest::policy_ids].
         ///
         /// This is a **required** field for requests.
@@ -1944,6 +1938,12 @@ pub mod row_access_policy_service {
         {
             use std::iter::Iterator;
             self.0.request.policy_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [force][crate::model::BatchDeleteRowAccessPoliciesRequest::force].
+        pub fn set_force<T: Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
+            self.0.request.force = v.into();
             self
         }
     }

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -1091,6 +1091,29 @@ impl Dataset {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Dataset::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [access][crate::model::Dataset::access].
+    pub fn set_access<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Access>,
+    {
+        use std::iter::Iterator;
+        self.access = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [creation_time][crate::model::Dataset::creation_time].
     pub fn set_creation_time<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.creation_time = v.into();
@@ -1228,6 +1251,18 @@ impl Dataset {
         self
     }
 
+    /// Sets the value of [tags][crate::model::Dataset::tags].
+    #[deprecated]
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::GcpTag>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [storage_billing_model][crate::model::Dataset::storage_billing_model].
     pub fn set_storage_billing_model<
         T: std::convert::Into<crate::model::dataset::StorageBillingModel>,
@@ -1247,41 +1282,6 @@ impl Dataset {
         v: T,
     ) -> Self {
         self.restrictions = v.into();
-        self
-    }
-
-    /// Sets the value of [access][crate::model::Dataset::access].
-    pub fn set_access<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Access>,
-    {
-        use std::iter::Iterator;
-        self.access = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::Dataset::tags].
-    #[deprecated]
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::GcpTag>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Dataset::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2469,6 +2469,18 @@ impl ListFormatDataset {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ListFormatDataset::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [friendly_name][crate::model::ListFormatDataset::friendly_name].
     pub fn set_friendly_name<T: std::convert::Into<std::option::Option<wkt::StringValue>>>(
         mut self,
@@ -2481,18 +2493,6 @@ impl ListFormatDataset {
     /// Sets the value of [location][crate::model::ListFormatDataset::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ListFormatDataset::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2823,15 +2823,6 @@ impl ExternalCatalogDatasetOptions {
         std::default::Default::default()
     }
 
-    /// Sets the value of [default_storage_location_uri][crate::model::ExternalCatalogDatasetOptions::default_storage_location_uri].
-    pub fn set_default_storage_location_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.default_storage_location_uri = v.into();
-        self
-    }
-
     /// Sets the value of [parameters][crate::model::ExternalCatalogDatasetOptions::parameters].
     pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
     where
@@ -2841,6 +2832,15 @@ impl ExternalCatalogDatasetOptions {
     {
         use std::iter::Iterator;
         self.parameters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [default_storage_location_uri][crate::model::ExternalCatalogDatasetOptions::default_storage_location_uri].
+    pub fn set_default_storage_location_uri<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.default_storage_location_uri = v.into();
         self
     }
 }
@@ -2887,6 +2887,18 @@ impl ExternalCatalogTableOptions {
         std::default::Default::default()
     }
 
+    /// Sets the value of [parameters][crate::model::ExternalCatalogTableOptions::parameters].
+    pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.parameters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [storage_descriptor][crate::model::ExternalCatalogTableOptions::storage_descriptor].
     pub fn set_storage_descriptor<
         T: std::convert::Into<std::option::Option<crate::model::StorageDescriptor>>,
@@ -2901,18 +2913,6 @@ impl ExternalCatalogTableOptions {
     /// Sets the value of [connection_id][crate::model::ExternalCatalogTableOptions::connection_id].
     pub fn set_connection_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.connection_id = v.into();
-        self
-    }
-
-    /// Sets the value of [parameters][crate::model::ExternalCatalogTableOptions::parameters].
-    pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.parameters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3353,15 +3353,6 @@ impl CsvOptions {
         self
     }
 
-    /// Sets the value of [source_column_match][crate::model::CsvOptions::source_column_match].
-    pub fn set_source_column_match<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_column_match = v.into();
-        self
-    }
-
     /// Sets the value of [null_markers][crate::model::CsvOptions::null_markers].
     pub fn set_null_markers<T, V>(mut self, v: T) -> Self
     where
@@ -3370,6 +3361,15 @@ impl CsvOptions {
     {
         use std::iter::Iterator;
         self.null_markers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [source_column_match][crate::model::CsvOptions::source_column_match].
+    pub fn set_source_column_match<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_column_match = v.into();
         self
     }
 }
@@ -3624,15 +3624,6 @@ impl BigtableColumnFamily {
         self
     }
 
-    /// Sets the value of [only_read_latest][crate::model::BigtableColumnFamily::only_read_latest].
-    pub fn set_only_read_latest<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.only_read_latest = v.into();
-        self
-    }
-
     /// Sets the value of [columns][crate::model::BigtableColumnFamily::columns].
     pub fn set_columns<T, V>(mut self, v: T) -> Self
     where
@@ -3641,6 +3632,15 @@ impl BigtableColumnFamily {
     {
         use std::iter::Iterator;
         self.columns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [only_read_latest][crate::model::BigtableColumnFamily::only_read_latest].
+    pub fn set_only_read_latest<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.only_read_latest = v.into();
         self
     }
 }
@@ -3699,6 +3699,17 @@ impl BigtableOptions {
         std::default::Default::default()
     }
 
+    /// Sets the value of [column_families][crate::model::BigtableOptions::column_families].
+    pub fn set_column_families<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BigtableColumnFamily>,
+    {
+        use std::iter::Iterator;
+        self.column_families = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [ignore_unspecified_column_families][crate::model::BigtableOptions::ignore_unspecified_column_families].
     pub fn set_ignore_unspecified_column_families<
         T: std::convert::Into<std::option::Option<wkt::BoolValue>>,
@@ -3727,17 +3738,6 @@ impl BigtableOptions {
         v: T,
     ) -> Self {
         self.output_column_families_as_json = v.into();
-        self
-    }
-
-    /// Sets the value of [column_families][crate::model::BigtableOptions::column_families].
-    pub fn set_column_families<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BigtableColumnFamily>,
-    {
-        use std::iter::Iterator;
-        self.column_families = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4020,6 +4020,17 @@ impl ExternalDataConfiguration {
         std::default::Default::default()
     }
 
+    /// Sets the value of [source_uris][crate::model::ExternalDataConfiguration::source_uris].
+    pub fn set_source_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.source_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [file_set_spec_type][crate::model::ExternalDataConfiguration::file_set_spec_type].
     pub fn set_file_set_spec_type<T: std::convert::Into<crate::model::FileSetSpecType>>(
         mut self,
@@ -4136,6 +4147,17 @@ impl ExternalDataConfiguration {
         self
     }
 
+    /// Sets the value of [decimal_target_types][crate::model::ExternalDataConfiguration::decimal_target_types].
+    pub fn set_decimal_target_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DecimalTargetType>,
+    {
+        use std::iter::Iterator;
+        self.decimal_target_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [avro_options][crate::model::ExternalDataConfiguration::avro_options].
     pub fn set_avro_options<
         T: std::convert::Into<std::option::Option<crate::model::AvroOptions>>,
@@ -4244,28 +4266,6 @@ impl ExternalDataConfiguration {
         v: T,
     ) -> Self {
         self.timestamp_format = v.into();
-        self
-    }
-
-    /// Sets the value of [source_uris][crate::model::ExternalDataConfiguration::source_uris].
-    pub fn set_source_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.source_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [decimal_target_types][crate::model::ExternalDataConfiguration::decimal_target_types].
-    pub fn set_decimal_target_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DecimalTargetType>,
-    {
-        use std::iter::Iterator;
-        self.decimal_target_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4861,6 +4861,18 @@ impl RemoteModelInfo {
         })
     }
 
+    /// Sets the value of [remote_service][crate::model::RemoteModelInfo::remote_service]
+    /// to hold a `Endpoint`.
+    ///
+    /// Note that all the setters affecting `remote_service` are
+    /// mutually exclusive.
+    pub fn set_endpoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.remote_service = std::option::Option::Some(
+            crate::model::remote_model_info::RemoteService::Endpoint(v.into()),
+        );
+        self
+    }
+
     /// The value of [remote_service][crate::model::RemoteModelInfo::remote_service]
     /// if it holds a `RemoteServiceType`, `None` if the field is not set or
     /// holds a different branch.
@@ -4874,18 +4886,6 @@ impl RemoteModelInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [remote_service][crate::model::RemoteModelInfo::remote_service]
-    /// to hold a `Endpoint`.
-    ///
-    /// Note that all the setters affecting `remote_service` are
-    /// mutually exclusive.
-    pub fn set_endpoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.remote_service = std::option::Option::Some(
-            crate::model::remote_model_info::RemoteService::Endpoint(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [remote_service][crate::model::RemoteModelInfo::remote_service]
@@ -5314,6 +5314,18 @@ impl Model {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Model::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [expiration_time][crate::model::Model::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.expiration_time = v.into();
@@ -5343,34 +5355,6 @@ impl Model {
         v: T,
     ) -> Self {
         self.model_type = v.into();
-        self
-    }
-
-    /// Sets the value of [hparam_search_spaces][crate::model::Model::hparam_search_spaces].
-    pub fn set_hparam_search_spaces<
-        T: std::convert::Into<std::option::Option<crate::model::model::HparamSearchSpaces>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.hparam_search_spaces = v.into();
-        self
-    }
-
-    /// Sets the value of [default_trial_id][crate::model::Model::default_trial_id].
-    pub fn set_default_trial_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.default_trial_id = v.into();
-        self
-    }
-
-    /// Sets the value of [remote_model_info][crate::model::Model::remote_model_info].
-    pub fn set_remote_model_info<
-        T: std::convert::Into<std::option::Option<crate::model::RemoteModelInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_model_info = v.into();
         self
     }
 
@@ -5418,6 +5402,23 @@ impl Model {
         self
     }
 
+    /// Sets the value of [hparam_search_spaces][crate::model::Model::hparam_search_spaces].
+    pub fn set_hparam_search_spaces<
+        T: std::convert::Into<std::option::Option<crate::model::model::HparamSearchSpaces>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.hparam_search_spaces = v.into();
+        self
+    }
+
+    /// Sets the value of [default_trial_id][crate::model::Model::default_trial_id].
+    pub fn set_default_trial_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.default_trial_id = v.into();
+        self
+    }
+
     /// Sets the value of [hparam_trials][crate::model::Model::hparam_trials].
     pub fn set_hparam_trials<T, V>(mut self, v: T) -> Self
     where
@@ -5440,15 +5441,14 @@ impl Model {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Model::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [remote_model_info][crate::model::Model::remote_model_info].
+    pub fn set_remote_model_info<
+        T: std::convert::Into<std::option::Option<crate::model::RemoteModelInfo>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.remote_model_info = v.into();
         self
     }
 }
@@ -6840,6 +6840,19 @@ pub mod model {
             self
         }
 
+        /// Sets the value of [binary_confusion_matrix_list][crate::model::model::BinaryClassificationMetrics::binary_confusion_matrix_list].
+        pub fn set_binary_confusion_matrix_list<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                    crate::model::model::binary_classification_metrics::BinaryConfusionMatrix,
+                >,
+        {
+            use std::iter::Iterator;
+            self.binary_confusion_matrix_list = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [positive_label][crate::model::model::BinaryClassificationMetrics::positive_label].
         pub fn set_positive_label<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -6855,19 +6868,6 @@ pub mod model {
             v: T,
         ) -> Self {
             self.negative_label = v.into();
-            self
-        }
-
-        /// Sets the value of [binary_confusion_matrix_list][crate::model::model::BinaryClassificationMetrics::binary_confusion_matrix_list].
-        pub fn set_binary_confusion_matrix_list<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<
-                    crate::model::model::binary_classification_metrics::BinaryConfusionMatrix,
-                >,
-        {
-            use std::iter::Iterator;
-            self.binary_confusion_matrix_list = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -7376,15 +7376,6 @@ pub mod model {
                 self
             }
 
-            /// Sets the value of [count][crate::model::model::clustering_metrics::Cluster::count].
-            pub fn set_count<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.count = v.into();
-                self
-            }
-
             /// Sets the value of [feature_values][crate::model::model::clustering_metrics::Cluster::feature_values].
             pub fn set_feature_values<T, V>(mut self, v: T) -> Self
             where
@@ -7395,6 +7386,15 @@ pub mod model {
             {
                 use std::iter::Iterator;
                 self.feature_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [count][crate::model::model::clustering_metrics::Cluster::count].
+            pub fn set_count<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.count = v.into();
                 self
             }
         }
@@ -7467,17 +7467,6 @@ pub mod model {
                     })
                 }
 
-                /// The value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
-                /// if it holds a `CategoricalValue`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn categorical_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::model::clustering_metrics::cluster::feature_value::CategoricalValue>>{
-                    #[allow(unreachable_patterns)]
-                    self.value.as_ref().and_then(|v| match v {
-                        crate::model::model::clustering_metrics::cluster::feature_value::Value::CategoricalValue(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
                 /// to hold a `NumericalValue`.
                 ///
@@ -7495,6 +7484,17 @@ pub mod model {
                         )
                     );
                     self
+                }
+
+                /// The value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
+                /// if it holds a `CategoricalValue`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn categorical_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::model::clustering_metrics::cluster::feature_value::CategoricalValue>>{
+                    #[allow(unreachable_patterns)]
+                    self.value.as_ref().and_then(|v| match v {
+                        crate::model::model::clustering_metrics::cluster::feature_value::Value::CategoricalValue(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
@@ -7877,6 +7877,28 @@ pub mod model {
                 self
             }
 
+            /// Sets the value of [time_series_ids][crate::model::model::arima_forecasting_metrics::ArimaSingleModelForecastingMetrics::time_series_ids].
+            pub fn set_time_series_ids<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.time_series_ids = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [seasonal_periods][crate::model::model::arima_forecasting_metrics::ArimaSingleModelForecastingMetrics::seasonal_periods].
+            pub fn set_seasonal_periods<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::model::seasonal_period::SeasonalPeriodType>,
+            {
+                use std::iter::Iterator;
+                self.seasonal_periods = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [has_holiday_effect][crate::model::model::arima_forecasting_metrics::ArimaSingleModelForecastingMetrics::has_holiday_effect].
             pub fn set_has_holiday_effect<
                 T: std::convert::Into<std::option::Option<wkt::BoolValue>>,
@@ -7907,28 +7929,6 @@ pub mod model {
                 v: T,
             ) -> Self {
                 self.has_step_changes = v.into();
-                self
-            }
-
-            /// Sets the value of [time_series_ids][crate::model::model::arima_forecasting_metrics::ArimaSingleModelForecastingMetrics::time_series_ids].
-            pub fn set_time_series_ids<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.time_series_ids = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [seasonal_periods][crate::model::model::arima_forecasting_metrics::ArimaSingleModelForecastingMetrics::seasonal_periods].
-            pub fn set_seasonal_periods<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::model::seasonal_period::SeasonalPeriodType>,
-            {
-                use std::iter::Iterator;
-                self.seasonal_periods = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -8030,98 +8030,6 @@ pub mod model {
             })
         }
 
-        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// if it holds a `BinaryClassificationMetrics`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn binary_classification_metrics(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::model::BinaryClassificationMetrics>>
-        {
-            #[allow(unreachable_patterns)]
-            self.metrics.as_ref().and_then(|v| match v {
-                crate::model::model::evaluation_metrics::Metrics::BinaryClassificationMetrics(
-                    v,
-                ) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// if it holds a `MultiClassClassificationMetrics`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn multi_class_classification_metrics(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::model::MultiClassClassificationMetrics>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.metrics.as_ref().and_then(|v| match v {
-                crate::model::model::evaluation_metrics::Metrics::MultiClassClassificationMetrics(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// if it holds a `ClusteringMetrics`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn clustering_metrics(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::model::ClusteringMetrics>> {
-            #[allow(unreachable_patterns)]
-            self.metrics.as_ref().and_then(|v| match v {
-                crate::model::model::evaluation_metrics::Metrics::ClusteringMetrics(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// if it holds a `RankingMetrics`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn ranking_metrics(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::model::RankingMetrics>> {
-            #[allow(unreachable_patterns)]
-            self.metrics.as_ref().and_then(|v| match v {
-                crate::model::model::evaluation_metrics::Metrics::RankingMetrics(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// if it holds a `ArimaForecastingMetrics`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn arima_forecasting_metrics(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::model::ArimaForecastingMetrics>>
-        {
-            #[allow(unreachable_patterns)]
-            self.metrics.as_ref().and_then(|v| match v {
-                crate::model::model::evaluation_metrics::Metrics::ArimaForecastingMetrics(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// if it holds a `DimensionalityReductionMetrics`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn dimensionality_reduction_metrics(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::model::DimensionalityReductionMetrics>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.metrics.as_ref().and_then(|v| match v {
-                crate::model::model::evaluation_metrics::Metrics::DimensionalityReductionMetrics(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// to hold a `RegressionMetrics`.
         ///
@@ -8137,6 +8045,22 @@ pub mod model {
                 crate::model::model::evaluation_metrics::Metrics::RegressionMetrics(v.into()),
             );
             self
+        }
+
+        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
+        /// if it holds a `BinaryClassificationMetrics`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn binary_classification_metrics(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::model::BinaryClassificationMetrics>>
+        {
+            #[allow(unreachable_patterns)]
+            self.metrics.as_ref().and_then(|v| match v {
+                crate::model::model::evaluation_metrics::Metrics::BinaryClassificationMetrics(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
@@ -8156,6 +8080,21 @@ pub mod model {
                 ),
             );
             self
+        }
+
+        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
+        /// if it holds a `MultiClassClassificationMetrics`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn multi_class_classification_metrics(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::model::MultiClassClassificationMetrics>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.metrics.as_ref().and_then(|v| match v {
+                crate::model::model::evaluation_metrics::Metrics::MultiClassClassificationMetrics(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
@@ -8179,6 +8118,21 @@ pub mod model {
             self
         }
 
+        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
+        /// if it holds a `ClusteringMetrics`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn clustering_metrics(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::model::ClusteringMetrics>> {
+            #[allow(unreachable_patterns)]
+            self.metrics.as_ref().and_then(|v| match v {
+                crate::model::model::evaluation_metrics::Metrics::ClusteringMetrics(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// to hold a `ClusteringMetrics`.
         ///
@@ -8194,6 +8148,21 @@ pub mod model {
                 crate::model::model::evaluation_metrics::Metrics::ClusteringMetrics(v.into()),
             );
             self
+        }
+
+        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
+        /// if it holds a `RankingMetrics`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn ranking_metrics(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::model::RankingMetrics>> {
+            #[allow(unreachable_patterns)]
+            self.metrics.as_ref().and_then(|v| match v {
+                crate::model::model::evaluation_metrics::Metrics::RankingMetrics(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
@@ -8213,6 +8182,22 @@ pub mod model {
             self
         }
 
+        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
+        /// if it holds a `ArimaForecastingMetrics`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn arima_forecasting_metrics(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::model::ArimaForecastingMetrics>>
+        {
+            #[allow(unreachable_patterns)]
+            self.metrics.as_ref().and_then(|v| match v {
+                crate::model::model::evaluation_metrics::Metrics::ArimaForecastingMetrics(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// to hold a `ArimaForecastingMetrics`.
         ///
@@ -8228,6 +8213,21 @@ pub mod model {
                 crate::model::model::evaluation_metrics::Metrics::ArimaForecastingMetrics(v.into()),
             );
             self
+        }
+
+        /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
+        /// if it holds a `DimensionalityReductionMetrics`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn dimensionality_reduction_metrics(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::model::DimensionalityReductionMetrics>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.metrics.as_ref().and_then(|v| match v {
+                crate::model::model::evaluation_metrics::Metrics::DimensionalityReductionMetrics(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
@@ -8513,12 +8513,6 @@ pub mod model {
             std::default::Default::default()
         }
 
-        /// Sets the value of [class_label][crate::model::model::GlobalExplanation::class_label].
-        pub fn set_class_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.class_label = v.into();
-            self
-        }
-
         /// Sets the value of [explanations][crate::model::model::GlobalExplanation::explanations].
         pub fn set_explanations<T, V>(mut self, v: T) -> Self
         where
@@ -8527,6 +8521,12 @@ pub mod model {
         {
             use std::iter::Iterator;
             self.explanations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [class_label][crate::model::model::GlobalExplanation::class_label].
+        pub fn set_class_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.class_label = v.into();
             self
         }
     }
@@ -9174,6 +9174,17 @@ pub mod model {
             self
         }
 
+        /// Sets the value of [results][crate::model::model::TrainingRun::results].
+        pub fn set_results<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::model::training_run::IterationResult>,
+        {
+            use std::iter::Iterator;
+            self.results = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [evaluation_metrics][crate::model::model::TrainingRun::evaluation_metrics].
         pub fn set_evaluation_metrics<
             T: std::convert::Into<std::option::Option<crate::model::model::EvaluationMetrics>>,
@@ -9207,6 +9218,17 @@ pub mod model {
             self
         }
 
+        /// Sets the value of [class_level_global_explanations][crate::model::model::TrainingRun::class_level_global_explanations].
+        pub fn set_class_level_global_explanations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::model::GlobalExplanation>,
+        {
+            use std::iter::Iterator;
+            self.class_level_global_explanations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [vertex_ai_model_id][crate::model::model::TrainingRun::vertex_ai_model_id].
         pub fn set_vertex_ai_model_id<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -9222,28 +9244,6 @@ pub mod model {
             v: T,
         ) -> Self {
             self.vertex_ai_model_version = v.into();
-            self
-        }
-
-        /// Sets the value of [results][crate::model::model::TrainingRun::results].
-        pub fn set_results<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::model::training_run::IterationResult>,
-        {
-            use std::iter::Iterator;
-            self.results = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [class_level_global_explanations][crate::model::model::TrainingRun::class_level_global_explanations].
-        pub fn set_class_level_global_explanations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::model::GlobalExplanation>,
-        {
-            use std::iter::Iterator;
-            self.class_level_global_explanations = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -9795,6 +9795,17 @@ pub mod model {
                 self
             }
 
+            /// Sets the value of [input_label_columns][crate::model::model::training_run::TrainingOptions::input_label_columns].
+            pub fn set_input_label_columns<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.input_label_columns = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [data_split_method][crate::model::model::training_run::TrainingOptions::data_split_method].
             pub fn set_data_split_method<
                 T: std::convert::Into<crate::model::model::DataSplitMethod>,
@@ -9838,6 +9849,19 @@ pub mod model {
             /// Sets the value of [initial_learn_rate][crate::model::model::training_run::TrainingOptions::initial_learn_rate].
             pub fn set_initial_learn_rate<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
                 self.initial_learn_rate = v.into();
+                self
+            }
+
+            /// Sets the value of [label_class_weights][crate::model::model::training_run::TrainingOptions::label_class_weights].
+            pub fn set_label_class_weights<T, K, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = (K, V)>,
+                K: std::convert::Into<std::string::String>,
+                V: std::convert::Into<f64>,
+            {
+                use std::iter::Iterator;
+                self.label_class_weights =
+                    v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
                 self
             }
 
@@ -9891,6 +9915,17 @@ pub mod model {
                 v: T,
             ) -> Self {
                 self.optimization_strategy = v.into();
+                self
+            }
+
+            /// Sets the value of [hidden_units][crate::model::model::training_run::TrainingOptions::hidden_units].
+            pub fn set_hidden_units<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<i64>,
+            {
+                use std::iter::Iterator;
+                self.hidden_units = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -10142,12 +10177,34 @@ pub mod model {
                 self
             }
 
+            /// Sets the value of [holiday_regions][crate::model::model::training_run::TrainingOptions::holiday_regions].
+            pub fn set_holiday_regions<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::model::HolidayRegion>,
+            {
+                use std::iter::Iterator;
+                self.holiday_regions = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [time_series_id_column][crate::model::model::training_run::TrainingOptions::time_series_id_column].
             pub fn set_time_series_id_column<T: std::convert::Into<std::string::String>>(
                 mut self,
                 v: T,
             ) -> Self {
                 self.time_series_id_column = v.into();
+                self
+            }
+
+            /// Sets the value of [time_series_id_columns][crate::model::model::training_run::TrainingOptions::time_series_id_columns].
+            pub fn set_time_series_id_columns<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.time_series_id_columns = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -10196,6 +10253,19 @@ pub mod model {
             /// Sets the value of [max_parallel_trials][crate::model::model::training_run::TrainingOptions::max_parallel_trials].
             pub fn set_max_parallel_trials<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
                 self.max_parallel_trials = v.into();
+                self
+            }
+
+            /// Sets the value of [hparam_tuning_objectives][crate::model::model::training_run::TrainingOptions::hparam_tuning_objectives].
+            pub fn set_hparam_tuning_objectives<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<
+                        crate::model::model::hparam_tuning_enums::HparamTuningObjective,
+                    >,
+            {
+                use std::iter::Iterator;
+                self.hparam_tuning_objectives = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -10461,6 +10531,28 @@ pub mod model {
                 self
             }
 
+            /// Sets the value of [vertex_ai_model_version_aliases][crate::model::model::training_run::TrainingOptions::vertex_ai_model_version_aliases].
+            pub fn set_vertex_ai_model_version_aliases<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.vertex_ai_model_version_aliases = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [dimension_id_columns][crate::model::model::training_run::TrainingOptions::dimension_id_columns].
+            pub fn set_dimension_id_columns<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.dimension_id_columns = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [contribution_metric][crate::model::model::training_run::TrainingOptions::contribution_metric].
             pub fn set_contribution_metric<
                 T: std::convert::Into<std::option::Option<std::string::String>>,
@@ -10489,98 +10581,6 @@ pub mod model {
                 v: T,
             ) -> Self {
                 self.min_apriori_support = v.into();
-                self
-            }
-
-            /// Sets the value of [input_label_columns][crate::model::model::training_run::TrainingOptions::input_label_columns].
-            pub fn set_input_label_columns<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.input_label_columns = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [hidden_units][crate::model::model::training_run::TrainingOptions::hidden_units].
-            pub fn set_hidden_units<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<i64>,
-            {
-                use std::iter::Iterator;
-                self.hidden_units = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [holiday_regions][crate::model::model::training_run::TrainingOptions::holiday_regions].
-            pub fn set_holiday_regions<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::model::HolidayRegion>,
-            {
-                use std::iter::Iterator;
-                self.holiday_regions = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [time_series_id_columns][crate::model::model::training_run::TrainingOptions::time_series_id_columns].
-            pub fn set_time_series_id_columns<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.time_series_id_columns = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [hparam_tuning_objectives][crate::model::model::training_run::TrainingOptions::hparam_tuning_objectives].
-            pub fn set_hparam_tuning_objectives<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<
-                        crate::model::model::hparam_tuning_enums::HparamTuningObjective,
-                    >,
-            {
-                use std::iter::Iterator;
-                self.hparam_tuning_objectives = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [vertex_ai_model_version_aliases][crate::model::model::training_run::TrainingOptions::vertex_ai_model_version_aliases].
-            pub fn set_vertex_ai_model_version_aliases<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.vertex_ai_model_version_aliases = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [dimension_id_columns][crate::model::model::training_run::TrainingOptions::dimension_id_columns].
-            pub fn set_dimension_id_columns<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.dimension_id_columns = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [label_class_weights][crate::model::model::training_run::TrainingOptions::label_class_weights].
-            pub fn set_label_class_weights<T, K, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = (K, V)>,
-                K: std::convert::Into<std::string::String>,
-                V: std::convert::Into<f64>,
-            {
-                use std::iter::Iterator;
-                self.label_class_weights =
-                    v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
                 self
             }
         }
@@ -10688,6 +10688,19 @@ pub mod model {
                 self
             }
 
+            /// Sets the value of [cluster_infos][crate::model::model::training_run::IterationResult::cluster_infos].
+            pub fn set_cluster_infos<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<
+                        crate::model::model::training_run::iteration_result::ClusterInfo,
+                    >,
+            {
+                use std::iter::Iterator;
+                self.cluster_infos = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [arima_result][crate::model::model::training_run::IterationResult::arima_result].
             pub fn set_arima_result<
                 T: std::convert::Into<
@@ -10700,19 +10713,6 @@ pub mod model {
                 v: T,
             ) -> Self {
                 self.arima_result = v.into();
-                self
-            }
-
-            /// Sets the value of [cluster_infos][crate::model::model::training_run::IterationResult::cluster_infos].
-            pub fn set_cluster_infos<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<
-                        crate::model::model::training_run::iteration_result::ClusterInfo,
-                    >,
-            {
-                use std::iter::Iterator;
-                self.cluster_infos = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -10896,17 +10896,6 @@ pub mod model {
                         std::default::Default::default()
                     }
 
-                    /// Sets the value of [intercept_coefficient][crate::model::model::training_run::iteration_result::arima_result::ArimaCoefficients::intercept_coefficient].
-                    pub fn set_intercept_coefficient<
-                        T: std::convert::Into<std::option::Option<wkt::DoubleValue>>,
-                    >(
-                        mut self,
-                        v: T,
-                    ) -> Self {
-                        self.intercept_coefficient = v.into();
-                        self
-                    }
-
                     /// Sets the value of [auto_regressive_coefficients][crate::model::model::training_run::iteration_result::arima_result::ArimaCoefficients::auto_regressive_coefficients].
                     pub fn set_auto_regressive_coefficients<T, V>(mut self, v: T) -> Self
                     where
@@ -10928,6 +10917,17 @@ pub mod model {
                         use std::iter::Iterator;
                         self.moving_average_coefficients =
                             v.into_iter().map(|i| i.into()).collect();
+                        self
+                    }
+
+                    /// Sets the value of [intercept_coefficient][crate::model::model::training_run::iteration_result::arima_result::ArimaCoefficients::intercept_coefficient].
+                    pub fn set_intercept_coefficient<
+                        T: std::convert::Into<std::option::Option<wkt::DoubleValue>>,
+                    >(
+                        mut self,
+                        v: T,
+                    ) -> Self {
+                        self.intercept_coefficient = v.into();
                         self
                     }
                 }
@@ -11059,6 +11059,30 @@ pub mod model {
                         self
                     }
 
+                    /// Sets the value of [time_series_ids][crate::model::model::training_run::iteration_result::arima_result::ArimaModelInfo::time_series_ids].
+                    pub fn set_time_series_ids<T, V>(mut self, v: T) -> Self
+                    where
+                        T: std::iter::IntoIterator<Item = V>,
+                        V: std::convert::Into<std::string::String>,
+                    {
+                        use std::iter::Iterator;
+                        self.time_series_ids = v.into_iter().map(|i| i.into()).collect();
+                        self
+                    }
+
+                    /// Sets the value of [seasonal_periods][crate::model::model::training_run::iteration_result::arima_result::ArimaModelInfo::seasonal_periods].
+                    pub fn set_seasonal_periods<T, V>(mut self, v: T) -> Self
+                    where
+                        T: std::iter::IntoIterator<Item = V>,
+                        V: std::convert::Into<
+                                crate::model::model::seasonal_period::SeasonalPeriodType,
+                            >,
+                    {
+                        use std::iter::Iterator;
+                        self.seasonal_periods = v.into_iter().map(|i| i.into()).collect();
+                        self
+                    }
+
                     /// Sets the value of [has_holiday_effect][crate::model::model::training_run::iteration_result::arima_result::ArimaModelInfo::has_holiday_effect].
                     pub fn set_has_holiday_effect<
                         T: std::convert::Into<std::option::Option<wkt::BoolValue>>,
@@ -11089,30 +11113,6 @@ pub mod model {
                         v: T,
                     ) -> Self {
                         self.has_step_changes = v.into();
-                        self
-                    }
-
-                    /// Sets the value of [time_series_ids][crate::model::model::training_run::iteration_result::arima_result::ArimaModelInfo::time_series_ids].
-                    pub fn set_time_series_ids<T, V>(mut self, v: T) -> Self
-                    where
-                        T: std::iter::IntoIterator<Item = V>,
-                        V: std::convert::Into<std::string::String>,
-                    {
-                        use std::iter::Iterator;
-                        self.time_series_ids = v.into_iter().map(|i| i.into()).collect();
-                        self
-                    }
-
-                    /// Sets the value of [seasonal_periods][crate::model::model::training_run::iteration_result::arima_result::ArimaModelInfo::seasonal_periods].
-                    pub fn set_seasonal_periods<T, V>(mut self, v: T) -> Self
-                    where
-                        T: std::iter::IntoIterator<Item = V>,
-                        V: std::convert::Into<
-                                crate::model::model::seasonal_period::SeasonalPeriodType,
-                            >,
-                    {
-                        use std::iter::Iterator;
-                        self.seasonal_periods = v.into_iter().map(|i| i.into()).collect();
                         self
                     }
                 }
@@ -11268,23 +11268,6 @@ pub mod model {
             })
         }
 
-        /// The value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
-        /// if it holds a `Candidates`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn candidates(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::model::double_hparam_search_space::DoubleCandidates>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.search_space.as_ref().and_then(|v| match v {
-                crate::model::model::double_hparam_search_space::SearchSpace::Candidates(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
         /// to hold a `Range`.
         ///
@@ -11302,6 +11285,23 @@ pub mod model {
                 crate::model::model::double_hparam_search_space::SearchSpace::Range(v.into()),
             );
             self
+        }
+
+        /// The value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
+        /// if it holds a `Candidates`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn candidates(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::model::double_hparam_search_space::DoubleCandidates>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.search_space.as_ref().and_then(|v| match v {
+                crate::model::model::double_hparam_search_space::SearchSpace::Candidates(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
@@ -11489,23 +11489,6 @@ pub mod model {
             })
         }
 
-        /// The value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
-        /// if it holds a `Candidates`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn candidates(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::model::int_hparam_search_space::IntCandidates>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.search_space.as_ref().and_then(|v| match v {
-                crate::model::model::int_hparam_search_space::SearchSpace::Candidates(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
         /// to hold a `Range`.
         ///
@@ -11523,6 +11506,23 @@ pub mod model {
                 crate::model::model::int_hparam_search_space::SearchSpace::Range(v.into()),
             );
             self
+        }
+
+        /// The value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
+        /// if it holds a `Candidates`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn candidates(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::model::int_hparam_search_space::IntCandidates>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.search_space.as_ref().and_then(|v| match v {
+                crate::model::model::int_hparam_search_space::SearchSpace::Candidates(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
@@ -14764,12 +14764,6 @@ impl ListModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [models][crate::model::ListModelsResponse::models].
     pub fn set_models<T, V>(mut self, v: T) -> Self
     where
@@ -14778,6 +14772,12 @@ impl ListModelsResponse {
     {
         use std::iter::Iterator;
         self.models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -15429,21 +15429,6 @@ impl PrivacyPolicy {
         })
     }
 
-    /// The value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
-    /// if it holds a `DifferentialPrivacyPolicy`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn differential_privacy_policy(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DifferentialPrivacyPolicy>> {
-        #[allow(unreachable_patterns)]
-        self.privacy_policy.as_ref().and_then(|v| match v {
-            crate::model::privacy_policy::PrivacyPolicy::DifferentialPrivacyPolicy(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
     /// to hold a `AggregationThresholdPolicy`.
     ///
@@ -15459,6 +15444,21 @@ impl PrivacyPolicy {
             crate::model::privacy_policy::PrivacyPolicy::AggregationThresholdPolicy(v.into()),
         );
         self
+    }
+
+    /// The value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
+    /// if it holds a `DifferentialPrivacyPolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn differential_privacy_policy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DifferentialPrivacyPolicy>> {
+        #[allow(unreachable_patterns)]
+        self.privacy_policy.as_ref().and_then(|v| match v {
+            crate::model::privacy_policy::PrivacyPolicy::DifferentialPrivacyPolicy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
@@ -15685,17 +15685,6 @@ impl QueryParameterType {
         self
     }
 
-    /// Sets the value of [range_element_type][crate::model::QueryParameterType::range_element_type].
-    pub fn set_range_element_type<
-        T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::QueryParameterType>>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.range_element_type = v.into();
-        self
-    }
-
     /// Sets the value of [struct_types][crate::model::QueryParameterType::struct_types].
     pub fn set_struct_types<T, V>(mut self, v: T) -> Self
     where
@@ -15704,6 +15693,17 @@ impl QueryParameterType {
     {
         use std::iter::Iterator;
         self.struct_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [range_element_type][crate::model::QueryParameterType::range_element_type].
+    pub fn set_range_element_type<
+        T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::QueryParameterType>>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.range_element_type = v.into();
         self
     }
 }
@@ -15813,17 +15813,6 @@ impl QueryParameterValue {
         self
     }
 
-    /// Sets the value of [range_value][crate::model::QueryParameterValue::range_value].
-    pub fn set_range_value<
-        T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::RangeValue>>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.range_value = v.into();
-        self
-    }
-
     /// Sets the value of [array_values][crate::model::QueryParameterValue::array_values].
     pub fn set_array_values<T, V>(mut self, v: T) -> Self
     where
@@ -15832,17 +15821,6 @@ impl QueryParameterValue {
     {
         use std::iter::Iterator;
         self.array_values = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [alt_struct_values][crate::model::QueryParameterValue::alt_struct_values].
-    pub fn set_alt_struct_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Value>,
-    {
-        use std::iter::Iterator;
-        self.alt_struct_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -15855,6 +15833,28 @@ impl QueryParameterValue {
     {
         use std::iter::Iterator;
         self.struct_values = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [range_value][crate::model::QueryParameterValue::range_value].
+    pub fn set_range_value<
+        T: std::convert::Into<std::option::Option<std::boxed::Box<crate::model::RangeValue>>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.range_value = v.into();
+        self
+    }
+
+    /// Sets the value of [alt_struct_values][crate::model::QueryParameterValue::alt_struct_values].
+    pub fn set_alt_struct_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.alt_struct_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -16404,6 +16404,17 @@ impl Routine {
         self
     }
 
+    /// Sets the value of [arguments][crate::model::Routine::arguments].
+    pub fn set_arguments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::routine::Argument>,
+    {
+        use std::iter::Iterator;
+        self.arguments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [return_type][crate::model::Routine::return_type].
     pub fn set_return_type<
         T: std::convert::Into<std::option::Option<crate::model::StandardSqlDataType>>,
@@ -16423,6 +16434,17 @@ impl Routine {
         v: T,
     ) -> Self {
         self.return_table_type = v.into();
+        self
+    }
+
+    /// Sets the value of [imported_libraries][crate::model::Routine::imported_libraries].
+    pub fn set_imported_libraries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.imported_libraries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -16495,28 +16517,6 @@ impl Routine {
         v: T,
     ) -> Self {
         self.data_governance_type = v.into();
-        self
-    }
-
-    /// Sets the value of [arguments][crate::model::Routine::arguments].
-    pub fn set_arguments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::routine::Argument>,
-    {
-        use std::iter::Iterator;
-        self.arguments = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [imported_libraries][crate::model::Routine::imported_libraries].
-    pub fn set_imported_libraries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.imported_libraries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -16962,12 +16962,6 @@ pub mod routine {
             self
         }
 
-        /// Sets the value of [max_batching_rows][crate::model::routine::RemoteFunctionOptions::max_batching_rows].
-        pub fn set_max_batching_rows<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.max_batching_rows = v.into();
-            self
-        }
-
         /// Sets the value of [user_defined_context][crate::model::routine::RemoteFunctionOptions::user_defined_context].
         pub fn set_user_defined_context<T, K, V>(mut self, v: T) -> Self
         where
@@ -16977,6 +16971,12 @@ pub mod routine {
         {
             use std::iter::Iterator;
             self.user_defined_context = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [max_batching_rows][crate::model::routine::RemoteFunctionOptions::max_batching_rows].
+        pub fn set_max_batching_rows<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.max_batching_rows = v.into();
             self
         }
     }
@@ -17783,15 +17783,21 @@ impl SparkOptions {
         self
     }
 
-    /// Sets the value of [main_file_uri][crate::model::SparkOptions::main_file_uri].
-    pub fn set_main_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.main_file_uri = v.into();
+    /// Sets the value of [properties][crate::model::SparkOptions::properties].
+    pub fn set_properties<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
-    /// Sets the value of [main_class][crate::model::SparkOptions::main_class].
-    pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.main_class = v.into();
+    /// Sets the value of [main_file_uri][crate::model::SparkOptions::main_file_uri].
+    pub fn set_main_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.main_file_uri = v.into();
         self
     }
 
@@ -17839,15 +17845,9 @@ impl SparkOptions {
         self
     }
 
-    /// Sets the value of [properties][crate::model::SparkOptions::properties].
-    pub fn set_properties<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [main_class][crate::model::SparkOptions::main_class].
+    pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.main_class = v.into();
         self
     }
 }
@@ -18268,12 +18268,6 @@ impl ListRoutinesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRoutinesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [routines][crate::model::ListRoutinesResponse::routines].
     pub fn set_routines<T, V>(mut self, v: T) -> Self
     where
@@ -18282,6 +18276,12 @@ impl ListRoutinesResponse {
     {
         use std::iter::Iterator;
         self.routines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRoutinesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -18443,12 +18443,6 @@ impl ListRowAccessPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRowAccessPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [row_access_policies][crate::model::ListRowAccessPoliciesResponse::row_access_policies].
     pub fn set_row_access_policies<T, V>(mut self, v: T) -> Self
     where
@@ -18457,6 +18451,12 @@ impl ListRowAccessPoliciesResponse {
     {
         use std::iter::Iterator;
         self.row_access_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRowAccessPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -18816,12 +18816,6 @@ impl BatchDeleteRowAccessPoliciesRequest {
         self
     }
 
-    /// Sets the value of [force][crate::model::BatchDeleteRowAccessPoliciesRequest::force].
-    pub fn set_force<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
-        self.force = v.into();
-        self
-    }
-
     /// Sets the value of [policy_ids][crate::model::BatchDeleteRowAccessPoliciesRequest::policy_ids].
     pub fn set_policy_ids<T, V>(mut self, v: T) -> Self
     where
@@ -18830,6 +18824,12 @@ impl BatchDeleteRowAccessPoliciesRequest {
     {
         use std::iter::Iterator;
         self.policy_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [force][crate::model::BatchDeleteRowAccessPoliciesRequest::force].
+    pub fn set_force<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
+        self.force = v.into();
         self
     }
 }
@@ -19144,36 +19144,6 @@ impl StandardSqlDataType {
         })
     }
 
-    /// The value of [sub_type][crate::model::StandardSqlDataType::sub_type]
-    /// if it holds a `StructType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn struct_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StandardSqlStructType>> {
-        #[allow(unreachable_patterns)]
-        self.sub_type.as_ref().and_then(|v| match v {
-            crate::model::standard_sql_data_type::SubType::StructType(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [sub_type][crate::model::StandardSqlDataType::sub_type]
-    /// if it holds a `RangeElementType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn range_element_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StandardSqlDataType>> {
-        #[allow(unreachable_patterns)]
-        self.sub_type.as_ref().and_then(|v| match v {
-            crate::model::standard_sql_data_type::SubType::RangeElementType(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [sub_type][crate::model::StandardSqlDataType::sub_type]
     /// to hold a `ArrayElementType`.
     ///
@@ -19191,6 +19161,21 @@ impl StandardSqlDataType {
         self
     }
 
+    /// The value of [sub_type][crate::model::StandardSqlDataType::sub_type]
+    /// if it holds a `StructType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn struct_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StandardSqlStructType>> {
+        #[allow(unreachable_patterns)]
+        self.sub_type.as_ref().and_then(|v| match v {
+            crate::model::standard_sql_data_type::SubType::StructType(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [sub_type][crate::model::StandardSqlDataType::sub_type]
     /// to hold a `StructType`.
     ///
@@ -19206,6 +19191,21 @@ impl StandardSqlDataType {
             crate::model::standard_sql_data_type::SubType::StructType(v.into()),
         );
         self
+    }
+
+    /// The value of [sub_type][crate::model::StandardSqlDataType::sub_type]
+    /// if it holds a `RangeElementType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn range_element_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StandardSqlDataType>> {
+        #[allow(unreachable_patterns)]
+        self.sub_type.as_ref().and_then(|v| match v {
+            crate::model::standard_sql_data_type::SubType::RangeElementType(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [sub_type][crate::model::StandardSqlDataType::sub_type]
@@ -19638,15 +19638,6 @@ impl SystemVariables {
         std::default::Default::default()
     }
 
-    /// Sets the value of [values][crate::model::SystemVariables::values].
-    pub fn set_values<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.values = v.into();
-        self
-    }
-
     /// Sets the value of [types][crate::model::SystemVariables::types].
     pub fn set_types<T, K, V>(mut self, v: T) -> Self
     where
@@ -19656,6 +19647,15 @@ impl SystemVariables {
     {
         use std::iter::Iterator;
         self.types = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [values][crate::model::SystemVariables::values].
+    pub fn set_values<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.values = v.into();
         self
     }
 }
@@ -19971,6 +19971,17 @@ impl ViewDefinition {
         self
     }
 
+    /// Sets the value of [user_defined_function_resources][crate::model::ViewDefinition::user_defined_function_resources].
+    pub fn set_user_defined_function_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::UserDefinedFunctionResource>,
+    {
+        use std::iter::Iterator;
+        self.user_defined_function_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [use_legacy_sql][crate::model::ViewDefinition::use_legacy_sql].
     pub fn set_use_legacy_sql<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(
         mut self,
@@ -19994,17 +20005,6 @@ impl ViewDefinition {
         v: T,
     ) -> Self {
         self.privacy_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [user_defined_function_resources][crate::model::ViewDefinition::user_defined_function_resources].
-    pub fn set_user_defined_function_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::UserDefinedFunctionResource>,
-    {
-        use std::iter::Iterator;
-        self.user_defined_function_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -20745,6 +20745,18 @@ impl Table {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Table::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [schema][crate::model::Table::schema].
     pub fn set_schema<T: std::convert::Into<std::option::Option<crate::model::TableSchema>>>(
         mut self,
@@ -21127,6 +21139,18 @@ impl Table {
         self
     }
 
+    /// Sets the value of [resource_tags][crate::model::Table::resource_tags].
+    pub fn set_resource_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [table_replication_info][crate::model::Table::table_replication_info].
     pub fn set_table_replication_info<
         T: std::convert::Into<std::option::Option<crate::model::TableReplicationInfo>>,
@@ -21135,17 +21159,6 @@ impl Table {
         v: T,
     ) -> Self {
         self.table_replication_info = v.into();
-        self
-    }
-
-    /// Sets the value of [external_catalog_table_options][crate::model::Table::external_catalog_table_options].
-    pub fn set_external_catalog_table_options<
-        T: std::convert::Into<std::option::Option<crate::model::ExternalCatalogTableOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.external_catalog_table_options = v.into();
         self
     }
 
@@ -21160,27 +21173,14 @@ impl Table {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Table::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [resource_tags][crate::model::Table::resource_tags].
-    pub fn set_resource_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [external_catalog_table_options][crate::model::Table::external_catalog_table_options].
+    pub fn set_external_catalog_table_options<
+        T: std::convert::Into<std::option::Option<crate::model::ExternalCatalogTableOptions>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.external_catalog_table_options = v.into();
         self
     }
 }
@@ -21866,6 +21866,18 @@ impl ListFormatTable {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ListFormatTable::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [view][crate::model::ListFormatTable::view].
     pub fn set_view<T: std::convert::Into<std::option::Option<crate::model::ListFormatView>>>(
         mut self,
@@ -21895,18 +21907,6 @@ impl ListFormatTable {
         v: T,
     ) -> Self {
         self.require_partition_filter = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ListFormatTable::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -21970,15 +21970,6 @@ impl TableList {
         self
     }
 
-    /// Sets the value of [total_items][crate::model::TableList::total_items].
-    pub fn set_total_items<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.total_items = v.into();
-        self
-    }
-
     /// Sets the value of [tables][crate::model::TableList::tables].
     pub fn set_tables<T, V>(mut self, v: T) -> Self
     where
@@ -21987,6 +21978,15 @@ impl TableList {
     {
         use std::iter::Iterator;
         self.tables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [total_items][crate::model::TableList::total_items].
+    pub fn set_total_items<T: std::convert::Into<std::option::Option<wkt::Int32Value>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.total_items = v.into();
         self
     }
 }
@@ -22283,17 +22283,6 @@ impl TableSchema {
         std::default::Default::default()
     }
 
-    /// Sets the value of [foreign_type_info][crate::model::TableSchema::foreign_type_info].
-    pub fn set_foreign_type_info<
-        T: std::convert::Into<std::option::Option<crate::model::ForeignTypeInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.foreign_type_info = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::model::TableSchema::fields].
     pub fn set_fields<T, V>(mut self, v: T) -> Self
     where
@@ -22302,6 +22291,17 @@ impl TableSchema {
     {
         use std::iter::Iterator;
         self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [foreign_type_info][crate::model::TableSchema::foreign_type_info].
+    pub fn set_foreign_type_info<
+        T: std::convert::Into<std::option::Option<crate::model::ForeignTypeInfo>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.foreign_type_info = v.into();
         self
     }
 }
@@ -22692,6 +22692,17 @@ impl TableFieldSchema {
         self
     }
 
+    /// Sets the value of [fields][crate::model::TableFieldSchema::fields].
+    pub fn set_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TableFieldSchema>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::TableFieldSchema::description].
     pub fn set_description<T: std::convert::Into<std::option::Option<wkt::StringValue>>>(
         mut self,
@@ -22709,6 +22720,17 @@ impl TableFieldSchema {
         v: T,
     ) -> Self {
         self.policy_tags = v.into();
+        self
+    }
+
+    /// Sets the value of [data_policies][crate::model::TableFieldSchema::data_policies].
+    pub fn set_data_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataPolicyOption>,
+    {
+        use std::iter::Iterator;
+        self.data_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -22778,28 +22800,6 @@ impl TableFieldSchema {
         v: T,
     ) -> Self {
         self.foreign_type_definition = v.into();
-        self
-    }
-
-    /// Sets the value of [fields][crate::model::TableFieldSchema::fields].
-    pub fn set_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TableFieldSchema>,
-    {
-        use std::iter::Iterator;
-        self.fields = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [data_policies][crate::model::TableFieldSchema::data_policies].
-    pub fn set_data_policies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataPolicyOption>,
-    {
-        use std::iter::Iterator;
-        self.data_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/billing/v1/src/model.rs
+++ b/src/generated/cloud/billing/v1/src/model.rs
@@ -357,12 +357,6 @@ impl ListBillingAccountsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBillingAccountsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [billing_accounts][crate::model::ListBillingAccountsResponse::billing_accounts].
     pub fn set_billing_accounts<T, V>(mut self, v: T) -> Self
     where
@@ -371,6 +365,12 @@ impl ListBillingAccountsResponse {
     {
         use std::iter::Iterator;
         self.billing_accounts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBillingAccountsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -592,12 +592,6 @@ impl ListProjectBillingInfoResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProjectBillingInfoResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [project_billing_info][crate::model::ListProjectBillingInfoResponse::project_billing_info].
     pub fn set_project_billing_info<T, V>(mut self, v: T) -> Self
     where
@@ -606,6 +600,12 @@ impl ListProjectBillingInfoResponse {
     {
         use std::iter::Iterator;
         self.project_billing_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProjectBillingInfoResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -912,26 +912,6 @@ impl Sku {
         self
     }
 
-    /// Sets the value of [service_provider_name][crate::model::Sku::service_provider_name].
-    pub fn set_service_provider_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_provider_name = v.into();
-        self
-    }
-
-    /// Sets the value of [geo_taxonomy][crate::model::Sku::geo_taxonomy].
-    pub fn set_geo_taxonomy<
-        T: std::convert::Into<std::option::Option<crate::model::GeoTaxonomy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.geo_taxonomy = v.into();
-        self
-    }
-
     /// Sets the value of [service_regions][crate::model::Sku::service_regions].
     pub fn set_service_regions<T, V>(mut self, v: T) -> Self
     where
@@ -951,6 +931,26 @@ impl Sku {
     {
         use std::iter::Iterator;
         self.pricing_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service_provider_name][crate::model::Sku::service_provider_name].
+    pub fn set_service_provider_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.service_provider_name = v.into();
+        self
+    }
+
+    /// Sets the value of [geo_taxonomy][crate::model::Sku::geo_taxonomy].
+    pub fn set_geo_taxonomy<
+        T: std::convert::Into<std::option::Option<crate::model::GeoTaxonomy>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.geo_taxonomy = v.into();
         self
     }
 }
@@ -1206,6 +1206,17 @@ impl PricingExpression {
         self
     }
 
+    /// Sets the value of [tiered_rates][crate::model::PricingExpression::tiered_rates].
+    pub fn set_tiered_rates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::pricing_expression::TierRate>,
+    {
+        use std::iter::Iterator;
+        self.tiered_rates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [usage_unit_description][crate::model::PricingExpression::usage_unit_description].
     pub fn set_usage_unit_description<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -1233,17 +1244,6 @@ impl PricingExpression {
     /// Sets the value of [base_unit_conversion_factor][crate::model::PricingExpression::base_unit_conversion_factor].
     pub fn set_base_unit_conversion_factor<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.base_unit_conversion_factor = v.into();
-        self
-    }
-
-    /// Sets the value of [tiered_rates][crate::model::PricingExpression::tiered_rates].
-    pub fn set_tiered_rates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::pricing_expression::TierRate>,
-    {
-        use std::iter::Iterator;
-        self.tiered_rates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1903,12 +1903,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -1917,6 +1911,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2069,12 +2069,6 @@ impl ListSkusResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSkusResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [skus][crate::model::ListSkusResponse::skus].
     pub fn set_skus<T, V>(mut self, v: T) -> Self
     where
@@ -2083,6 +2077,12 @@ impl ListSkusResponse {
     {
         use std::iter::Iterator;
         self.skus = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSkusResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -133,26 +133,6 @@ impl Policy {
         self
     }
 
-    /// Sets the value of [default_admission_rule][crate::model::Policy::default_admission_rule].
-    pub fn set_default_admission_rule<
-        T: std::convert::Into<std::option::Option<crate::model::AdmissionRule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.default_admission_rule = v.into();
-        self
-    }
-
-    /// Sets the value of [update_time][crate::model::Policy::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [admission_whitelist_patterns][crate::model::Policy::admission_whitelist_patterns].
     pub fn set_admission_whitelist_patterns<T, V>(mut self, v: T) -> Self
     where
@@ -212,6 +192,26 @@ impl Policy {
         use std::iter::Iterator;
         self.istio_service_identity_admission_rules =
             v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [default_admission_rule][crate::model::Policy::default_admission_rule].
+    pub fn set_default_admission_rule<
+        T: std::convert::Into<std::option::Option<crate::model::AdmissionRule>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.default_admission_rule = v.into();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::Policy::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -455,17 +455,6 @@ impl AdmissionRule {
         self
     }
 
-    /// Sets the value of [enforcement_mode][crate::model::AdmissionRule::enforcement_mode].
-    pub fn set_enforcement_mode<
-        T: std::convert::Into<crate::model::admission_rule::EnforcementMode>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enforcement_mode = v.into();
-        self
-    }
-
     /// Sets the value of [require_attestations_by][crate::model::AdmissionRule::require_attestations_by].
     pub fn set_require_attestations_by<T, V>(mut self, v: T) -> Self
     where
@@ -474,6 +463,17 @@ impl AdmissionRule {
     {
         use std::iter::Iterator;
         self.require_attestations_by = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enforcement_mode][crate::model::AdmissionRule::enforcement_mode].
+    pub fn set_enforcement_mode<
+        T: std::convert::Into<crate::model::admission_rule::EnforcementMode>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.enforcement_mode = v.into();
         self
     }
 }
@@ -949,15 +949,6 @@ impl UserOwnedGrafeasNote {
         self
     }
 
-    /// Sets the value of [delegation_service_account_email][crate::model::UserOwnedGrafeasNote::delegation_service_account_email].
-    pub fn set_delegation_service_account_email<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.delegation_service_account_email = v.into();
-        self
-    }
-
     /// Sets the value of [public_keys][crate::model::UserOwnedGrafeasNote::public_keys].
     pub fn set_public_keys<T, V>(mut self, v: T) -> Self
     where
@@ -966,6 +957,15 @@ impl UserOwnedGrafeasNote {
     {
         use std::iter::Iterator;
         self.public_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [delegation_service_account_email][crate::model::UserOwnedGrafeasNote::delegation_service_account_email].
+    pub fn set_delegation_service_account_email<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.delegation_service_account_email = v.into();
         self
     }
 }
@@ -1336,21 +1336,6 @@ impl AttestorPublicKey {
         })
     }
 
-    /// The value of [public_key][crate::model::AttestorPublicKey::public_key]
-    /// if it holds a `PkixPublicKey`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pkix_public_key(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PkixPublicKey>> {
-        #[allow(unreachable_patterns)]
-        self.public_key.as_ref().and_then(|v| match v {
-            crate::model::attestor_public_key::PublicKey::PkixPublicKey(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [public_key][crate::model::AttestorPublicKey::public_key]
     /// to hold a `AsciiArmoredPgpPublicKey`.
     ///
@@ -1364,6 +1349,21 @@ impl AttestorPublicKey {
             crate::model::attestor_public_key::PublicKey::AsciiArmoredPgpPublicKey(v.into()),
         );
         self
+    }
+
+    /// The value of [public_key][crate::model::AttestorPublicKey::public_key]
+    /// if it holds a `PkixPublicKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pkix_public_key(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PkixPublicKey>> {
+        #[allow(unreachable_patterns)]
+        self.public_key.as_ref().and_then(|v| match v {
+            crate::model::attestor_public_key::PublicKey::PkixPublicKey(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [public_key][crate::model::AttestorPublicKey::public_key]
@@ -1721,12 +1721,6 @@ impl ListAttestorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAttestorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [attestors][crate::model::ListAttestorsResponse::attestors].
     pub fn set_attestors<T, V>(mut self, v: T) -> Self
     where
@@ -1735,6 +1729,12 @@ impl ListAttestorsResponse {
     {
         use std::iter::Iterator;
         self.attestors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAttestorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -140,12 +140,6 @@ impl ListCertificateIssuanceConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificateIssuanceConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificate_issuance_configs][crate::model::ListCertificateIssuanceConfigsResponse::certificate_issuance_configs].
     pub fn set_certificate_issuance_configs<T, V>(mut self, v: T) -> Self
     where
@@ -154,6 +148,12 @@ impl ListCertificateIssuanceConfigsResponse {
     {
         use std::iter::Iterator;
         self.certificate_issuance_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificateIssuanceConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -396,6 +396,18 @@ impl CertificateIssuanceConfig {
         self
     }
 
+    /// Sets the value of [labels][crate::model::CertificateIssuanceConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::CertificateIssuanceConfig::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -440,18 +452,6 @@ impl CertificateIssuanceConfig {
         v: T,
     ) -> Self {
         self.key_algorithm = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::CertificateIssuanceConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -817,12 +817,6 @@ impl ListCertificatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificates][crate::model::ListCertificatesResponse::certificates].
     pub fn set_certificates<T, V>(mut self, v: T) -> Self
     where
@@ -831,6 +825,12 @@ impl ListCertificatesResponse {
     {
         use std::iter::Iterator;
         self.certificates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1148,12 +1148,6 @@ impl ListCertificateMapsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificateMapsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificate_maps][crate::model::ListCertificateMapsResponse::certificate_maps].
     pub fn set_certificate_maps<T, V>(mut self, v: T) -> Self
     where
@@ -1162,6 +1156,12 @@ impl ListCertificateMapsResponse {
     {
         use std::iter::Iterator;
         self.certificate_maps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificateMapsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1487,12 +1487,6 @@ impl ListCertificateMapEntriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificateMapEntriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificate_map_entries][crate::model::ListCertificateMapEntriesResponse::certificate_map_entries].
     pub fn set_certificate_map_entries<T, V>(mut self, v: T) -> Self
     where
@@ -1501,6 +1495,12 @@ impl ListCertificateMapEntriesResponse {
     {
         use std::iter::Iterator;
         self.certificate_map_entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificateMapEntriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1821,12 +1821,6 @@ impl ListDnsAuthorizationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDnsAuthorizationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [dns_authorizations][crate::model::ListDnsAuthorizationsResponse::dns_authorizations].
     pub fn set_dns_authorizations<T, V>(mut self, v: T) -> Self
     where
@@ -1835,6 +1829,12 @@ impl ListDnsAuthorizationsResponse {
     {
         use std::iter::Iterator;
         self.dns_authorizations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDnsAuthorizationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2240,6 +2240,29 @@ impl Certificate {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Certificate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [san_dnsnames][crate::model::Certificate::san_dnsnames].
+    pub fn set_san_dnsnames<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.san_dnsnames = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [pem_certificate][crate::model::Certificate::pem_certificate].
     pub fn set_pem_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pem_certificate = v.into();
@@ -2261,29 +2284,6 @@ impl Certificate {
         v: T,
     ) -> Self {
         self.scope = v.into();
-        self
-    }
-
-    /// Sets the value of [san_dnsnames][crate::model::Certificate::san_dnsnames].
-    pub fn set_san_dnsnames<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.san_dnsnames = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Certificate::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2313,19 +2313,6 @@ impl Certificate {
         })
     }
 
-    /// The value of [r#type][crate::model::Certificate::r#type]
-    /// if it holds a `Managed`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn managed(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::certificate::ManagedCertificate>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::certificate::Type::Managed(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::Certificate::r#type]
     /// to hold a `SelfManaged`.
     ///
@@ -2340,6 +2327,19 @@ impl Certificate {
         self.r#type =
             std::option::Option::Some(crate::model::certificate::Type::SelfManaged(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Certificate::r#type]
+    /// if it holds a `Managed`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn managed(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::certificate::ManagedCertificate>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::certificate::Type::Managed(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Certificate::r#type]
@@ -2475,6 +2475,28 @@ pub mod certificate {
             std::default::Default::default()
         }
 
+        /// Sets the value of [domains][crate::model::certificate::ManagedCertificate::domains].
+        pub fn set_domains<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.domains = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [dns_authorizations][crate::model::certificate::ManagedCertificate::dns_authorizations].
+        pub fn set_dns_authorizations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.dns_authorizations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [issuance_config][crate::model::certificate::ManagedCertificate::issuance_config].
         pub fn set_issuance_config<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -2507,28 +2529,6 @@ pub mod certificate {
             v: T,
         ) -> Self {
             self.provisioning_issue = v.into();
-            self
-        }
-
-        /// Sets the value of [domains][crate::model::certificate::ManagedCertificate::domains].
-        pub fn set_domains<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.domains = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [dns_authorizations][crate::model::certificate::ManagedCertificate::dns_authorizations].
-        pub fn set_dns_authorizations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.dns_authorizations = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -3483,17 +3483,6 @@ impl CertificateMap {
         self
     }
 
-    /// Sets the value of [gclb_targets][crate::model::CertificateMap::gclb_targets].
-    pub fn set_gclb_targets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::certificate_map::GclbTarget>,
-    {
-        use std::iter::Iterator;
-        self.gclb_targets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::CertificateMap::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -3503,6 +3492,17 @@ impl CertificateMap {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [gclb_targets][crate::model::CertificateMap::gclb_targets].
+    pub fn set_gclb_targets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::certificate_map::GclbTarget>,
+    {
+        use std::iter::Iterator;
+        self.gclb_targets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3583,19 +3583,6 @@ pub mod certificate_map {
             })
         }
 
-        /// The value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
-        /// if it holds a `TargetSslProxy`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn target_ssl_proxy(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.target_proxy.as_ref().and_then(|v| match v {
-                crate::model::certificate_map::gclb_target::TargetProxy::TargetSslProxy(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
         /// to hold a `TargetHttpsProxy`.
         ///
@@ -3609,6 +3596,19 @@ pub mod certificate_map {
                 crate::model::certificate_map::gclb_target::TargetProxy::TargetHttpsProxy(v.into()),
             );
             self
+        }
+
+        /// The value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
+        /// if it holds a `TargetSslProxy`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn target_ssl_proxy(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.target_proxy.as_ref().and_then(|v| match v {
+                crate::model::certificate_map::gclb_target::TargetProxy::TargetSslProxy(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
@@ -3784,9 +3784,15 @@ impl CertificateMapEntry {
         self
     }
 
-    /// Sets the value of [state][crate::model::CertificateMapEntry::state].
-    pub fn set_state<T: std::convert::Into<crate::model::ServingState>>(mut self, v: T) -> Self {
-        self.state = v.into();
+    /// Sets the value of [labels][crate::model::CertificateMapEntry::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -3801,15 +3807,9 @@ impl CertificateMapEntry {
         self
     }
 
-    /// Sets the value of [labels][crate::model::CertificateMapEntry::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [state][crate::model::CertificateMapEntry::state].
+    pub fn set_state<T: std::convert::Into<crate::model::ServingState>>(mut self, v: T) -> Self {
+        self.state = v.into();
         self
     }
 
@@ -3838,17 +3838,6 @@ impl CertificateMapEntry {
         })
     }
 
-    /// The value of [r#match][crate::model::CertificateMapEntry::r#match]
-    /// if it holds a `Matcher`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn matcher(&self) -> std::option::Option<&crate::model::certificate_map_entry::Matcher> {
-        #[allow(unreachable_patterns)]
-        self.r#match.as_ref().and_then(|v| match v {
-            crate::model::certificate_map_entry::Match::Matcher(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#match][crate::model::CertificateMapEntry::r#match]
     /// to hold a `Hostname`.
     ///
@@ -3859,6 +3848,17 @@ impl CertificateMapEntry {
             crate::model::certificate_map_entry::Match::Hostname(v.into()),
         );
         self
+    }
+
+    /// The value of [r#match][crate::model::CertificateMapEntry::r#match]
+    /// if it holds a `Matcher`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn matcher(&self) -> std::option::Option<&crate::model::certificate_map_entry::Matcher> {
+        #[allow(unreachable_patterns)]
+        self.r#match.as_ref().and_then(|v| match v {
+            crate::model::certificate_map_entry::Match::Matcher(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#match][crate::model::CertificateMapEntry::r#match]
@@ -4110,6 +4110,18 @@ impl DnsAuthorization {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DnsAuthorization::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::DnsAuthorization::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4139,18 +4151,6 @@ impl DnsAuthorization {
         v: T,
     ) -> Self {
         self.r#type = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DnsAuthorization::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4464,12 +4464,6 @@ impl ListTrustConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTrustConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [trust_configs][crate::model::ListTrustConfigsResponse::trust_configs].
     pub fn set_trust_configs<T, V>(mut self, v: T) -> Self
     where
@@ -4478,6 +4472,12 @@ impl ListTrustConfigsResponse {
     {
         use std::iter::Iterator;
         self.trust_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTrustConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4778,6 +4778,18 @@ impl TrustConfig {
         self
     }
 
+    /// Sets the value of [labels][crate::model::TrustConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::TrustConfig::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4798,18 +4810,6 @@ impl TrustConfig {
     {
         use std::iter::Iterator;
         self.trust_stores = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::TrustConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/chronicle/v1/src/model.rs
+++ b/src/generated/cloud/chronicle/v1/src/model.rs
@@ -226,12 +226,6 @@ impl ListDataAccessLabelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataAccessLabelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_access_labels][crate::model::ListDataAccessLabelsResponse::data_access_labels].
     pub fn set_data_access_labels<T, V>(mut self, v: T) -> Self
     where
@@ -240,6 +234,12 @@ impl ListDataAccessLabelsResponse {
     {
         use std::iter::Iterator;
         self.data_access_labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataAccessLabelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -551,6 +551,17 @@ impl ListDataAccessScopesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [data_access_scopes][crate::model::ListDataAccessScopesResponse::data_access_scopes].
+    pub fn set_data_access_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataAccessScope>,
+    {
+        use std::iter::Iterator;
+        self.data_access_scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [global_data_access_scope_granted][crate::model::ListDataAccessScopesResponse::global_data_access_scope_granted].
     pub fn set_global_data_access_scope_granted<
         T: std::convert::Into<std::option::Option<bool>>,
@@ -565,17 +576,6 @@ impl ListDataAccessScopesResponse {
     /// Sets the value of [next_page_token][crate::model::ListDataAccessScopesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [data_access_scopes][crate::model::ListDataAccessScopesResponse::data_access_scopes].
-    pub fn set_data_access_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataAccessScope>,
-    {
-        use std::iter::Iterator;
-        self.data_access_scopes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -934,6 +934,28 @@ impl DataAccessScope {
         self
     }
 
+    /// Sets the value of [allowed_data_access_labels][crate::model::DataAccessScope::allowed_data_access_labels].
+    pub fn set_allowed_data_access_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataAccessLabelReference>,
+    {
+        use std::iter::Iterator;
+        self.allowed_data_access_labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [denied_data_access_labels][crate::model::DataAccessScope::denied_data_access_labels].
+    pub fn set_denied_data_access_labels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataAccessLabelReference>,
+    {
+        use std::iter::Iterator;
+        self.denied_data_access_labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::DataAccessScope::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -979,28 +1001,6 @@ impl DataAccessScope {
     /// Sets the value of [allow_all][crate::model::DataAccessScope::allow_all].
     pub fn set_allow_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_all = v.into();
-        self
-    }
-
-    /// Sets the value of [allowed_data_access_labels][crate::model::DataAccessScope::allowed_data_access_labels].
-    pub fn set_allowed_data_access_labels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataAccessLabelReference>,
-    {
-        use std::iter::Iterator;
-        self.allowed_data_access_labels = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [denied_data_access_labels][crate::model::DataAccessScope::denied_data_access_labels].
-    pub fn set_denied_data_access_labels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataAccessLabelReference>,
-    {
-        use std::iter::Iterator;
-        self.denied_data_access_labels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1071,47 +1071,6 @@ impl DataAccessLabelReference {
         })
     }
 
-    /// The value of [label][crate::model::DataAccessLabelReference::label]
-    /// if it holds a `LogType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn log_type(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.label.as_ref().and_then(|v| match v {
-            crate::model::data_access_label_reference::Label::LogType(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [label][crate::model::DataAccessLabelReference::label]
-    /// if it holds a `AssetNamespace`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn asset_namespace(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.label.as_ref().and_then(|v| match v {
-            crate::model::data_access_label_reference::Label::AssetNamespace(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [label][crate::model::DataAccessLabelReference::label]
-    /// if it holds a `IngestionLabel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ingestion_label(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IngestionLabel>> {
-        #[allow(unreachable_patterns)]
-        self.label.as_ref().and_then(|v| match v {
-            crate::model::data_access_label_reference::Label::IngestionLabel(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
     /// to hold a `DataAccessLabel`.
     ///
@@ -1127,6 +1086,19 @@ impl DataAccessLabelReference {
         self
     }
 
+    /// The value of [label][crate::model::DataAccessLabelReference::label]
+    /// if it holds a `LogType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn log_type(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.label.as_ref().and_then(|v| match v {
+            crate::model::data_access_label_reference::Label::LogType(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
     /// to hold a `LogType`.
     ///
@@ -1139,6 +1111,19 @@ impl DataAccessLabelReference {
         self
     }
 
+    /// The value of [label][crate::model::DataAccessLabelReference::label]
+    /// if it holds a `AssetNamespace`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn asset_namespace(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.label.as_ref().and_then(|v| match v {
+            crate::model::data_access_label_reference::Label::AssetNamespace(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
     /// to hold a `AssetNamespace`.
     ///
@@ -1149,6 +1134,21 @@ impl DataAccessLabelReference {
             crate::model::data_access_label_reference::Label::AssetNamespace(v.into()),
         );
         self
+    }
+
+    /// The value of [label][crate::model::DataAccessLabelReference::label]
+    /// if it holds a `IngestionLabel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ingestion_label(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IngestionLabel>> {
+        #[allow(unreachable_patterns)]
+        self.label.as_ref().and_then(|v| match v {
+            crate::model::data_access_label_reference::Label::IngestionLabel(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
@@ -1723,12 +1723,6 @@ impl ListWatchlistsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWatchlistsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [watchlists][crate::model::ListWatchlistsResponse::watchlists].
     pub fn set_watchlists<T, V>(mut self, v: T) -> Self
     where
@@ -1737,6 +1731,12 @@ impl ListWatchlistsResponse {
     {
         use std::iter::Iterator;
         self.watchlists = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWatchlistsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2208,12 +2208,6 @@ impl ListReferenceListsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReferenceListsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [reference_lists][crate::model::ListReferenceListsResponse::reference_lists].
     pub fn set_reference_lists<T, V>(mut self, v: T) -> Self
     where
@@ -2222,6 +2216,12 @@ impl ListReferenceListsResponse {
     {
         use std::iter::Iterator;
         self.reference_lists = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReferenceListsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2461,6 +2461,28 @@ impl ReferenceList {
         self
     }
 
+    /// Sets the value of [entries][crate::model::ReferenceList::entries].
+    pub fn set_entries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReferenceListEntry>,
+    {
+        use std::iter::Iterator;
+        self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::ReferenceList::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [syntax_type][crate::model::ReferenceList::syntax_type].
     pub fn set_syntax_type<T: std::convert::Into<crate::model::ReferenceListSyntaxType>>(
         mut self,
@@ -2482,28 +2504,6 @@ impl ReferenceList {
         v: T,
     ) -> Self {
         self.scope_info = v.into();
-        self
-    }
-
-    /// Sets the value of [entries][crate::model::ReferenceList::entries].
-    pub fn set_entries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ReferenceListEntry>,
-    {
-        use std::iter::Iterator;
-        self.entries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [rules][crate::model::ReferenceList::rules].
-    pub fn set_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2703,6 +2703,18 @@ impl Rule {
         self
     }
 
+    /// Sets the value of [metadata][crate::model::Rule::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Rule::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2736,36 +2748,6 @@ impl Rule {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Rule::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [scope][crate::model::Rule::scope].
-    pub fn set_scope<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.scope = v.into();
-        self
-    }
-
-    /// Sets the value of [near_real_time_live_rule_eligible][crate::model::Rule::near_real_time_live_rule_eligible].
-    pub fn set_near_real_time_live_rule_eligible<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.near_real_time_live_rule_eligible = v.into();
-        self
-    }
-
-    /// Sets the value of [inputs_used][crate::model::Rule::inputs_used].
-    pub fn set_inputs_used<T: std::convert::Into<std::option::Option<crate::model::InputsUsed>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.inputs_used = v.into();
-        self
-    }
-
     /// Sets the value of [reference_lists][crate::model::Rule::reference_lists].
     pub fn set_reference_lists<T, V>(mut self, v: T) -> Self
     where
@@ -2788,6 +2770,18 @@ impl Rule {
         self
     }
 
+    /// Sets the value of [etag][crate::model::Rule::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [scope][crate::model::Rule::scope].
+    pub fn set_scope<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.scope = v.into();
+        self
+    }
+
     /// Sets the value of [compilation_diagnostics][crate::model::Rule::compilation_diagnostics].
     pub fn set_compilation_diagnostics<T, V>(mut self, v: T) -> Self
     where
@@ -2799,15 +2793,21 @@ impl Rule {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::Rule::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [near_real_time_live_rule_eligible][crate::model::Rule::near_real_time_live_rule_eligible].
+    pub fn set_near_real_time_live_rule_eligible<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.near_real_time_live_rule_eligible = v.into();
+        self
+    }
+
+    /// Sets the value of [inputs_used][crate::model::Rule::inputs_used].
+    pub fn set_inputs_used<T: std::convert::Into<std::option::Option<crate::model::InputsUsed>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.inputs_used = v.into();
         self
     }
 }
@@ -3085,17 +3085,6 @@ impl RuleDeployment {
         self
     }
 
-    /// Sets the value of [last_alert_status_change_time][crate::model::RuleDeployment::last_alert_status_change_time].
-    pub fn set_last_alert_status_change_time<
-        T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.last_alert_status_change_time = v.into();
-        self
-    }
-
     /// Sets the value of [producer_rules][crate::model::RuleDeployment::producer_rules].
     pub fn set_producer_rules<T, V>(mut self, v: T) -> Self
     where
@@ -3115,6 +3104,17 @@ impl RuleDeployment {
     {
         use std::iter::Iterator;
         self.consumer_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [last_alert_status_change_time][crate::model::RuleDeployment::last_alert_status_change_time].
+    pub fn set_last_alert_status_change_time<
+        T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.last_alert_status_change_time = v.into();
         self
     }
 }
@@ -3711,12 +3711,6 @@ impl ListRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rules][crate::model::ListRulesResponse::rules].
     pub fn set_rules<T, V>(mut self, v: T) -> Self
     where
@@ -3725,6 +3719,12 @@ impl ListRulesResponse {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3947,12 +3947,6 @@ impl ListRuleRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRuleRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rules][crate::model::ListRuleRevisionsResponse::rules].
     pub fn set_rules<T, V>(mut self, v: T) -> Self
     where
@@ -3961,6 +3955,12 @@ impl ListRuleRevisionsResponse {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRuleRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4163,12 +4163,6 @@ impl ListRetrohuntsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRetrohuntsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [retrohunts][crate::model::ListRetrohuntsResponse::retrohunts].
     pub fn set_retrohunts<T, V>(mut self, v: T) -> Self
     where
@@ -4177,6 +4171,12 @@ impl ListRetrohuntsResponse {
     {
         use std::iter::Iterator;
         self.retrohunts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRetrohuntsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4333,12 +4333,6 @@ impl ListRuleDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRuleDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rule_deployments][crate::model::ListRuleDeploymentsResponse::rule_deployments].
     pub fn set_rule_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -4347,6 +4341,12 @@ impl ListRuleDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.rule_deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRuleDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/model.rs
@@ -214,12 +214,6 @@ impl ListAccessApprovalRequestsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAccessApprovalRequestsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [access_approval_requests][crate::model::ListAccessApprovalRequestsResponse::access_approval_requests].
     pub fn set_access_approval_requests<T, V>(mut self, v: T) -> Self
     where
@@ -228,6 +222,12 @@ impl ListAccessApprovalRequestsResponse {
     {
         use std::iter::Iterator;
         self.access_approval_requests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAccessApprovalRequestsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1014,12 +1014,6 @@ impl ListWorkloadsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workloads][crate::model::ListWorkloadsResponse::workloads].
     pub fn set_workloads<T, V>(mut self, v: T) -> Self
     where
@@ -1028,6 +1022,12 @@ impl ListWorkloadsResponse {
     {
         use std::iter::Iterator;
         self.workloads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1516,12 +1516,6 @@ impl ListCustomersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCustomersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [customers][crate::model::ListCustomersResponse::customers].
     pub fn set_customers<T, V>(mut self, v: T) -> Self
     where
@@ -1530,6 +1524,12 @@ impl ListCustomersResponse {
     {
         use std::iter::Iterator;
         self.customers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCustomersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2498,33 +2498,6 @@ impl Partner {
         self
     }
 
-    /// Sets the value of [partner_project_id][crate::model::Partner::partner_project_id].
-    pub fn set_partner_project_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.partner_project_id = v.into();
-        self
-    }
-
-    /// Sets the value of [create_time][crate::model::Partner::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [update_time][crate::model::Partner::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [skus][crate::model::Partner::skus].
     pub fn set_skus<T, V>(mut self, v: T) -> Self
     where
@@ -2555,6 +2528,33 @@ impl Partner {
     {
         use std::iter::Iterator;
         self.operated_cloud_regions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [partner_project_id][crate::model::Partner::partner_project_id].
+    pub fn set_partner_project_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.partner_project_id = v.into();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::Partner::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::Partner::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -3044,17 +3044,6 @@ pub mod violation {
             self
         }
 
-        /// Sets the value of [remediation_type][crate::model::violation::Remediation::remediation_type].
-        pub fn set_remediation_type<
-            T: std::convert::Into<crate::model::violation::remediation::RemediationType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.remediation_type = v.into();
-            self
-        }
-
         /// Sets the value of [compliant_values][crate::model::violation::Remediation::compliant_values].
         pub fn set_compliant_values<T, V>(mut self, v: T) -> Self
         where
@@ -3063,6 +3052,17 @@ pub mod violation {
         {
             use std::iter::Iterator;
             self.compliant_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [remediation_type][crate::model::violation::Remediation::remediation_type].
+        pub fn set_remediation_type<
+            T: std::convert::Into<crate::model::violation::remediation::RemediationType>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.remediation_type = v.into();
             self
         }
     }
@@ -3738,12 +3738,6 @@ impl ListViolationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListViolationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [violations][crate::model::ListViolationsResponse::violations].
     pub fn set_violations<T, V>(mut self, v: T) -> Self
     where
@@ -3752,6 +3746,12 @@ impl ListViolationsResponse {
     {
         use std::iter::Iterator;
         self.violations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListViolationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -3054,14 +3054,6 @@ pub mod data_migration_service {
             self
         }
 
-        /// Sets the value of [auto_commit][crate::model::ImportMappingRulesRequest::auto_commit].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_auto_commit<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.auto_commit = v.into();
-            self
-        }
-
         /// Sets the value of [rules_files][crate::model::ImportMappingRulesRequest::rules_files].
         ///
         /// This is a **required** field for requests.
@@ -3072,6 +3064,14 @@ pub mod data_migration_service {
         {
             use std::iter::Iterator;
             self.0.request.rules_files = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [auto_commit][crate::model::ImportMappingRulesRequest::auto_commit].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_auto_commit<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.auto_commit = v.into();
             self
         }
     }

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -151,12 +151,6 @@ impl ListMigrationJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMigrationJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [migration_jobs][crate::model::ListMigrationJobsResponse::migration_jobs].
     pub fn set_migration_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -165,6 +159,12 @@ impl ListMigrationJobsResponse {
     {
         use std::iter::Iterator;
         self.migration_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMigrationJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -762,21 +762,6 @@ impl GenerateSshScriptRequest {
         })
     }
 
-    /// The value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
-    /// if it holds a `VmSelectionConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vm_selection_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VmSelectionConfig>> {
-        #[allow(unreachable_patterns)]
-        self.vm_config.as_ref().and_then(|v| match v {
-            crate::model::generate_ssh_script_request::VmConfig::VmSelectionConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
     /// to hold a `VmCreationConfig`.
     ///
@@ -792,6 +777,21 @@ impl GenerateSshScriptRequest {
             crate::model::generate_ssh_script_request::VmConfig::VmCreationConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
+    /// if it holds a `VmSelectionConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vm_selection_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VmSelectionConfig>> {
+        #[allow(unreachable_patterns)]
+        self.vm_config.as_ref().and_then(|v| match v {
+            crate::model::generate_ssh_script_request::VmConfig::VmSelectionConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
@@ -1176,12 +1176,6 @@ impl ListConnectionProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connection_profiles][crate::model::ListConnectionProfilesResponse::connection_profiles].
     pub fn set_connection_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -1190,6 +1184,12 @@ impl ListConnectionProfilesResponse {
     {
         use std::iter::Iterator;
         self.connection_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1707,12 +1707,6 @@ impl ListPrivateConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [private_connections][crate::model::ListPrivateConnectionsResponse::private_connections].
     pub fn set_private_connections<T, V>(mut self, v: T) -> Self
     where
@@ -1721,6 +1715,12 @@ impl ListPrivateConnectionsResponse {
     {
         use std::iter::Iterator;
         self.private_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2045,12 +2045,6 @@ impl ListConversionWorkspacesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversionWorkspacesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversion_workspaces][crate::model::ListConversionWorkspacesResponse::conversion_workspaces].
     pub fn set_conversion_workspaces<T, V>(mut self, v: T) -> Self
     where
@@ -2059,6 +2053,12 @@ impl ListConversionWorkspacesResponse {
     {
         use std::iter::Iterator;
         self.conversion_workspaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversionWorkspacesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2621,12 +2621,6 @@ impl ListMappingRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMappingRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [mapping_rules][crate::model::ListMappingRulesResponse::mapping_rules].
     pub fn set_mapping_rules<T, V>(mut self, v: T) -> Self
     where
@@ -2635,6 +2629,12 @@ impl ListMappingRulesResponse {
     {
         use std::iter::Iterator;
         self.mapping_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMappingRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2770,17 +2770,6 @@ impl SeedConversionWorkspaceRequest {
         })
     }
 
-    /// The value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
-    /// if it holds a `DestinationConnectionProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn destination_connection_profile(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.seed_from.as_ref().and_then(|v| match v {
-            crate::model::seed_conversion_workspace_request::SeedFrom::DestinationConnectionProfile(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
     /// to hold a `SourceConnectionProfile`.
     ///
@@ -2796,6 +2785,17 @@ impl SeedConversionWorkspaceRequest {
             ),
         );
         self
+    }
+
+    /// The value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
+    /// if it holds a `DestinationConnectionProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn destination_connection_profile(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.seed_from.as_ref().and_then(|v| match v {
+            crate::model::seed_conversion_workspace_request::SeedFrom::DestinationConnectionProfile(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
@@ -2957,12 +2957,6 @@ impl ImportMappingRulesRequest {
         self
     }
 
-    /// Sets the value of [auto_commit][crate::model::ImportMappingRulesRequest::auto_commit].
-    pub fn set_auto_commit<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.auto_commit = v.into();
-        self
-    }
-
     /// Sets the value of [rules_files][crate::model::ImportMappingRulesRequest::rules_files].
     pub fn set_rules_files<T, V>(mut self, v: T) -> Self
     where
@@ -2971,6 +2965,12 @@ impl ImportMappingRulesRequest {
     {
         use std::iter::Iterator;
         self.rules_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [auto_commit][crate::model::ImportMappingRulesRequest::auto_commit].
+    pub fn set_auto_commit<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.auto_commit = v.into();
         self
     }
 }
@@ -3328,12 +3328,6 @@ impl DescribeDatabaseEntitiesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::DescribeDatabaseEntitiesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [database_entities][crate::model::DescribeDatabaseEntitiesResponse::database_entities].
     pub fn set_database_entities<T, V>(mut self, v: T) -> Self
     where
@@ -3342,6 +3336,12 @@ impl DescribeDatabaseEntitiesResponse {
     {
         use std::iter::Iterator;
         self.database_entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::DescribeDatabaseEntitiesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3764,12 +3764,6 @@ impl FetchStaticIpsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchStaticIpsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [static_ips][crate::model::FetchStaticIpsResponse::static_ips].
     pub fn set_static_ips<T, V>(mut self, v: T) -> Self
     where
@@ -3778,6 +3772,12 @@ impl FetchStaticIpsResponse {
     {
         use std::iter::Iterator;
         self.static_ips = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchStaticIpsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4247,20 +4247,6 @@ impl PostgreSqlConnectionProfile {
         })
     }
 
-    /// The value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
-    /// if it holds a `PrivateServiceConnectConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn private_service_connect_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PrivateServiceConnectConnectivity>>
-    {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::postgre_sql_connection_profile::Connectivity::PrivateServiceConnectConnectivity(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
     /// to hold a `StaticIpConnectivity`.
     ///
@@ -4278,6 +4264,20 @@ impl PostgreSqlConnectionProfile {
             ),
         );
         self
+    }
+
+    /// The value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
+    /// if it holds a `PrivateServiceConnectConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn private_service_connect_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PrivateServiceConnectConnectivity>>
+    {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::postgre_sql_connection_profile::Connectivity::PrivateServiceConnectConnectivity(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
@@ -4460,36 +4460,6 @@ impl OracleConnectionProfile {
         })
     }
 
-    /// The value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
-    /// if it holds a `ForwardSshConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn forward_ssh_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ForwardSshTunnelConnectivity>> {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::oracle_connection_profile::Connectivity::ForwardSshConnectivity(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
-    /// if it holds a `PrivateConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn private_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PrivateConnectivity>> {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::oracle_connection_profile::Connectivity::PrivateConnectivity(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
     /// to hold a `StaticServiceIpConnectivity`.
     ///
@@ -4509,6 +4479,21 @@ impl OracleConnectionProfile {
         self
     }
 
+    /// The value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
+    /// if it holds a `ForwardSshConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn forward_ssh_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ForwardSshTunnelConnectivity>> {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::oracle_connection_profile::Connectivity::ForwardSshConnectivity(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
     /// to hold a `ForwardSshConnectivity`.
     ///
@@ -4524,6 +4509,21 @@ impl OracleConnectionProfile {
             crate::model::oracle_connection_profile::Connectivity::ForwardSshConnectivity(v.into()),
         );
         self
+    }
+
+    /// The value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
+    /// if it holds a `PrivateConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn private_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PrivateConnectivity>> {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::oracle_connection_profile::Connectivity::PrivateConnectivity(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
@@ -4766,17 +4766,6 @@ impl SqlAclEntry {
         })
     }
 
-    /// The value of [expiration][crate::model::SqlAclEntry::expiration]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.expiration.as_ref().and_then(|v| match v {
-            crate::model::sql_acl_entry::Expiration::Ttl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [expiration][crate::model::SqlAclEntry::expiration]
     /// to hold a `ExpireTime`.
     ///
@@ -4790,6 +4779,17 @@ impl SqlAclEntry {
             crate::model::sql_acl_entry::Expiration::ExpireTime(v.into()),
         );
         self
+    }
+
+    /// The value of [expiration][crate::model::SqlAclEntry::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::sql_acl_entry::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [expiration][crate::model::SqlAclEntry::expiration]
@@ -5061,6 +5061,18 @@ impl CloudSqlSettings {
         self
     }
 
+    /// Sets the value of [user_labels][crate::model::CloudSqlSettings::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [tier][crate::model::CloudSqlSettings::tier].
     pub fn set_tier<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tier = v.into();
@@ -5104,6 +5116,18 @@ impl CloudSqlSettings {
         v: T,
     ) -> Self {
         self.auto_storage_increase = v.into();
+        self
+    }
+
+    /// Sets the value of [database_flags][crate::model::CloudSqlSettings::database_flags].
+    pub fn set_database_flags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.database_flags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5186,30 +5210,6 @@ impl CloudSqlSettings {
         v: T,
     ) -> Self {
         self.edition = v.into();
-        self
-    }
-
-    /// Sets the value of [user_labels][crate::model::CloudSqlSettings::user_labels].
-    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [database_flags][crate::model::CloudSqlSettings::database_flags].
-    pub fn set_database_flags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.database_flags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6005,6 +6005,18 @@ impl AlloyDbSettings {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AlloyDbSettings::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [primary_instance_settings][crate::model::AlloyDbSettings::primary_instance_settings].
     pub fn set_primary_instance_settings<
         T: std::convert::Into<
@@ -6026,18 +6038,6 @@ impl AlloyDbSettings {
         v: T,
     ) -> Self {
         self.encryption_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AlloyDbSettings::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6170,12 +6170,6 @@ pub mod alloy_db_settings {
             self
         }
 
-        /// Sets the value of [private_ip][crate::model::alloy_db_settings::PrimaryInstanceSettings::private_ip].
-        pub fn set_private_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.private_ip = v.into();
-            self
-        }
-
         /// Sets the value of [database_flags][crate::model::alloy_db_settings::PrimaryInstanceSettings::database_flags].
         pub fn set_database_flags<T, K, V>(mut self, v: T) -> Self
         where
@@ -6197,6 +6191,12 @@ pub mod alloy_db_settings {
         {
             use std::iter::Iterator;
             self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [private_ip][crate::model::alloy_db_settings::PrimaryInstanceSettings::private_ip].
+        pub fn set_private_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.private_ip = v.into();
             self
         }
     }
@@ -6531,6 +6531,18 @@ impl ForwardSshTunnelConnectivity {
         })
     }
 
+    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
+    /// to hold a `Password`.
+    ///
+    /// Note that all the setters affecting `authentication_method` are
+    /// mutually exclusive.
+    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.authentication_method = std::option::Option::Some(
+            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::Password(v.into()),
+        );
+        self
+    }
+
     /// The value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
     /// if it holds a `PrivateKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -6542,18 +6554,6 @@ impl ForwardSshTunnelConnectivity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
-    /// to hold a `Password`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::Password(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
@@ -6849,6 +6849,18 @@ impl MigrationJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::MigrationJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::MigrationJob::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -6994,18 +7006,6 @@ impl MigrationJob {
         self
     }
 
-    /// Sets the value of [labels][crate::model::MigrationJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity].
     ///
     /// Note that all the setters affecting `connectivity` are mutually
@@ -7035,36 +7035,6 @@ impl MigrationJob {
         })
     }
 
-    /// The value of [connectivity][crate::model::MigrationJob::connectivity]
-    /// if it holds a `VpcPeeringConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vpc_peering_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VpcPeeringConnectivity>> {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::migration_job::Connectivity::VpcPeeringConnectivity(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connectivity][crate::model::MigrationJob::connectivity]
-    /// if it holds a `StaticIpConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn static_ip_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StaticIpConnectivity>> {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::migration_job::Connectivity::StaticIpConnectivity(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity]
     /// to hold a `ReverseSshConnectivity`.
     ///
@@ -7082,6 +7052,21 @@ impl MigrationJob {
         self
     }
 
+    /// The value of [connectivity][crate::model::MigrationJob::connectivity]
+    /// if it holds a `VpcPeeringConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vpc_peering_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VpcPeeringConnectivity>> {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::migration_job::Connectivity::VpcPeeringConnectivity(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity]
     /// to hold a `VpcPeeringConnectivity`.
     ///
@@ -7097,6 +7082,21 @@ impl MigrationJob {
             crate::model::migration_job::Connectivity::VpcPeeringConnectivity(v.into()),
         );
         self
+    }
+
+    /// The value of [connectivity][crate::model::MigrationJob::connectivity]
+    /// if it holds a `StaticIpConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn static_ip_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StaticIpConnectivity>> {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::migration_job::Connectivity::StaticIpConnectivity(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity]
@@ -8043,6 +8043,18 @@ impl ConnectionProfile {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ConnectionProfile::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::ConnectionProfile::state].
     pub fn set_state<T: std::convert::Into<crate::model::connection_profile::State>>(
         mut self,
@@ -8073,18 +8085,6 @@ impl ConnectionProfile {
         v: T,
     ) -> Self {
         self.provider = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ConnectionProfile::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -8119,66 +8119,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// if it holds a `Postgresql`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgreSqlConnectionProfile>> {
-        #[allow(unreachable_patterns)]
-        self.connection_profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::ConnectionProfile::Postgresql(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// if it holds a `Oracle`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oracle(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OracleConnectionProfile>> {
-        #[allow(unreachable_patterns)]
-        self.connection_profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::ConnectionProfile::Oracle(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// if it holds a `Cloudsql`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloudsql(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlConnectionProfile>> {
-        #[allow(unreachable_patterns)]
-        self.connection_profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::ConnectionProfile::Cloudsql(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// if it holds a `Alloydb`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn alloydb(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AlloyDbConnectionProfile>> {
-        #[allow(unreachable_patterns)]
-        self.connection_profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::ConnectionProfile::Alloydb(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
     /// to hold a `Mysql`.
     ///
@@ -8194,6 +8134,21 @@ impl ConnectionProfile {
             crate::model::connection_profile::ConnectionProfile::Mysql(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
+    /// if it holds a `Postgresql`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgreSqlConnectionProfile>> {
+        #[allow(unreachable_patterns)]
+        self.connection_profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::ConnectionProfile::Postgresql(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
@@ -8213,6 +8168,21 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
+    /// if it holds a `Oracle`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oracle(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OracleConnectionProfile>> {
+        #[allow(unreachable_patterns)]
+        self.connection_profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::ConnectionProfile::Oracle(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
     /// to hold a `Oracle`.
     ///
@@ -8230,6 +8200,21 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
+    /// if it holds a `Cloudsql`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloudsql(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlConnectionProfile>> {
+        #[allow(unreachable_patterns)]
+        self.connection_profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::ConnectionProfile::Cloudsql(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
     /// to hold a `Cloudsql`.
     ///
@@ -8245,6 +8230,21 @@ impl ConnectionProfile {
             crate::model::connection_profile::ConnectionProfile::Cloudsql(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
+    /// if it holds a `Alloydb`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn alloydb(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AlloyDbConnectionProfile>> {
+        #[allow(unreachable_patterns)]
+        self.connection_profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::ConnectionProfile::Alloydb(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
@@ -8954,6 +8954,18 @@ impl PrivateConnection {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PrivateConnection::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::PrivateConnection::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -8975,18 +8987,6 @@ impl PrivateConnection {
         v: T,
     ) -> Self {
         self.error = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::PrivateConnection::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -9390,6 +9390,18 @@ impl ConversionWorkspace {
         self
     }
 
+    /// Sets the value of [global_settings][crate::model::ConversionWorkspace::global_settings].
+    pub fn set_global_settings<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.global_settings = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [has_uncommitted_changes][crate::model::ConversionWorkspace::has_uncommitted_changes].
     pub fn set_has_uncommitted_changes<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.has_uncommitted_changes = v.into();
@@ -9435,18 +9447,6 @@ impl ConversionWorkspace {
     /// Sets the value of [display_name][crate::model::ConversionWorkspace::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
-        self
-    }
-
-    /// Sets the value of [global_settings][crate::model::ConversionWorkspace::global_settings].
-    pub fn set_global_settings<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.global_settings = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -9593,57 +9593,6 @@ impl BackgroundJobLogEntry {
         })
     }
 
-    /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// if it holds a `ImportRulesJobDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn import_rules_job_details(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::background_job_log_entry::ImportRulesJobDetails>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.job_details.as_ref().and_then(|v| match v {
-            crate::model::background_job_log_entry::JobDetails::ImportRulesJobDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// if it holds a `ConvertJobDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn convert_job_details(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::background_job_log_entry::ConvertJobDetails>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.job_details.as_ref().and_then(|v| match v {
-            crate::model::background_job_log_entry::JobDetails::ConvertJobDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// if it holds a `ApplyJobDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn apply_job_details(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::background_job_log_entry::ApplyJobDetails>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.job_details.as_ref().and_then(|v| match v {
-            crate::model::background_job_log_entry::JobDetails::ApplyJobDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
     /// to hold a `SeedJobDetails`.
     ///
@@ -9659,6 +9608,23 @@ impl BackgroundJobLogEntry {
             crate::model::background_job_log_entry::JobDetails::SeedJobDetails(v.into()),
         );
         self
+    }
+
+    /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
+    /// if it holds a `ImportRulesJobDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn import_rules_job_details(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::background_job_log_entry::ImportRulesJobDetails>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.job_details.as_ref().and_then(|v| match v {
+            crate::model::background_job_log_entry::JobDetails::ImportRulesJobDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
@@ -9680,6 +9646,23 @@ impl BackgroundJobLogEntry {
         self
     }
 
+    /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
+    /// if it holds a `ConvertJobDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn convert_job_details(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::background_job_log_entry::ConvertJobDetails>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.job_details.as_ref().and_then(|v| match v {
+            crate::model::background_job_log_entry::JobDetails::ConvertJobDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
     /// to hold a `ConvertJobDetails`.
     ///
@@ -9697,6 +9680,23 @@ impl BackgroundJobLogEntry {
             crate::model::background_job_log_entry::JobDetails::ConvertJobDetails(v.into()),
         );
         self
+    }
+
+    /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
+    /// if it holds a `ApplyJobDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn apply_job_details(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::background_job_log_entry::ApplyJobDetails>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.job_details.as_ref().and_then(|v| match v {
+            crate::model::background_job_log_entry::JobDetails::ApplyJobDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
@@ -9787,15 +9787,6 @@ pub mod background_job_log_entry {
             std::default::Default::default()
         }
 
-        /// Sets the value of [file_format][crate::model::background_job_log_entry::ImportRulesJobDetails::file_format].
-        pub fn set_file_format<T: std::convert::Into<crate::model::ImportRulesFileFormat>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.file_format = v.into();
-            self
-        }
-
         /// Sets the value of [files][crate::model::background_job_log_entry::ImportRulesJobDetails::files].
         pub fn set_files<T, V>(mut self, v: T) -> Self
         where
@@ -9804,6 +9795,15 @@ pub mod background_job_log_entry {
         {
             use std::iter::Iterator;
             self.files = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [file_format][crate::model::background_job_log_entry::ImportRulesJobDetails::file_format].
+        pub fn set_file_format<T: std::convert::Into<crate::model::ImportRulesFileFormat>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.file_format = v.into();
             self
         }
     }
@@ -10287,150 +10287,6 @@ impl MappingRule {
         })
     }
 
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `MultiEntityRename`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn multi_entity_rename(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MultiEntityRename>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::MultiEntityRename(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `EntityMove`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity_move(&self) -> std::option::Option<&std::boxed::Box<crate::model::EntityMove>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::EntityMove(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `SingleColumnChange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn single_column_change(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SingleColumnChange>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::SingleColumnChange(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `MultiColumnDataTypeChange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn multi_column_data_type_change(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MultiColumnDatatypeChange>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::MultiColumnDataTypeChange(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `ConditionalColumnSetValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn conditional_column_set_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ConditionalColumnSetValue>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::ConditionalColumnSetValue(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `ConvertRowidColumn`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn convert_rowid_column(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ConvertRowIdToColumn>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::ConvertRowidColumn(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `SetTablePrimaryKey`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn set_table_primary_key(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SetTablePrimaryKey>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::SetTablePrimaryKey(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `SinglePackageChange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn single_package_change(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SinglePackageChange>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::SinglePackageChange(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `SourceSqlChange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn source_sql_change(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceSqlChange>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::SourceSqlChange(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::MappingRule::details]
-    /// if it holds a `FilterTableColumns`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filter_table_columns(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FilterTableColumns>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::mapping_rule::Details::FilterTableColumns(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [details][crate::model::MappingRule::details]
     /// to hold a `SingleEntityRename`.
     ///
@@ -10446,6 +10302,21 @@ impl MappingRule {
             crate::model::mapping_rule::Details::SingleEntityRename(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `MultiEntityRename`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn multi_entity_rename(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MultiEntityRename>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::MultiEntityRename(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::MappingRule::details]
@@ -10465,6 +10336,17 @@ impl MappingRule {
         self
     }
 
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `EntityMove`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity_move(&self) -> std::option::Option<&std::boxed::Box<crate::model::EntityMove>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::EntityMove(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::MappingRule::details]
     /// to hold a `EntityMove`.
     ///
@@ -10477,6 +10359,21 @@ impl MappingRule {
         self.details =
             std::option::Option::Some(crate::model::mapping_rule::Details::EntityMove(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `SingleColumnChange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn single_column_change(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SingleColumnChange>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::SingleColumnChange(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::MappingRule::details]
@@ -10496,6 +10393,21 @@ impl MappingRule {
         self
     }
 
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `MultiColumnDataTypeChange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn multi_column_data_type_change(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MultiColumnDatatypeChange>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::MultiColumnDataTypeChange(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::MappingRule::details]
     /// to hold a `MultiColumnDataTypeChange`.
     ///
@@ -10511,6 +10423,21 @@ impl MappingRule {
             crate::model::mapping_rule::Details::MultiColumnDataTypeChange(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `ConditionalColumnSetValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn conditional_column_set_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ConditionalColumnSetValue>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::ConditionalColumnSetValue(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::MappingRule::details]
@@ -10530,6 +10457,21 @@ impl MappingRule {
         self
     }
 
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `ConvertRowidColumn`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn convert_rowid_column(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ConvertRowIdToColumn>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::ConvertRowidColumn(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::MappingRule::details]
     /// to hold a `ConvertRowidColumn`.
     ///
@@ -10545,6 +10487,21 @@ impl MappingRule {
             crate::model::mapping_rule::Details::ConvertRowidColumn(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `SetTablePrimaryKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn set_table_primary_key(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SetTablePrimaryKey>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::SetTablePrimaryKey(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::MappingRule::details]
@@ -10564,6 +10521,21 @@ impl MappingRule {
         self
     }
 
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `SinglePackageChange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn single_package_change(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SinglePackageChange>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::SinglePackageChange(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::MappingRule::details]
     /// to hold a `SinglePackageChange`.
     ///
@@ -10581,6 +10553,19 @@ impl MappingRule {
         self
     }
 
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `SourceSqlChange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn source_sql_change(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceSqlChange>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::SourceSqlChange(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::MappingRule::details]
     /// to hold a `SourceSqlChange`.
     ///
@@ -10596,6 +10581,21 @@ impl MappingRule {
             crate::model::mapping_rule::Details::SourceSqlChange(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::MappingRule::details]
+    /// if it holds a `FilterTableColumns`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filter_table_columns(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FilterTableColumns>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::mapping_rule::Details::FilterTableColumns(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::MappingRule::details]
@@ -11110,12 +11110,6 @@ impl SingleColumnChange {
         self
     }
 
-    /// Sets the value of [comment][crate::model::SingleColumnChange::comment].
-    pub fn set_comment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.comment = v.into();
-        self
-    }
-
     /// Sets the value of [set_values][crate::model::SingleColumnChange::set_values].
     pub fn set_set_values<T, V>(mut self, v: T) -> Self
     where
@@ -11124,6 +11118,12 @@ impl SingleColumnChange {
     {
         use std::iter::Iterator;
         self.set_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [comment][crate::model::SingleColumnChange::comment].
+    pub fn set_comment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.comment = v.into();
         self
     }
 }
@@ -11282,21 +11282,6 @@ impl MultiColumnDatatypeChange {
         })
     }
 
-    /// The value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
-    /// if it holds a `SourceNumericFilter`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn source_numeric_filter(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceNumericFilter>> {
-        #[allow(unreachable_patterns)]
-        self.source_filter.as_ref().and_then(|v| match v {
-            crate::model::multi_column_datatype_change::SourceFilter::SourceNumericFilter(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
     /// to hold a `SourceTextFilter`.
     ///
@@ -11312,6 +11297,21 @@ impl MultiColumnDatatypeChange {
             crate::model::multi_column_datatype_change::SourceFilter::SourceTextFilter(v.into()),
         );
         self
+    }
+
+    /// The value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
+    /// if it holds a `SourceNumericFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn source_numeric_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceNumericFilter>> {
+        #[allow(unreachable_patterns)]
+        self.source_filter.as_ref().and_then(|v| match v {
+            crate::model::multi_column_datatype_change::SourceFilter::SourceNumericFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
@@ -11564,21 +11564,6 @@ impl ConditionalColumnSetValue {
         })
     }
 
-    /// The value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
-    /// if it holds a `SourceNumericFilter`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn source_numeric_filter(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceNumericFilter>> {
-        #[allow(unreachable_patterns)]
-        self.source_filter.as_ref().and_then(|v| match v {
-            crate::model::conditional_column_set_value::SourceFilter::SourceNumericFilter(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
     /// to hold a `SourceTextFilter`.
     ///
@@ -11594,6 +11579,21 @@ impl ConditionalColumnSetValue {
             crate::model::conditional_column_set_value::SourceFilter::SourceTextFilter(v.into()),
         );
         self
+    }
+
+    /// The value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
+    /// if it holds a `SourceNumericFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn source_numeric_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceNumericFilter>> {
+        #[allow(unreachable_patterns)]
+        self.source_filter.as_ref().and_then(|v| match v {
+            crate::model::conditional_column_set_value::SourceFilter::SourceNumericFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
@@ -11685,6 +11685,17 @@ impl ValueTransformation {
         })
     }
 
+    /// Sets the value of [filter][crate::model::ValueTransformation::filter]
+    /// to hold a `IsNull`.
+    ///
+    /// Note that all the setters affecting `filter` are
+    /// mutually exclusive.
+    pub fn set_is_null<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(mut self, v: T) -> Self {
+        self.filter =
+            std::option::Option::Some(crate::model::value_transformation::Filter::IsNull(v.into()));
+        self
+    }
+
     /// The value of [filter][crate::model::ValueTransformation::filter]
     /// if it holds a `ValueList`, `None` if the field is not set or
     /// holds a different branch.
@@ -11698,47 +11709,6 @@ impl ValueTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [filter][crate::model::ValueTransformation::filter]
-    /// if it holds a `IntComparison`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int_comparison(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IntComparisonFilter>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Filter::IntComparison(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::ValueTransformation::filter]
-    /// if it holds a `DoubleComparison`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_comparison(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DoubleComparisonFilter>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Filter::DoubleComparison(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [filter][crate::model::ValueTransformation::filter]
-    /// to hold a `IsNull`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_is_null<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(mut self, v: T) -> Self {
-        self.filter =
-            std::option::Option::Some(crate::model::value_transformation::Filter::IsNull(v.into()));
-        self
     }
 
     /// Sets the value of [filter][crate::model::ValueTransformation::filter]
@@ -11756,6 +11726,21 @@ impl ValueTransformation {
         self
     }
 
+    /// The value of [filter][crate::model::ValueTransformation::filter]
+    /// if it holds a `IntComparison`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int_comparison(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IntComparisonFilter>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Filter::IntComparison(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [filter][crate::model::ValueTransformation::filter]
     /// to hold a `IntComparison`.
     ///
@@ -11771,6 +11756,21 @@ impl ValueTransformation {
             crate::model::value_transformation::Filter::IntComparison(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::ValueTransformation::filter]
+    /// if it holds a `DoubleComparison`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_comparison(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DoubleComparisonFilter>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Filter::DoubleComparison(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::ValueTransformation::filter]
@@ -11817,73 +11817,6 @@ impl ValueTransformation {
         })
     }
 
-    /// The value of [action][crate::model::ValueTransformation::action]
-    /// if it holds a `AssignSpecificValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn assign_specific_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AssignSpecificValue>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Action::AssignSpecificValue(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::ValueTransformation::action]
-    /// if it holds a `AssignMinValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn assign_min_value(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Action::AssignMinValue(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::ValueTransformation::action]
-    /// if it holds a `AssignMaxValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn assign_max_value(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Action::AssignMaxValue(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::ValueTransformation::action]
-    /// if it holds a `RoundScale`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn round_scale(&self) -> std::option::Option<&std::boxed::Box<crate::model::RoundToScale>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Action::RoundScale(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::ValueTransformation::action]
-    /// if it holds a `ApplyHash`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn apply_hash(&self) -> std::option::Option<&std::boxed::Box<crate::model::ApplyHash>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::value_transformation::Action::ApplyHash(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [action][crate::model::ValueTransformation::action]
     /// to hold a `AssignNull`.
     ///
@@ -11897,6 +11830,21 @@ impl ValueTransformation {
             crate::model::value_transformation::Action::AssignNull(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::ValueTransformation::action]
+    /// if it holds a `AssignSpecificValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn assign_specific_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AssignSpecificValue>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Action::AssignSpecificValue(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::ValueTransformation::action]
@@ -11916,6 +11864,19 @@ impl ValueTransformation {
         self
     }
 
+    /// The value of [action][crate::model::ValueTransformation::action]
+    /// if it holds a `AssignMinValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn assign_min_value(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Action::AssignMinValue(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::ValueTransformation::action]
     /// to hold a `AssignMinValue`.
     ///
@@ -11929,6 +11890,19 @@ impl ValueTransformation {
             crate::model::value_transformation::Action::AssignMinValue(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::ValueTransformation::action]
+    /// if it holds a `AssignMaxValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn assign_max_value(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Action::AssignMaxValue(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::ValueTransformation::action]
@@ -11946,6 +11920,19 @@ impl ValueTransformation {
         self
     }
 
+    /// The value of [action][crate::model::ValueTransformation::action]
+    /// if it holds a `RoundScale`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn round_scale(&self) -> std::option::Option<&std::boxed::Box<crate::model::RoundToScale>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Action::RoundScale(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::ValueTransformation::action]
     /// to hold a `RoundScale`.
     ///
@@ -11959,6 +11946,19 @@ impl ValueTransformation {
             crate::model::value_transformation::Action::RoundScale(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::ValueTransformation::action]
+    /// if it holds a `ApplyHash`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn apply_hash(&self) -> std::option::Option<&std::boxed::Box<crate::model::ApplyHash>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::value_transformation::Action::ApplyHash(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::ValueTransformation::action]
@@ -12097,12 +12097,6 @@ impl SetTablePrimaryKey {
         std::default::Default::default()
     }
 
-    /// Sets the value of [primary_key][crate::model::SetTablePrimaryKey::primary_key].
-    pub fn set_primary_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.primary_key = v.into();
-        self
-    }
-
     /// Sets the value of [primary_key_columns][crate::model::SetTablePrimaryKey::primary_key_columns].
     pub fn set_primary_key_columns<T, V>(mut self, v: T) -> Self
     where
@@ -12111,6 +12105,12 @@ impl SetTablePrimaryKey {
     {
         use std::iter::Iterator;
         self.primary_key_columns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [primary_key][crate::model::SetTablePrimaryKey::primary_key].
+    pub fn set_primary_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.primary_key = v.into();
         self
     }
 }
@@ -12305,12 +12305,6 @@ impl ValueListFilter {
         self
     }
 
-    /// Sets the value of [ignore_case][crate::model::ValueListFilter::ignore_case].
-    pub fn set_ignore_case<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.ignore_case = v.into();
-        self
-    }
-
     /// Sets the value of [values][crate::model::ValueListFilter::values].
     pub fn set_values<T, V>(mut self, v: T) -> Self
     where
@@ -12319,6 +12313,12 @@ impl ValueListFilter {
     {
         use std::iter::Iterator;
         self.values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ignore_case][crate::model::ValueListFilter::ignore_case].
+    pub fn set_ignore_case<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.ignore_case = v.into();
         self
     }
 }
@@ -12711,132 +12711,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `Schema`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn schema(&self) -> std::option::Option<&std::boxed::Box<crate::model::SchemaEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::Schema(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `Table`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn table(&self) -> std::option::Option<&std::boxed::Box<crate::model::TableEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::Table(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `View`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn view(&self) -> std::option::Option<&std::boxed::Box<crate::model::ViewEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::View(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `Sequence`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sequence(&self) -> std::option::Option<&std::boxed::Box<crate::model::SequenceEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::Sequence(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `StoredProcedure`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn stored_procedure(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StoredProcedureEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::StoredProcedure(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `DatabaseFunction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn database_function(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FunctionEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::DatabaseFunction(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `Synonym`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn synonym(&self) -> std::option::Option<&std::boxed::Box<crate::model::SynonymEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::Synonym(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `DatabasePackage`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn database_package(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PackageEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::DatabasePackage(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `Udt`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn udt(&self) -> std::option::Option<&std::boxed::Box<crate::model::UDTEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::Udt(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// if it holds a `MaterializedView`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn materialized_view(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MaterializedViewEntity>> {
-        #[allow(unreachable_patterns)]
-        self.entity_body.as_ref().and_then(|v| match v {
-            crate::model::database_entity::EntityBody::MaterializedView(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// to hold a `Database`.
     ///
@@ -12854,6 +12728,17 @@ impl DatabaseEntity {
         self
     }
 
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `Schema`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn schema(&self) -> std::option::Option<&std::boxed::Box<crate::model::SchemaEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::Schema(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// to hold a `Schema`.
     ///
@@ -12866,6 +12751,17 @@ impl DatabaseEntity {
         self.entity_body =
             std::option::Option::Some(crate::model::database_entity::EntityBody::Schema(v.into()));
         self
+    }
+
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `Table`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn table(&self) -> std::option::Option<&std::boxed::Box<crate::model::TableEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::Table(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12882,6 +12778,17 @@ impl DatabaseEntity {
         self
     }
 
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `View`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn view(&self) -> std::option::Option<&std::boxed::Box<crate::model::ViewEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::View(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// to hold a `View`.
     ///
@@ -12894,6 +12801,17 @@ impl DatabaseEntity {
         self.entity_body =
             std::option::Option::Some(crate::model::database_entity::EntityBody::View(v.into()));
         self
+    }
+
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `Sequence`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sequence(&self) -> std::option::Option<&std::boxed::Box<crate::model::SequenceEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::Sequence(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12909,6 +12827,21 @@ impl DatabaseEntity {
             crate::model::database_entity::EntityBody::Sequence(v.into()),
         );
         self
+    }
+
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `StoredProcedure`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn stored_procedure(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StoredProcedureEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::StoredProcedure(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12928,6 +12861,21 @@ impl DatabaseEntity {
         self
     }
 
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `DatabaseFunction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn database_function(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FunctionEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::DatabaseFunction(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// to hold a `DatabaseFunction`.
     ///
@@ -12945,6 +12893,17 @@ impl DatabaseEntity {
         self
     }
 
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `Synonym`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn synonym(&self) -> std::option::Option<&std::boxed::Box<crate::model::SynonymEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::Synonym(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// to hold a `Synonym`.
     ///
@@ -12957,6 +12916,21 @@ impl DatabaseEntity {
         self.entity_body =
             std::option::Option::Some(crate::model::database_entity::EntityBody::Synonym(v.into()));
         self
+    }
+
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `DatabasePackage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn database_package(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PackageEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::DatabasePackage(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12976,6 +12950,17 @@ impl DatabaseEntity {
         self
     }
 
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `Udt`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn udt(&self) -> std::option::Option<&std::boxed::Box<crate::model::UDTEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::Udt(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// to hold a `Udt`.
     ///
@@ -12988,6 +12973,21 @@ impl DatabaseEntity {
         self.entity_body =
             std::option::Option::Some(crate::model::database_entity::EntityBody::Udt(v.into()));
         self
+    }
+
+    /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
+    /// if it holds a `MaterializedView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn materialized_view(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MaterializedViewEntity>> {
+        #[allow(unreachable_patterns)]
+        self.entity_body.as_ref().and_then(|v| match v {
+            crate::model::database_entity::EntityBody::MaterializedView(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -13301,21 +13301,6 @@ impl TableEntity {
         std::default::Default::default()
     }
 
-    /// Sets the value of [custom_features][crate::model::TableEntity::custom_features].
-    pub fn set_custom_features<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.custom_features = v.into();
-        self
-    }
-
-    /// Sets the value of [comment][crate::model::TableEntity::comment].
-    pub fn set_comment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.comment = v.into();
-        self
-    }
-
     /// Sets the value of [columns][crate::model::TableEntity::columns].
     pub fn set_columns<T, V>(mut self, v: T) -> Self
     where
@@ -13357,6 +13342,21 @@ impl TableEntity {
     {
         use std::iter::Iterator;
         self.triggers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [custom_features][crate::model::TableEntity::custom_features].
+    pub fn set_custom_features<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.custom_features = v.into();
+        self
+    }
+
+    /// Sets the value of [comment][crate::model::TableEntity::comment].
+    pub fn set_comment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.comment = v.into();
         self
     }
 }
@@ -13544,6 +13544,17 @@ impl ColumnEntity {
         self
     }
 
+    /// Sets the value of [set_values][crate::model::ColumnEntity::set_values].
+    pub fn set_set_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.set_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [comment][crate::model::ColumnEntity::comment].
     pub fn set_comment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.comment = v.into();
@@ -13559,17 +13570,6 @@ impl ColumnEntity {
     /// Sets the value of [default_value][crate::model::ColumnEntity::default_value].
     pub fn set_default_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.default_value = v.into();
-        self
-    }
-
-    /// Sets the value of [set_values][crate::model::ColumnEntity::set_values].
-    pub fn set_set_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.set_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13646,12 +13646,34 @@ impl ConstraintEntity {
         self
     }
 
+    /// Sets the value of [table_columns][crate::model::ConstraintEntity::table_columns].
+    pub fn set_table_columns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.table_columns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [custom_features][crate::model::ConstraintEntity::custom_features].
     pub fn set_custom_features<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
         mut self,
         v: T,
     ) -> Self {
         self.custom_features = v.into();
+        self
+    }
+
+    /// Sets the value of [reference_columns][crate::model::ConstraintEntity::reference_columns].
+    pub fn set_reference_columns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.reference_columns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -13664,28 +13686,6 @@ impl ConstraintEntity {
     /// Sets the value of [table_name][crate::model::ConstraintEntity::table_name].
     pub fn set_table_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.table_name = v.into();
-        self
-    }
-
-    /// Sets the value of [table_columns][crate::model::ConstraintEntity::table_columns].
-    pub fn set_table_columns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.table_columns = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [reference_columns][crate::model::ConstraintEntity::reference_columns].
-    pub fn set_reference_columns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.reference_columns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13746,6 +13746,17 @@ impl IndexEntity {
         self
     }
 
+    /// Sets the value of [table_columns][crate::model::IndexEntity::table_columns].
+    pub fn set_table_columns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.table_columns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [unique][crate::model::IndexEntity::unique].
     pub fn set_unique<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.unique = v.into();
@@ -13758,17 +13769,6 @@ impl IndexEntity {
         v: T,
     ) -> Self {
         self.custom_features = v.into();
-        self
-    }
-
-    /// Sets the value of [table_columns][crate::model::IndexEntity::table_columns].
-    pub fn set_table_columns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.table_columns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13823,6 +13823,17 @@ impl TriggerEntity {
         self
     }
 
+    /// Sets the value of [triggering_events][crate::model::TriggerEntity::triggering_events].
+    pub fn set_triggering_events<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.triggering_events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [trigger_type][crate::model::TriggerEntity::trigger_type].
     pub fn set_trigger_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.trigger_type = v.into();
@@ -13841,17 +13852,6 @@ impl TriggerEntity {
         v: T,
     ) -> Self {
         self.custom_features = v.into();
-        self
-    }
-
-    /// Sets the value of [triggering_events][crate::model::TriggerEntity::triggering_events].
-    pub fn set_triggering_events<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.triggering_events = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
@@ -565,12 +565,6 @@ pub mod consumer_procurement_service {
             self
         }
 
-        /// Sets the value of [request_id][crate::model::PlaceOrderRequest::request_id].
-        pub fn set_request_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.request_id = v.into();
-            self
-        }
-
         /// Sets the value of [line_item_info][crate::model::PlaceOrderRequest::line_item_info].
         pub fn set_line_item_info<T, V>(mut self, v: T) -> Self
         where
@@ -579,6 +573,12 @@ pub mod consumer_procurement_service {
         {
             use std::iter::Iterator;
             self.0.request.line_item_info = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [request_id][crate::model::PlaceOrderRequest::request_id].
+        pub fn set_request_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.request_id = v.into();
             self
         }
     }
@@ -793,6 +793,17 @@ pub mod consumer_procurement_service {
             self
         }
 
+        /// Sets the value of [modifications][crate::model::ModifyOrderRequest::modifications].
+        pub fn set_modifications<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::modify_order_request::Modification>,
+        {
+            use std::iter::Iterator;
+            self.0.request.modifications = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [display_name][crate::model::ModifyOrderRequest::display_name].
         pub fn set_display_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.display_name = v.into();
@@ -802,17 +813,6 @@ pub mod consumer_procurement_service {
         /// Sets the value of [etag][crate::model::ModifyOrderRequest::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
-            self
-        }
-
-        /// Sets the value of [modifications][crate::model::ModifyOrderRequest::modifications].
-        pub fn set_modifications<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::modify_order_request::Modification>,
-        {
-            use std::iter::Iterator;
-            self.0.request.modifications = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -82,22 +82,6 @@ impl AssignmentProtocol {
         })
     }
 
-    /// The value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
-    /// if it holds a `AutoAssignmentType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn auto_assignment_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::assignment_protocol::AutoAssignmentType>>
-    {
-        #[allow(unreachable_patterns)]
-        self.assignment_type.as_ref().and_then(|v| match v {
-            crate::model::assignment_protocol::AssignmentType::AutoAssignmentType(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
     /// to hold a `ManualAssignmentType`.
     ///
@@ -115,6 +99,22 @@ impl AssignmentProtocol {
             crate::model::assignment_protocol::AssignmentType::ManualAssignmentType(v.into()),
         );
         self
+    }
+
+    /// The value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
+    /// if it holds a `AutoAssignmentType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn auto_assignment_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::assignment_protocol::AutoAssignmentType>>
+    {
+        #[allow(unreachable_patterns)]
+        self.assignment_type.as_ref().and_then(|v| match v {
+            crate::model::assignment_protocol::AssignmentType::AutoAssignmentType(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
@@ -673,12 +673,6 @@ impl EnumerateLicensedUsersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::EnumerateLicensedUsersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [licensed_users][crate::model::EnumerateLicensedUsersResponse::licensed_users].
     pub fn set_licensed_users<T, V>(mut self, v: T) -> Self
     where
@@ -687,6 +681,12 @@ impl EnumerateLicensedUsersResponse {
     {
         use std::iter::Iterator;
         self.licensed_users = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::EnumerateLicensedUsersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -777,6 +777,28 @@ impl Order {
         self
     }
 
+    /// Sets the value of [line_items][crate::model::Order::line_items].
+    pub fn set_line_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LineItem>,
+    {
+        use std::iter::Iterator;
+        self.line_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [cancelled_line_items][crate::model::Order::cancelled_line_items].
+    pub fn set_cancelled_line_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LineItem>,
+    {
+        use std::iter::Iterator;
+        self.cancelled_line_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Order::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -798,28 +820,6 @@ impl Order {
     /// Sets the value of [etag][crate::model::Order::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [line_items][crate::model::Order::line_items].
-    pub fn set_line_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LineItem>,
-    {
-        use std::iter::Iterator;
-        self.line_items = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [cancelled_line_items][crate::model::Order::cancelled_line_items].
-    pub fn set_cancelled_line_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LineItem>,
-    {
-        use std::iter::Iterator;
-        self.cancelled_line_items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1107,17 +1107,6 @@ impl LineItemInfo {
         self
     }
 
-    /// Sets the value of [subscription][crate::model::LineItemInfo::subscription].
-    pub fn set_subscription<
-        T: std::convert::Into<std::option::Option<crate::model::Subscription>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.subscription = v.into();
-        self
-    }
-
     /// Sets the value of [parameters][crate::model::LineItemInfo::parameters].
     pub fn set_parameters<T, V>(mut self, v: T) -> Self
     where
@@ -1126,6 +1115,17 @@ impl LineItemInfo {
     {
         use std::iter::Iterator;
         self.parameters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [subscription][crate::model::LineItemInfo::subscription].
+    pub fn set_subscription<
+        T: std::convert::Into<std::option::Option<crate::model::Subscription>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.subscription = v.into();
         self
     }
 }
@@ -1229,6 +1229,18 @@ pub mod parameter {
             })
         }
 
+        /// Sets the value of [kind][crate::model::parameter::Value::kind]
+        /// to hold a `Int64Value`.
+        ///
+        /// Note that all the setters affecting `kind` are
+        /// mutually exclusive.
+        pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.kind = std::option::Option::Some(
+                crate::model::parameter::value::Kind::Int64Value(v.into()),
+            );
+            self
+        }
+
         /// The value of [kind][crate::model::parameter::Value::kind]
         /// if it holds a `StringValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -1240,31 +1252,6 @@ pub mod parameter {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [kind][crate::model::parameter::Value::kind]
-        /// if it holds a `DoubleValue`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn double_value(&self) -> std::option::Option<&f64> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::parameter::value::Kind::DoubleValue(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [kind][crate::model::parameter::Value::kind]
-        /// to hold a `Int64Value`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::parameter::value::Kind::Int64Value(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [kind][crate::model::parameter::Value::kind]
@@ -1280,6 +1267,19 @@ pub mod parameter {
                 crate::model::parameter::value::Kind::StringValue(v.into()),
             );
             self
+        }
+
+        /// The value of [kind][crate::model::parameter::Value::kind]
+        /// if it holds a `DoubleValue`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn double_value(&self) -> std::option::Option<&f64> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::parameter::value::Kind::DoubleValue(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [kind][crate::model::parameter::Value::kind]
@@ -1434,12 +1434,6 @@ impl PlaceOrderRequest {
         self
     }
 
-    /// Sets the value of [request_id][crate::model::PlaceOrderRequest::request_id].
-    pub fn set_request_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.request_id = v.into();
-        self
-    }
-
     /// Sets the value of [line_item_info][crate::model::PlaceOrderRequest::line_item_info].
     pub fn set_line_item_info<T, V>(mut self, v: T) -> Self
     where
@@ -1448,6 +1442,12 @@ impl PlaceOrderRequest {
     {
         use std::iter::Iterator;
         self.line_item_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [request_id][crate::model::PlaceOrderRequest::request_id].
+    pub fn set_request_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.request_id = v.into();
         self
     }
 }
@@ -1626,12 +1626,6 @@ impl ListOrdersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOrdersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [orders][crate::model::ListOrdersResponse::orders].
     pub fn set_orders<T, V>(mut self, v: T) -> Self
     where
@@ -1640,6 +1634,12 @@ impl ListOrdersResponse {
     {
         use std::iter::Iterator;
         self.orders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOrdersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1709,6 +1709,17 @@ impl ModifyOrderRequest {
         self
     }
 
+    /// Sets the value of [modifications][crate::model::ModifyOrderRequest::modifications].
+    pub fn set_modifications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::modify_order_request::Modification>,
+    {
+        use std::iter::Iterator;
+        self.modifications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::ModifyOrderRequest::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -1718,17 +1729,6 @@ impl ModifyOrderRequest {
     /// Sets the value of [etag][crate::model::ModifyOrderRequest::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [modifications][crate::model::ModifyOrderRequest::modifications].
-    pub fn set_modifications<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::modify_order_request::Modification>,
-    {
-        use std::iter::Iterator;
-        self.modifications = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -298,21 +298,6 @@ impl VerifyAttestationRequest {
         })
     }
 
-    /// The value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
-    /// if it holds a `SevSnpAttestation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sev_snp_attestation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SevSnpAttestation>> {
-        #[allow(unreachable_patterns)]
-        self.tee_attestation.as_ref().and_then(|v| match v {
-            crate::model::verify_attestation_request::TeeAttestation::SevSnpAttestation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
     /// to hold a `TdCcel`.
     ///
@@ -326,6 +311,21 @@ impl VerifyAttestationRequest {
             crate::model::verify_attestation_request::TeeAttestation::TdCcel(v.into()),
         );
         self
+    }
+
+    /// The value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
+    /// if it holds a `SevSnpAttestation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sev_snp_attestation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SevSnpAttestation>> {
+        #[allow(unreachable_patterns)]
+        self.tee_attestation.as_ref().and_then(|v| match v {
+            crate::model::verify_attestation_request::TeeAttestation::SevSnpAttestation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
@@ -620,12 +620,6 @@ impl TokenOptions {
         self
     }
 
-    /// Sets the value of [token_type][crate::model::TokenOptions::token_type].
-    pub fn set_token_type<T: std::convert::Into<crate::model::TokenType>>(mut self, v: T) -> Self {
-        self.token_type = v.into();
-        self
-    }
-
     /// Sets the value of [nonce][crate::model::TokenOptions::nonce].
     pub fn set_nonce<T, V>(mut self, v: T) -> Self
     where
@@ -634,6 +628,12 @@ impl TokenOptions {
     {
         use std::iter::Iterator;
         self.nonce = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [token_type][crate::model::TokenOptions::token_type].
+    pub fn set_token_type<T: std::convert::Into<crate::model::TokenType>>(mut self, v: T) -> Self {
+        self.token_type = v.into();
         self
     }
 
@@ -874,6 +874,17 @@ impl TpmAttestation {
         std::default::Default::default()
     }
 
+    /// Sets the value of [quotes][crate::model::TpmAttestation::quotes].
+    pub fn set_quotes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::tpm_attestation::Quote>,
+    {
+        use std::iter::Iterator;
+        self.quotes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [tcg_event_log][crate::model::TpmAttestation::tcg_event_log].
     pub fn set_tcg_event_log<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.tcg_event_log = v.into();
@@ -889,17 +900,6 @@ impl TpmAttestation {
     /// Sets the value of [ak_cert][crate::model::TpmAttestation::ak_cert].
     pub fn set_ak_cert<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.ak_cert = v.into();
-        self
-    }
-
-    /// Sets the value of [quotes][crate::model::TpmAttestation::quotes].
-    pub fn set_quotes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::tpm_attestation::Quote>,
-    {
-        use std::iter::Iterator;
-        self.quotes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -967,18 +967,6 @@ pub mod tpm_attestation {
             self
         }
 
-        /// Sets the value of [raw_quote][crate::model::tpm_attestation::Quote::raw_quote].
-        pub fn set_raw_quote<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.raw_quote = v.into();
-            self
-        }
-
-        /// Sets the value of [raw_signature][crate::model::tpm_attestation::Quote::raw_signature].
-        pub fn set_raw_signature<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.raw_signature = v.into();
-            self
-        }
-
         /// Sets the value of [pcr_values][crate::model::tpm_attestation::Quote::pcr_values].
         pub fn set_pcr_values<T, K, V>(mut self, v: T) -> Self
         where
@@ -988,6 +976,18 @@ pub mod tpm_attestation {
         {
             use std::iter::Iterator;
             self.pcr_values = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [raw_quote][crate::model::tpm_attestation::Quote::raw_quote].
+        pub fn set_raw_quote<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.raw_quote = v.into();
+            self
+        }
+
+        /// Sets the value of [raw_signature][crate::model::tpm_attestation::Quote::raw_signature].
+        pub fn set_raw_signature<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.raw_signature = v.into();
             self
         }
     }

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -199,6 +199,18 @@ impl Deployment {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Deployment::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Deployment::state].
     pub fn set_state<T: std::convert::Into<crate::model::deployment::State>>(
         mut self,
@@ -249,6 +261,17 @@ impl Deployment {
     /// Sets the value of [delete_logs][crate::model::Deployment::delete_logs].
     pub fn set_delete_logs<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.delete_logs = v.into();
+        self
+    }
+
+    /// Sets the value of [tf_errors][crate::model::Deployment::tf_errors].
+    pub fn set_tf_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TerraformError>,
+    {
+        use std::iter::Iterator;
+        self.tf_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -328,29 +351,6 @@ impl Deployment {
         v: T,
     ) -> Self {
         self.quota_validation = v.into();
-        self
-    }
-
-    /// Sets the value of [tf_errors][crate::model::Deployment::tf_errors].
-    pub fn set_tf_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TerraformError>,
-    {
-        use std::iter::Iterator;
-        self.tf_errors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Deployment::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -993,17 +993,6 @@ impl TerraformBlueprint {
         })
     }
 
-    /// The value of [source][crate::model::TerraformBlueprint::source]
-    /// if it holds a `GitSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn git_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GitSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::terraform_blueprint::Source::GitSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::TerraformBlueprint::source]
     /// to hold a `GcsSource`.
     ///
@@ -1014,6 +1003,17 @@ impl TerraformBlueprint {
             crate::model::terraform_blueprint::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::TerraformBlueprint::source]
+    /// if it holds a `GitSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn git_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GitSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::terraform_blueprint::Source::GitSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::TerraformBlueprint::source]
@@ -1328,12 +1328,6 @@ impl ListDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::ListDeploymentsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -1342,6 +1336,12 @@ impl ListDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1539,12 +1539,6 @@ impl ListRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [revisions][crate::model::ListRevisionsResponse::revisions].
     pub fn set_revisions<T, V>(mut self, v: T) -> Self
     where
@@ -1553,6 +1547,12 @@ impl ListRevisionsResponse {
     {
         use std::iter::Iterator;
         self.revisions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2133,21 +2133,6 @@ impl OperationMetadata {
         })
     }
 
-    /// The value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
-    /// if it holds a `PreviewMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn preview_metadata(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PreviewOperationMetadata>> {
-        #[allow(unreachable_patterns)]
-        self.resource_metadata.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::ResourceMetadata::PreviewMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
     /// to hold a `DeploymentMetadata`.
     ///
@@ -2163,6 +2148,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::ResourceMetadata::DeploymentMetadata(v.into()),
         );
         self
+    }
+
+    /// The value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
+    /// if it holds a `PreviewMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn preview_metadata(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PreviewOperationMetadata>> {
+        #[allow(unreachable_patterns)]
+        self.resource_metadata.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::ResourceMetadata::PreviewMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
@@ -2401,6 +2401,17 @@ impl Revision {
         self
     }
 
+    /// Sets the value of [tf_errors][crate::model::Revision::tf_errors].
+    pub fn set_tf_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TerraformError>,
+    {
+        use std::iter::Iterator;
+        self.tf_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [error_logs][crate::model::Revision::error_logs].
     pub fn set_error_logs<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.error_logs = v.into();
@@ -2455,17 +2466,6 @@ impl Revision {
         v: T,
     ) -> Self {
         self.quota_validation = v.into();
-        self
-    }
-
-    /// Sets the value of [tf_errors][crate::model::Revision::tf_errors].
-    pub fn set_tf_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TerraformError>,
-    {
-        use std::iter::Iterator;
-        self.tf_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3446,6 +3446,18 @@ impl Resource {
         self
     }
 
+    /// Sets the value of [cai_assets][crate::model::Resource::cai_assets].
+    pub fn set_cai_assets<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ResourceCAIInfo>,
+    {
+        use std::iter::Iterator;
+        self.cai_assets = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [intent][crate::model::Resource::intent].
     pub fn set_intent<T: std::convert::Into<crate::model::resource::Intent>>(
         mut self,
@@ -3458,18 +3470,6 @@ impl Resource {
     /// Sets the value of [state][crate::model::Resource::state].
     pub fn set_state<T: std::convert::Into<crate::model::resource::State>>(mut self, v: T) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [cai_assets][crate::model::Resource::cai_assets].
-    pub fn set_cai_assets<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::ResourceCAIInfo>,
-    {
-        use std::iter::Iterator;
-        self.cai_assets = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4029,12 +4029,6 @@ impl ListResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::ListResourcesResponse::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -4043,6 +4037,12 @@ impl ListResourcesResponse {
     {
         use std::iter::Iterator;
         self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4629,6 +4629,18 @@ impl Preview {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Preview::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Preview::state].
     pub fn set_state<T: std::convert::Into<crate::model::preview::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -4700,6 +4712,17 @@ impl Preview {
         self
     }
 
+    /// Sets the value of [tf_errors][crate::model::Preview::tf_errors].
+    pub fn set_tf_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TerraformError>,
+    {
+        use std::iter::Iterator;
+        self.tf_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [error_logs][crate::model::Preview::error_logs].
     pub fn set_error_logs<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.error_logs = v.into();
@@ -4737,29 +4760,6 @@ impl Preview {
         v: T,
     ) -> Self {
         self.tf_version_constraint = v.into();
-        self
-    }
-
-    /// Sets the value of [tf_errors][crate::model::Preview::tf_errors].
-    pub fn set_tf_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TerraformError>,
-    {
-        use std::iter::Iterator;
-        self.tf_errors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Preview::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5866,12 +5866,6 @@ impl ListPreviewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPreviewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [previews][crate::model::ListPreviewsResponse::previews].
     pub fn set_previews<T, V>(mut self, v: T) -> Self
     where
@@ -5880,6 +5874,12 @@ impl ListPreviewsResponse {
     {
         use std::iter::Iterator;
         self.previews = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPreviewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6232,12 +6232,6 @@ impl ListTerraformVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTerraformVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [terraform_versions][crate::model::ListTerraformVersionsResponse::terraform_versions].
     pub fn set_terraform_versions<T, V>(mut self, v: T) -> Self
     where
@@ -6246,6 +6240,12 @@ impl ListTerraformVersionsResponse {
     {
         use std::iter::Iterator;
         self.terraform_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTerraformVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -102,48 +102,6 @@ impl AuthConfig {
         })
     }
 
-    /// The value of [r#type][crate::model::AuthConfig::r#type]
-    /// if it holds a `Oauth2JwtBearer`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oauth2_jwt_bearer(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::auth_config::Oauth2JwtBearer>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::auth_config::Type::Oauth2JwtBearer(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::AuthConfig::r#type]
-    /// if it holds a `Oauth2ClientCredentials`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oauth2_client_credentials(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::auth_config::Oauth2ClientCredentials>>
-    {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::auth_config::Type::Oauth2ClientCredentials(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::AuthConfig::r#type]
-    /// if it holds a `SshPublicKey`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ssh_public_key(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::auth_config::SshPublicKey>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::auth_config::Type::SshPublicKey(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
     /// to hold a `UserPassword`.
     ///
@@ -158,6 +116,19 @@ impl AuthConfig {
         self.r#type =
             std::option::Option::Some(crate::model::auth_config::Type::UserPassword(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::AuthConfig::r#type]
+    /// if it holds a `Oauth2JwtBearer`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oauth2_jwt_bearer(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::auth_config::Oauth2JwtBearer>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::auth_config::Type::Oauth2JwtBearer(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
@@ -176,6 +147,22 @@ impl AuthConfig {
         self
     }
 
+    /// The value of [r#type][crate::model::AuthConfig::r#type]
+    /// if it holds a `Oauth2ClientCredentials`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oauth2_client_credentials(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::auth_config::Oauth2ClientCredentials>>
+    {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::auth_config::Type::Oauth2ClientCredentials(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
     /// to hold a `Oauth2ClientCredentials`.
     ///
@@ -191,6 +178,19 @@ impl AuthConfig {
             crate::model::auth_config::Type::Oauth2ClientCredentials(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::AuthConfig::r#type]
+    /// if it holds a `SshPublicKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ssh_public_key(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::auth_config::SshPublicKey>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::auth_config::Type::SshPublicKey(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
@@ -559,6 +559,17 @@ impl AuthConfigTemplate {
         self
     }
 
+    /// Sets the value of [config_variable_templates][crate::model::AuthConfigTemplate::config_variable_templates].
+    pub fn set_config_variable_templates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConfigVariableTemplate>,
+    {
+        use std::iter::Iterator;
+        self.config_variable_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::AuthConfigTemplate::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -568,17 +579,6 @@ impl AuthConfigTemplate {
     /// Sets the value of [description][crate::model::AuthConfigTemplate::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [config_variable_templates][crate::model::AuthConfigTemplate::config_variable_templates].
-    pub fn set_config_variable_templates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConfigVariableTemplate>,
-    {
-        use std::iter::Iterator;
-        self.config_variable_templates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -808,6 +808,17 @@ impl ConfigVariableTemplate {
         self
     }
 
+    /// Sets the value of [enum_options][crate::model::ConfigVariableTemplate::enum_options].
+    pub fn set_enum_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EnumOption>,
+    {
+        use std::iter::Iterator;
+        self.enum_options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [authorization_code_link][crate::model::ConfigVariableTemplate::authorization_code_link].
     pub fn set_authorization_code_link<
         T: std::convert::Into<std::option::Option<crate::model::AuthorizationCodeLink>>,
@@ -831,17 +842,6 @@ impl ConfigVariableTemplate {
     /// Sets the value of [is_advanced][crate::model::ConfigVariableTemplate::is_advanced].
     pub fn set_is_advanced<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.is_advanced = v.into();
-        self
-    }
-
-    /// Sets the value of [enum_options][crate::model::ConfigVariableTemplate::enum_options].
-    pub fn set_enum_options<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EnumOption>,
-    {
-        use std::iter::Iterator;
-        self.enum_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1280,39 +1280,6 @@ impl ConfigVariable {
         })
     }
 
-    /// The value of [value][crate::model::ConfigVariable::value]
-    /// if it holds a `BoolValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bool_value(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::config_variable::Value::BoolValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::ConfigVariable::value]
-    /// if it holds a `StringValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::config_variable::Value::StringValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::ConfigVariable::value]
-    /// if it holds a `SecretValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn secret_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::Secret>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::config_variable::Value::SecretValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::ConfigVariable::value]
     /// to hold a `IntValue`.
     ///
@@ -1322,6 +1289,17 @@ impl ConfigVariable {
         self.value =
             std::option::Option::Some(crate::model::config_variable::Value::IntValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::ConfigVariable::value]
+    /// if it holds a `BoolValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bool_value(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::config_variable::Value::BoolValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::ConfigVariable::value]
@@ -1335,6 +1313,17 @@ impl ConfigVariable {
         self
     }
 
+    /// The value of [value][crate::model::ConfigVariable::value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::config_variable::Value::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::ConfigVariable::value]
     /// to hold a `StringValue`.
     ///
@@ -1344,6 +1333,17 @@ impl ConfigVariable {
         self.value =
             std::option::Option::Some(crate::model::config_variable::Value::StringValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::ConfigVariable::value]
+    /// if it holds a `SecretValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn secret_value(&self) -> std::option::Option<&std::boxed::Box<crate::model::Secret>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::config_variable::Value::SecretValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::ConfigVariable::value]
@@ -1431,6 +1431,17 @@ impl RoleGrant {
         self
     }
 
+    /// Sets the value of [roles][crate::model::RoleGrant::roles].
+    pub fn set_roles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [resource][crate::model::RoleGrant::resource].
     pub fn set_resource<
         T: std::convert::Into<std::option::Option<crate::model::role_grant::Resource>>,
@@ -1448,17 +1459,6 @@ impl RoleGrant {
         v: T,
     ) -> Self {
         self.helper_text_template = v.into();
-        self
-    }
-
-    /// Sets the value of [roles][crate::model::RoleGrant::roles].
-    pub fn set_roles<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.roles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1852,6 +1852,17 @@ impl AuthorizationCodeLink {
         self
     }
 
+    /// Sets the value of [scopes][crate::model::AuthorizationCodeLink::scopes].
+    pub fn set_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [client_id][crate::model::AuthorizationCodeLink::client_id].
     pub fn set_client_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.client_id = v.into();
@@ -1861,17 +1872,6 @@ impl AuthorizationCodeLink {
     /// Sets the value of [enable_pkce][crate::model::AuthorizationCodeLink::enable_pkce].
     pub fn set_enable_pkce<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_pkce = v.into();
-        self
-    }
-
-    /// Sets the value of [scopes][crate::model::AuthorizationCodeLink::scopes].
-    pub fn set_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.scopes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2008,6 +2008,18 @@ impl Connection {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Connection::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Connection::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -2034,6 +2046,17 @@ impl Connection {
         self
     }
 
+    /// Sets the value of [config_variables][crate::model::Connection::config_variables].
+    pub fn set_config_variables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConfigVariable>,
+    {
+        use std::iter::Iterator;
+        self.config_variables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [auth_config][crate::model::Connection::auth_config].
     pub fn set_auth_config<T: std::convert::Into<std::option::Option<crate::model::AuthConfig>>>(
         mut self,
@@ -2049,6 +2072,17 @@ impl Connection {
         v: T,
     ) -> Self {
         self.lock_config = v.into();
+        self
+    }
+
+    /// Sets the value of [destination_configs][crate::model::Connection::destination_configs].
+    pub fn set_destination_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DestinationConfig>,
+    {
+        use std::iter::Iterator;
+        self.destination_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2103,40 +2137,6 @@ impl Connection {
         v: T,
     ) -> Self {
         self.ssl_config = v.into();
-        self
-    }
-
-    /// Sets the value of [config_variables][crate::model::Connection::config_variables].
-    pub fn set_config_variables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConfigVariable>,
-    {
-        use std::iter::Iterator;
-        self.config_variables = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [destination_configs][crate::model::Connection::destination_configs].
-    pub fn set_destination_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DestinationConfig>,
-    {
-        use std::iter::Iterator;
-        self.destination_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Connection::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2232,6 +2232,28 @@ impl ConnectionSchemaMetadata {
         std::default::Default::default()
     }
 
+    /// Sets the value of [entities][crate::model::ConnectionSchemaMetadata::entities].
+    pub fn set_entities<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [actions][crate::model::ConnectionSchemaMetadata::actions].
+    pub fn set_actions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [name][crate::model::ConnectionSchemaMetadata::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
@@ -2262,28 +2284,6 @@ impl ConnectionSchemaMetadata {
         v: T,
     ) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [entities][crate::model::ConnectionSchemaMetadata::entities].
-    pub fn set_entities<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.entities = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [actions][crate::model::ConnectionSchemaMetadata::actions].
-    pub fn set_actions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.actions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2952,12 +2952,6 @@ impl ListConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connections][crate::model::ListConnectionsResponse::connections].
     pub fn set_connections<T, V>(mut self, v: T) -> Self
     where
@@ -2966,6 +2960,12 @@ impl ListConnectionsResponse {
     {
         use std::iter::Iterator;
         self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3363,12 +3363,6 @@ impl ListRuntimeEntitySchemasResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRuntimeEntitySchemasResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [runtime_entity_schemas][crate::model::ListRuntimeEntitySchemasResponse::runtime_entity_schemas].
     pub fn set_runtime_entity_schemas<T, V>(mut self, v: T) -> Self
     where
@@ -3377,6 +3371,12 @@ impl ListRuntimeEntitySchemasResponse {
     {
         use std::iter::Iterator;
         self.runtime_entity_schemas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRuntimeEntitySchemasResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3496,12 +3496,6 @@ impl ListRuntimeActionSchemasResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRuntimeActionSchemasResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [runtime_action_schemas][crate::model::ListRuntimeActionSchemasResponse::runtime_action_schemas].
     pub fn set_runtime_action_schemas<T, V>(mut self, v: T) -> Self
     where
@@ -3510,6 +3504,12 @@ impl ListRuntimeActionSchemasResponse {
     {
         use std::iter::Iterator;
         self.runtime_action_schemas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRuntimeActionSchemasResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3845,6 +3845,18 @@ impl Connector {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Connector::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [documentation_uri][crate::model::Connector::documentation_uri].
     pub fn set_documentation_uri<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -3887,18 +3899,6 @@ impl Connector {
         v: T,
     ) -> Self {
         self.launch_stage = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Connector::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4024,12 +4024,6 @@ impl ListConnectorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connectors][crate::model::ListConnectorsResponse::connectors].
     pub fn set_connectors<T, V>(mut self, v: T) -> Self
     where
@@ -4038,6 +4032,12 @@ impl ListConnectorsResponse {
     {
         use std::iter::Iterator;
         self.connectors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4174,6 +4174,18 @@ impl ConnectorVersion {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ConnectorVersion::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [launch_stage][crate::model::ConnectorVersion::launch_stage].
     pub fn set_launch_stage<T: std::convert::Into<crate::model::LaunchStage>>(
         mut self,
@@ -4186,6 +4198,28 @@ impl ConnectorVersion {
     /// Sets the value of [release_version][crate::model::ConnectorVersion::release_version].
     pub fn set_release_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.release_version = v.into();
+        self
+    }
+
+    /// Sets the value of [auth_config_templates][crate::model::ConnectorVersion::auth_config_templates].
+    pub fn set_auth_config_templates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AuthConfigTemplate>,
+    {
+        use std::iter::Iterator;
+        self.auth_config_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [config_variable_templates][crate::model::ConnectorVersion::config_variable_templates].
+    pub fn set_config_variable_templates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConfigVariableTemplate>,
+    {
+        use std::iter::Iterator;
+        self.config_variable_templates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4217,6 +4251,17 @@ impl ConnectorVersion {
         self
     }
 
+    /// Sets the value of [role_grants][crate::model::ConnectorVersion::role_grants].
+    pub fn set_role_grants<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RoleGrant>,
+    {
+        use std::iter::Iterator;
+        self.role_grants = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [role_grant][crate::model::ConnectorVersion::role_grant].
     pub fn set_role_grant<T: std::convert::Into<std::option::Option<crate::model::RoleGrant>>>(
         mut self,
@@ -4234,51 +4279,6 @@ impl ConnectorVersion {
         v: T,
     ) -> Self {
         self.ssl_config_template = v.into();
-        self
-    }
-
-    /// Sets the value of [auth_config_templates][crate::model::ConnectorVersion::auth_config_templates].
-    pub fn set_auth_config_templates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AuthConfigTemplate>,
-    {
-        use std::iter::Iterator;
-        self.auth_config_templates = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [config_variable_templates][crate::model::ConnectorVersion::config_variable_templates].
-    pub fn set_config_variable_templates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConfigVariableTemplate>,
-    {
-        use std::iter::Iterator;
-        self.config_variable_templates = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [role_grants][crate::model::ConnectorVersion::role_grants].
-    pub fn set_role_grants<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RoleGrant>,
-    {
-        use std::iter::Iterator;
-        self.role_grants = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ConnectorVersion::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4430,12 +4430,6 @@ impl ListConnectorVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectorVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connector_versions][crate::model::ListConnectorVersionsResponse::connector_versions].
     pub fn set_connector_versions<T, V>(mut self, v: T) -> Self
     where
@@ -4444,6 +4438,12 @@ impl ListConnectorVersionsResponse {
     {
         use std::iter::Iterator;
         self.connector_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectorVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4583,6 +4583,18 @@ impl EgressControlConfig {
         })
     }
 
+    /// Sets the value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
+    /// to hold a `Backends`.
+    ///
+    /// Note that all the setters affecting `oneof_backends` are
+    /// mutually exclusive.
+    pub fn set_backends<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.oneof_backends = std::option::Option::Some(
+            crate::model::egress_control_config::OneofBackends::Backends(v.into()),
+        );
+        self
+    }
+
     /// The value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
     /// if it holds a `ExtractionRules`, `None` if the field is not set or
     /// holds a different branch.
@@ -4596,18 +4608,6 @@ impl EgressControlConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
-    /// to hold a `Backends`.
-    ///
-    /// Note that all the setters affecting `oneof_backends` are
-    /// mutually exclusive.
-    pub fn set_backends<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.oneof_backends = std::option::Option::Some(
-            crate::model::egress_control_config::OneofBackends::Backends(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
@@ -5018,17 +5018,6 @@ impl Destination {
         })
     }
 
-    /// The value of [destination][crate::model::Destination::destination]
-    /// if it holds a `Host`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn host(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::destination::Destination::Host(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::Destination::destination]
     /// to hold a `ServiceAttachment`.
     ///
@@ -5042,6 +5031,17 @@ impl Destination {
             crate::model::destination::Destination::ServiceAttachment(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::Destination::destination]
+    /// if it holds a `Host`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn host(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::destination::Destination::Host(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::Destination::destination]
@@ -5161,6 +5161,18 @@ impl Provider {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Provider::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [documentation_uri][crate::model::Provider::documentation_uri].
     pub fn set_documentation_uri<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -5203,18 +5215,6 @@ impl Provider {
         v: T,
     ) -> Self {
         self.launch_stage = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Provider::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5340,12 +5340,6 @@ impl ListProvidersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProvidersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [providers][crate::model::ListProvidersResponse::providers].
     pub fn set_providers<T, V>(mut self, v: T) -> Self
     where
@@ -5354,6 +5348,12 @@ impl ListProvidersResponse {
     {
         use std::iter::Iterator;
         self.providers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProvidersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -3699,15 +3699,6 @@ pub mod contact_center_insights {
             self
         }
 
-        /// Sets the value of [measure_mask][crate::model::QueryMetricsRequest::measure_mask].
-        pub fn set_measure_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.measure_mask = v.into();
-            self
-        }
-
         /// Sets the value of [dimensions][crate::model::QueryMetricsRequest::dimensions].
         pub fn set_dimensions<T, V>(mut self, v: T) -> Self
         where
@@ -3716,6 +3707,15 @@ pub mod contact_center_insights {
         {
             use std::iter::Iterator;
             self.0.request.dimensions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [measure_mask][crate::model::QueryMetricsRequest::measure_mask].
+        pub fn set_measure_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.measure_mask = v.into();
             self
         }
     }

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -159,17 +159,6 @@ impl CalculateStatsResponse {
         self
     }
 
-    /// Sets the value of [conversation_count_time_series][crate::model::CalculateStatsResponse::conversation_count_time_series].
-    pub fn set_conversation_count_time_series<
-        T: std::convert::Into<std::option::Option<crate::model::calculate_stats_response::TimeSeries>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conversation_count_time_series = v.into();
-        self
-    }
-
     /// Sets the value of [smart_highlighter_matches][crate::model::CalculateStatsResponse::smart_highlighter_matches].
     pub fn set_smart_highlighter_matches<T, K, V>(mut self, v: T) -> Self
     where
@@ -217,6 +206,17 @@ impl CalculateStatsResponse {
     {
         use std::iter::Iterator;
         self.issue_matches_stats = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [conversation_count_time_series][crate::model::CalculateStatsResponse::conversation_count_time_series].
+    pub fn set_conversation_count_time_series<
+        T: std::convert::Into<std::option::Option<crate::model::calculate_stats_response::TimeSeries>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.conversation_count_time_series = v.into();
         self
     }
 }
@@ -783,12 +783,6 @@ impl ListConversationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversations][crate::model::ListConversationsResponse::conversations].
     pub fn set_conversations<T, V>(mut self, v: T) -> Self
     where
@@ -797,6 +791,12 @@ impl ListConversationsResponse {
     {
         use std::iter::Iterator;
         self.conversations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1594,6 +1594,17 @@ impl IngestConversationsMetadata {
         self
     }
 
+    /// Sets the value of [partial_errors][crate::model::IngestConversationsMetadata::partial_errors].
+    pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.partial_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [ingest_conversations_stats][crate::model::IngestConversationsMetadata::ingest_conversations_stats].
     pub fn set_ingest_conversations_stats<
         T: std::convert::Into<
@@ -1606,17 +1617,6 @@ impl IngestConversationsMetadata {
         v: T,
     ) -> Self {
         self.ingest_conversations_stats = v.into();
-        self
-    }
-
-    /// Sets the value of [partial_errors][crate::model::IngestConversationsMetadata::partial_errors].
-    pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.partial_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1857,12 +1857,6 @@ impl ListAnalysesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAnalysesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [analyses][crate::model::ListAnalysesResponse::analyses].
     pub fn set_analyses<T, V>(mut self, v: T) -> Self
     where
@@ -1871,6 +1865,12 @@ impl ListAnalysesResponse {
     {
         use std::iter::Iterator;
         self.analyses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAnalysesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4203,12 +4203,6 @@ impl ListPhraseMatchersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPhraseMatchersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [phrase_matchers][crate::model::ListPhraseMatchersResponse::phrase_matchers].
     pub fn set_phrase_matchers<T, V>(mut self, v: T) -> Self
     where
@@ -4217,6 +4211,12 @@ impl ListPhraseMatchersResponse {
     {
         use std::iter::Iterator;
         self.phrase_matchers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPhraseMatchersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4683,12 +4683,6 @@ impl ListAnalysisRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAnalysisRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [analysis_rules][crate::model::ListAnalysisRulesResponse::analysis_rules].
     pub fn set_analysis_rules<T, V>(mut self, v: T) -> Self
     where
@@ -4697,6 +4691,12 @@ impl ListAnalysisRulesResponse {
     {
         use std::iter::Iterator;
         self.analysis_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAnalysisRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5055,12 +5055,6 @@ impl ListViewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListViewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [views][crate::model::ListViewsResponse::views].
     pub fn set_views<T, V>(mut self, v: T) -> Self
     where
@@ -5069,6 +5063,12 @@ impl ListViewsResponse {
     {
         use std::iter::Iterator;
         self.views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5235,55 +5235,6 @@ impl Dimension {
         })
     }
 
-    /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// if it holds a `AgentDimensionMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn agent_dimension_metadata(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::dimension::AgentDimensionMetadata>>
-    {
-        #[allow(unreachable_patterns)]
-        self.dimension_metadata.as_ref().and_then(|v| match v {
-            crate::model::dimension::DimensionMetadata::AgentDimensionMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// if it holds a `QaQuestionDimensionMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn qa_question_dimension_metadata(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::dimension::QaQuestionDimensionMetadata>>
-    {
-        #[allow(unreachable_patterns)]
-        self.dimension_metadata.as_ref().and_then(|v| match v {
-            crate::model::dimension::DimensionMetadata::QaQuestionDimensionMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// if it holds a `QaQuestionAnswerDimensionMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn qa_question_answer_dimension_metadata(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::dimension::QaQuestionAnswerDimensionMetadata>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.dimension_metadata.as_ref().and_then(|v| match v {
-            crate::model::dimension::DimensionMetadata::QaQuestionAnswerDimensionMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
     /// to hold a `IssueDimensionMetadata`.
     ///
@@ -5299,6 +5250,22 @@ impl Dimension {
             crate::model::dimension::DimensionMetadata::IssueDimensionMetadata(v.into()),
         );
         self
+    }
+
+    /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
+    /// if it holds a `AgentDimensionMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn agent_dimension_metadata(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::dimension::AgentDimensionMetadata>>
+    {
+        #[allow(unreachable_patterns)]
+        self.dimension_metadata.as_ref().and_then(|v| match v {
+            crate::model::dimension::DimensionMetadata::AgentDimensionMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
@@ -5318,6 +5285,22 @@ impl Dimension {
         self
     }
 
+    /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
+    /// if it holds a `QaQuestionDimensionMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn qa_question_dimension_metadata(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::dimension::QaQuestionDimensionMetadata>>
+    {
+        #[allow(unreachable_patterns)]
+        self.dimension_metadata.as_ref().and_then(|v| match v {
+            crate::model::dimension::DimensionMetadata::QaQuestionDimensionMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
     /// to hold a `QaQuestionDimensionMetadata`.
     ///
@@ -5333,6 +5316,23 @@ impl Dimension {
             crate::model::dimension::DimensionMetadata::QaQuestionDimensionMetadata(v.into()),
         );
         self
+    }
+
+    /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
+    /// if it holds a `QaQuestionAnswerDimensionMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn qa_question_answer_dimension_metadata(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::dimension::QaQuestionAnswerDimensionMetadata>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.dimension_metadata.as_ref().and_then(|v| match v {
+            crate::model::dimension::DimensionMetadata::QaQuestionAnswerDimensionMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
@@ -5877,15 +5877,6 @@ impl QueryMetricsRequest {
         self
     }
 
-    /// Sets the value of [measure_mask][crate::model::QueryMetricsRequest::measure_mask].
-    pub fn set_measure_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.measure_mask = v.into();
-        self
-    }
-
     /// Sets the value of [dimensions][crate::model::QueryMetricsRequest::dimensions].
     pub fn set_dimensions<T, V>(mut self, v: T) -> Self
     where
@@ -5894,6 +5885,15 @@ impl QueryMetricsRequest {
     {
         use std::iter::Iterator;
         self.dimensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [measure_mask][crate::model::QueryMetricsRequest::measure_mask].
+    pub fn set_measure_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.measure_mask = v.into();
         self
     }
 }
@@ -6130,17 +6130,6 @@ impl QueryMetricsResponse {
         self
     }
 
-    /// Sets the value of [macro_average_slice][crate::model::QueryMetricsResponse::macro_average_slice].
-    pub fn set_macro_average_slice<
-        T: std::convert::Into<std::option::Option<crate::model::query_metrics_response::Slice>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.macro_average_slice = v.into();
-        self
-    }
-
     /// Sets the value of [slices][crate::model::QueryMetricsResponse::slices].
     pub fn set_slices<T, V>(mut self, v: T) -> Self
     where
@@ -6149,6 +6138,17 @@ impl QueryMetricsResponse {
     {
         use std::iter::Iterator;
         self.slices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [macro_average_slice][crate::model::QueryMetricsResponse::macro_average_slice].
+    pub fn set_macro_average_slice<
+        T: std::convert::Into<std::option::Option<crate::model::query_metrics_response::Slice>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.macro_average_slice = v.into();
         self
     }
 }
@@ -6203,6 +6203,17 @@ pub mod query_metrics_response {
             std::default::Default::default()
         }
 
+        /// Sets the value of [dimensions][crate::model::query_metrics_response::Slice::dimensions].
+        pub fn set_dimensions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Dimension>,
+        {
+            use std::iter::Iterator;
+            self.dimensions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [total][crate::model::query_metrics_response::Slice::total].
         pub fn set_total<
             T: std::convert::Into<
@@ -6226,17 +6237,6 @@ pub mod query_metrics_response {
             v: T,
         ) -> Self {
             self.time_series = v.into();
-            self
-        }
-
-        /// Sets the value of [dimensions][crate::model::query_metrics_response::Slice::dimensions].
-        pub fn set_dimensions<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::Dimension>,
-        {
-            use std::iter::Iterator;
-            self.dimensions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6498,17 +6498,6 @@ pub mod query_metrics_response {
                     self
                 }
 
-                /// Sets the value of [average_qa_question_normalized_score][crate::model::query_metrics_response::slice::data_point::ConversationMeasure::average_qa_question_normalized_score].
-                pub fn set_average_qa_question_normalized_score<
-                    T: std::convert::Into<std::option::Option<f64>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.average_qa_question_normalized_score = v.into();
-                    self
-                }
-
                 /// Sets the value of [qa_tag_scores][crate::model::query_metrics_response::slice::data_point::ConversationMeasure::qa_tag_scores].
                 pub fn set_qa_tag_scores<T, V>(mut self, v: T) -> Self
                 where
@@ -6517,6 +6506,17 @@ pub mod query_metrics_response {
                 {
                     use std::iter::Iterator;
                     self.qa_tag_scores = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [average_qa_question_normalized_score][crate::model::query_metrics_response::slice::data_point::ConversationMeasure::average_qa_question_normalized_score].
+                pub fn set_average_qa_question_normalized_score<
+                    T: std::convert::Into<std::option::Option<f64>>,
+                >(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.average_qa_question_normalized_score = v.into();
                     self
                 }
             }
@@ -6827,12 +6827,6 @@ impl ListQaQuestionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListQaQuestionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [qa_questions][crate::model::ListQaQuestionsResponse::qa_questions].
     pub fn set_qa_questions<T, V>(mut self, v: T) -> Self
     where
@@ -6841,6 +6835,12 @@ impl ListQaQuestionsResponse {
     {
         use std::iter::Iterator;
         self.qa_questions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListQaQuestionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7399,12 +7399,6 @@ impl TuneQaScorecardRevisionMetadata {
         self
     }
 
-    /// Sets the value of [tuning_completion_ratio][crate::model::TuneQaScorecardRevisionMetadata::tuning_completion_ratio].
-    pub fn set_tuning_completion_ratio<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.tuning_completion_ratio = v.into();
-        self
-    }
-
     /// Sets the value of [qa_question_dataset_validation_results][crate::model::TuneQaScorecardRevisionMetadata::qa_question_dataset_validation_results].
     pub fn set_qa_question_dataset_validation_results<T, V>(mut self, v: T) -> Self
     where
@@ -7426,6 +7420,12 @@ impl TuneQaScorecardRevisionMetadata {
     {
         use std::iter::Iterator;
         self.qa_question_dataset_tuning_metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [tuning_completion_ratio][crate::model::TuneQaScorecardRevisionMetadata::tuning_completion_ratio].
+    pub fn set_tuning_completion_ratio<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.tuning_completion_ratio = v.into();
         self
     }
 }
@@ -7476,12 +7476,6 @@ pub mod tune_qa_scorecard_revision_metadata {
             self
         }
 
-        /// Sets the value of [valid_feedback_labels_count][crate::model::tune_qa_scorecard_revision_metadata::QaQuestionDatasetValidationResult::valid_feedback_labels_count].
-        pub fn set_valid_feedback_labels_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.valid_feedback_labels_count = v.into();
-            self
-        }
-
         /// Sets the value of [dataset_validation_warnings][crate::model::tune_qa_scorecard_revision_metadata::QaQuestionDatasetValidationResult::dataset_validation_warnings].
         pub fn set_dataset_validation_warnings<T, V>(mut self, v: T) -> Self
         where
@@ -7490,6 +7484,12 @@ pub mod tune_qa_scorecard_revision_metadata {
         {
             use std::iter::Iterator;
             self.dataset_validation_warnings = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [valid_feedback_labels_count][crate::model::tune_qa_scorecard_revision_metadata::QaQuestionDatasetValidationResult::valid_feedback_labels_count].
+        pub fn set_valid_feedback_labels_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.valid_feedback_labels_count = v.into();
             self
         }
     }
@@ -7774,12 +7774,6 @@ impl ListQaScorecardsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListQaScorecardsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [qa_scorecards][crate::model::ListQaScorecardsResponse::qa_scorecards].
     pub fn set_qa_scorecards<T, V>(mut self, v: T) -> Self
     where
@@ -7788,6 +7782,12 @@ impl ListQaScorecardsResponse {
     {
         use std::iter::Iterator;
         self.qa_scorecards = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListQaScorecardsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7907,12 +7907,6 @@ impl ListQaScorecardRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListQaScorecardRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [qa_scorecard_revisions][crate::model::ListQaScorecardRevisionsResponse::qa_scorecard_revisions].
     pub fn set_qa_scorecard_revisions<T, V>(mut self, v: T) -> Self
     where
@@ -7921,6 +7915,12 @@ impl ListQaScorecardRevisionsResponse {
     {
         use std::iter::Iterator;
         self.qa_scorecard_revisions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListQaScorecardRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8110,12 +8110,6 @@ impl ListFeedbackLabelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeedbackLabelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [feedback_labels][crate::model::ListFeedbackLabelsResponse::feedback_labels].
     pub fn set_feedback_labels<T, V>(mut self, v: T) -> Self
     where
@@ -8124,6 +8118,12 @@ impl ListFeedbackLabelsResponse {
     {
         use std::iter::Iterator;
         self.feedback_labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeedbackLabelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8365,12 +8365,6 @@ impl ListAllFeedbackLabelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAllFeedbackLabelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [feedback_labels][crate::model::ListAllFeedbackLabelsResponse::feedback_labels].
     pub fn set_feedback_labels<T, V>(mut self, v: T) -> Self
     where
@@ -8379,6 +8373,12 @@ impl ListAllFeedbackLabelsResponse {
     {
         use std::iter::Iterator;
         self.feedback_labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAllFeedbackLabelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8797,6 +8797,17 @@ impl BulkUploadFeedbackLabelsMetadata {
         self
     }
 
+    /// Sets the value of [partial_errors][crate::model::BulkUploadFeedbackLabelsMetadata::partial_errors].
+    pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.partial_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [upload_stats][crate::model::BulkUploadFeedbackLabelsMetadata::upload_stats].
     pub fn set_upload_stats<
         T: std::convert::Into<
@@ -8809,17 +8820,6 @@ impl BulkUploadFeedbackLabelsMetadata {
         v: T,
     ) -> Self {
         self.upload_stats = v.into();
-        self
-    }
-
-    /// Sets the value of [partial_errors][crate::model::BulkUploadFeedbackLabelsMetadata::partial_errors].
-    pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.partial_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9534,6 +9534,17 @@ impl BulkDownloadFeedbackLabelsMetadata {
         self
     }
 
+    /// Sets the value of [partial_errors][crate::model::BulkDownloadFeedbackLabelsMetadata::partial_errors].
+    pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.partial_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [download_stats][crate::model::BulkDownloadFeedbackLabelsMetadata::download_stats].
     pub fn set_download_stats<
         T: std::convert::Into<
@@ -9546,17 +9557,6 @@ impl BulkDownloadFeedbackLabelsMetadata {
         v: T,
     ) -> Self {
         self.download_stats = v.into();
-        self
-    }
-
-    /// Sets the value of [partial_errors][crate::model::BulkDownloadFeedbackLabelsMetadata::partial_errors].
-    pub fn set_partial_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.partial_errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9810,6 +9810,18 @@ impl Conversation {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Conversation::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [quality_metadata][crate::model::Conversation::quality_metadata].
     pub fn set_quality_metadata<
         T: std::convert::Into<std::option::Option<crate::model::conversation::QualityMetadata>>,
@@ -9886,15 +9898,6 @@ impl Conversation {
         self
     }
 
-    /// Sets the value of [obfuscated_user_id][crate::model::Conversation::obfuscated_user_id].
-    pub fn set_obfuscated_user_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.obfuscated_user_id = v.into();
-        self
-    }
-
     /// Sets the value of [runtime_annotations][crate::model::Conversation::runtime_annotations].
     pub fn set_runtime_annotations<T, V>(mut self, v: T) -> Self
     where
@@ -9903,18 +9906,6 @@ impl Conversation {
     {
         use std::iter::Iterator;
         self.runtime_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Conversation::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -9927,6 +9918,15 @@ impl Conversation {
     {
         use std::iter::Iterator;
         self.dialogflow_intents = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [obfuscated_user_id][crate::model::Conversation::obfuscated_user_id].
+    pub fn set_obfuscated_user_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.obfuscated_user_id = v.into();
         self
     }
 
@@ -9998,17 +9998,6 @@ impl Conversation {
         })
     }
 
-    /// The value of [expiration][crate::model::Conversation::expiration]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.expiration.as_ref().and_then(|v| match v {
-            crate::model::conversation::Expiration::Ttl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [expiration][crate::model::Conversation::expiration]
     /// to hold a `ExpireTime`.
     ///
@@ -10021,6 +10010,17 @@ impl Conversation {
         self.expiration =
             std::option::Option::Some(crate::model::conversation::Expiration::ExpireTime(v.into()));
         self
+    }
+
+    /// The value of [expiration][crate::model::Conversation::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::conversation::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [expiration][crate::model::Conversation::expiration]
@@ -10375,6 +10375,19 @@ pub mod conversation {
                 self
             }
 
+            /// Sets the value of [words][crate::model::conversation::transcript::TranscriptSegment::words].
+            pub fn set_words<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<
+                        crate::model::conversation::transcript::transcript_segment::WordInfo,
+                    >,
+            {
+                use std::iter::Iterator;
+                self.words = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [language_code][crate::model::conversation::transcript::TranscriptSegment::language_code].
             pub fn set_language_code<T: std::convert::Into<std::string::String>>(
                 mut self,
@@ -10415,19 +10428,6 @@ pub mod conversation {
                 v: T,
             ) -> Self {
                 self.sentiment = v.into();
-                self
-            }
-
-            /// Sets the value of [words][crate::model::conversation::transcript::TranscriptSegment::words].
-            pub fn set_words<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<
-                        crate::model::conversation::transcript::transcript_segment::WordInfo,
-                    >,
-            {
-                use std::iter::Iterator;
-                self.words = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -10854,21 +10854,6 @@ impl ConversationDataSource {
         })
     }
 
-    /// The value of [source][crate::model::ConversationDataSource::source]
-    /// if it holds a `DialogflowSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dialogflow_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DialogflowSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::conversation_data_source::Source::DialogflowSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ConversationDataSource::source]
     /// to hold a `GcsSource`.
     ///
@@ -10882,6 +10867,21 @@ impl ConversationDataSource {
             crate::model::conversation_data_source::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ConversationDataSource::source]
+    /// if it holds a `DialogflowSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dialogflow_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DialogflowSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::conversation_data_source::Source::DialogflowSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ConversationDataSource::source]
@@ -11156,28 +11156,6 @@ pub mod analysis_result {
             std::default::Default::default()
         }
 
-        /// Sets the value of [silence][crate::model::analysis_result::CallAnalysisMetadata::silence].
-        pub fn set_silence<
-            T: std::convert::Into<std::option::Option<crate::model::ConversationLevelSilence>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.silence = v.into();
-            self
-        }
-
-        /// Sets the value of [issue_model_result][crate::model::analysis_result::CallAnalysisMetadata::issue_model_result].
-        pub fn set_issue_model_result<
-            T: std::convert::Into<std::option::Option<crate::model::IssueModelResult>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.issue_model_result = v.into();
-            self
-        }
-
         /// Sets the value of [annotations][crate::model::analysis_result::CallAnalysisMetadata::annotations].
         pub fn set_annotations<T, V>(mut self, v: T) -> Self
         where
@@ -11186,6 +11164,18 @@ pub mod analysis_result {
         {
             use std::iter::Iterator;
             self.annotations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [entities][crate::model::analysis_result::CallAnalysisMetadata::entities].
+        pub fn set_entities<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::Entity>,
+        {
+            use std::iter::Iterator;
+            self.entities = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -11200,26 +11190,14 @@ pub mod analysis_result {
             self
         }
 
-        /// Sets the value of [qa_scorecard_results][crate::model::analysis_result::CallAnalysisMetadata::qa_scorecard_results].
-        pub fn set_qa_scorecard_results<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::QaScorecardResult>,
-        {
-            use std::iter::Iterator;
-            self.qa_scorecard_results = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [entities][crate::model::analysis_result::CallAnalysisMetadata::entities].
-        pub fn set_entities<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<crate::model::Entity>,
-        {
-            use std::iter::Iterator;
-            self.entities = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        /// Sets the value of [silence][crate::model::analysis_result::CallAnalysisMetadata::silence].
+        pub fn set_silence<
+            T: std::convert::Into<std::option::Option<crate::model::ConversationLevelSilence>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.silence = v.into();
             self
         }
 
@@ -11244,6 +11222,28 @@ pub mod analysis_result {
         {
             use std::iter::Iterator;
             self.phrase_matchers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [issue_model_result][crate::model::analysis_result::CallAnalysisMetadata::issue_model_result].
+        pub fn set_issue_model_result<
+            T: std::convert::Into<std::option::Option<crate::model::IssueModelResult>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.issue_model_result = v.into();
+            self
+        }
+
+        /// Sets the value of [qa_scorecard_results][crate::model::analysis_result::CallAnalysisMetadata::qa_scorecard_results].
+        pub fn set_qa_scorecard_results<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::QaScorecardResult>,
+        {
+            use std::iter::Iterator;
+            self.qa_scorecard_results = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -11407,6 +11407,17 @@ impl FeedbackLabel {
         })
     }
 
+    /// Sets the value of [label_type][crate::model::FeedbackLabel::label_type]
+    /// to hold a `Label`.
+    ///
+    /// Note that all the setters affecting `label_type` are
+    /// mutually exclusive.
+    pub fn set_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.label_type =
+            std::option::Option::Some(crate::model::feedback_label::LabelType::Label(v.into()));
+        self
+    }
+
     /// The value of [label_type][crate::model::FeedbackLabel::label_type]
     /// if it holds a `QaAnswerLabel`, `None` if the field is not set or
     /// holds a different branch.
@@ -11420,17 +11431,6 @@ impl FeedbackLabel {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [label_type][crate::model::FeedbackLabel::label_type]
-    /// to hold a `Label`.
-    ///
-    /// Note that all the setters affecting `label_type` are
-    /// mutually exclusive.
-    pub fn set_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.label_type =
-            std::option::Option::Some(crate::model::feedback_label::LabelType::Label(v.into()));
-        self
     }
 
     /// Sets the value of [label_type][crate::model::FeedbackLabel::label_type]
@@ -11709,95 +11709,6 @@ impl CallAnnotation {
         })
     }
 
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `SentimentData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sentiment_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SentimentData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::SentimentData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `SilenceData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn silence_data(&self) -> std::option::Option<&std::boxed::Box<crate::model::SilenceData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::SilenceData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `HoldData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn hold_data(&self) -> std::option::Option<&std::boxed::Box<crate::model::HoldData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::HoldData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `EntityMentionData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity_mention_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::EntityMentionData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::EntityMentionData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `IntentMatchData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn intent_match_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IntentMatchData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::IntentMatchData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `PhraseMatchData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn phrase_match_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PhraseMatchData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::PhraseMatchData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::CallAnnotation::data]
-    /// if it holds a `IssueMatchData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn issue_match_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IssueMatchData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::call_annotation::Data::IssueMatchData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data][crate::model::CallAnnotation::data]
     /// to hold a `InterruptionData`.
     ///
@@ -11813,6 +11724,19 @@ impl CallAnnotation {
             crate::model::call_annotation::Data::InterruptionData(v.into()),
         );
         self
+    }
+
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `SentimentData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sentiment_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SentimentData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::SentimentData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::CallAnnotation::data]
@@ -11831,6 +11755,17 @@ impl CallAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `SilenceData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn silence_data(&self) -> std::option::Option<&std::boxed::Box<crate::model::SilenceData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::SilenceData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::CallAnnotation::data]
     /// to hold a `SilenceData`.
     ///
@@ -11845,6 +11780,17 @@ impl CallAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `HoldData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn hold_data(&self) -> std::option::Option<&std::boxed::Box<crate::model::HoldData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::HoldData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::CallAnnotation::data]
     /// to hold a `HoldData`.
     ///
@@ -11857,6 +11803,21 @@ impl CallAnnotation {
         self.data =
             std::option::Option::Some(crate::model::call_annotation::Data::HoldData(v.into()));
         self
+    }
+
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `EntityMentionData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity_mention_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::EntityMentionData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::EntityMentionData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::CallAnnotation::data]
@@ -11876,6 +11837,19 @@ impl CallAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `IntentMatchData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn intent_match_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IntentMatchData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::IntentMatchData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::CallAnnotation::data]
     /// to hold a `IntentMatchData`.
     ///
@@ -11893,6 +11867,19 @@ impl CallAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `PhraseMatchData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn phrase_match_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PhraseMatchData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::PhraseMatchData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::CallAnnotation::data]
     /// to hold a `PhraseMatchData`.
     ///
@@ -11908,6 +11895,19 @@ impl CallAnnotation {
             crate::model::call_annotation::Data::PhraseMatchData(v.into()),
         );
         self
+    }
+
+    /// The value of [data][crate::model::CallAnnotation::data]
+    /// if it holds a `IssueMatchData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn issue_match_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IssueMatchData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::call_annotation::Data::IssueMatchData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::CallAnnotation::data]
@@ -12115,6 +12115,18 @@ impl Entity {
         self
     }
 
+    /// Sets the value of [metadata][crate::model::Entity::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [salience][crate::model::Entity::salience].
     pub fn set_salience<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.salience = v.into();
@@ -12129,18 +12141,6 @@ impl Entity {
         v: T,
     ) -> Self {
         self.sentiment = v.into();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::Entity::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -13476,15 +13476,6 @@ impl Issue {
         self
     }
 
-    /// Sets the value of [display_description][crate::model::Issue::display_description].
-    pub fn set_display_description<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.display_description = v.into();
-        self
-    }
-
     /// Sets the value of [sample_utterances][crate::model::Issue::sample_utterances].
     pub fn set_sample_utterances<T, V>(mut self, v: T) -> Self
     where
@@ -13493,6 +13484,15 @@ impl Issue {
     {
         use std::iter::Iterator;
         self.sample_utterances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [display_description][crate::model::Issue::display_description].
+    pub fn set_display_description<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.display_description = v.into();
         self
     }
 }
@@ -13750,6 +13750,17 @@ impl PhraseMatcher {
         self
     }
 
+    /// Sets the value of [phrase_match_rule_groups][crate::model::PhraseMatcher::phrase_match_rule_groups].
+    pub fn set_phrase_match_rule_groups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PhraseMatchRuleGroup>,
+    {
+        use std::iter::Iterator;
+        self.phrase_match_rule_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [activation_update_time][crate::model::PhraseMatcher::activation_update_time].
     pub fn set_activation_update_time<
         T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
@@ -13776,17 +13787,6 @@ impl PhraseMatcher {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [phrase_match_rule_groups][crate::model::PhraseMatcher::phrase_match_rule_groups].
-    pub fn set_phrase_match_rule_groups<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PhraseMatchRuleGroup>,
-    {
-        use std::iter::Iterator;
-        self.phrase_match_rule_groups = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -14433,6 +14433,19 @@ impl Settings {
         self
     }
 
+    /// Sets the value of [pubsub_notification_settings][crate::model::Settings::pubsub_notification_settings].
+    pub fn set_pubsub_notification_settings<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.pubsub_notification_settings =
+            v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [analysis_config][crate::model::Settings::analysis_config].
     pub fn set_analysis_config<
         T: std::convert::Into<std::option::Option<crate::model::settings::AnalysisConfig>>,
@@ -14463,19 +14476,6 @@ impl Settings {
         v: T,
     ) -> Self {
         self.speech_config = v.into();
-        self
-    }
-
-    /// Sets the value of [pubsub_notification_settings][crate::model::Settings::pubsub_notification_settings].
-    pub fn set_pubsub_notification_settings<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.pubsub_notification_settings =
-            v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -14972,76 +14972,6 @@ impl RuntimeAnnotation {
         })
     }
 
-    /// The value of [data][crate::model::RuntimeAnnotation::data]
-    /// if it holds a `FaqAnswer`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn faq_answer(&self) -> std::option::Option<&std::boxed::Box<crate::model::FaqAnswerData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::runtime_annotation::Data::FaqAnswer(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::RuntimeAnnotation::data]
-    /// if it holds a `SmartReply`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn smart_reply(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SmartReplyData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::runtime_annotation::Data::SmartReply(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::RuntimeAnnotation::data]
-    /// if it holds a `SmartComposeSuggestion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn smart_compose_suggestion(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SmartComposeSuggestionData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::runtime_annotation::Data::SmartComposeSuggestion(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::RuntimeAnnotation::data]
-    /// if it holds a `DialogflowInteraction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dialogflow_interaction(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DialogflowInteractionData>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::runtime_annotation::Data::DialogflowInteraction(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data][crate::model::RuntimeAnnotation::data]
-    /// if it holds a `ConversationSummarizationSuggestion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn conversation_summarization_suggestion(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ConversationSummarizationSuggestionData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::runtime_annotation::Data::ConversationSummarizationSuggestion(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
     /// to hold a `ArticleSuggestion`.
     ///
@@ -15059,6 +14989,17 @@ impl RuntimeAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::RuntimeAnnotation::data]
+    /// if it holds a `FaqAnswer`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn faq_answer(&self) -> std::option::Option<&std::boxed::Box<crate::model::FaqAnswerData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::runtime_annotation::Data::FaqAnswer(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
     /// to hold a `FaqAnswer`.
     ///
@@ -15073,6 +15014,19 @@ impl RuntimeAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::RuntimeAnnotation::data]
+    /// if it holds a `SmartReply`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn smart_reply(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SmartReplyData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::runtime_annotation::Data::SmartReply(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
     /// to hold a `SmartReply`.
     ///
@@ -15085,6 +15039,21 @@ impl RuntimeAnnotation {
         self.data =
             std::option::Option::Some(crate::model::runtime_annotation::Data::SmartReply(v.into()));
         self
+    }
+
+    /// The value of [data][crate::model::RuntimeAnnotation::data]
+    /// if it holds a `SmartComposeSuggestion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn smart_compose_suggestion(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SmartComposeSuggestionData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::runtime_annotation::Data::SmartComposeSuggestion(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
@@ -15104,6 +15073,21 @@ impl RuntimeAnnotation {
         self
     }
 
+    /// The value of [data][crate::model::RuntimeAnnotation::data]
+    /// if it holds a `DialogflowInteraction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dialogflow_interaction(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DialogflowInteractionData>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::runtime_annotation::Data::DialogflowInteraction(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
     /// to hold a `DialogflowInteraction`.
     ///
@@ -15119,6 +15103,22 @@ impl RuntimeAnnotation {
             crate::model::runtime_annotation::Data::DialogflowInteraction(v.into()),
         );
         self
+    }
+
+    /// The value of [data][crate::model::RuntimeAnnotation::data]
+    /// if it holds a `ConversationSummarizationSuggestion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn conversation_summarization_suggestion(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ConversationSummarizationSuggestionData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::runtime_annotation::Data::ConversationSummarizationSuggestion(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
@@ -15641,18 +15641,6 @@ impl ArticleSuggestionData {
         self
     }
 
-    /// Sets the value of [query_record][crate::model::ArticleSuggestionData::query_record].
-    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query_record = v.into();
-        self
-    }
-
-    /// Sets the value of [source][crate::model::ArticleSuggestionData::source].
-    pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = v.into();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::ArticleSuggestionData::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -15662,6 +15650,18 @@ impl ArticleSuggestionData {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [query_record][crate::model::ArticleSuggestionData::query_record].
+    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query_record = v.into();
+        self
+    }
+
+    /// Sets the value of [source][crate::model::ArticleSuggestionData::source].
+    pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = v.into();
         self
     }
 }
@@ -15736,18 +15736,6 @@ impl FaqAnswerData {
         self
     }
 
-    /// Sets the value of [query_record][crate::model::FaqAnswerData::query_record].
-    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query_record = v.into();
-        self
-    }
-
-    /// Sets the value of [source][crate::model::FaqAnswerData::source].
-    pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = v.into();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::FaqAnswerData::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -15757,6 +15745,18 @@ impl FaqAnswerData {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [query_record][crate::model::FaqAnswerData::query_record].
+    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query_record = v.into();
+        self
+    }
+
+    /// Sets the value of [source][crate::model::FaqAnswerData::source].
+    pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = v.into();
         self
     }
 }
@@ -15815,12 +15815,6 @@ impl SmartReplyData {
         self
     }
 
-    /// Sets the value of [query_record][crate::model::SmartReplyData::query_record].
-    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query_record = v.into();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::SmartReplyData::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -15830,6 +15824,12 @@ impl SmartReplyData {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [query_record][crate::model::SmartReplyData::query_record].
+    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query_record = v.into();
         self
     }
 }
@@ -15888,12 +15888,6 @@ impl SmartComposeSuggestionData {
         self
     }
 
-    /// Sets the value of [query_record][crate::model::SmartComposeSuggestionData::query_record].
-    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query_record = v.into();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::SmartComposeSuggestionData::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -15903,6 +15897,12 @@ impl SmartComposeSuggestionData {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [query_record][crate::model::SmartComposeSuggestionData::query_record].
+    pub fn set_query_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query_record = v.into();
         self
     }
 }
@@ -16012,9 +16012,33 @@ impl ConversationSummarizationSuggestionData {
         self
     }
 
+    /// Sets the value of [text_sections][crate::model::ConversationSummarizationSuggestionData::text_sections].
+    pub fn set_text_sections<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.text_sections = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [confidence][crate::model::ConversationSummarizationSuggestionData::confidence].
     pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.confidence = v.into();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::ConversationSummarizationSuggestionData::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -16030,30 +16054,6 @@ impl ConversationSummarizationSuggestionData {
         v: T,
     ) -> Self {
         self.conversation_model = v.into();
-        self
-    }
-
-    /// Sets the value of [text_sections][crate::model::ConversationSummarizationSuggestionData::text_sections].
-    pub fn set_text_sections<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.text_sections = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::ConversationSummarizationSuggestionData::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -16153,19 +16153,6 @@ impl ConversationParticipant {
         })
     }
 
-    /// The value of [participant][crate::model::ConversationParticipant::participant]
-    /// if it holds a `UserId`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn user_id(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.participant.as_ref().and_then(|v| match v {
-            crate::model::conversation_participant::Participant::UserId(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [participant][crate::model::ConversationParticipant::participant]
     /// to hold a `DialogflowParticipantName`.
     ///
@@ -16181,6 +16168,19 @@ impl ConversationParticipant {
             ),
         );
         self
+    }
+
+    /// The value of [participant][crate::model::ConversationParticipant::participant]
+    /// if it holds a `UserId`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn user_id(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.participant.as_ref().and_then(|v| match v {
+            crate::model::conversation_participant::Participant::UserId(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [participant][crate::model::ConversationParticipant::participant]
@@ -16540,6 +16540,17 @@ impl AnnotatorSelector {
         self
     }
 
+    /// Sets the value of [phrase_matchers][crate::model::AnnotatorSelector::phrase_matchers].
+    pub fn set_phrase_matchers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.phrase_matchers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [run_sentiment_annotator][crate::model::AnnotatorSelector::run_sentiment_annotator].
     pub fn set_run_sentiment_annotator<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.run_sentiment_annotator = v.into();
@@ -16561,6 +16572,17 @@ impl AnnotatorSelector {
     /// Sets the value of [run_issue_model_annotator][crate::model::AnnotatorSelector::run_issue_model_annotator].
     pub fn set_run_issue_model_annotator<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.run_issue_model_annotator = v.into();
+        self
+    }
+
+    /// Sets the value of [issue_models][crate::model::AnnotatorSelector::issue_models].
+    pub fn set_issue_models<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.issue_models = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -16597,28 +16619,6 @@ impl AnnotatorSelector {
         v: T,
     ) -> Self {
         self.qa_config = v.into();
-        self
-    }
-
-    /// Sets the value of [phrase_matchers][crate::model::AnnotatorSelector::phrase_matchers].
-    pub fn set_phrase_matchers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.phrase_matchers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [issue_models][crate::model::AnnotatorSelector::issue_models].
-    pub fn set_issue_models<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.issue_models = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -16685,21 +16685,6 @@ pub mod annotator_selector {
             })
         }
 
-        /// The value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
-        /// if it holds a `SummarizationModel`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn summarization_model(
-            &self,
-        ) -> std::option::Option<
-            &crate::model::annotator_selector::summarization_config::SummarizationModel,
-        > {
-            #[allow(unreachable_patterns)]
-            self.model_source.as_ref().and_then(|v| match v {
-                crate::model::annotator_selector::summarization_config::ModelSource::SummarizationModel(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
         /// to hold a `ConversationProfile`.
         ///
@@ -16715,6 +16700,21 @@ pub mod annotator_selector {
                 )
             );
             self
+        }
+
+        /// The value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
+        /// if it holds a `SummarizationModel`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn summarization_model(
+            &self,
+        ) -> std::option::Option<
+            &crate::model::annotator_selector::summarization_config::SummarizationModel,
+        > {
+            #[allow(unreachable_patterns)]
+            self.model_source.as_ref().and_then(|v| match v {
+                crate::model::annotator_selector::summarization_config::ModelSource::SummarizationModel(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
@@ -17154,6 +17154,28 @@ impl QaQuestion {
         self
     }
 
+    /// Sets the value of [answer_choices][crate::model::QaQuestion::answer_choices].
+    pub fn set_answer_choices<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::qa_question::AnswerChoice>,
+    {
+        use std::iter::Iterator;
+        self.answer_choices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::QaQuestion::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [order][crate::model::QaQuestion::order].
     pub fn set_order<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.order = v.into();
@@ -17179,28 +17201,6 @@ impl QaQuestion {
         v: T,
     ) -> Self {
         self.tuning_metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [answer_choices][crate::model::QaQuestion::answer_choices].
-    pub fn set_answer_choices<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::qa_question::AnswerChoice>,
-    {
-        use std::iter::Iterator;
-        self.answer_choices = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::QaQuestion::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -17285,6 +17285,18 @@ pub mod qa_question {
             })
         }
 
+        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
+        /// to hold a `StrValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_str_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::qa_question::answer_choice::Value::StrValue(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::qa_question::AnswerChoice::value]
         /// if it holds a `NumValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -17296,6 +17308,18 @@ pub mod qa_question {
                 }
                 _ => std::option::Option::None,
             })
+        }
+
+        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
+        /// to hold a `NumValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_num_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::qa_question::answer_choice::Value::NumValue(v.into()),
+            );
+            self
         }
 
         /// The value of [value][crate::model::qa_question::AnswerChoice::value]
@@ -17311,6 +17335,18 @@ pub mod qa_question {
             })
         }
 
+        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
+        /// to hold a `BoolValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::qa_question::answer_choice::Value::BoolValue(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::qa_question::AnswerChoice::value]
         /// if it holds a `NaValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -17322,42 +17358,6 @@ pub mod qa_question {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `StrValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_str_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::StrValue(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `NumValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_num_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::NumValue(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `BoolValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::BoolValue(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
@@ -17474,15 +17474,6 @@ pub mod qa_question {
             self
         }
 
-        /// Sets the value of [tuning_error][crate::model::qa_question::TuningMetadata::tuning_error].
-        pub fn set_tuning_error<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.tuning_error = v.into();
-            self
-        }
-
         /// Sets the value of [dataset_validation_warnings][crate::model::qa_question::TuningMetadata::dataset_validation_warnings].
         pub fn set_dataset_validation_warnings<T, V>(mut self, v: T) -> Self
         where
@@ -17491,6 +17482,15 @@ pub mod qa_question {
         {
             use std::iter::Iterator;
             self.dataset_validation_warnings = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [tuning_error][crate::model::qa_question::TuningMetadata::tuning_error].
+        pub fn set_tuning_error<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.tuning_error = v.into();
             self
         }
     }
@@ -17650,15 +17650,6 @@ impl QaScorecardRevision {
         self
     }
 
-    /// Sets the value of [state][crate::model::QaScorecardRevision::state].
-    pub fn set_state<T: std::convert::Into<crate::model::qa_scorecard_revision::State>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state = v.into();
-        self
-    }
-
     /// Sets the value of [alternate_ids][crate::model::QaScorecardRevision::alternate_ids].
     pub fn set_alternate_ids<T, V>(mut self, v: T) -> Self
     where
@@ -17667,6 +17658,15 @@ impl QaScorecardRevision {
     {
         use std::iter::Iterator;
         self.alternate_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::QaScorecardRevision::state].
+    pub fn set_state<T: std::convert::Into<crate::model::qa_scorecard_revision::State>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.state = v.into();
         self
     }
 }
@@ -18047,6 +18047,18 @@ pub mod qa_answer {
             })
         }
 
+        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
+        /// to hold a `StrValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_str_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::qa_answer::answer_value::Value::StrValue(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::qa_answer::AnswerValue::value]
         /// if it holds a `NumValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -18058,6 +18070,18 @@ pub mod qa_answer {
                 }
                 _ => std::option::Option::None,
             })
+        }
+
+        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
+        /// to hold a `NumValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_num_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::qa_answer::answer_value::Value::NumValue(v.into()),
+            );
+            self
         }
 
         /// The value of [value][crate::model::qa_answer::AnswerValue::value]
@@ -18073,6 +18097,18 @@ pub mod qa_answer {
             })
         }
 
+        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
+        /// to hold a `BoolValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::qa_answer::answer_value::Value::BoolValue(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::qa_answer::AnswerValue::value]
         /// if it holds a `NaValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -18084,42 +18120,6 @@ pub mod qa_answer {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `StrValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_str_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::StrValue(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `NumValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_num_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::NumValue(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `BoolValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::BoolValue(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
@@ -18458,6 +18458,17 @@ impl QaScorecardResult {
         self
     }
 
+    /// Sets the value of [qa_answers][crate::model::QaScorecardResult::qa_answers].
+    pub fn set_qa_answers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::QaAnswer>,
+    {
+        use std::iter::Iterator;
+        self.qa_answers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [score][crate::model::QaScorecardResult::score].
     pub fn set_score<T: std::convert::Into<std::option::Option<f64>>>(mut self, v: T) -> Self {
         self.score = v.into();
@@ -18479,17 +18490,6 @@ impl QaScorecardResult {
         v: T,
     ) -> Self {
         self.normalized_score = v.into();
-        self
-    }
-
-    /// Sets the value of [qa_answers][crate::model::QaScorecardResult::qa_answers].
-    pub fn set_qa_answers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::QaAnswer>,
-    {
-        use std::iter::Iterator;
-        self.qa_answers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -1188,18 +1188,6 @@ pub mod lineage {
             self
         }
 
-        /// Sets the value of [page_size][crate::model::BatchSearchLinkProcessesRequest::page_size].
-        pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
-            self.0.request.page_size = v.into();
-            self
-        }
-
-        /// Sets the value of [page_token][crate::model::BatchSearchLinkProcessesRequest::page_token].
-        pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.page_token = v.into();
-            self
-        }
-
         /// Sets the value of [links][crate::model::BatchSearchLinkProcessesRequest::links].
         ///
         /// This is a **required** field for requests.
@@ -1210,6 +1198,18 @@ pub mod lineage {
         {
             use std::iter::Iterator;
             self.0.request.links = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [page_size][crate::model::BatchSearchLinkProcessesRequest::page_size].
+        pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
+            self.0.request.page_size = v.into();
+            self
+        }
+
+        /// Sets the value of [page_token][crate::model::BatchSearchLinkProcessesRequest::page_token].
+        pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.page_token = v.into();
             self
         }
     }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -85,15 +85,6 @@ impl Process {
         self
     }
 
-    /// Sets the value of [origin][crate::model::Process::origin].
-    pub fn set_origin<T: std::convert::Into<std::option::Option<crate::model::Origin>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.origin = v.into();
-        self
-    }
-
     /// Sets the value of [attributes][crate::model::Process::attributes].
     pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
     where
@@ -103,6 +94,15 @@ impl Process {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [origin][crate::model::Process::origin].
+    pub fn set_origin<T: std::convert::Into<std::option::Option<crate::model::Origin>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.origin = v.into();
         self
     }
 }
@@ -173,6 +173,18 @@ impl Run {
         self
     }
 
+    /// Sets the value of [attributes][crate::model::Run::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::Run::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -194,18 +206,6 @@ impl Run {
     /// Sets the value of [state][crate::model::Run::state].
     pub fn set_state<T: std::convert::Into<crate::model::run::State>>(mut self, v: T) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [attributes][crate::model::Run::attributes].
-    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<wkt::Value>,
-    {
-        use std::iter::Iterator;
-        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -416,6 +416,17 @@ impl LineageEvent {
         self
     }
 
+    /// Sets the value of [links][crate::model::LineageEvent::links].
+    pub fn set_links<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventLink>,
+    {
+        use std::iter::Iterator;
+        self.links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::LineageEvent::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -431,17 +442,6 @@ impl LineageEvent {
         v: T,
     ) -> Self {
         self.end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [links][crate::model::LineageEvent::links].
-    pub fn set_links<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventLink>,
-    {
-        use std::iter::Iterator;
-        self.links = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1279,12 +1279,6 @@ impl ListProcessesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProcessesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [processes][crate::model::ListProcessesResponse::processes].
     pub fn set_processes<T, V>(mut self, v: T) -> Self
     where
@@ -1293,6 +1287,12 @@ impl ListProcessesResponse {
     {
         use std::iter::Iterator;
         self.processes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProcessesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1602,12 +1602,6 @@ impl ListRunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [runs][crate::model::ListRunsResponse::runs].
     pub fn set_runs<T, V>(mut self, v: T) -> Self
     where
@@ -1616,6 +1610,12 @@ impl ListRunsResponse {
     {
         use std::iter::Iterator;
         self.runs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1864,12 +1864,6 @@ impl ListLineageEventsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLineageEventsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [lineage_events][crate::model::ListLineageEventsResponse::lineage_events].
     pub fn set_lineage_events<T, V>(mut self, v: T) -> Self
     where
@@ -1878,6 +1872,12 @@ impl ListLineageEventsResponse {
     {
         use std::iter::Iterator;
         self.lineage_events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLineageEventsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2032,17 +2032,6 @@ impl SearchLinksRequest {
         })
     }
 
-    /// The value of [criteria][crate::model::SearchLinksRequest::criteria]
-    /// if it holds a `Target`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn target(&self) -> std::option::Option<&std::boxed::Box<crate::model::EntityReference>> {
-        #[allow(unreachable_patterns)]
-        self.criteria.as_ref().and_then(|v| match v {
-            crate::model::search_links_request::Criteria::Target(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [criteria][crate::model::SearchLinksRequest::criteria]
     /// to hold a `Source`.
     ///
@@ -2056,6 +2045,17 @@ impl SearchLinksRequest {
             crate::model::search_links_request::Criteria::Source(v.into()),
         );
         self
+    }
+
+    /// The value of [criteria][crate::model::SearchLinksRequest::criteria]
+    /// if it holds a `Target`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn target(&self) -> std::option::Option<&std::boxed::Box<crate::model::EntityReference>> {
+        #[allow(unreachable_patterns)]
+        self.criteria.as_ref().and_then(|v| match v {
+            crate::model::search_links_request::Criteria::Target(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [criteria][crate::model::SearchLinksRequest::criteria]
@@ -2127,12 +2127,6 @@ impl SearchLinksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchLinksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [links][crate::model::SearchLinksResponse::links].
     pub fn set_links<T, V>(mut self, v: T) -> Self
     where
@@ -2141,6 +2135,12 @@ impl SearchLinksResponse {
     {
         use std::iter::Iterator;
         self.links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchLinksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2306,6 +2306,17 @@ impl BatchSearchLinkProcessesRequest {
         self
     }
 
+    /// Sets the value of [links][crate::model::BatchSearchLinkProcessesRequest::links].
+    pub fn set_links<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::BatchSearchLinkProcessesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -2315,17 +2326,6 @@ impl BatchSearchLinkProcessesRequest {
     /// Sets the value of [page_token][crate::model::BatchSearchLinkProcessesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [links][crate::model::BatchSearchLinkProcessesRequest::links].
-    pub fn set_links<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.links = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2363,12 +2363,6 @@ impl BatchSearchLinkProcessesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::BatchSearchLinkProcessesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [process_links][crate::model::BatchSearchLinkProcessesResponse::process_links].
     pub fn set_process_links<T, V>(mut self, v: T) -> Self
     where
@@ -2377,6 +2371,12 @@ impl BatchSearchLinkProcessesResponse {
     {
         use std::iter::Iterator;
         self.process_links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::BatchSearchLinkProcessesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -842,12 +842,6 @@ impl StorageProperties {
         std::default::Default::default()
     }
 
-    /// Sets the value of [file_type][crate::model::StorageProperties::file_type].
-    pub fn set_file_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.file_type = v.into();
-        self
-    }
-
     /// Sets the value of [file_pattern][crate::model::StorageProperties::file_pattern].
     pub fn set_file_pattern<T, V>(mut self, v: T) -> Self
     where
@@ -856,6 +850,12 @@ impl StorageProperties {
     {
         use std::iter::Iterator;
         self.file_pattern = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [file_type][crate::model::StorageProperties::file_type].
+    pub fn set_file_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.file_type = v.into();
         self
     }
 }
@@ -1072,31 +1072,6 @@ pub mod search_catalog_request {
             std::default::Default::default()
         }
 
-        /// Sets the value of [include_gcp_public_datasets][crate::model::search_catalog_request::Scope::include_gcp_public_datasets].
-        pub fn set_include_gcp_public_datasets<T: std::convert::Into<bool>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.include_gcp_public_datasets = v.into();
-            self
-        }
-
-        /// Sets the value of [starred_only][crate::model::search_catalog_request::Scope::starred_only].
-        pub fn set_starred_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.starred_only = v.into();
-            self
-        }
-
-        /// Sets the value of [include_public_tag_templates][crate::model::search_catalog_request::Scope::include_public_tag_templates].
-        #[deprecated]
-        pub fn set_include_public_tag_templates<T: std::convert::Into<bool>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.include_public_tag_templates = v.into();
-            self
-        }
-
         /// Sets the value of [include_org_ids][crate::model::search_catalog_request::Scope::include_org_ids].
         pub fn set_include_org_ids<T, V>(mut self, v: T) -> Self
         where
@@ -1119,6 +1094,15 @@ pub mod search_catalog_request {
             self
         }
 
+        /// Sets the value of [include_gcp_public_datasets][crate::model::search_catalog_request::Scope::include_gcp_public_datasets].
+        pub fn set_include_gcp_public_datasets<T: std::convert::Into<bool>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.include_gcp_public_datasets = v.into();
+            self
+        }
+
         /// Sets the value of [restricted_locations][crate::model::search_catalog_request::Scope::restricted_locations].
         pub fn set_restricted_locations<T, V>(mut self, v: T) -> Self
         where
@@ -1127,6 +1111,22 @@ pub mod search_catalog_request {
         {
             use std::iter::Iterator;
             self.restricted_locations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [starred_only][crate::model::search_catalog_request::Scope::starred_only].
+        pub fn set_starred_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.starred_only = v.into();
+            self
+        }
+
+        /// Sets the value of [include_public_tag_templates][crate::model::search_catalog_request::Scope::include_public_tag_templates].
+        #[deprecated]
+        pub fn set_include_public_tag_templates<T: std::convert::Into<bool>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.include_public_tag_templates = v.into();
             self
         }
     }
@@ -1178,6 +1178,17 @@ impl SearchCatalogResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [results][crate::model::SearchCatalogResponse::results].
+    pub fn set_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SearchCatalogResult>,
+    {
+        use std::iter::Iterator;
+        self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [total_size][crate::model::SearchCatalogResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
@@ -1187,17 +1198,6 @@ impl SearchCatalogResponse {
     /// Sets the value of [next_page_token][crate::model::SearchCatalogResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [results][crate::model::SearchCatalogResponse::results].
-    pub fn set_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SearchCatalogResult>,
-    {
-        use std::iter::Iterator;
-        self.results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1535,12 +1535,6 @@ impl ListEntryGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntryGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entry_groups][crate::model::ListEntryGroupsResponse::entry_groups].
     pub fn set_entry_groups<T, V>(mut self, v: T) -> Self
     where
@@ -1549,6 +1543,12 @@ impl ListEntryGroupsResponse {
     {
         use std::iter::Iterator;
         self.entry_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntryGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1861,6 +1861,18 @@ impl LookupEntryRequest {
         })
     }
 
+    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
+    /// to hold a `LinkedResource`.
+    ///
+    /// Note that all the setters affecting `target_name` are
+    /// mutually exclusive.
+    pub fn set_linked_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.target_name = std::option::Option::Some(
+            crate::model::lookup_entry_request::TargetName::LinkedResource(v.into()),
+        );
+        self
+    }
+
     /// The value of [target_name][crate::model::LookupEntryRequest::target_name]
     /// if it holds a `SqlResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1874,6 +1886,18 @@ impl LookupEntryRequest {
         })
     }
 
+    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
+    /// to hold a `SqlResource`.
+    ///
+    /// Note that all the setters affecting `target_name` are
+    /// mutually exclusive.
+    pub fn set_sql_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.target_name = std::option::Option::Some(
+            crate::model::lookup_entry_request::TargetName::SqlResource(v.into()),
+        );
+        self
+    }
+
     /// The value of [target_name][crate::model::LookupEntryRequest::target_name]
     /// if it holds a `FullyQualifiedName`, `None` if the field is not set or
     /// holds a different branch.
@@ -1885,30 +1909,6 @@ impl LookupEntryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-    /// to hold a `LinkedResource`.
-    ///
-    /// Note that all the setters affecting `target_name` are
-    /// mutually exclusive.
-    pub fn set_linked_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target_name = std::option::Option::Some(
-            crate::model::lookup_entry_request::TargetName::LinkedResource(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-    /// to hold a `SqlResource`.
-    ///
-    /// Note that all the setters affecting `target_name` are
-    /// mutually exclusive.
-    pub fn set_sql_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target_name = std::option::Option::Some(
-            crate::model::lookup_entry_request::TargetName::SqlResource(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
@@ -2209,6 +2209,18 @@ impl Entry {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Entry::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [data_source][crate::model::Entry::data_source].
     pub fn set_data_source<T: std::convert::Into<std::option::Option<crate::model::DataSource>>>(
         mut self,
@@ -2226,18 +2238,6 @@ impl Entry {
         v: T,
     ) -> Self {
         self.personal_details = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Entry::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2266,6 +2266,16 @@ impl Entry {
         })
     }
 
+    /// Sets the value of [entry_type][crate::model::Entry::entry_type]
+    /// to hold a `Type`.
+    ///
+    /// Note that all the setters affecting `entry_type` are
+    /// mutually exclusive.
+    pub fn set_type<T: std::convert::Into<crate::model::EntryType>>(mut self, v: T) -> Self {
+        self.entry_type = std::option::Option::Some(crate::model::entry::EntryType::Type(v.into()));
+        self
+    }
+
     /// The value of [entry_type][crate::model::Entry::entry_type]
     /// if it holds a `UserSpecifiedType`, `None` if the field is not set or
     /// holds a different branch.
@@ -2275,16 +2285,6 @@ impl Entry {
             crate::model::entry::EntryType::UserSpecifiedType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entry_type][crate::model::Entry::entry_type]
-    /// to hold a `Type`.
-    ///
-    /// Note that all the setters affecting `entry_type` are
-    /// mutually exclusive.
-    pub fn set_type<T: std::convert::Into<crate::model::EntryType>>(mut self, v: T) -> Self {
-        self.entry_type = std::option::Option::Some(crate::model::entry::EntryType::Type(v.into()));
-        self
     }
 
     /// Sets the value of [entry_type][crate::model::Entry::entry_type]
@@ -2324,17 +2324,6 @@ impl Entry {
         })
     }
 
-    /// The value of [system][crate::model::Entry::system]
-    /// if it holds a `UserSpecifiedSystem`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn user_specified_system(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.system.as_ref().and_then(|v| match v {
-            crate::model::entry::System::UserSpecifiedSystem(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [system][crate::model::Entry::system]
     /// to hold a `IntegratedSystem`.
     ///
@@ -2347,6 +2336,17 @@ impl Entry {
         self.system =
             std::option::Option::Some(crate::model::entry::System::IntegratedSystem(v.into()));
         self
+    }
+
+    /// The value of [system][crate::model::Entry::system]
+    /// if it holds a `UserSpecifiedSystem`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn user_specified_system(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.system.as_ref().and_then(|v| match v {
+            crate::model::entry::System::UserSpecifiedSystem(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [system][crate::model::Entry::system]
@@ -2392,34 +2392,6 @@ impl Entry {
         })
     }
 
-    /// The value of [system_spec][crate::model::Entry::system_spec]
-    /// if it holds a `LookerSystemSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn looker_system_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::LookerSystemSpec>> {
-        #[allow(unreachable_patterns)]
-        self.system_spec.as_ref().and_then(|v| match v {
-            crate::model::entry::SystemSpec::LookerSystemSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [system_spec][crate::model::Entry::system_spec]
-    /// if it holds a `CloudBigtableSystemSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_bigtable_system_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudBigtableSystemSpec>> {
-        #[allow(unreachable_patterns)]
-        self.system_spec.as_ref().and_then(|v| match v {
-            crate::model::entry::SystemSpec::CloudBigtableSystemSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [system_spec][crate::model::Entry::system_spec]
     /// to hold a `SqlDatabaseSystemSpec`.
     ///
@@ -2437,6 +2409,19 @@ impl Entry {
         self
     }
 
+    /// The value of [system_spec][crate::model::Entry::system_spec]
+    /// if it holds a `LookerSystemSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn looker_system_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::LookerSystemSpec>> {
+        #[allow(unreachable_patterns)]
+        self.system_spec.as_ref().and_then(|v| match v {
+            crate::model::entry::SystemSpec::LookerSystemSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [system_spec][crate::model::Entry::system_spec]
     /// to hold a `LookerSystemSpec`.
     ///
@@ -2451,6 +2436,21 @@ impl Entry {
         self.system_spec =
             std::option::Option::Some(crate::model::entry::SystemSpec::LookerSystemSpec(v.into()));
         self
+    }
+
+    /// The value of [system_spec][crate::model::Entry::system_spec]
+    /// if it holds a `CloudBigtableSystemSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_bigtable_system_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudBigtableSystemSpec>> {
+        #[allow(unreachable_patterns)]
+        self.system_spec.as_ref().and_then(|v| match v {
+            crate::model::entry::SystemSpec::CloudBigtableSystemSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [system_spec][crate::model::Entry::system_spec]
@@ -2497,34 +2497,6 @@ impl Entry {
         })
     }
 
-    /// The value of [type_spec][crate::model::Entry::type_spec]
-    /// if it holds a `BigqueryTableSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_table_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryTableSpec>> {
-        #[allow(unreachable_patterns)]
-        self.type_spec.as_ref().and_then(|v| match v {
-            crate::model::entry::TypeSpec::BigqueryTableSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_spec][crate::model::Entry::type_spec]
-    /// if it holds a `BigqueryDateShardedSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_date_sharded_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDateShardedSpec>> {
-        #[allow(unreachable_patterns)]
-        self.type_spec.as_ref().and_then(|v| match v {
-            crate::model::entry::TypeSpec::BigqueryDateShardedSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [type_spec][crate::model::Entry::type_spec]
     /// to hold a `GcsFilesetSpec`.
     ///
@@ -2541,6 +2513,19 @@ impl Entry {
         self
     }
 
+    /// The value of [type_spec][crate::model::Entry::type_spec]
+    /// if it holds a `BigqueryTableSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_table_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryTableSpec>> {
+        #[allow(unreachable_patterns)]
+        self.type_spec.as_ref().and_then(|v| match v {
+            crate::model::entry::TypeSpec::BigqueryTableSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [type_spec][crate::model::Entry::type_spec]
     /// to hold a `BigqueryTableSpec`.
     ///
@@ -2555,6 +2540,21 @@ impl Entry {
         self.type_spec =
             std::option::Option::Some(crate::model::entry::TypeSpec::BigqueryTableSpec(v.into()));
         self
+    }
+
+    /// The value of [type_spec][crate::model::Entry::type_spec]
+    /// if it holds a `BigqueryDateShardedSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_date_sharded_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDateShardedSpec>> {
+        #[allow(unreachable_patterns)]
+        self.type_spec.as_ref().and_then(|v| match v {
+            crate::model::entry::TypeSpec::BigqueryDateShardedSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_spec][crate::model::Entry::type_spec]
@@ -2599,87 +2599,6 @@ impl Entry {
         })
     }
 
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `DataSourceConnectionSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_source_connection_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataSourceConnectionSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::DataSourceConnectionSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `RoutineSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn routine_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::RoutineSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::RoutineSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `DatasetSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dataset_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::DatasetSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::DatasetSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `FilesetSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fileset_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::FilesetSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::FilesetSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `ServiceSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn service_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::ServiceSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::ServiceSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `ModelSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn model_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::ModelSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::ModelSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::Entry::spec]
-    /// if it holds a `FeatureOnlineStoreSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn feature_online_store_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FeatureOnlineStoreSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::entry::Spec::FeatureOnlineStoreSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [spec][crate::model::Entry::spec]
     /// to hold a `DatabaseTableSpec`.
     ///
@@ -2694,6 +2613,19 @@ impl Entry {
         self.spec =
             std::option::Option::Some(crate::model::entry::Spec::DatabaseTableSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `DataSourceConnectionSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_source_connection_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataSourceConnectionSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::DataSourceConnectionSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::Entry::spec]
@@ -2713,6 +2645,17 @@ impl Entry {
         self
     }
 
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `RoutineSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn routine_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::RoutineSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::RoutineSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [spec][crate::model::Entry::spec]
     /// to hold a `RoutineSpec`.
     ///
@@ -2724,6 +2667,17 @@ impl Entry {
     ) -> Self {
         self.spec = std::option::Option::Some(crate::model::entry::Spec::RoutineSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `DatasetSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dataset_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::DatasetSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::DatasetSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::Entry::spec]
@@ -2739,6 +2693,17 @@ impl Entry {
         self
     }
 
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `FilesetSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fileset_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::FilesetSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::FilesetSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [spec][crate::model::Entry::spec]
     /// to hold a `FilesetSpec`.
     ///
@@ -2750,6 +2715,17 @@ impl Entry {
     ) -> Self {
         self.spec = std::option::Option::Some(crate::model::entry::Spec::FilesetSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `ServiceSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn service_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::ServiceSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::ServiceSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::Entry::spec]
@@ -2765,6 +2741,17 @@ impl Entry {
         self
     }
 
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `ModelSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn model_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::ModelSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::ModelSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [spec][crate::model::Entry::spec]
     /// to hold a `ModelSpec`.
     ///
@@ -2776,6 +2763,19 @@ impl Entry {
     ) -> Self {
         self.spec = std::option::Option::Some(crate::model::entry::Spec::ModelSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::Entry::spec]
+    /// if it holds a `FeatureOnlineStoreSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn feature_online_store_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FeatureOnlineStoreSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::entry::Spec::FeatureOnlineStoreSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::Entry::spec]
@@ -3061,17 +3061,6 @@ pub mod database_table_spec {
             })
         }
 
-        /// The value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
-        /// if it holds a `SqlQuery`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sql_query(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.source_definition.as_ref().and_then(|v| match v {
-                crate::model::database_table_spec::database_view_spec::SourceDefinition::SqlQuery(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
         /// to hold a `BaseTable`.
         ///
@@ -3084,6 +3073,17 @@ pub mod database_table_spec {
                 ),
             );
             self
+        }
+
+        /// The value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
+        /// if it holds a `SqlQuery`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sql_query(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.source_definition.as_ref().and_then(|v| match v {
+                crate::model::database_table_spec::database_view_spec::SourceDefinition::SqlQuery(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
@@ -3530,6 +3530,17 @@ impl RoutineSpec {
         self
     }
 
+    /// Sets the value of [routine_arguments][crate::model::RoutineSpec::routine_arguments].
+    pub fn set_routine_arguments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::routine_spec::Argument>,
+    {
+        use std::iter::Iterator;
+        self.routine_arguments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [return_type][crate::model::RoutineSpec::return_type].
     pub fn set_return_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.return_type = v.into();
@@ -3539,17 +3550,6 @@ impl RoutineSpec {
     /// Sets the value of [definition_body][crate::model::RoutineSpec::definition_body].
     pub fn set_definition_body<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.definition_body = v.into();
-        self
-    }
-
-    /// Sets the value of [routine_arguments][crate::model::RoutineSpec::routine_arguments].
-    pub fn set_routine_arguments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::routine_spec::Argument>,
-    {
-        use std::iter::Iterator;
-        self.routine_arguments = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4723,6 +4723,17 @@ impl VertexModelSpec {
         self
     }
 
+    /// Sets the value of [version_aliases][crate::model::VertexModelSpec::version_aliases].
+    pub fn set_version_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.version_aliases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [version_description][crate::model::VertexModelSpec::version_description].
     pub fn set_version_description<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -4749,17 +4760,6 @@ impl VertexModelSpec {
         v: T,
     ) -> Self {
         self.container_image_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [version_aliases][crate::model::VertexModelSpec::version_aliases].
-    pub fn set_version_aliases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.version_aliases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6298,12 +6298,6 @@ impl ListTagsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTagsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tags][crate::model::ListTagsResponse::tags].
     pub fn set_tags<T, V>(mut self, v: T) -> Self
     where
@@ -6312,6 +6306,12 @@ impl ListTagsResponse {
     {
         use std::iter::Iterator;
         self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTagsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6783,12 +6783,6 @@ impl ListEntriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entries][crate::model::ListEntriesResponse::entries].
     pub fn set_entries<T, V>(mut self, v: T) -> Self
     where
@@ -6797,6 +6791,12 @@ impl ListEntriesResponse {
     {
         use std::iter::Iterator;
         self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7472,19 +7472,6 @@ impl SetConfigRequest {
         })
     }
 
-    /// The value of [configuration][crate::model::SetConfigRequest::configuration]
-    /// if it holds a `CatalogUiExperience`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn catalog_ui_experience(&self) -> std::option::Option<&crate::model::CatalogUIExperience> {
-        #[allow(unreachable_patterns)]
-        self.configuration.as_ref().and_then(|v| match v {
-            crate::model::set_config_request::Configuration::CatalogUiExperience(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [configuration][crate::model::SetConfigRequest::configuration]
     /// to hold a `TagTemplateMigration`.
     ///
@@ -7498,6 +7485,19 @@ impl SetConfigRequest {
             crate::model::set_config_request::Configuration::TagTemplateMigration(v.into()),
         );
         self
+    }
+
+    /// The value of [configuration][crate::model::SetConfigRequest::configuration]
+    /// if it holds a `CatalogUiExperience`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn catalog_ui_experience(&self) -> std::option::Option<&crate::model::CatalogUIExperience> {
+        #[allow(unreachable_patterns)]
+        self.configuration.as_ref().and_then(|v| match v {
+            crate::model::set_config_request::Configuration::CatalogUiExperience(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [configuration][crate::model::SetConfigRequest::configuration]
@@ -7864,6 +7864,17 @@ impl DataplexTableSpec {
         std::default::Default::default()
     }
 
+    /// Sets the value of [external_tables][crate::model::DataplexTableSpec::external_tables].
+    pub fn set_external_tables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataplexExternalTable>,
+    {
+        use std::iter::Iterator;
+        self.external_tables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [dataplex_spec][crate::model::DataplexTableSpec::dataplex_spec].
     pub fn set_dataplex_spec<
         T: std::convert::Into<std::option::Option<crate::model::DataplexSpec>>,
@@ -7878,17 +7889,6 @@ impl DataplexTableSpec {
     /// Sets the value of [user_managed][crate::model::DataplexTableSpec::user_managed].
     pub fn set_user_managed<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.user_managed = v.into();
-        self
-    }
-
-    /// Sets the value of [external_tables][crate::model::DataplexTableSpec::external_tables].
-    pub fn set_external_tables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataplexExternalTable>,
-    {
-        use std::iter::Iterator;
-        self.external_tables = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8352,71 +8352,6 @@ impl PhysicalSchema {
         })
     }
 
-    /// The value of [schema][crate::model::PhysicalSchema::schema]
-    /// if it holds a `Thrift`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn thrift(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::ThriftSchema>> {
-        #[allow(unreachable_patterns)]
-        self.schema.as_ref().and_then(|v| match v {
-            crate::model::physical_schema::Schema::Thrift(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [schema][crate::model::PhysicalSchema::schema]
-    /// if it holds a `Protobuf`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn protobuf(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::ProtobufSchema>> {
-        #[allow(unreachable_patterns)]
-        self.schema.as_ref().and_then(|v| match v {
-            crate::model::physical_schema::Schema::Protobuf(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [schema][crate::model::PhysicalSchema::schema]
-    /// if it holds a `Parquet`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn parquet(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::ParquetSchema>> {
-        #[allow(unreachable_patterns)]
-        self.schema.as_ref().and_then(|v| match v {
-            crate::model::physical_schema::Schema::Parquet(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [schema][crate::model::PhysicalSchema::schema]
-    /// if it holds a `Orc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn orc(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::OrcSchema>> {
-        #[allow(unreachable_patterns)]
-        self.schema.as_ref().and_then(|v| match v {
-            crate::model::physical_schema::Schema::Orc(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [schema][crate::model::PhysicalSchema::schema]
-    /// if it holds a `Csv`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn csv(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::CsvSchema>> {
-        #[allow(unreachable_patterns)]
-        self.schema.as_ref().and_then(|v| match v {
-            crate::model::physical_schema::Schema::Csv(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
     /// to hold a `Avro`.
     ///
@@ -8431,6 +8366,19 @@ impl PhysicalSchema {
         self.schema =
             std::option::Option::Some(crate::model::physical_schema::Schema::Avro(v.into()));
         self
+    }
+
+    /// The value of [schema][crate::model::PhysicalSchema::schema]
+    /// if it holds a `Thrift`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn thrift(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::ThriftSchema>> {
+        #[allow(unreachable_patterns)]
+        self.schema.as_ref().and_then(|v| match v {
+            crate::model::physical_schema::Schema::Thrift(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
@@ -8449,6 +8397,19 @@ impl PhysicalSchema {
         self
     }
 
+    /// The value of [schema][crate::model::PhysicalSchema::schema]
+    /// if it holds a `Protobuf`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn protobuf(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::ProtobufSchema>> {
+        #[allow(unreachable_patterns)]
+        self.schema.as_ref().and_then(|v| match v {
+            crate::model::physical_schema::Schema::Protobuf(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
     /// to hold a `Protobuf`.
     ///
@@ -8463,6 +8424,19 @@ impl PhysicalSchema {
         self.schema =
             std::option::Option::Some(crate::model::physical_schema::Schema::Protobuf(v.into()));
         self
+    }
+
+    /// The value of [schema][crate::model::PhysicalSchema::schema]
+    /// if it holds a `Parquet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn parquet(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::ParquetSchema>> {
+        #[allow(unreachable_patterns)]
+        self.schema.as_ref().and_then(|v| match v {
+            crate::model::physical_schema::Schema::Parquet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
@@ -8481,6 +8455,19 @@ impl PhysicalSchema {
         self
     }
 
+    /// The value of [schema][crate::model::PhysicalSchema::schema]
+    /// if it holds a `Orc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn orc(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::OrcSchema>> {
+        #[allow(unreachable_patterns)]
+        self.schema.as_ref().and_then(|v| match v {
+            crate::model::physical_schema::Schema::Orc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
     /// to hold a `Orc`.
     ///
@@ -8495,6 +8482,19 @@ impl PhysicalSchema {
         self.schema =
             std::option::Option::Some(crate::model::physical_schema::Schema::Orc(v.into()));
         self
+    }
+
+    /// The value of [schema][crate::model::PhysicalSchema::schema]
+    /// if it holds a `Csv`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn csv(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::physical_schema::CsvSchema>> {
+        #[allow(unreachable_patterns)]
+        self.schema.as_ref().and_then(|v| match v {
+            crate::model::physical_schema::Schema::Csv(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
@@ -8822,17 +8822,6 @@ impl Taxonomy {
         self
     }
 
-    /// Sets the value of [service][crate::model::Taxonomy::service].
-    pub fn set_service<
-        T: std::convert::Into<std::option::Option<crate::model::taxonomy::Service>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service = v.into();
-        self
-    }
-
     /// Sets the value of [activated_policy_types][crate::model::Taxonomy::activated_policy_types].
     pub fn set_activated_policy_types<T, V>(mut self, v: T) -> Self
     where
@@ -8841,6 +8830,17 @@ impl Taxonomy {
     {
         use std::iter::Iterator;
         self.activated_policy_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service][crate::model::Taxonomy::service].
+    pub fn set_service<
+        T: std::convert::Into<std::option::Option<crate::model::taxonomy::Service>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.service = v.into();
         self
     }
 }
@@ -9373,12 +9373,6 @@ impl ListTaxonomiesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTaxonomiesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [taxonomies][crate::model::ListTaxonomiesResponse::taxonomies].
     pub fn set_taxonomies<T, V>(mut self, v: T) -> Self
     where
@@ -9387,6 +9381,12 @@ impl ListTaxonomiesResponse {
     {
         use std::iter::Iterator;
         self.taxonomies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTaxonomiesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9675,12 +9675,6 @@ impl ListPolicyTagsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPolicyTagsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policy_tags][crate::model::ListPolicyTagsResponse::policy_tags].
     pub fn set_policy_tags<T, V>(mut self, v: T) -> Self
     where
@@ -9689,6 +9683,12 @@ impl ListPolicyTagsResponse {
     {
         use std::iter::Iterator;
         self.policy_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPolicyTagsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10009,21 +10009,6 @@ impl ImportTaxonomiesRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportTaxonomiesRequest::source]
-    /// if it holds a `CrossRegionalSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cross_regional_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CrossRegionalSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_taxonomies_request::Source::CrossRegionalSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportTaxonomiesRequest::source]
     /// to hold a `InlineSource`.
     ///
@@ -10037,6 +10022,21 @@ impl ImportTaxonomiesRequest {
             crate::model::import_taxonomies_request::Source::InlineSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportTaxonomiesRequest::source]
+    /// if it holds a `CrossRegionalSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cross_regional_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CrossRegionalSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_taxonomies_request::Source::CrossRegionalSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportTaxonomiesRequest::source]
@@ -10509,6 +10509,17 @@ impl ColumnSchema {
         self
     }
 
+    /// Sets the value of [subcolumns][crate::model::ColumnSchema::subcolumns].
+    pub fn set_subcolumns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ColumnSchema>,
+    {
+        use std::iter::Iterator;
+        self.subcolumns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [range_element_type][crate::model::ColumnSchema::range_element_type].
     pub fn set_range_element_type<
         T: std::convert::Into<std::option::Option<crate::model::column_schema::FieldElementType>>,
@@ -10523,17 +10534,6 @@ impl ColumnSchema {
     /// Sets the value of [gc_rule][crate::model::ColumnSchema::gc_rule].
     pub fn set_gc_rule<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.gc_rule = v.into();
-        self
-    }
-
-    /// Sets the value of [subcolumns][crate::model::ColumnSchema::subcolumns].
-    pub fn set_subcolumns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ColumnSchema>,
-    {
-        use std::iter::Iterator;
-        self.subcolumns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -11167,19 +11167,6 @@ impl SearchCatalogResult {
         })
     }
 
-    /// The value of [system][crate::model::SearchCatalogResult::system]
-    /// if it holds a `UserSpecifiedSystem`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn user_specified_system(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.system.as_ref().and_then(|v| match v {
-            crate::model::search_catalog_result::System::UserSpecifiedSystem(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [system][crate::model::SearchCatalogResult::system]
     /// to hold a `IntegratedSystem`.
     ///
@@ -11193,6 +11180,19 @@ impl SearchCatalogResult {
             crate::model::search_catalog_result::System::IntegratedSystem(v.into()),
         );
         self
+    }
+
+    /// The value of [system][crate::model::SearchCatalogResult::system]
+    /// if it holds a `UserSpecifiedSystem`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn user_specified_system(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.system.as_ref().and_then(|v| match v {
+            crate::model::search_catalog_result::System::UserSpecifiedSystem(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [system][crate::model::SearchCatalogResult::system]
@@ -11294,19 +11294,6 @@ impl BigQueryTableSpec {
         })
     }
 
-    /// The value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
-    /// if it holds a `TableSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn table_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::TableSpec>> {
-        #[allow(unreachable_patterns)]
-        self.type_spec.as_ref().and_then(|v| match v {
-            crate::model::big_query_table_spec::TypeSpec::TableSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
     /// to hold a `ViewSpec`.
     ///
@@ -11320,6 +11307,19 @@ impl BigQueryTableSpec {
             crate::model::big_query_table_spec::TypeSpec::ViewSpec(v.into()),
         );
         self
+    }
+
+    /// The value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
+    /// if it holds a `TableSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn table_spec(&self) -> std::option::Option<&std::boxed::Box<crate::model::TableSpec>> {
+        #[allow(unreachable_patterns)]
+        self.type_spec.as_ref().and_then(|v| match v {
+            crate::model::big_query_table_spec::TypeSpec::TableSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
@@ -11592,17 +11592,6 @@ impl Tag {
         self
     }
 
-    /// Sets the value of [dataplex_transfer_status][crate::model::Tag::dataplex_transfer_status].
-    pub fn set_dataplex_transfer_status<
-        T: std::convert::Into<crate::model::tag_template::DataplexTransferStatus>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dataplex_transfer_status = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::model::Tag::fields].
     pub fn set_fields<T, K, V>(mut self, v: T) -> Self
     where
@@ -11612,6 +11601,17 @@ impl Tag {
     {
         use std::iter::Iterator;
         self.fields = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [dataplex_transfer_status][crate::model::Tag::dataplex_transfer_status].
+    pub fn set_dataplex_transfer_status<
+        T: std::convert::Into<crate::model::tag_template::DataplexTransferStatus>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.dataplex_transfer_status = v.into();
         self
     }
 
@@ -11753,6 +11753,16 @@ impl TagField {
         })
     }
 
+    /// Sets the value of [kind][crate::model::TagField::kind]
+    /// to hold a `DoubleValue`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::DoubleValue(v.into()));
+        self
+    }
+
     /// The value of [kind][crate::model::TagField::kind]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11762,6 +11772,16 @@ impl TagField {
             crate::model::tag_field::Kind::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [kind][crate::model::TagField::kind]
+    /// to hold a `StringValue`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::StringValue(v.into()));
+        self
     }
 
     /// The value of [kind][crate::model::TagField::kind]
@@ -11775,6 +11795,16 @@ impl TagField {
         })
     }
 
+    /// Sets the value of [kind][crate::model::TagField::kind]
+    /// to hold a `BoolValue`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::BoolValue(v.into()));
+        self
+    }
+
     /// The value of [kind][crate::model::TagField::kind]
     /// if it holds a `TimestampValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11784,60 +11814,6 @@ impl TagField {
             crate::model::tag_field::Kind::TimestampValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [kind][crate::model::TagField::kind]
-    /// if it holds a `EnumValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn enum_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::tag_field::EnumValue>> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::tag_field::Kind::EnumValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::TagField::kind]
-    /// if it holds a `RichtextValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn richtext_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::tag_field::Kind::RichtextValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::DoubleValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::StringValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::BoolValue(v.into()));
-        self
     }
 
     /// Sets the value of [kind][crate::model::TagField::kind]
@@ -11854,6 +11830,19 @@ impl TagField {
         self
     }
 
+    /// The value of [kind][crate::model::TagField::kind]
+    /// if it holds a `EnumValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn enum_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::tag_field::EnumValue>> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::tag_field::Kind::EnumValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::TagField::kind]
     /// to hold a `EnumValue`.
     ///
@@ -11867,6 +11856,17 @@ impl TagField {
     ) -> Self {
         self.kind = std::option::Option::Some(crate::model::tag_field::Kind::EnumValue(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::TagField::kind]
+    /// if it holds a `RichtextValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn richtext_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::tag_field::Kind::RichtextValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::TagField::kind]
@@ -12039,17 +12039,6 @@ impl TagTemplate {
         self
     }
 
-    /// Sets the value of [dataplex_transfer_status][crate::model::TagTemplate::dataplex_transfer_status].
-    pub fn set_dataplex_transfer_status<
-        T: std::convert::Into<crate::model::tag_template::DataplexTransferStatus>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dataplex_transfer_status = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::model::TagTemplate::fields].
     pub fn set_fields<T, K, V>(mut self, v: T) -> Self
     where
@@ -12059,6 +12048,17 @@ impl TagTemplate {
     {
         use std::iter::Iterator;
         self.fields = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [dataplex_transfer_status][crate::model::TagTemplate::dataplex_transfer_status].
+    pub fn set_dataplex_transfer_status<
+        T: std::convert::Into<crate::model::tag_template::DataplexTransferStatus>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.dataplex_transfer_status = v.into();
         self
     }
 }
@@ -12363,19 +12363,6 @@ impl FieldType {
         })
     }
 
-    /// The value of [type_decl][crate::model::FieldType::type_decl]
-    /// if it holds a `EnumType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn enum_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::field_type::EnumType>> {
-        #[allow(unreachable_patterns)]
-        self.type_decl.as_ref().and_then(|v| match v {
-            crate::model::field_type::TypeDecl::EnumType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [type_decl][crate::model::FieldType::type_decl]
     /// to hold a `PrimitiveType`.
     ///
@@ -12388,6 +12375,19 @@ impl FieldType {
         self.type_decl =
             std::option::Option::Some(crate::model::field_type::TypeDecl::PrimitiveType(v.into()));
         self
+    }
+
+    /// The value of [type_decl][crate::model::FieldType::type_decl]
+    /// if it holds a `EnumType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn enum_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::field_type::EnumType>> {
+        #[allow(unreachable_patterns)]
+        self.type_decl.as_ref().and_then(|v| match v {
+            crate::model::field_type::TypeDecl::EnumType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_decl][crate::model::FieldType::type_decl]
@@ -12900,15 +12900,6 @@ impl UsageSignal {
         self
     }
 
-    /// Sets the value of [favorite_count][crate::model::UsageSignal::favorite_count].
-    pub fn set_favorite_count<T: std::convert::Into<std::option::Option<i64>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.favorite_count = v.into();
-        self
-    }
-
     /// Sets the value of [usage_within_time_range][crate::model::UsageSignal::usage_within_time_range].
     pub fn set_usage_within_time_range<T, K, V>(mut self, v: T) -> Self
     where
@@ -12931,6 +12922,15 @@ impl UsageSignal {
         use std::iter::Iterator;
         self.common_usage_within_time_range =
             v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [favorite_count][crate::model::UsageSignal::favorite_count].
+    pub fn set_favorite_count<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.favorite_count = v.into();
         self
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/model.rs
+++ b/src/generated/cloud/datafusion/v1/src/model.rs
@@ -128,12 +128,6 @@ impl Version {
         self
     }
 
-    /// Sets the value of [r#type][crate::model::Version::type].
-    pub fn set_type<T: std::convert::Into<crate::model::version::Type>>(mut self, v: T) -> Self {
-        self.r#type = v.into();
-        self
-    }
-
     /// Sets the value of [available_features][crate::model::Version::available_features].
     pub fn set_available_features<T, V>(mut self, v: T) -> Self
     where
@@ -142,6 +136,12 @@ impl Version {
     {
         use std::iter::Iterator;
         self.available_features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [r#type][crate::model::Version::type].
+    pub fn set_type<T: std::convert::Into<crate::model::version::Type>>(mut self, v: T) -> Self {
+        self.r#type = v.into();
         self
     }
 }
@@ -851,6 +851,30 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::model::Instance::options].
+    pub fn set_options<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Instance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -915,6 +939,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [available_version][crate::model::Instance::available_version].
+    pub fn set_available_version<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Version>,
+    {
+        use std::iter::Iterator;
+        self.available_version = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [api_endpoint][crate::model::Instance::api_endpoint].
     pub fn set_api_endpoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.api_endpoint = v.into();
@@ -924,6 +959,17 @@ impl Instance {
     /// Sets the value of [gcs_bucket][crate::model::Instance::gcs_bucket].
     pub fn set_gcs_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.gcs_bucket = v.into();
+        self
+    }
+
+    /// Sets the value of [accelerators][crate::model::Instance::accelerators].
+    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Accelerator>,
+    {
+        use std::iter::Iterator;
+        self.accelerators = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -971,28 +1017,6 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [available_version][crate::model::Instance::available_version].
-    pub fn set_available_version<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Version>,
-    {
-        use std::iter::Iterator;
-        self.available_version = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [accelerators][crate::model::Instance::accelerators].
-    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Accelerator>,
-    {
-        use std::iter::Iterator;
-        self.accelerators = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [disabled_reason][crate::model::Instance::disabled_reason].
     pub fn set_disabled_reason<T, V>(mut self, v: T) -> Self
     where
@@ -1001,30 +1025,6 @@ impl Instance {
     {
         use std::iter::Iterator;
         self.disabled_reason = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [options][crate::model::Instance::options].
-    pub fn set_options<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.options = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1607,12 +1607,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -1621,6 +1615,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1746,12 +1746,6 @@ impl ListAvailableVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAvailableVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [available_versions][crate::model::ListAvailableVersionsResponse::available_versions].
     pub fn set_available_versions<T, V>(mut self, v: T) -> Self
     where
@@ -1760,6 +1754,12 @@ impl ListAvailableVersionsResponse {
     {
         use std::iter::Iterator;
         self.available_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAvailableVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/dataplex/v1/src/builder.rs
+++ b/src/generated/cloud/dataplex/v1/src/builder.rs
@@ -1789,14 +1789,6 @@ pub mod catalog_service {
             self
         }
 
-        /// Sets the value of [entry][crate::model::LookupEntryRequest::entry].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_entry<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.entry = v.into();
-            self
-        }
-
         /// Sets the value of [aspect_types][crate::model::LookupEntryRequest::aspect_types].
         pub fn set_aspect_types<T, V>(mut self, v: T) -> Self
         where
@@ -1816,6 +1808,14 @@ pub mod catalog_service {
         {
             use std::iter::Iterator;
             self.0.request.paths = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [entry][crate::model::LookupEntryRequest::entry].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_entry<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.entry = v.into();
             self
         }
     }

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -137,6 +137,18 @@ impl Environment {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Environment::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Environment::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -190,18 +202,6 @@ impl Environment {
         v: T,
     ) -> Self {
         self.endpoints = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Environment::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -743,12 +743,6 @@ impl Content {
         self
     }
 
-    /// Sets the value of [description][crate::model::Content::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Content::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -758,6 +752,12 @@ impl Content {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::Content::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
         self
     }
 
@@ -821,19 +821,6 @@ impl Content {
         })
     }
 
-    /// The value of [content][crate::model::Content::content]
-    /// if it holds a `Notebook`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn notebook(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::content::Notebook>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::content::Content::Notebook(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [content][crate::model::Content::content]
     /// to hold a `SqlScript`.
     ///
@@ -848,6 +835,19 @@ impl Content {
         self.content =
             std::option::Option::Some(crate::model::content::Content::SqlScript(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Content::content]
+    /// if it holds a `Notebook`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn notebook(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::content::Notebook>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::content::Content::Notebook(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Content::content]
@@ -1406,6 +1406,18 @@ impl AspectType {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AspectType::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::AspectType::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -1440,18 +1452,6 @@ impl AspectType {
         v: T,
     ) -> Self {
         self.transfer_status = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AspectType::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1622,6 +1622,28 @@ pub mod aspect_type {
             self
         }
 
+        /// Sets the value of [record_fields][crate::model::aspect_type::MetadataTemplate::record_fields].
+        pub fn set_record_fields<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::aspect_type::MetadataTemplate>,
+        {
+            use std::iter::Iterator;
+            self.record_fields = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [enum_values][crate::model::aspect_type::MetadataTemplate::enum_values].
+        pub fn set_enum_values<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::aspect_type::metadata_template::EnumValue>,
+        {
+            use std::iter::Iterator;
+            self.enum_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [map_items][crate::model::aspect_type::MetadataTemplate::map_items].
         pub fn set_map_items<
             T: std::convert::Into<
@@ -1687,28 +1709,6 @@ pub mod aspect_type {
             v: T,
         ) -> Self {
             self.annotations = v.into();
-            self
-        }
-
-        /// Sets the value of [record_fields][crate::model::aspect_type::MetadataTemplate::record_fields].
-        pub fn set_record_fields<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::aspect_type::MetadataTemplate>,
-        {
-            use std::iter::Iterator;
-            self.record_fields = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [enum_values][crate::model::aspect_type::MetadataTemplate::enum_values].
-        pub fn set_enum_values<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::aspect_type::metadata_template::EnumValue>,
-        {
-            use std::iter::Iterator;
-            self.enum_values = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2020,6 +2020,18 @@ impl EntryGroup {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EntryGroup::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::EntryGroup::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -2032,18 +2044,6 @@ impl EntryGroup {
         v: T,
     ) -> Self {
         self.transfer_status = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::EntryGroup::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2170,9 +2170,32 @@ impl EntryType {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EntryType::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::EntryType::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [type_aliases][crate::model::EntryType::type_aliases].
+    pub fn set_type_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.type_aliases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2188,28 +2211,6 @@ impl EntryType {
         self
     }
 
-    /// Sets the value of [authorization][crate::model::EntryType::authorization].
-    pub fn set_authorization<
-        T: std::convert::Into<std::option::Option<crate::model::entry_type::Authorization>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorization = v.into();
-        self
-    }
-
-    /// Sets the value of [type_aliases][crate::model::EntryType::type_aliases].
-    pub fn set_type_aliases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.type_aliases = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [required_aspects][crate::model::EntryType::required_aspects].
     pub fn set_required_aspects<T, V>(mut self, v: T) -> Self
     where
@@ -2221,15 +2222,14 @@ impl EntryType {
         self
     }
 
-    /// Sets the value of [labels][crate::model::EntryType::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [authorization][crate::model::EntryType::authorization].
+    pub fn set_authorization<
+        T: std::convert::Into<std::option::Option<crate::model::entry_type::Authorization>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.authorization = v.into();
         self
     }
 }
@@ -2565,6 +2565,18 @@ impl Entry {
         self
     }
 
+    /// Sets the value of [aspects][crate::model::Entry::aspects].
+    pub fn set_aspects<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::Aspect>,
+    {
+        use std::iter::Iterator;
+        self.aspects = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [parent_entry][crate::model::Entry::parent_entry].
     pub fn set_parent_entry<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent_entry = v.into();
@@ -2588,18 +2600,6 @@ impl Entry {
         v: T,
     ) -> Self {
         self.entry_source = v.into();
-        self
-    }
-
-    /// Sets the value of [aspects][crate::model::Entry::aspects].
-    pub fn set_aspects<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::Aspect>,
-    {
-        use std::iter::Iterator;
-        self.aspects = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2709,6 +2709,29 @@ impl EntrySource {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EntrySource::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [ancestors][crate::model::EntrySource::ancestors].
+    pub fn set_ancestors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::entry_source::Ancestor>,
+    {
+        use std::iter::Iterator;
+        self.ancestors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::EntrySource::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2730,29 +2753,6 @@ impl EntrySource {
     /// Sets the value of [location][crate::model::EntrySource::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
-        self
-    }
-
-    /// Sets the value of [ancestors][crate::model::EntrySource::ancestors].
-    pub fn set_ancestors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::entry_source::Ancestor>,
-    {
-        use std::iter::Iterator;
-        self.ancestors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::EntrySource::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3093,12 +3093,6 @@ impl ListEntryGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntryGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entry_groups][crate::model::ListEntryGroupsResponse::entry_groups].
     pub fn set_entry_groups<T, V>(mut self, v: T) -> Self
     where
@@ -3107,6 +3101,12 @@ impl ListEntryGroupsResponse {
     {
         use std::iter::Iterator;
         self.entry_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntryGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3462,12 +3462,6 @@ impl ListEntryTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntryTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entry_types][crate::model::ListEntryTypesResponse::entry_types].
     pub fn set_entry_types<T, V>(mut self, v: T) -> Self
     where
@@ -3476,6 +3470,12 @@ impl ListEntryTypesResponse {
     {
         use std::iter::Iterator;
         self.entry_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntryTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3832,12 +3832,6 @@ impl ListAspectTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAspectTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [aspect_types][crate::model::ListAspectTypesResponse::aspect_types].
     pub fn set_aspect_types<T, V>(mut self, v: T) -> Self
     where
@@ -3846,6 +3840,12 @@ impl ListAspectTypesResponse {
     {
         use std::iter::Iterator;
         self.aspect_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAspectTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4240,12 +4240,6 @@ impl ListEntriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entries][crate::model::ListEntriesResponse::entries].
     pub fn set_entries<T, V>(mut self, v: T) -> Self
     where
@@ -4254,6 +4248,12 @@ impl ListEntriesResponse {
     {
         use std::iter::Iterator;
         self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4404,12 +4404,6 @@ impl LookupEntryRequest {
         self
     }
 
-    /// Sets the value of [entry][crate::model::LookupEntryRequest::entry].
-    pub fn set_entry<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.entry = v.into();
-        self
-    }
-
     /// Sets the value of [aspect_types][crate::model::LookupEntryRequest::aspect_types].
     pub fn set_aspect_types<T, V>(mut self, v: T) -> Self
     where
@@ -4429,6 +4423,12 @@ impl LookupEntryRequest {
     {
         use std::iter::Iterator;
         self.paths = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [entry][crate::model::LookupEntryRequest::entry].
+    pub fn set_entry<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.entry = v.into();
         self
     }
 }
@@ -4677,6 +4677,17 @@ impl SearchEntriesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [results][crate::model::SearchEntriesResponse::results].
+    pub fn set_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SearchEntriesResult>,
+    {
+        use std::iter::Iterator;
+        self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [total_size][crate::model::SearchEntriesResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
@@ -4686,17 +4697,6 @@ impl SearchEntriesResponse {
     /// Sets the value of [next_page_token][crate::model::SearchEntriesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [results][crate::model::SearchEntriesResponse::results].
-    pub fn set_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SearchEntriesResult>,
-    {
-        use std::iter::Iterator;
-        self.results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5058,12 +5058,6 @@ impl ListMetadataJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMetadataJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [metadata_jobs][crate::model::ListMetadataJobsResponse::metadata_jobs].
     pub fn set_metadata_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -5072,6 +5066,12 @@ impl ListMetadataJobsResponse {
     {
         use std::iter::Iterator;
         self.metadata_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMetadataJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5223,6 +5223,18 @@ impl MetadataJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::MetadataJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [r#type][crate::model::MetadataJob::type].
     pub fn set_type<T: std::convert::Into<crate::model::metadata_job::Type>>(
         mut self,
@@ -5240,18 +5252,6 @@ impl MetadataJob {
         v: T,
     ) -> Self {
         self.status = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::MetadataJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5282,19 +5282,6 @@ impl MetadataJob {
         })
     }
 
-    /// The value of [spec][crate::model::MetadataJob::spec]
-    /// if it holds a `ExportSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn export_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::metadata_job::ExportJobSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::metadata_job::Spec::ExportSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [spec][crate::model::MetadataJob::spec]
     /// to hold a `ImportSpec`.
     ///
@@ -5309,6 +5296,19 @@ impl MetadataJob {
         self.spec =
             std::option::Option::Some(crate::model::metadata_job::Spec::ImportSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::MetadataJob::spec]
+    /// if it holds a `ExportSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn export_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::metadata_job::ExportJobSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::metadata_job::Spec::ExportSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::MetadataJob::spec]
@@ -5354,19 +5354,6 @@ impl MetadataJob {
         })
     }
 
-    /// The value of [result][crate::model::MetadataJob::result]
-    /// if it holds a `ExportResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn export_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::metadata_job::ExportJobResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::metadata_job::Result::ExportResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::MetadataJob::result]
     /// to hold a `ImportResult`.
     ///
@@ -5381,6 +5368,19 @@ impl MetadataJob {
         self.result =
             std::option::Option::Some(crate::model::metadata_job::Result::ImportResult(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::MetadataJob::result]
+    /// if it holds a `ExportResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn export_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::metadata_job::ExportJobResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::metadata_job::Result::ExportResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::MetadataJob::result]
@@ -7443,12 +7443,6 @@ impl ListEncryptionConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEncryptionConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [encryption_configs][crate::model::ListEncryptionConfigsResponse::encryption_configs].
     pub fn set_encryption_configs<T, V>(mut self, v: T) -> Self
     where
@@ -7457,6 +7451,12 @@ impl ListEncryptionConfigsResponse {
     {
         use std::iter::Iterator;
         self.encryption_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEncryptionConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7742,12 +7742,6 @@ impl ListContentResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListContentResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [content][crate::model::ListContentResponse::content].
     pub fn set_content<T, V>(mut self, v: T) -> Self
     where
@@ -7756,6 +7750,12 @@ impl ListContentResponse {
     {
         use std::iter::Iterator;
         self.content = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListContentResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8329,6 +8329,28 @@ pub mod data_discovery_spec {
             std::default::Default::default()
         }
 
+        /// Sets the value of [include_patterns][crate::model::data_discovery_spec::StorageConfig::include_patterns].
+        pub fn set_include_patterns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.include_patterns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [exclude_patterns][crate::model::data_discovery_spec::StorageConfig::exclude_patterns].
+        pub fn set_exclude_patterns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.exclude_patterns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [csv_options][crate::model::data_discovery_spec::StorageConfig::csv_options].
         pub fn set_csv_options<
             T: std::convert::Into<
@@ -8356,28 +8378,6 @@ pub mod data_discovery_spec {
             v: T,
         ) -> Self {
             self.json_options = v.into();
-            self
-        }
-
-        /// Sets the value of [include_patterns][crate::model::data_discovery_spec::StorageConfig::include_patterns].
-        pub fn set_include_patterns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.include_patterns = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [exclude_patterns][crate::model::data_discovery_spec::StorageConfig::exclude_patterns].
-        pub fn set_exclude_patterns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.exclude_patterns = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -9300,28 +9300,6 @@ pub mod data_profile_result {
                     })
                 }
 
-                /// The value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
-                /// if it holds a `IntegerProfile`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn integer_profile(&self) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::IntegerFieldInfo>>{
-                    #[allow(unreachable_patterns)]
-                    self.field_info.as_ref().and_then(|v| match v {
-                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::IntegerProfile(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
-                /// The value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
-                /// if it holds a `DoubleProfile`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn double_profile(&self) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::DoubleFieldInfo>>{
-                    #[allow(unreachable_patterns)]
-                    self.field_info.as_ref().and_then(|v| match v {
-                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::DoubleProfile(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
                 /// to hold a `StringProfile`.
                 ///
@@ -9336,6 +9314,17 @@ pub mod data_profile_result {
                     self
                 }
 
+                /// The value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
+                /// if it holds a `IntegerProfile`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn integer_profile(&self) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::IntegerFieldInfo>>{
+                    #[allow(unreachable_patterns)]
+                    self.field_info.as_ref().and_then(|v| match v {
+                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::IntegerProfile(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
+                }
+
                 /// Sets the value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
                 /// to hold a `IntegerProfile`.
                 ///
@@ -9348,6 +9337,17 @@ pub mod data_profile_result {
                         )
                     );
                     self
+                }
+
+                /// The value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
+                /// if it holds a `DoubleProfile`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn double_profile(&self) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::DoubleFieldInfo>>{
+                    #[allow(unreachable_patterns)]
+                    self.field_info.as_ref().and_then(|v| match v {
+                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::DoubleProfile(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
@@ -9508,12 +9508,6 @@ pub mod data_profile_result {
                         self
                     }
 
-                    /// Sets the value of [max][crate::model::data_profile_result::profile::field::profile_info::IntegerFieldInfo::max].
-                    pub fn set_max<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                        self.max = v.into();
-                        self
-                    }
-
                     /// Sets the value of [quartiles][crate::model::data_profile_result::profile::field::profile_info::IntegerFieldInfo::quartiles].
                     pub fn set_quartiles<T, V>(mut self, v: T) -> Self
                     where
@@ -9522,6 +9516,12 @@ pub mod data_profile_result {
                     {
                         use std::iter::Iterator;
                         self.quartiles = v.into_iter().map(|i| i.into()).collect();
+                        self
+                    }
+
+                    /// Sets the value of [max][crate::model::data_profile_result::profile::field::profile_info::IntegerFieldInfo::max].
+                    pub fn set_max<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                        self.max = v.into();
                         self
                     }
                 }
@@ -9604,12 +9604,6 @@ pub mod data_profile_result {
                         self
                     }
 
-                    /// Sets the value of [max][crate::model::data_profile_result::profile::field::profile_info::DoubleFieldInfo::max].
-                    pub fn set_max<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-                        self.max = v.into();
-                        self
-                    }
-
                     /// Sets the value of [quartiles][crate::model::data_profile_result::profile::field::profile_info::DoubleFieldInfo::quartiles].
                     pub fn set_quartiles<T, V>(mut self, v: T) -> Self
                     where
@@ -9618,6 +9612,12 @@ pub mod data_profile_result {
                     {
                         use std::iter::Iterator;
                         self.quartiles = v.into_iter().map(|i| i.into()).collect();
+                        self
+                    }
+
+                    /// Sets the value of [max][crate::model::data_profile_result::profile::field::profile_info::DoubleFieldInfo::max].
+                    pub fn set_max<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+                        self.max = v.into();
                         self
                     }
                 }
@@ -9978,6 +9978,17 @@ impl DataQualitySpec {
         std::default::Default::default()
     }
 
+    /// Sets the value of [rules][crate::model::DataQualitySpec::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataQualityRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [sampling_percent][crate::model::DataQualitySpec::sampling_percent].
     pub fn set_sampling_percent<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.sampling_percent = v.into();
@@ -9998,17 +10009,6 @@ impl DataQualitySpec {
         v: T,
     ) -> Self {
         self.post_scan_actions = v.into();
-        self
-    }
-
-    /// Sets the value of [rules][crate::model::DataQualitySpec::rules].
-    pub fn set_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataQualityRule>,
-    {
-        use std::iter::Iterator;
-        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10418,36 +10418,6 @@ impl DataQualityResult {
         self
     }
 
-    /// Sets the value of [row_count][crate::model::DataQualityResult::row_count].
-    pub fn set_row_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.row_count = v.into();
-        self
-    }
-
-    /// Sets the value of [scanned_data][crate::model::DataQualityResult::scanned_data].
-    pub fn set_scanned_data<
-        T: std::convert::Into<std::option::Option<crate::model::ScannedData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scanned_data = v.into();
-        self
-    }
-
-    /// Sets the value of [post_scan_actions_result][crate::model::DataQualityResult::post_scan_actions_result].
-    pub fn set_post_scan_actions_result<
-        T: std::convert::Into<
-                std::option::Option<crate::model::data_quality_result::PostScanActionsResult>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.post_scan_actions_result = v.into();
-        self
-    }
-
     /// Sets the value of [dimensions][crate::model::DataQualityResult::dimensions].
     pub fn set_dimensions<T, V>(mut self, v: T) -> Self
     where
@@ -10478,6 +10448,36 @@ impl DataQualityResult {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [row_count][crate::model::DataQualityResult::row_count].
+    pub fn set_row_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.row_count = v.into();
+        self
+    }
+
+    /// Sets the value of [scanned_data][crate::model::DataQualityResult::scanned_data].
+    pub fn set_scanned_data<
+        T: std::convert::Into<std::option::Option<crate::model::ScannedData>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.scanned_data = v.into();
+        self
+    }
+
+    /// Sets the value of [post_scan_actions_result][crate::model::DataQualityResult::post_scan_actions_result].
+    pub fn set_post_scan_actions_result<
+        T: std::convert::Into<
+                std::option::Option<crate::model::data_quality_result::PostScanActionsResult>,
+            >,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.post_scan_actions_result = v.into();
         self
     }
 }
@@ -11099,136 +11099,6 @@ impl DataQualityRule {
         })
     }
 
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `NonNullExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn non_null_expectation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::NonNullExpectation>>
-    {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::NonNullExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `SetExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn set_expectation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::SetExpectation>>
-    {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::SetExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `RegexExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn regex_expectation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::RegexExpectation>>
-    {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::RegexExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `UniquenessExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn uniqueness_expectation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::UniquenessExpectation>>
-    {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::UniquenessExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `StatisticRangeExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn statistic_range_expectation(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::data_quality_rule::StatisticRangeExpectation>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::StatisticRangeExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `RowConditionExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn row_condition_expectation(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::data_quality_rule::RowConditionExpectation>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::RowConditionExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `TableConditionExpectation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn table_condition_expectation(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::data_quality_rule::TableConditionExpectation>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::TableConditionExpectation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// if it holds a `SqlAssertion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_assertion(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::SqlAssertion>> {
-        #[allow(unreachable_patterns)]
-        self.rule_type.as_ref().and_then(|v| match v {
-            crate::model::data_quality_rule::RuleType::SqlAssertion(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// to hold a `RangeExpectation`.
     ///
@@ -11244,6 +11114,22 @@ impl DataQualityRule {
             crate::model::data_quality_rule::RuleType::RangeExpectation(v.into()),
         );
         self
+    }
+
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `NonNullExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn non_null_expectation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::NonNullExpectation>>
+    {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::NonNullExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -11263,6 +11149,22 @@ impl DataQualityRule {
         self
     }
 
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `SetExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn set_expectation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::SetExpectation>>
+    {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::SetExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// to hold a `SetExpectation`.
     ///
@@ -11278,6 +11180,22 @@ impl DataQualityRule {
             crate::model::data_quality_rule::RuleType::SetExpectation(v.into()),
         );
         self
+    }
+
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `RegexExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn regex_expectation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::RegexExpectation>>
+    {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::RegexExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -11297,6 +11215,22 @@ impl DataQualityRule {
         self
     }
 
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `UniquenessExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn uniqueness_expectation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::UniquenessExpectation>>
+    {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::UniquenessExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// to hold a `UniquenessExpectation`.
     ///
@@ -11312,6 +11246,23 @@ impl DataQualityRule {
             crate::model::data_quality_rule::RuleType::UniquenessExpectation(v.into()),
         );
         self
+    }
+
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `StatisticRangeExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn statistic_range_expectation(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::data_quality_rule::StatisticRangeExpectation>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::StatisticRangeExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -11333,6 +11284,23 @@ impl DataQualityRule {
         self
     }
 
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `RowConditionExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn row_condition_expectation(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::data_quality_rule::RowConditionExpectation>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::RowConditionExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// to hold a `RowConditionExpectation`.
     ///
@@ -11352,6 +11320,23 @@ impl DataQualityRule {
         self
     }
 
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `TableConditionExpectation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn table_condition_expectation(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::data_quality_rule::TableConditionExpectation>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::TableConditionExpectation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// to hold a `TableConditionExpectation`.
     ///
@@ -11369,6 +11354,21 @@ impl DataQualityRule {
             crate::model::data_quality_rule::RuleType::TableConditionExpectation(v.into()),
         );
         self
+    }
+
+    /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
+    /// if it holds a `SqlAssertion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_assertion(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_quality_rule::SqlAssertion>> {
+        #[allow(unreachable_patterns)]
+        self.rule_type.as_ref().and_then(|v| match v {
+            crate::model::data_quality_rule::RuleType::SqlAssertion(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -12147,6 +12147,18 @@ impl DataTaxonomy {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataTaxonomy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [attribute_count][crate::model::DataTaxonomy::attribute_count].
     pub fn set_attribute_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.attribute_count = v.into();
@@ -12162,18 +12174,6 @@ impl DataTaxonomy {
     /// Sets the value of [class_count][crate::model::DataTaxonomy::class_count].
     pub fn set_class_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.class_count = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DataTaxonomy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -12310,6 +12310,18 @@ impl DataAttribute {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataAttribute::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [parent_id][crate::model::DataAttribute::parent_id].
     pub fn set_parent_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent_id = v.into();
@@ -12347,18 +12359,6 @@ impl DataAttribute {
         v: T,
     ) -> Self {
         self.data_access_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DataAttribute::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -12485,6 +12485,18 @@ impl DataAttributeBinding {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataAttributeBinding::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::DataAttributeBinding::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -12510,18 +12522,6 @@ impl DataAttributeBinding {
     {
         use std::iter::Iterator;
         self.paths = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DataAttributeBinding::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -12924,12 +12924,6 @@ impl ListDataTaxonomiesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataTaxonomiesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_taxonomies][crate::model::ListDataTaxonomiesResponse::data_taxonomies].
     pub fn set_data_taxonomies<T, V>(mut self, v: T) -> Self
     where
@@ -12938,6 +12932,12 @@ impl ListDataTaxonomiesResponse {
     {
         use std::iter::Iterator;
         self.data_taxonomies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataTaxonomiesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -13297,12 +13297,6 @@ impl ListDataAttributesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataAttributesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_attributes][crate::model::ListDataAttributesResponse::data_attributes].
     pub fn set_data_attributes<T, V>(mut self, v: T) -> Self
     where
@@ -13311,6 +13305,12 @@ impl ListDataAttributesResponse {
     {
         use std::iter::Iterator;
         self.data_attributes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataAttributesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -13673,12 +13673,6 @@ impl ListDataAttributeBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataAttributeBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_attribute_bindings][crate::model::ListDataAttributeBindingsResponse::data_attribute_bindings].
     pub fn set_data_attribute_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -13687,6 +13681,12 @@ impl ListDataAttributeBindingsResponse {
     {
         use std::iter::Iterator;
         self.data_attribute_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataAttributeBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -14245,12 +14245,6 @@ impl ListDataScansResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataScansResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_scans][crate::model::ListDataScansResponse::data_scans].
     pub fn set_data_scans<T, V>(mut self, v: T) -> Self
     where
@@ -14259,6 +14253,12 @@ impl ListDataScansResponse {
     {
         use std::iter::Iterator;
         self.data_scans = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataScansResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -14664,12 +14664,6 @@ impl ListDataScanJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataScanJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_scan_jobs][crate::model::ListDataScanJobsResponse::data_scan_jobs].
     pub fn set_data_scan_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -14678,6 +14672,12 @@ impl ListDataScanJobsResponse {
     {
         use std::iter::Iterator;
         self.data_scan_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataScanJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -14899,6 +14899,18 @@ impl DataScan {
         self
     }
 
+    /// Sets the value of [labels][crate::model::DataScan::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::DataScan::state].
     pub fn set_state<T: std::convert::Into<crate::model::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -14960,18 +14972,6 @@ impl DataScan {
         self
     }
 
-    /// Sets the value of [labels][crate::model::DataScan::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [spec][crate::model::DataScan::spec].
     ///
     /// Note that all the setters affecting `spec` are mutually
@@ -14997,32 +14997,6 @@ impl DataScan {
         })
     }
 
-    /// The value of [spec][crate::model::DataScan::spec]
-    /// if it holds a `DataProfileSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_profile_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::data_scan::Spec::DataProfileSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::DataScan::spec]
-    /// if it holds a `DataDiscoverySpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_discovery_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoverySpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::data_scan::Spec::DataDiscoverySpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [spec][crate::model::DataScan::spec]
     /// to hold a `DataQualitySpec`.
     ///
@@ -15039,6 +15013,19 @@ impl DataScan {
         self
     }
 
+    /// The value of [spec][crate::model::DataScan::spec]
+    /// if it holds a `DataProfileSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_profile_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::data_scan::Spec::DataProfileSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [spec][crate::model::DataScan::spec]
     /// to hold a `DataProfileSpec`.
     ///
@@ -15053,6 +15040,19 @@ impl DataScan {
         self.spec =
             std::option::Option::Some(crate::model::data_scan::Spec::DataProfileSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::DataScan::spec]
+    /// if it holds a `DataDiscoverySpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_discovery_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoverySpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::data_scan::Spec::DataDiscoverySpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::DataScan::spec]
@@ -15098,32 +15098,6 @@ impl DataScan {
         })
     }
 
-    /// The value of [result][crate::model::DataScan::result]
-    /// if it holds a `DataProfileResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_profile_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::data_scan::Result::DataProfileResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::DataScan::result]
-    /// if it holds a `DataDiscoveryResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_discovery_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoveryResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::data_scan::Result::DataDiscoveryResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::DataScan::result]
     /// to hold a `DataQualityResult`.
     ///
@@ -15140,6 +15114,19 @@ impl DataScan {
         self
     }
 
+    /// The value of [result][crate::model::DataScan::result]
+    /// if it holds a `DataProfileResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_profile_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::data_scan::Result::DataProfileResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [result][crate::model::DataScan::result]
     /// to hold a `DataProfileResult`.
     ///
@@ -15154,6 +15141,19 @@ impl DataScan {
         self.result =
             std::option::Option::Some(crate::model::data_scan::Result::DataProfileResult(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::DataScan::result]
+    /// if it holds a `DataDiscoveryResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_discovery_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoveryResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::data_scan::Result::DataDiscoveryResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::DataScan::result]
@@ -15536,32 +15536,6 @@ impl DataScanJob {
         })
     }
 
-    /// The value of [spec][crate::model::DataScanJob::spec]
-    /// if it holds a `DataProfileSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_profile_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileSpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::data_scan_job::Spec::DataProfileSpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [spec][crate::model::DataScanJob::spec]
-    /// if it holds a `DataDiscoverySpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_discovery_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoverySpec>> {
-        #[allow(unreachable_patterns)]
-        self.spec.as_ref().and_then(|v| match v {
-            crate::model::data_scan_job::Spec::DataDiscoverySpec(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [spec][crate::model::DataScanJob::spec]
     /// to hold a `DataQualitySpec`.
     ///
@@ -15578,6 +15552,19 @@ impl DataScanJob {
         self
     }
 
+    /// The value of [spec][crate::model::DataScanJob::spec]
+    /// if it holds a `DataProfileSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_profile_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileSpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::data_scan_job::Spec::DataProfileSpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [spec][crate::model::DataScanJob::spec]
     /// to hold a `DataProfileSpec`.
     ///
@@ -15592,6 +15579,19 @@ impl DataScanJob {
         self.spec =
             std::option::Option::Some(crate::model::data_scan_job::Spec::DataProfileSpec(v.into()));
         self
+    }
+
+    /// The value of [spec][crate::model::DataScanJob::spec]
+    /// if it holds a `DataDiscoverySpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_discovery_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoverySpec>> {
+        #[allow(unreachable_patterns)]
+        self.spec.as_ref().and_then(|v| match v {
+            crate::model::data_scan_job::Spec::DataDiscoverySpec(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [spec][crate::model::DataScanJob::spec]
@@ -15640,36 +15640,6 @@ impl DataScanJob {
         })
     }
 
-    /// The value of [result][crate::model::DataScanJob::result]
-    /// if it holds a `DataProfileResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_profile_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::data_scan_job::Result::DataProfileResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::DataScanJob::result]
-    /// if it holds a `DataDiscoveryResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_discovery_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoveryResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::data_scan_job::Result::DataDiscoveryResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::DataScanJob::result]
     /// to hold a `DataQualityResult`.
     ///
@@ -15687,6 +15657,21 @@ impl DataScanJob {
         self
     }
 
+    /// The value of [result][crate::model::DataScanJob::result]
+    /// if it holds a `DataProfileResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_profile_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataProfileResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::data_scan_job::Result::DataProfileResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [result][crate::model::DataScanJob::result]
     /// to hold a `DataProfileResult`.
     ///
@@ -15702,6 +15687,21 @@ impl DataScanJob {
             crate::model::data_scan_job::Result::DataProfileResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::DataScanJob::result]
+    /// if it holds a `DataDiscoveryResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_discovery_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DataDiscoveryResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::data_scan_job::Result::DataDiscoveryResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::DataScanJob::result]
@@ -16039,59 +16039,6 @@ impl DiscoveryEvent {
         })
     }
 
-    /// The value of [details][crate::model::DiscoveryEvent::details]
-    /// if it holds a `Entity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::EntityDetails>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::discovery_event::Details::Entity(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::DiscoveryEvent::details]
-    /// if it holds a `Partition`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn partition(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::PartitionDetails>>
-    {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::discovery_event::Details::Partition(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::DiscoveryEvent::details]
-    /// if it holds a `Action`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::ActionDetails>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::discovery_event::Details::Action(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::DiscoveryEvent::details]
-    /// if it holds a `Table`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn table(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::TableDetails>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::discovery_event::Details::Table(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [details][crate::model::DiscoveryEvent::details]
     /// to hold a `Config`.
     ///
@@ -16106,6 +16053,19 @@ impl DiscoveryEvent {
         self.details =
             std::option::Option::Some(crate::model::discovery_event::Details::Config(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::DiscoveryEvent::details]
+    /// if it holds a `Entity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::EntityDetails>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::discovery_event::Details::Entity(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::DiscoveryEvent::details]
@@ -16124,6 +16084,20 @@ impl DiscoveryEvent {
         self
     }
 
+    /// The value of [details][crate::model::DiscoveryEvent::details]
+    /// if it holds a `Partition`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn partition(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::PartitionDetails>>
+    {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::discovery_event::Details::Partition(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::DiscoveryEvent::details]
     /// to hold a `Partition`.
     ///
@@ -16140,6 +16114,19 @@ impl DiscoveryEvent {
         self
     }
 
+    /// The value of [details][crate::model::DiscoveryEvent::details]
+    /// if it holds a `Action`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::ActionDetails>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::discovery_event::Details::Action(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::DiscoveryEvent::details]
     /// to hold a `Action`.
     ///
@@ -16154,6 +16141,19 @@ impl DiscoveryEvent {
         self.details =
             std::option::Option::Some(crate::model::discovery_event::Details::Action(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::DiscoveryEvent::details]
+    /// if it holds a `Table`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn table(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::discovery_event::TableDetails>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::discovery_event::Details::Table(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::DiscoveryEvent::details]
@@ -18843,20 +18843,6 @@ impl DataScanEvent {
         })
     }
 
-    /// The value of [result][crate::model::DataScanEvent::result]
-    /// if it holds a `DataQuality`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_quality(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_scan_event::DataQualityResult>>
-    {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::data_scan_event::Result::DataQuality(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::DataScanEvent::result]
     /// to hold a `DataProfile`.
     ///
@@ -18871,6 +18857,20 @@ impl DataScanEvent {
         self.result =
             std::option::Option::Some(crate::model::data_scan_event::Result::DataProfile(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::DataScanEvent::result]
+    /// if it holds a `DataQuality`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_quality(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_scan_event::DataQualityResult>>
+    {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::data_scan_event::Result::DataQuality(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::DataScanEvent::result]
@@ -18920,23 +18920,6 @@ impl DataScanEvent {
         })
     }
 
-    /// The value of [applied_configs][crate::model::DataScanEvent::applied_configs]
-    /// if it holds a `DataQualityConfigs`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn data_quality_configs(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::data_scan_event::DataQualityAppliedConfigs>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.applied_configs.as_ref().and_then(|v| match v {
-            crate::model::data_scan_event::AppliedConfigs::DataQualityConfigs(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [applied_configs][crate::model::DataScanEvent::applied_configs]
     /// to hold a `DataProfileConfigs`.
     ///
@@ -18954,6 +18937,23 @@ impl DataScanEvent {
             crate::model::data_scan_event::AppliedConfigs::DataProfileConfigs(v.into()),
         );
         self
+    }
+
+    /// The value of [applied_configs][crate::model::DataScanEvent::applied_configs]
+    /// if it holds a `DataQualityConfigs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn data_quality_configs(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::data_scan_event::DataQualityAppliedConfigs>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.applied_configs.as_ref().and_then(|v| match v {
+            crate::model::data_scan_event::AppliedConfigs::DataQualityConfigs(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [applied_configs][crate::model::DataScanEvent::applied_configs]
@@ -19088,12 +19088,6 @@ pub mod data_scan_event {
             self
         }
 
-        /// Sets the value of [score][crate::model::data_scan_event::DataQualityResult::score].
-        pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.score = v.into();
-            self
-        }
-
         /// Sets the value of [dimension_passed][crate::model::data_scan_event::DataQualityResult::dimension_passed].
         pub fn set_dimension_passed<T, K, V>(mut self, v: T) -> Self
         where
@@ -19103,6 +19097,12 @@ pub mod data_scan_event {
         {
             use std::iter::Iterator;
             self.dimension_passed = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [score][crate::model::data_scan_event::DataQualityResult::score].
+        pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.score = v.into();
             self
         }
 
@@ -21549,12 +21549,6 @@ impl ListEntitiesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntitiesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entities][crate::model::ListEntitiesResponse::entities].
     pub fn set_entities<T, V>(mut self, v: T) -> Self
     where
@@ -21563,6 +21557,12 @@ impl ListEntitiesResponse {
     {
         use std::iter::Iterator;
         self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntitiesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -21994,12 +21994,6 @@ impl ListPartitionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPartitionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [partitions][crate::model::ListPartitionsResponse::partitions].
     pub fn set_partitions<T, V>(mut self, v: T) -> Self
     where
@@ -22008,6 +22002,12 @@ impl ListPartitionsResponse {
     {
         use std::iter::Iterator;
         self.partitions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPartitionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -22602,6 +22602,17 @@ impl Partition {
         self
     }
 
+    /// Sets the value of [values][crate::model::Partition::values].
+    pub fn set_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [location][crate::model::Partition::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
@@ -22612,17 +22623,6 @@ impl Partition {
     #[deprecated]
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [values][crate::model::Partition::values].
-    pub fn set_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -22685,15 +22685,6 @@ impl Schema {
         self
     }
 
-    /// Sets the value of [partition_style][crate::model::Schema::partition_style].
-    pub fn set_partition_style<T: std::convert::Into<crate::model::schema::PartitionStyle>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.partition_style = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::model::Schema::fields].
     pub fn set_fields<T, V>(mut self, v: T) -> Self
     where
@@ -22713,6 +22704,15 @@ impl Schema {
     {
         use std::iter::Iterator;
         self.partition_fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [partition_style][crate::model::Schema::partition_style].
+    pub fn set_partition_style<T: std::convert::Into<crate::model::schema::PartitionStyle>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.partition_style = v.into();
         self
     }
 }
@@ -23445,32 +23445,6 @@ impl StorageFormat {
         })
     }
 
-    /// The value of [options][crate::model::StorageFormat::options]
-    /// if it holds a `Json`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn json(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::storage_format::JsonOptions>> {
-        #[allow(unreachable_patterns)]
-        self.options.as_ref().and_then(|v| match v {
-            crate::model::storage_format::Options::Json(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [options][crate::model::StorageFormat::options]
-    /// if it holds a `Iceberg`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn iceberg(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::storage_format::IcebergOptions>> {
-        #[allow(unreachable_patterns)]
-        self.options.as_ref().and_then(|v| match v {
-            crate::model::storage_format::Options::Iceberg(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [options][crate::model::StorageFormat::options]
     /// to hold a `Csv`.
     ///
@@ -23487,6 +23461,19 @@ impl StorageFormat {
         self
     }
 
+    /// The value of [options][crate::model::StorageFormat::options]
+    /// if it holds a `Json`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn json(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::storage_format::JsonOptions>> {
+        #[allow(unreachable_patterns)]
+        self.options.as_ref().and_then(|v| match v {
+            crate::model::storage_format::Options::Json(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [options][crate::model::StorageFormat::options]
     /// to hold a `Json`.
     ///
@@ -23501,6 +23488,19 @@ impl StorageFormat {
         self.options =
             std::option::Option::Some(crate::model::storage_format::Options::Json(v.into()));
         self
+    }
+
+    /// The value of [options][crate::model::StorageFormat::options]
+    /// if it holds a `Iceberg`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn iceberg(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::storage_format::IcebergOptions>> {
+        #[allow(unreachable_patterns)]
+        self.options.as_ref().and_then(|v| match v {
+            crate::model::storage_format::Options::Iceberg(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [options][crate::model::StorageFormat::options]
@@ -24233,19 +24233,6 @@ impl Trigger {
         })
     }
 
-    /// The value of [mode][crate::model::Trigger::mode]
-    /// if it holds a `Schedule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn schedule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::trigger::Schedule>> {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::trigger::Mode::Schedule(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::Trigger::mode]
     /// to hold a `OnDemand`.
     ///
@@ -24259,6 +24246,19 @@ impl Trigger {
     ) -> Self {
         self.mode = std::option::Option::Some(crate::model::trigger::Mode::OnDemand(v.into()));
         self
+    }
+
+    /// The value of [mode][crate::model::Trigger::mode]
+    /// if it holds a `Schedule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn schedule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::trigger::Schedule>> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::trigger::Mode::Schedule(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::Trigger::mode]
@@ -24410,17 +24410,6 @@ impl DataSource {
         })
     }
 
-    /// The value of [source][crate::model::DataSource::source]
-    /// if it holds a `Resource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn resource(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::data_source::Source::Resource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::DataSource::source]
     /// to hold a `Entity`.
     ///
@@ -24430,6 +24419,17 @@ impl DataSource {
         self.source =
             std::option::Option::Some(crate::model::data_source::Source::Entity(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::DataSource::source]
+    /// if it holds a `Resource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn resource(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::data_source::Source::Resource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::DataSource::source]
@@ -24723,6 +24723,18 @@ impl Lake {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Lake::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Lake::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -24771,18 +24783,6 @@ impl Lake {
         v: T,
     ) -> Self {
         self.metastore_status = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Lake::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -25217,6 +25217,18 @@ impl Zone {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Zone::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Zone::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -25265,18 +25277,6 @@ impl Zone {
         v: T,
     ) -> Self {
         self.asset_status = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Zone::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -25522,6 +25522,28 @@ pub mod zone {
             self
         }
 
+        /// Sets the value of [include_patterns][crate::model::zone::DiscoverySpec::include_patterns].
+        pub fn set_include_patterns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.include_patterns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [exclude_patterns][crate::model::zone::DiscoverySpec::exclude_patterns].
+        pub fn set_exclude_patterns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.exclude_patterns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [csv_options][crate::model::zone::DiscoverySpec::csv_options].
         pub fn set_csv_options<
             T: std::convert::Into<std::option::Option<crate::model::zone::discovery_spec::CsvOptions>>,
@@ -25543,28 +25565,6 @@ pub mod zone {
             v: T,
         ) -> Self {
             self.json_options = v.into();
-            self
-        }
-
-        /// Sets the value of [include_patterns][crate::model::zone::DiscoverySpec::include_patterns].
-        pub fn set_include_patterns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.include_patterns = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [exclude_patterns][crate::model::zone::DiscoverySpec::exclude_patterns].
-        pub fn set_exclude_patterns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.exclude_patterns = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -26039,104 +26039,6 @@ impl Action {
         })
     }
 
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `IncompatibleDataSchema`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn incompatible_data_schema(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::IncompatibleDataSchema>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::IncompatibleDataSchema(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `InvalidDataPartition`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn invalid_data_partition(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::InvalidDataPartition>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::InvalidDataPartition(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `MissingData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn missing_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::MissingData>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::MissingData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `MissingResource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn missing_resource(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::MissingResource>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::MissingResource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `UnauthorizedResource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn unauthorized_resource(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::UnauthorizedResource>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::UnauthorizedResource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `FailedSecurityPolicyApply`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn failed_security_policy_apply(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::FailedSecurityPolicyApply>>
-    {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::FailedSecurityPolicyApply(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Action::details]
-    /// if it holds a `InvalidDataOrganization`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn invalid_data_organization(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::InvalidDataOrganization>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::action::Details::InvalidDataOrganization(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [details][crate::model::Action::details]
     /// to hold a `InvalidDataFormat`.
     ///
@@ -26151,6 +26053,21 @@ impl Action {
         self.details =
             std::option::Option::Some(crate::model::action::Details::InvalidDataFormat(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `IncompatibleDataSchema`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn incompatible_data_schema(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::IncompatibleDataSchema>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::IncompatibleDataSchema(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Action::details]
@@ -26170,6 +26087,19 @@ impl Action {
         self
     }
 
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `InvalidDataPartition`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn invalid_data_partition(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::InvalidDataPartition>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::InvalidDataPartition(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Action::details]
     /// to hold a `InvalidDataPartition`.
     ///
@@ -26185,6 +26115,19 @@ impl Action {
             crate::model::action::Details::InvalidDataPartition(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `MissingData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn missing_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::MissingData>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::MissingData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Action::details]
@@ -26203,6 +26146,19 @@ impl Action {
         self
     }
 
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `MissingResource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn missing_resource(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::MissingResource>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::MissingResource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Action::details]
     /// to hold a `MissingResource`.
     ///
@@ -26217,6 +26173,19 @@ impl Action {
         self.details =
             std::option::Option::Some(crate::model::action::Details::MissingResource(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `UnauthorizedResource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn unauthorized_resource(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::UnauthorizedResource>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::UnauthorizedResource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Action::details]
@@ -26236,6 +26205,22 @@ impl Action {
         self
     }
 
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `FailedSecurityPolicyApply`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn failed_security_policy_apply(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::FailedSecurityPolicyApply>>
+    {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::FailedSecurityPolicyApply(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Action::details]
     /// to hold a `FailedSecurityPolicyApply`.
     ///
@@ -26251,6 +26236,21 @@ impl Action {
             crate::model::action::Details::FailedSecurityPolicyApply(v.into()),
         );
         self
+    }
+
+    /// The value of [details][crate::model::Action::details]
+    /// if it holds a `InvalidDataOrganization`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn invalid_data_organization(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::InvalidDataOrganization>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::action::Details::InvalidDataOrganization(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Action::details]
@@ -26392,6 +26392,17 @@ pub mod action {
             std::default::Default::default()
         }
 
+        /// Sets the value of [sampled_data_locations][crate::model::action::InvalidDataFormat::sampled_data_locations].
+        pub fn set_sampled_data_locations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.sampled_data_locations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [expected_format][crate::model::action::InvalidDataFormat::expected_format].
         pub fn set_expected_format<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -26404,17 +26415,6 @@ pub mod action {
         /// Sets the value of [new_format][crate::model::action::InvalidDataFormat::new_format].
         pub fn set_new_format<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.new_format = v.into();
-            self
-        }
-
-        /// Sets the value of [sampled_data_locations][crate::model::action::InvalidDataFormat::sampled_data_locations].
-        pub fn set_sampled_data_locations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.sampled_data_locations = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -26483,17 +26483,6 @@ pub mod action {
             self
         }
 
-        /// Sets the value of [schema_change][crate::model::action::IncompatibleDataSchema::schema_change].
-        pub fn set_schema_change<
-            T: std::convert::Into<crate::model::action::incompatible_data_schema::SchemaChange>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.schema_change = v.into();
-            self
-        }
-
         /// Sets the value of [sampled_data_locations][crate::model::action::IncompatibleDataSchema::sampled_data_locations].
         pub fn set_sampled_data_locations<T, V>(mut self, v: T) -> Self
         where
@@ -26502,6 +26491,17 @@ pub mod action {
         {
             use std::iter::Iterator;
             self.sampled_data_locations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [schema_change][crate::model::action::IncompatibleDataSchema::schema_change].
+        pub fn set_schema_change<
+            T: std::convert::Into<crate::model::action::incompatible_data_schema::SchemaChange>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.schema_change = v.into();
             self
         }
     }
@@ -27152,6 +27152,18 @@ impl Asset {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Asset::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Asset::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -27216,18 +27228,6 @@ impl Asset {
         v: T,
     ) -> Self {
         self.discovery_status = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Asset::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -27504,6 +27504,28 @@ pub mod asset {
             self
         }
 
+        /// Sets the value of [include_patterns][crate::model::asset::DiscoverySpec::include_patterns].
+        pub fn set_include_patterns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.include_patterns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [exclude_patterns][crate::model::asset::DiscoverySpec::exclude_patterns].
+        pub fn set_exclude_patterns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.exclude_patterns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [csv_options][crate::model::asset::DiscoverySpec::csv_options].
         pub fn set_csv_options<
             T: std::convert::Into<
@@ -27527,28 +27549,6 @@ pub mod asset {
             v: T,
         ) -> Self {
             self.json_options = v.into();
-            self
-        }
-
-        /// Sets the value of [include_patterns][crate::model::asset::DiscoverySpec::include_patterns].
-        pub fn set_include_patterns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.include_patterns = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [exclude_patterns][crate::model::asset::DiscoverySpec::exclude_patterns].
-        pub fn set_exclude_patterns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.exclude_patterns = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -29002,12 +29002,6 @@ impl ListLakesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLakesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [lakes][crate::model::ListLakesResponse::lakes].
     pub fn set_lakes<T, V>(mut self, v: T) -> Self
     where
@@ -29016,6 +29010,12 @@ impl ListLakesResponse {
     {
         use std::iter::Iterator;
         self.lakes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLakesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -29133,12 +29133,6 @@ impl ListActionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListActionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [actions][crate::model::ListActionsResponse::actions].
     pub fn set_actions<T, V>(mut self, v: T) -> Self
     where
@@ -29147,6 +29141,12 @@ impl ListActionsResponse {
     {
         use std::iter::Iterator;
         self.actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListActionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -29474,12 +29474,6 @@ impl ListZonesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListZonesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [zones][crate::model::ListZonesResponse::zones].
     pub fn set_zones<T, V>(mut self, v: T) -> Self
     where
@@ -29488,6 +29482,12 @@ impl ListZonesResponse {
     {
         use std::iter::Iterator;
         self.zones = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListZonesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -29873,12 +29873,6 @@ impl ListAssetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assets][crate::model::ListAssetsResponse::assets].
     pub fn set_assets<T, V>(mut self, v: T) -> Self
     where
@@ -29887,6 +29881,12 @@ impl ListAssetsResponse {
     {
         use std::iter::Iterator;
         self.assets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -30371,12 +30371,6 @@ impl ListTasksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tasks][crate::model::ListTasksResponse::tasks].
     pub fn set_tasks<T, V>(mut self, v: T) -> Self
     where
@@ -30385,6 +30379,12 @@ impl ListTasksResponse {
     {
         use std::iter::Iterator;
         self.tasks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -30678,12 +30678,6 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -30692,6 +30686,12 @@ impl ListJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -31022,12 +31022,6 @@ impl ListEnvironmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [environments][crate::model::ListEnvironmentsResponse::environments].
     pub fn set_environments<T, V>(mut self, v: T) -> Self
     where
@@ -31036,6 +31030,12 @@ impl ListEnvironmentsResponse {
     {
         use std::iter::Iterator;
         self.environments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -31193,12 +31193,6 @@ impl ListSessionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sessions][crate::model::ListSessionsResponse::sessions].
     pub fn set_sessions<T, V>(mut self, v: T) -> Self
     where
@@ -31207,6 +31201,12 @@ impl ListSessionsResponse {
     {
         use std::iter::Iterator;
         self.sessions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -31344,6 +31344,18 @@ impl Task {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Task::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [trigger_spec][crate::model::Task::trigger_spec].
     pub fn set_trigger_spec<
         T: std::convert::Into<std::option::Option<crate::model::task::TriggerSpec>>,
@@ -31377,18 +31389,6 @@ impl Task {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Task::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [config][crate::model::Task::config].
     ///
     /// Note that all the setters affecting `config` are mutually
@@ -31414,19 +31414,6 @@ impl Task {
         })
     }
 
-    /// The value of [config][crate::model::Task::config]
-    /// if it holds a `Notebook`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn notebook(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::task::NotebookTaskConfig>> {
-        #[allow(unreachable_patterns)]
-        self.config.as_ref().and_then(|v| match v {
-            crate::model::task::Config::Notebook(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [config][crate::model::Task::config]
     /// to hold a `Spark`.
     ///
@@ -31440,6 +31427,19 @@ impl Task {
     ) -> Self {
         self.config = std::option::Option::Some(crate::model::task::Config::Spark(v.into()));
         self
+    }
+
+    /// The value of [config][crate::model::Task::config]
+    /// if it holds a `Notebook`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn notebook(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::task::NotebookTaskConfig>> {
+        #[allow(unreachable_patterns)]
+        self.config.as_ref().and_then(|v| match v {
+            crate::model::task::Config::Notebook(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [config][crate::model::Task::config]
@@ -31862,17 +31862,6 @@ pub mod task {
                 })
             }
 
-            /// The value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
-            /// if it holds a `SubNetwork`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn sub_network(&self) -> std::option::Option<&std::string::String> {
-                #[allow(unreachable_patterns)]
-                self.network_name.as_ref().and_then(|v| match v {
-                    crate::model::task::infrastructure_spec::vpc_network::NetworkName::SubNetwork(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
             /// to hold a `Network`.
             ///
@@ -31885,6 +31874,17 @@ pub mod task {
                     ),
                 );
                 self
+            }
+
+            /// The value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
+            /// if it holds a `SubNetwork`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn sub_network(&self) -> std::option::Option<&std::string::String> {
+                #[allow(unreachable_patterns)]
+                self.network_name.as_ref().and_then(|v| match v {
+                    crate::model::task::infrastructure_spec::vpc_network::NetworkName::SubNetwork(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
@@ -32286,6 +32286,18 @@ pub mod task {
             std::default::Default::default()
         }
 
+        /// Sets the value of [args][crate::model::task::ExecutionSpec::args].
+        pub fn set_args<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.args = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [service_account][crate::model::task::ExecutionSpec::service_account].
         pub fn set_service_account<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -32315,18 +32327,6 @@ pub mod task {
         /// Sets the value of [kms_key][crate::model::task::ExecutionSpec::kms_key].
         pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.kms_key = v.into();
-            self
-        }
-
-        /// Sets the value of [args][crate::model::task::ExecutionSpec::args].
-        pub fn set_args<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.args = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -32373,17 +32373,6 @@ pub mod task {
             std::default::Default::default()
         }
 
-        /// Sets the value of [infrastructure_spec][crate::model::task::SparkTaskConfig::infrastructure_spec].
-        pub fn set_infrastructure_spec<
-            T: std::convert::Into<std::option::Option<crate::model::task::InfrastructureSpec>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.infrastructure_spec = v.into();
-            self
-        }
-
         /// Sets the value of [file_uris][crate::model::task::SparkTaskConfig::file_uris].
         pub fn set_file_uris<T, V>(mut self, v: T) -> Self
         where
@@ -32403,6 +32392,17 @@ pub mod task {
         {
             use std::iter::Iterator;
             self.archive_uris = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [infrastructure_spec][crate::model::task::SparkTaskConfig::infrastructure_spec].
+        pub fn set_infrastructure_spec<
+            T: std::convert::Into<std::option::Option<crate::model::task::InfrastructureSpec>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.infrastructure_spec = v.into();
             self
         }
 
@@ -32433,58 +32433,6 @@ pub mod task {
             })
         }
 
-        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// if it holds a `MainClass`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn main_class(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.driver.as_ref().and_then(|v| match v {
-                crate::model::task::spark_task_config::Driver::MainClass(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// if it holds a `PythonScriptFile`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn python_script_file(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.driver.as_ref().and_then(|v| match v {
-                crate::model::task::spark_task_config::Driver::PythonScriptFile(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// if it holds a `SqlScriptFile`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sql_script_file(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.driver.as_ref().and_then(|v| match v {
-                crate::model::task::spark_task_config::Driver::SqlScriptFile(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// if it holds a `SqlScript`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sql_script(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.driver.as_ref().and_then(|v| match v {
-                crate::model::task::spark_task_config::Driver::SqlScript(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
         /// to hold a `MainJarFileUri`.
         ///
@@ -32500,6 +32448,19 @@ pub mod task {
             self
         }
 
+        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
+        /// if it holds a `MainClass`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn main_class(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.driver.as_ref().and_then(|v| match v {
+                crate::model::task::spark_task_config::Driver::MainClass(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
         /// to hold a `MainClass`.
         ///
@@ -32510,6 +32471,19 @@ pub mod task {
                 crate::model::task::spark_task_config::Driver::MainClass(v.into()),
             );
             self
+        }
+
+        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
+        /// if it holds a `PythonScriptFile`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn python_script_file(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.driver.as_ref().and_then(|v| match v {
+                crate::model::task::spark_task_config::Driver::PythonScriptFile(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
@@ -32527,6 +32501,19 @@ pub mod task {
             self
         }
 
+        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
+        /// if it holds a `SqlScriptFile`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sql_script_file(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.driver.as_ref().and_then(|v| match v {
+                crate::model::task::spark_task_config::Driver::SqlScriptFile(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
         /// to hold a `SqlScriptFile`.
         ///
@@ -32540,6 +32527,19 @@ pub mod task {
                 crate::model::task::spark_task_config::Driver::SqlScriptFile(v.into()),
             );
             self
+        }
+
+        /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
+        /// if it holds a `SqlScript`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sql_script(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.driver.as_ref().and_then(|v| match v {
+                crate::model::task::spark_task_config::Driver::SqlScript(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
@@ -32864,6 +32864,18 @@ impl Job {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Job::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [trigger][crate::model::Job::trigger].
     pub fn set_trigger<T: std::convert::Into<crate::model::job::Trigger>>(mut self, v: T) -> Self {
         self.trigger = v.into();
@@ -32878,18 +32890,6 @@ impl Job {
         v: T,
     ) -> Self {
         self.execution_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Job::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -766,12 +766,6 @@ impl ListAutoscalingPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutoscalingPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policies][crate::model::ListAutoscalingPoliciesResponse::policies].
     pub fn set_policies<T, V>(mut self, v: T) -> Self
     where
@@ -780,6 +774,12 @@ impl ListAutoscalingPoliciesResponse {
     {
         use std::iter::Iterator;
         self.policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutoscalingPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1038,12 +1038,6 @@ impl ListBatchesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBatchesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [batches][crate::model::ListBatchesResponse::batches].
     pub fn set_batches<T, V>(mut self, v: T) -> Self
     where
@@ -1052,6 +1046,12 @@ impl ListBatchesResponse {
     {
         use std::iter::Iterator;
         self.batches = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBatchesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1258,6 +1258,18 @@ impl Batch {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Batch::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [runtime_config][crate::model::Batch::runtime_config].
     pub fn set_runtime_config<
         T: std::convert::Into<std::option::Option<crate::model::RuntimeConfig>>,
@@ -1297,18 +1309,6 @@ impl Batch {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Batch::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [batch_config][crate::model::Batch::batch_config].
     ///
     /// Note that all the setters affecting `batch_config` are mutually
@@ -1336,43 +1336,6 @@ impl Batch {
         })
     }
 
-    /// The value of [batch_config][crate::model::Batch::batch_config]
-    /// if it holds a `SparkBatch`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_batch(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkBatch>> {
-        #[allow(unreachable_patterns)]
-        self.batch_config.as_ref().and_then(|v| match v {
-            crate::model::batch::BatchConfig::SparkBatch(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [batch_config][crate::model::Batch::batch_config]
-    /// if it holds a `SparkRBatch`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_r_batch(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkRBatch>> {
-        #[allow(unreachable_patterns)]
-        self.batch_config.as_ref().and_then(|v| match v {
-            crate::model::batch::BatchConfig::SparkRBatch(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [batch_config][crate::model::Batch::batch_config]
-    /// if it holds a `SparkSqlBatch`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_sql_batch(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSqlBatch>> {
-        #[allow(unreachable_patterns)]
-        self.batch_config.as_ref().and_then(|v| match v {
-            crate::model::batch::BatchConfig::SparkSqlBatch(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [batch_config][crate::model::Batch::batch_config]
     /// to hold a `PysparkBatch`.
     ///
@@ -1385,6 +1348,17 @@ impl Batch {
         self.batch_config =
             std::option::Option::Some(crate::model::batch::BatchConfig::PysparkBatch(v.into()));
         self
+    }
+
+    /// The value of [batch_config][crate::model::Batch::batch_config]
+    /// if it holds a `SparkBatch`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_batch(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkBatch>> {
+        #[allow(unreachable_patterns)]
+        self.batch_config.as_ref().and_then(|v| match v {
+            crate::model::batch::BatchConfig::SparkBatch(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [batch_config][crate::model::Batch::batch_config]
@@ -1401,6 +1375,19 @@ impl Batch {
         self
     }
 
+    /// The value of [batch_config][crate::model::Batch::batch_config]
+    /// if it holds a `SparkRBatch`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_r_batch(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkRBatch>> {
+        #[allow(unreachable_patterns)]
+        self.batch_config.as_ref().and_then(|v| match v {
+            crate::model::batch::BatchConfig::SparkRBatch(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [batch_config][crate::model::Batch::batch_config]
     /// to hold a `SparkRBatch`.
     ///
@@ -1413,6 +1400,19 @@ impl Batch {
         self.batch_config =
             std::option::Option::Some(crate::model::batch::BatchConfig::SparkRBatch(v.into()));
         self
+    }
+
+    /// The value of [batch_config][crate::model::Batch::batch_config]
+    /// if it holds a `SparkSqlBatch`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_sql_batch(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSqlBatch>> {
+        #[allow(unreachable_patterns)]
+        self.batch_config.as_ref().and_then(|v| match v {
+            crate::model::batch::BatchConfig::SparkSqlBatch(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [batch_config][crate::model::Batch::batch_config]
@@ -1915,17 +1915,6 @@ impl SparkBatch {
         })
     }
 
-    /// The value of [driver][crate::model::SparkBatch::driver]
-    /// if it holds a `MainClass`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.driver.as_ref().and_then(|v| match v {
-            crate::model::spark_batch::Driver::MainClass(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [driver][crate::model::SparkBatch::driver]
     /// to hold a `MainJarFileUri`.
     ///
@@ -1938,6 +1927,17 @@ impl SparkBatch {
         self.driver =
             std::option::Option::Some(crate::model::spark_batch::Driver::MainJarFileUri(v.into()));
         self
+    }
+
+    /// The value of [driver][crate::model::SparkBatch::driver]
+    /// if it holds a `MainClass`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.driver.as_ref().and_then(|v| match v {
+            crate::model::spark_batch::Driver::MainClass(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [driver][crate::model::SparkBatch::driver]
@@ -2102,17 +2102,6 @@ impl SparkSqlBatch {
         self
     }
 
-    /// Sets the value of [jar_file_uris][crate::model::SparkSqlBatch::jar_file_uris].
-    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [query_variables][crate::model::SparkSqlBatch::query_variables].
     pub fn set_query_variables<T, K, V>(mut self, v: T) -> Self
     where
@@ -2122,6 +2111,17 @@ impl SparkSqlBatch {
     {
         use std::iter::Iterator;
         self.query_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [jar_file_uris][crate::model::SparkSqlBatch::jar_file_uris].
+    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2244,12 +2244,35 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Cluster::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [status][crate::model::Cluster::status].
     pub fn set_status<T: std::convert::Into<std::option::Option<crate::model::ClusterStatus>>>(
         mut self,
         v: T,
     ) -> Self {
         self.status = v.into();
+        self
+    }
+
+    /// Sets the value of [status_history][crate::model::Cluster::status_history].
+    pub fn set_status_history<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClusterStatus>,
+    {
+        use std::iter::Iterator;
+        self.status_history = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2265,29 +2288,6 @@ impl Cluster {
         v: T,
     ) -> Self {
         self.metrics = v.into();
-        self
-    }
-
-    /// Sets the value of [status_history][crate::model::Cluster::status_history].
-    pub fn set_status_history<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClusterStatus>,
-    {
-        use std::iter::Iterator;
-        self.status_history = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Cluster::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2483,6 +2483,17 @@ impl ClusterConfig {
         self
     }
 
+    /// Sets the value of [initialization_actions][crate::model::ClusterConfig::initialization_actions].
+    pub fn set_initialization_actions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NodeInitializationAction>,
+    {
+        use std::iter::Iterator;
+        self.initialization_actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [encryption_config][crate::model::ClusterConfig::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionConfig>>,
@@ -2557,17 +2568,6 @@ impl ClusterConfig {
         v: T,
     ) -> Self {
         self.dataproc_metric_config = v.into();
-        self
-    }
-
-    /// Sets the value of [initialization_actions][crate::model::ClusterConfig::initialization_actions].
-    pub fn set_initialization_actions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NodeInitializationAction>,
-    {
-        use std::iter::Iterator;
-        self.initialization_actions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2794,12 +2794,6 @@ impl EndpointConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [enable_http_port_access][crate::model::EndpointConfig::enable_http_port_access].
-    pub fn set_enable_http_port_access<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_http_port_access = v.into();
-        self
-    }
-
     /// Sets the value of [http_ports][crate::model::EndpointConfig::http_ports].
     pub fn set_http_ports<T, K, V>(mut self, v: T) -> Self
     where
@@ -2809,6 +2803,12 @@ impl EndpointConfig {
     {
         use std::iter::Iterator;
         self.http_ports = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [enable_http_port_access][crate::model::EndpointConfig::enable_http_port_access].
+    pub fn set_enable_http_port_access<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_http_port_access = v.into();
         self
     }
 }
@@ -3114,6 +3114,40 @@ impl GceClusterConfig {
         self
     }
 
+    /// Sets the value of [service_account_scopes][crate::model::GceClusterConfig::service_account_scopes].
+    pub fn set_service_account_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.service_account_scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::GceClusterConfig::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::GceClusterConfig::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [reservation_affinity][crate::model::GceClusterConfig::reservation_affinity].
     pub fn set_reservation_affinity<
         T: std::convert::Into<std::option::Option<crate::model::ReservationAffinity>>,
@@ -3155,40 +3189,6 @@ impl GceClusterConfig {
         v: T,
     ) -> Self {
         self.confidential_instance_config = v.into();
-        self
-    }
-
-    /// Sets the value of [service_account_scopes][crate::model::GceClusterConfig::service_account_scopes].
-    pub fn set_service_account_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.service_account_scopes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::GceClusterConfig::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::GceClusterConfig::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3640,6 +3640,28 @@ impl InstanceGroupConfig {
         self
     }
 
+    /// Sets the value of [instance_names][crate::model::InstanceGroupConfig::instance_names].
+    pub fn set_instance_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.instance_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [instance_references][crate::model::InstanceGroupConfig::instance_references].
+    pub fn set_instance_references<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InstanceReference>,
+    {
+        use std::iter::Iterator;
+        self.instance_references = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [image_uri][crate::model::InstanceGroupConfig::image_uri].
     pub fn set_image_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.image_uri = v.into();
@@ -3692,6 +3714,17 @@ impl InstanceGroupConfig {
         self
     }
 
+    /// Sets the value of [accelerators][crate::model::InstanceGroupConfig::accelerators].
+    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AcceleratorConfig>,
+    {
+        use std::iter::Iterator;
+        self.accelerators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [min_cpu_platform][crate::model::InstanceGroupConfig::min_cpu_platform].
     pub fn set_min_cpu_platform<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -3726,39 +3759,6 @@ impl InstanceGroupConfig {
         v: T,
     ) -> Self {
         self.startup_config = v.into();
-        self
-    }
-
-    /// Sets the value of [instance_names][crate::model::InstanceGroupConfig::instance_names].
-    pub fn set_instance_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.instance_names = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [instance_references][crate::model::InstanceGroupConfig::instance_references].
-    pub fn set_instance_references<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InstanceReference>,
-    {
-        use std::iter::Iterator;
-        self.instance_references = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [accelerators][crate::model::InstanceGroupConfig::accelerators].
-    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AcceleratorConfig>,
-    {
-        use std::iter::Iterator;
-        self.accelerators = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4271,12 +4271,6 @@ pub mod instance_flexibility_policy {
             std::default::Default::default()
         }
 
-        /// Sets the value of [rank][crate::model::instance_flexibility_policy::InstanceSelection::rank].
-        pub fn set_rank<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.rank = v.into();
-            self
-        }
-
         /// Sets the value of [machine_types][crate::model::instance_flexibility_policy::InstanceSelection::machine_types].
         pub fn set_machine_types<T, V>(mut self, v: T) -> Self
         where
@@ -4285,6 +4279,12 @@ pub mod instance_flexibility_policy {
         {
             use std::iter::Iterator;
             self.machine_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [rank][crate::model::instance_flexibility_policy::InstanceSelection::rank].
+        pub fn set_rank<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.rank = v.into();
             self
         }
     }
@@ -4619,17 +4619,6 @@ impl NodeGroup {
         self
     }
 
-    /// Sets the value of [node_group_config][crate::model::NodeGroup::node_group_config].
-    pub fn set_node_group_config<
-        T: std::convert::Into<std::option::Option<crate::model::InstanceGroupConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.node_group_config = v.into();
-        self
-    }
-
     /// Sets the value of [roles][crate::model::NodeGroup::roles].
     pub fn set_roles<T, V>(mut self, v: T) -> Self
     where
@@ -4638,6 +4627,17 @@ impl NodeGroup {
     {
         use std::iter::Iterator;
         self.roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [node_group_config][crate::model::NodeGroup::node_group_config].
+    pub fn set_node_group_config<
+        T: std::convert::Into<std::option::Option<crate::model::InstanceGroupConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.node_group_config = v.into();
         self
     }
 
@@ -5620,17 +5620,6 @@ impl SoftwareConfig {
         self
     }
 
-    /// Sets the value of [optional_components][crate::model::SoftwareConfig::optional_components].
-    pub fn set_optional_components<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Component>,
-    {
-        use std::iter::Iterator;
-        self.optional_components = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [properties][crate::model::SoftwareConfig::properties].
     pub fn set_properties<T, K, V>(mut self, v: T) -> Self
     where
@@ -5640,6 +5629,17 @@ impl SoftwareConfig {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [optional_components][crate::model::SoftwareConfig::optional_components].
+    pub fn set_optional_components<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Component>,
+    {
+        use std::iter::Iterator;
+        self.optional_components = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5728,17 +5728,6 @@ impl LifecycleConfig {
         })
     }
 
-    /// The value of [ttl][crate::model::LifecycleConfig::ttl]
-    /// if it holds a `AutoDeleteTtl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn auto_delete_ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.ttl.as_ref().and_then(|v| match v {
-            crate::model::lifecycle_config::Ttl::AutoDeleteTtl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [ttl][crate::model::LifecycleConfig::ttl]
     /// to hold a `AutoDeleteTime`.
     ///
@@ -5752,6 +5741,17 @@ impl LifecycleConfig {
             v.into(),
         ));
         self
+    }
+
+    /// The value of [ttl][crate::model::LifecycleConfig::ttl]
+    /// if it holds a `AutoDeleteTtl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn auto_delete_ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.ttl.as_ref().and_then(|v| match v {
+            crate::model::lifecycle_config::Ttl::AutoDeleteTtl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [ttl][crate::model::LifecycleConfig::ttl]
@@ -6881,12 +6881,6 @@ impl ListClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
     pub fn set_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -6895,6 +6889,12 @@ impl ListClustersResponse {
     {
         use std::iter::Iterator;
         self.clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7717,17 +7717,6 @@ impl HadoopJob {
         std::default::Default::default()
     }
 
-    /// Sets the value of [logging_config][crate::model::HadoopJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [args][crate::model::HadoopJob::args].
     pub fn set_args<T, V>(mut self, v: T) -> Self
     where
@@ -7784,6 +7773,17 @@ impl HadoopJob {
         self
     }
 
+    /// Sets the value of [logging_config][crate::model::HadoopJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
+        self
+    }
+
     /// Sets the value of [driver][crate::model::HadoopJob::driver].
     ///
     /// Note that all the setters affecting `driver` are mutually
@@ -7809,17 +7809,6 @@ impl HadoopJob {
         })
     }
 
-    /// The value of [driver][crate::model::HadoopJob::driver]
-    /// if it holds a `MainClass`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.driver.as_ref().and_then(|v| match v {
-            crate::model::hadoop_job::Driver::MainClass(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [driver][crate::model::HadoopJob::driver]
     /// to hold a `MainJarFileUri`.
     ///
@@ -7832,6 +7821,17 @@ impl HadoopJob {
         self.driver =
             std::option::Option::Some(crate::model::hadoop_job::Driver::MainJarFileUri(v.into()));
         self
+    }
+
+    /// The value of [driver][crate::model::HadoopJob::driver]
+    /// if it holds a `MainClass`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.driver.as_ref().and_then(|v| match v {
+            crate::model::hadoop_job::Driver::MainClass(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [driver][crate::model::HadoopJob::driver]
@@ -7938,17 +7938,6 @@ impl SparkJob {
         std::default::Default::default()
     }
 
-    /// Sets the value of [logging_config][crate::model::SparkJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [args][crate::model::SparkJob::args].
     pub fn set_args<T, V>(mut self, v: T) -> Self
     where
@@ -8005,6 +7994,17 @@ impl SparkJob {
         self
     }
 
+    /// Sets the value of [logging_config][crate::model::SparkJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
+        self
+    }
+
     /// Sets the value of [driver][crate::model::SparkJob::driver].
     ///
     /// Note that all the setters affecting `driver` are mutually
@@ -8030,17 +8030,6 @@ impl SparkJob {
         })
     }
 
-    /// The value of [driver][crate::model::SparkJob::driver]
-    /// if it holds a `MainClass`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.driver.as_ref().and_then(|v| match v {
-            crate::model::spark_job::Driver::MainClass(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [driver][crate::model::SparkJob::driver]
     /// to hold a `MainJarFileUri`.
     ///
@@ -8053,6 +8042,17 @@ impl SparkJob {
         self.driver =
             std::option::Option::Some(crate::model::spark_job::Driver::MainJarFileUri(v.into()));
         self
+    }
+
+    /// The value of [driver][crate::model::SparkJob::driver]
+    /// if it holds a `MainClass`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.driver.as_ref().and_then(|v| match v {
+            crate::model::spark_job::Driver::MainClass(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [driver][crate::model::SparkJob::driver]
@@ -8170,17 +8170,6 @@ impl PySparkJob {
         self
     }
 
-    /// Sets the value of [logging_config][crate::model::PySparkJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [args][crate::model::PySparkJob::args].
     pub fn set_args<T, V>(mut self, v: T) -> Self
     where
@@ -8245,6 +8234,17 @@ impl PySparkJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::PySparkJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 }
@@ -8358,17 +8358,6 @@ impl HiveJob {
         self
     }
 
-    /// Sets the value of [jar_file_uris][crate::model::HiveJob::jar_file_uris].
-    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [script_variables][crate::model::HiveJob::script_variables].
     pub fn set_script_variables<T, K, V>(mut self, v: T) -> Self
     where
@@ -8390,6 +8379,17 @@ impl HiveJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [jar_file_uris][crate::model::HiveJob::jar_file_uris].
+    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8418,17 +8418,6 @@ impl HiveJob {
         })
     }
 
-    /// The value of [queries][crate::model::HiveJob::queries]
-    /// if it holds a `QueryList`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
-        #[allow(unreachable_patterns)]
-        self.queries.as_ref().and_then(|v| match v {
-            crate::model::hive_job::Queries::QueryList(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [queries][crate::model::HiveJob::queries]
     /// to hold a `QueryFileUri`.
     ///
@@ -8438,6 +8427,17 @@ impl HiveJob {
         self.queries =
             std::option::Option::Some(crate::model::hive_job::Queries::QueryFileUri(v.into()));
         self
+    }
+
+    /// The value of [queries][crate::model::HiveJob::queries]
+    /// if it holds a `QueryList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
+        #[allow(unreachable_patterns)]
+        self.queries.as_ref().and_then(|v| match v {
+            crate::model::hive_job::Queries::QueryList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [queries][crate::model::HiveJob::queries]
@@ -8519,28 +8519,6 @@ impl SparkSqlJob {
         std::default::Default::default()
     }
 
-    /// Sets the value of [logging_config][crate::model::SparkSqlJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
-    /// Sets the value of [jar_file_uris][crate::model::SparkSqlJob::jar_file_uris].
-    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [script_variables][crate::model::SparkSqlJob::script_variables].
     pub fn set_script_variables<T, K, V>(mut self, v: T) -> Self
     where
@@ -8562,6 +8540,28 @@ impl SparkSqlJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [jar_file_uris][crate::model::SparkSqlJob::jar_file_uris].
+    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::SparkSqlJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 
@@ -8590,17 +8590,6 @@ impl SparkSqlJob {
         })
     }
 
-    /// The value of [queries][crate::model::SparkSqlJob::queries]
-    /// if it holds a `QueryList`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
-        #[allow(unreachable_patterns)]
-        self.queries.as_ref().and_then(|v| match v {
-            crate::model::spark_sql_job::Queries::QueryList(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [queries][crate::model::SparkSqlJob::queries]
     /// to hold a `QueryFileUri`.
     ///
@@ -8610,6 +8599,17 @@ impl SparkSqlJob {
         self.queries =
             std::option::Option::Some(crate::model::spark_sql_job::Queries::QueryFileUri(v.into()));
         self
+    }
+
+    /// The value of [queries][crate::model::SparkSqlJob::queries]
+    /// if it holds a `QueryList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
+        #[allow(unreachable_patterns)]
+        self.queries.as_ref().and_then(|v| match v {
+            crate::model::spark_sql_job::Queries::QueryList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [queries][crate::model::SparkSqlJob::queries]
@@ -8705,28 +8705,6 @@ impl PigJob {
         self
     }
 
-    /// Sets the value of [logging_config][crate::model::PigJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
-    /// Sets the value of [jar_file_uris][crate::model::PigJob::jar_file_uris].
-    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [script_variables][crate::model::PigJob::script_variables].
     pub fn set_script_variables<T, K, V>(mut self, v: T) -> Self
     where
@@ -8748,6 +8726,28 @@ impl PigJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [jar_file_uris][crate::model::PigJob::jar_file_uris].
+    pub fn set_jar_file_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.jar_file_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::PigJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 
@@ -8776,17 +8776,6 @@ impl PigJob {
         })
     }
 
-    /// The value of [queries][crate::model::PigJob::queries]
-    /// if it holds a `QueryList`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
-        #[allow(unreachable_patterns)]
-        self.queries.as_ref().and_then(|v| match v {
-            crate::model::pig_job::Queries::QueryList(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [queries][crate::model::PigJob::queries]
     /// to hold a `QueryFileUri`.
     ///
@@ -8796,6 +8785,17 @@ impl PigJob {
         self.queries =
             std::option::Option::Some(crate::model::pig_job::Queries::QueryFileUri(v.into()));
         self
+    }
+
+    /// The value of [queries][crate::model::PigJob::queries]
+    /// if it holds a `QueryList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
+        #[allow(unreachable_patterns)]
+        self.queries.as_ref().and_then(|v| match v {
+            crate::model::pig_job::Queries::QueryList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [queries][crate::model::PigJob::queries]
@@ -8893,17 +8893,6 @@ impl SparkRJob {
         self
     }
 
-    /// Sets the value of [logging_config][crate::model::SparkRJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [args][crate::model::SparkRJob::args].
     pub fn set_args<T, V>(mut self, v: T) -> Self
     where
@@ -8946,6 +8935,17 @@ impl SparkRJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::SparkRJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 }
@@ -9017,17 +9017,6 @@ impl PrestoJob {
         self
     }
 
-    /// Sets the value of [logging_config][crate::model::PrestoJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [client_tags][crate::model::PrestoJob::client_tags].
     pub fn set_client_tags<T, V>(mut self, v: T) -> Self
     where
@@ -9048,6 +9037,17 @@ impl PrestoJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::PrestoJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 
@@ -9076,17 +9076,6 @@ impl PrestoJob {
         })
     }
 
-    /// The value of [queries][crate::model::PrestoJob::queries]
-    /// if it holds a `QueryList`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
-        #[allow(unreachable_patterns)]
-        self.queries.as_ref().and_then(|v| match v {
-            crate::model::presto_job::Queries::QueryList(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [queries][crate::model::PrestoJob::queries]
     /// to hold a `QueryFileUri`.
     ///
@@ -9096,6 +9085,17 @@ impl PrestoJob {
         self.queries =
             std::option::Option::Some(crate::model::presto_job::Queries::QueryFileUri(v.into()));
         self
+    }
+
+    /// The value of [queries][crate::model::PrestoJob::queries]
+    /// if it holds a `QueryList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
+        #[allow(unreachable_patterns)]
+        self.queries.as_ref().and_then(|v| match v {
+            crate::model::presto_job::Queries::QueryList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [queries][crate::model::PrestoJob::queries]
@@ -9198,17 +9198,6 @@ impl TrinoJob {
         self
     }
 
-    /// Sets the value of [logging_config][crate::model::TrinoJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [client_tags][crate::model::TrinoJob::client_tags].
     pub fn set_client_tags<T, V>(mut self, v: T) -> Self
     where
@@ -9229,6 +9218,17 @@ impl TrinoJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::TrinoJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 
@@ -9257,17 +9257,6 @@ impl TrinoJob {
         })
     }
 
-    /// The value of [queries][crate::model::TrinoJob::queries]
-    /// if it holds a `QueryList`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
-        #[allow(unreachable_patterns)]
-        self.queries.as_ref().and_then(|v| match v {
-            crate::model::trino_job::Queries::QueryList(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [queries][crate::model::TrinoJob::queries]
     /// to hold a `QueryFileUri`.
     ///
@@ -9277,6 +9266,17 @@ impl TrinoJob {
         self.queries =
             std::option::Option::Some(crate::model::trino_job::Queries::QueryFileUri(v.into()));
         self
+    }
+
+    /// The value of [queries][crate::model::TrinoJob::queries]
+    /// if it holds a `QueryList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn query_list(&self) -> std::option::Option<&std::boxed::Box<crate::model::QueryList>> {
+        #[allow(unreachable_patterns)]
+        self.queries.as_ref().and_then(|v| match v {
+            crate::model::trino_job::Queries::QueryList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [queries][crate::model::TrinoJob::queries]
@@ -9372,23 +9372,6 @@ impl FlinkJob {
         std::default::Default::default()
     }
 
-    /// Sets the value of [savepoint_uri][crate::model::FlinkJob::savepoint_uri].
-    pub fn set_savepoint_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.savepoint_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [logging_config][crate::model::FlinkJob::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [args][crate::model::FlinkJob::args].
     pub fn set_args<T, V>(mut self, v: T) -> Self
     where
@@ -9411,6 +9394,12 @@ impl FlinkJob {
         self
     }
 
+    /// Sets the value of [savepoint_uri][crate::model::FlinkJob::savepoint_uri].
+    pub fn set_savepoint_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.savepoint_uri = v.into();
+        self
+    }
+
     /// Sets the value of [properties][crate::model::FlinkJob::properties].
     pub fn set_properties<T, K, V>(mut self, v: T) -> Self
     where
@@ -9420,6 +9409,17 @@ impl FlinkJob {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::FlinkJob::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 
@@ -9448,17 +9448,6 @@ impl FlinkJob {
         })
     }
 
-    /// The value of [driver][crate::model::FlinkJob::driver]
-    /// if it holds a `MainClass`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.driver.as_ref().and_then(|v| match v {
-            crate::model::flink_job::Driver::MainClass(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [driver][crate::model::FlinkJob::driver]
     /// to hold a `MainJarFileUri`.
     ///
@@ -9471,6 +9460,17 @@ impl FlinkJob {
         self.driver =
             std::option::Option::Some(crate::model::flink_job::Driver::MainJarFileUri(v.into()));
         self
+    }
+
+    /// The value of [driver][crate::model::FlinkJob::driver]
+    /// if it holds a `MainClass`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn main_class(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.driver.as_ref().and_then(|v| match v {
+            crate::model::flink_job::Driver::MainClass(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [driver][crate::model::FlinkJob::driver]
@@ -10409,6 +10409,28 @@ impl Job {
         self
     }
 
+    /// Sets the value of [status_history][crate::model::Job::status_history].
+    pub fn set_status_history<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::JobStatus>,
+    {
+        use std::iter::Iterator;
+        self.status_history = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [yarn_applications][crate::model::Job::yarn_applications].
+    pub fn set_yarn_applications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::YarnApplication>,
+    {
+        use std::iter::Iterator;
+        self.yarn_applications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [driver_output_resource_uri][crate::model::Job::driver_output_resource_uri].
     pub fn set_driver_output_resource_uri<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -10424,6 +10446,18 @@ impl Job {
         v: T,
     ) -> Self {
         self.driver_control_files_uri = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Job::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -10461,40 +10495,6 @@ impl Job {
         self
     }
 
-    /// Sets the value of [status_history][crate::model::Job::status_history].
-    pub fn set_status_history<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::JobStatus>,
-    {
-        use std::iter::Iterator;
-        self.status_history = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [yarn_applications][crate::model::Job::yarn_applications].
-    pub fn set_yarn_applications<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::YarnApplication>,
-    {
-        use std::iter::Iterator;
-        self.yarn_applications = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Job::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [type_job][crate::model::Job::type_job].
     ///
     /// Note that all the setters affecting `type_job` are mutually
@@ -10518,107 +10518,6 @@ impl Job {
         })
     }
 
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `SparkJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::SparkJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `PysparkJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pyspark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PySparkJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::PysparkJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `HiveJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn hive_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::HiveJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::HiveJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `PigJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pig_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PigJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::PigJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `SparkRJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_r_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkRJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::SparkRJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `SparkSqlJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_sql_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSqlJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::SparkSqlJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `PrestoJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn presto_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PrestoJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::PrestoJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `TrinoJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn trino_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::TrinoJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::TrinoJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [type_job][crate::model::Job::type_job]
-    /// if it holds a `FlinkJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn flink_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::FlinkJob>> {
-        #[allow(unreachable_patterns)]
-        self.type_job.as_ref().and_then(|v| match v {
-            crate::model::job::TypeJob::FlinkJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [type_job][crate::model::Job::type_job]
     /// to hold a `HadoopJob`.
     ///
@@ -10630,6 +10529,17 @@ impl Job {
     ) -> Self {
         self.type_job = std::option::Option::Some(crate::model::job::TypeJob::HadoopJob(v.into()));
         self
+    }
+
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `SparkJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::SparkJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_job][crate::model::Job::type_job]
@@ -10645,6 +10555,17 @@ impl Job {
         self
     }
 
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `PysparkJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pyspark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PySparkJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::PysparkJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [type_job][crate::model::Job::type_job]
     /// to hold a `PysparkJob`.
     ///
@@ -10656,6 +10577,17 @@ impl Job {
     ) -> Self {
         self.type_job = std::option::Option::Some(crate::model::job::TypeJob::PysparkJob(v.into()));
         self
+    }
+
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `HiveJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn hive_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::HiveJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::HiveJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_job][crate::model::Job::type_job]
@@ -10671,6 +10603,17 @@ impl Job {
         self
     }
 
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `PigJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pig_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PigJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::PigJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [type_job][crate::model::Job::type_job]
     /// to hold a `PigJob`.
     ///
@@ -10684,6 +10627,17 @@ impl Job {
         self
     }
 
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `SparkRJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_r_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkRJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::SparkRJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [type_job][crate::model::Job::type_job]
     /// to hold a `SparkRJob`.
     ///
@@ -10695,6 +10649,19 @@ impl Job {
     ) -> Self {
         self.type_job = std::option::Option::Some(crate::model::job::TypeJob::SparkRJob(v.into()));
         self
+    }
+
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `SparkSqlJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_sql_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSqlJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::SparkSqlJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_job][crate::model::Job::type_job]
@@ -10711,6 +10678,17 @@ impl Job {
         self
     }
 
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `PrestoJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn presto_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PrestoJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::PrestoJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [type_job][crate::model::Job::type_job]
     /// to hold a `PrestoJob`.
     ///
@@ -10724,6 +10702,17 @@ impl Job {
         self
     }
 
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `TrinoJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn trino_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::TrinoJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::TrinoJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [type_job][crate::model::Job::type_job]
     /// to hold a `TrinoJob`.
     ///
@@ -10735,6 +10724,17 @@ impl Job {
     ) -> Self {
         self.type_job = std::option::Option::Some(crate::model::job::TypeJob::TrinoJob(v.into()));
         self
+    }
+
+    /// The value of [type_job][crate::model::Job::type_job]
+    /// if it holds a `FlinkJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn flink_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::FlinkJob>> {
+        #[allow(unreachable_patterns)]
+        self.type_job.as_ref().and_then(|v| match v {
+            crate::model::job::TypeJob::FlinkJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [type_job][crate::model::Job::type_job]
@@ -11466,12 +11466,6 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -11480,6 +11474,12 @@ impl ListJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -11926,17 +11926,6 @@ impl BatchOperationMetadata {
         self
     }
 
-    /// Sets the value of [warnings][crate::model::BatchOperationMetadata::warnings].
-    pub fn set_warnings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.warnings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::BatchOperationMetadata::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -11946,6 +11935,17 @@ impl BatchOperationMetadata {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [warnings][crate::model::BatchOperationMetadata::warnings].
+    pub fn set_warnings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.warnings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -12180,17 +12180,6 @@ impl SessionOperationMetadata {
         self
     }
 
-    /// Sets the value of [warnings][crate::model::SessionOperationMetadata::warnings].
-    pub fn set_warnings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.warnings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::SessionOperationMetadata::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -12200,6 +12189,17 @@ impl SessionOperationMetadata {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [warnings][crate::model::SessionOperationMetadata::warnings].
+    pub fn set_warnings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.warnings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -12643,6 +12643,17 @@ impl ClusterOperationMetadata {
         self
     }
 
+    /// Sets the value of [status_history][crate::model::ClusterOperationMetadata::status_history].
+    pub fn set_status_history<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClusterOperationStatus>,
+    {
+        use std::iter::Iterator;
+        self.status_history = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [operation_type][crate::model::ClusterOperationMetadata::operation_type].
     pub fn set_operation_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_type = v.into();
@@ -12655,14 +12666,15 @@ impl ClusterOperationMetadata {
         self
     }
 
-    /// Sets the value of [status_history][crate::model::ClusterOperationMetadata::status_history].
-    pub fn set_status_history<T, V>(mut self, v: T) -> Self
+    /// Sets the value of [labels][crate::model::ClusterOperationMetadata::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClusterOperationStatus>,
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
     {
         use std::iter::Iterator;
-        self.status_history = v.into_iter().map(|i| i.into()).collect();
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -12685,18 +12697,6 @@ impl ClusterOperationMetadata {
     {
         use std::iter::Iterator;
         self.child_operation_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ClusterOperationMetadata::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -12776,6 +12776,17 @@ impl NodeGroupOperationMetadata {
         self
     }
 
+    /// Sets the value of [status_history][crate::model::NodeGroupOperationMetadata::status_history].
+    pub fn set_status_history<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClusterOperationStatus>,
+    {
+        use std::iter::Iterator;
+        self.status_history = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [operation_type][crate::model::NodeGroupOperationMetadata::operation_type].
     pub fn set_operation_type<
         T: std::convert::Into<crate::model::node_group_operation_metadata::NodeGroupOperationType>,
@@ -12793,14 +12804,15 @@ impl NodeGroupOperationMetadata {
         self
     }
 
-    /// Sets the value of [status_history][crate::model::NodeGroupOperationMetadata::status_history].
-    pub fn set_status_history<T, V>(mut self, v: T) -> Self
+    /// Sets the value of [labels][crate::model::NodeGroupOperationMetadata::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClusterOperationStatus>,
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
     {
         use std::iter::Iterator;
-        self.status_history = v.into_iter().map(|i| i.into()).collect();
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -12812,18 +12824,6 @@ impl NodeGroupOperationMetadata {
     {
         use std::iter::Iterator;
         self.warnings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NodeGroupOperationMetadata::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -13195,12 +13195,6 @@ impl ListSessionTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [session_templates][crate::model::ListSessionTemplatesResponse::session_templates].
     pub fn set_session_templates<T, V>(mut self, v: T) -> Self
     where
@@ -13209,6 +13203,12 @@ impl ListSessionTemplatesResponse {
     {
         use std::iter::Iterator;
         self.session_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -13354,6 +13354,18 @@ impl SessionTemplate {
         self
     }
 
+    /// Sets the value of [labels][crate::model::SessionTemplate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [runtime_config][crate::model::SessionTemplate::runtime_config].
     pub fn set_runtime_config<
         T: std::convert::Into<std::option::Option<crate::model::RuntimeConfig>>,
@@ -13391,18 +13403,6 @@ impl SessionTemplate {
         self
     }
 
-    /// Sets the value of [labels][crate::model::SessionTemplate::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [session_config][crate::model::SessionTemplate::session_config].
     ///
     /// Note that all the setters affecting `session_config` are mutually
@@ -13432,21 +13432,6 @@ impl SessionTemplate {
         })
     }
 
-    /// The value of [session_config][crate::model::SessionTemplate::session_config]
-    /// if it holds a `SparkConnectSession`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_connect_session(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkConnectConfig>> {
-        #[allow(unreachable_patterns)]
-        self.session_config.as_ref().and_then(|v| match v {
-            crate::model::session_template::SessionConfig::SparkConnectSession(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [session_config][crate::model::SessionTemplate::session_config]
     /// to hold a `JupyterSession`.
     ///
@@ -13462,6 +13447,21 @@ impl SessionTemplate {
             crate::model::session_template::SessionConfig::JupyterSession(v.into()),
         );
         self
+    }
+
+    /// The value of [session_config][crate::model::SessionTemplate::session_config]
+    /// if it holds a `SparkConnectSession`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_connect_session(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkConnectConfig>> {
+        #[allow(unreachable_patterns)]
+        self.session_config.as_ref().and_then(|v| match v {
+            crate::model::session_template::SessionConfig::SparkConnectSession(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [session_config][crate::model::SessionTemplate::session_config]
@@ -13721,12 +13721,6 @@ impl ListSessionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sessions][crate::model::ListSessionsResponse::sessions].
     pub fn set_sessions<T, V>(mut self, v: T) -> Self
     where
@@ -13735,6 +13729,12 @@ impl ListSessionsResponse {
     {
         use std::iter::Iterator;
         self.sessions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -14012,6 +14012,18 @@ impl Session {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Session::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [runtime_config][crate::model::Session::runtime_config].
     pub fn set_runtime_config<
         T: std::convert::Into<std::option::Option<crate::model::RuntimeConfig>>,
@@ -14040,15 +14052,6 @@ impl Session {
         self
     }
 
-    /// Sets the value of [session_template][crate::model::Session::session_template].
-    pub fn set_session_template<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.session_template = v.into();
-        self
-    }
-
     /// Sets the value of [state_history][crate::model::Session::state_history].
     pub fn set_state_history<T, V>(mut self, v: T) -> Self
     where
@@ -14060,15 +14063,12 @@ impl Session {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Session::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [session_template][crate::model::Session::session_template].
+    pub fn set_session_template<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.session_template = v.into();
         self
     }
 
@@ -14099,21 +14099,6 @@ impl Session {
         })
     }
 
-    /// The value of [session_config][crate::model::Session::session_config]
-    /// if it holds a `SparkConnectSession`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_connect_session(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkConnectConfig>> {
-        #[allow(unreachable_patterns)]
-        self.session_config.as_ref().and_then(|v| match v {
-            crate::model::session::SessionConfig::SparkConnectSession(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [session_config][crate::model::Session::session_config]
     /// to hold a `JupyterSession`.
     ///
@@ -14129,6 +14114,21 @@ impl Session {
             crate::model::session::SessionConfig::JupyterSession(v.into()),
         );
         self
+    }
+
+    /// The value of [session_config][crate::model::Session::session_config]
+    /// if it holds a `SparkConnectSession`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_connect_session(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkConnectConfig>> {
+        #[allow(unreachable_patterns)]
+        self.session_config.as_ref().and_then(|v| match v {
+            crate::model::session::SessionConfig::SparkConnectSession(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [session_config][crate::model::Session::session_config]
@@ -14645,6 +14645,18 @@ impl RuntimeConfig {
         self
     }
 
+    /// Sets the value of [properties][crate::model::RuntimeConfig::properties].
+    pub fn set_properties<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [repository_config][crate::model::RuntimeConfig::repository_config].
     pub fn set_repository_config<
         T: std::convert::Into<std::option::Option<crate::model::RepositoryConfig>>,
@@ -14670,18 +14682,6 @@ impl RuntimeConfig {
     /// Sets the value of [cohort][crate::model::RuntimeConfig::cohort].
     pub fn set_cohort<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cohort = v.into();
-        self
-    }
-
-    /// Sets the value of [properties][crate::model::RuntimeConfig::properties].
-    pub fn set_properties<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -14829,6 +14829,17 @@ impl ExecutionConfig {
         self
     }
 
+    /// Sets the value of [network_tags][crate::model::ExecutionConfig::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [kms_key][crate::model::ExecutionConfig::kms_key].
     pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key = v.into();
@@ -14870,17 +14881,6 @@ impl ExecutionConfig {
         self
     }
 
-    /// Sets the value of [network_tags][crate::model::ExecutionConfig::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [network][crate::model::ExecutionConfig::network].
     ///
     /// Note that all the setters affecting `network` are mutually
@@ -14906,6 +14906,18 @@ impl ExecutionConfig {
         })
     }
 
+    /// Sets the value of [network][crate::model::ExecutionConfig::network]
+    /// to hold a `NetworkUri`.
+    ///
+    /// Note that all the setters affecting `network` are
+    /// mutually exclusive.
+    pub fn set_network_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.network = std::option::Option::Some(
+            crate::model::execution_config::Network::NetworkUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [network][crate::model::ExecutionConfig::network]
     /// if it holds a `SubnetworkUri`, `None` if the field is not set or
     /// holds a different branch.
@@ -14917,18 +14929,6 @@ impl ExecutionConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [network][crate::model::ExecutionConfig::network]
-    /// to hold a `NetworkUri`.
-    ///
-    /// Note that all the setters affecting `network` are
-    /// mutually exclusive.
-    pub fn set_network_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.network = std::option::Option::Some(
-            crate::model::execution_config::Network::NetworkUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [network][crate::model::ExecutionConfig::network]
@@ -15108,6 +15108,18 @@ impl RuntimeInfo {
         std::default::Default::default()
     }
 
+    /// Sets the value of [endpoints][crate::model::RuntimeInfo::endpoints].
+    pub fn set_endpoints<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.endpoints = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [output_uri][crate::model::RuntimeInfo::output_uri].
     pub fn set_output_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.output_uri = v.into();
@@ -15142,18 +15154,6 @@ impl RuntimeInfo {
         v: T,
     ) -> Self {
         self.current_usage = v.into();
-        self
-    }
-
-    /// Sets the value of [endpoints][crate::model::RuntimeInfo::endpoints].
-    pub fn set_endpoints<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.endpoints = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -15639,17 +15639,6 @@ impl GkeNodePoolTarget {
         self
     }
 
-    /// Sets the value of [node_pool_config][crate::model::GkeNodePoolTarget::node_pool_config].
-    pub fn set_node_pool_config<
-        T: std::convert::Into<std::option::Option<crate::model::GkeNodePoolConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.node_pool_config = v.into();
-        self
-    }
-
     /// Sets the value of [roles][crate::model::GkeNodePoolTarget::roles].
     pub fn set_roles<T, V>(mut self, v: T) -> Self
     where
@@ -15658,6 +15647,17 @@ impl GkeNodePoolTarget {
     {
         use std::iter::Iterator;
         self.roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [node_pool_config][crate::model::GkeNodePoolTarget::node_pool_config].
+    pub fn set_node_pool_config<
+        T: std::convert::Into<std::option::Option<crate::model::GkeNodePoolConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.node_pool_config = v.into();
         self
     }
 }
@@ -15882,6 +15882,17 @@ impl GkeNodePoolConfig {
         self
     }
 
+    /// Sets the value of [locations][crate::model::GkeNodePoolConfig::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [autoscaling][crate::model::GkeNodePoolConfig::autoscaling].
     pub fn set_autoscaling<
         T: std::convert::Into<
@@ -15894,17 +15905,6 @@ impl GkeNodePoolConfig {
         v: T,
     ) -> Self {
         self.autoscaling = v.into();
-        self
-    }
-
-    /// Sets the value of [locations][crate::model::GkeNodePoolConfig::locations].
-    pub fn set_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -16020,6 +16020,17 @@ pub mod gke_node_pool_config {
             self
         }
 
+        /// Sets the value of [accelerators][crate::model::gke_node_pool_config::GkeNodeConfig::accelerators].
+        pub fn set_accelerators<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::gke_node_pool_config::GkeNodePoolAcceleratorConfig>,
+        {
+            use std::iter::Iterator;
+            self.accelerators = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [min_cpu_platform][crate::model::gke_node_pool_config::GkeNodeConfig::min_cpu_platform].
         pub fn set_min_cpu_platform<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -16041,17 +16052,6 @@ pub mod gke_node_pool_config {
         /// Sets the value of [spot][crate::model::gke_node_pool_config::GkeNodeConfig::spot].
         pub fn set_spot<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.spot = v.into();
-            self
-        }
-
-        /// Sets the value of [accelerators][crate::model::gke_node_pool_config::GkeNodeConfig::accelerators].
-        pub fn set_accelerators<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::gke_node_pool_config::GkeNodePoolAcceleratorConfig>,
-        {
-            use std::iter::Iterator;
-            self.accelerators = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -16738,6 +16738,18 @@ impl WorkflowTemplate {
         self
     }
 
+    /// Sets the value of [labels][crate::model::WorkflowTemplate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [placement][crate::model::WorkflowTemplate::placement].
     pub fn set_placement<
         T: std::convert::Into<std::option::Option<crate::model::WorkflowTemplatePlacement>>,
@@ -16746,26 +16758,6 @@ impl WorkflowTemplate {
         v: T,
     ) -> Self {
         self.placement = v.into();
-        self
-    }
-
-    /// Sets the value of [dag_timeout][crate::model::WorkflowTemplate::dag_timeout].
-    pub fn set_dag_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dag_timeout = v.into();
-        self
-    }
-
-    /// Sets the value of [encryption_config][crate::model::WorkflowTemplate::encryption_config].
-    pub fn set_encryption_config<
-        T: std::convert::Into<std::option::Option<crate::model::workflow_template::EncryptionConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_config = v.into();
         self
     }
 
@@ -16791,15 +16783,23 @@ impl WorkflowTemplate {
         self
     }
 
-    /// Sets the value of [labels][crate::model::WorkflowTemplate::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [dag_timeout][crate::model::WorkflowTemplate::dag_timeout].
+    pub fn set_dag_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.dag_timeout = v.into();
+        self
+    }
+
+    /// Sets the value of [encryption_config][crate::model::WorkflowTemplate::encryption_config].
+    pub fn set_encryption_config<
+        T: std::convert::Into<std::option::Option<crate::model::workflow_template::EncryptionConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.encryption_config = v.into();
         self
     }
 }
@@ -16928,21 +16928,6 @@ impl WorkflowTemplatePlacement {
         })
     }
 
-    /// The value of [placement][crate::model::WorkflowTemplatePlacement::placement]
-    /// if it holds a `ClusterSelector`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cluster_selector(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ClusterSelector>> {
-        #[allow(unreachable_patterns)]
-        self.placement.as_ref().and_then(|v| match v {
-            crate::model::workflow_template_placement::Placement::ClusterSelector(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [placement][crate::model::WorkflowTemplatePlacement::placement]
     /// to hold a `ManagedCluster`.
     ///
@@ -16958,6 +16943,21 @@ impl WorkflowTemplatePlacement {
             crate::model::workflow_template_placement::Placement::ManagedCluster(v.into()),
         );
         self
+    }
+
+    /// The value of [placement][crate::model::WorkflowTemplatePlacement::placement]
+    /// if it holds a `ClusterSelector`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cluster_selector(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ClusterSelector>> {
+        #[allow(unreachable_patterns)]
+        self.placement.as_ref().and_then(|v| match v {
+            crate::model::workflow_template_placement::Placement::ClusterSelector(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [placement][crate::model::WorkflowTemplatePlacement::placement]
@@ -17196,6 +17196,18 @@ impl OrderedJob {
         self
     }
 
+    /// Sets the value of [labels][crate::model::OrderedJob::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [scheduling][crate::model::OrderedJob::scheduling].
     pub fn set_scheduling<
         T: std::convert::Into<std::option::Option<crate::model::JobScheduling>>,
@@ -17215,18 +17227,6 @@ impl OrderedJob {
     {
         use std::iter::Iterator;
         self.prerequisite_step_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::OrderedJob::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -17255,107 +17255,6 @@ impl OrderedJob {
         })
     }
 
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `SparkJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::SparkJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `PysparkJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pyspark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PySparkJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::PysparkJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `HiveJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn hive_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::HiveJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::HiveJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `PigJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pig_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PigJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::PigJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `SparkRJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_r_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkRJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::SparkRJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `SparkSqlJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_sql_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSqlJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::SparkSqlJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `PrestoJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn presto_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PrestoJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::PrestoJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `TrinoJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn trino_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::TrinoJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::TrinoJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::OrderedJob::job_type]
-    /// if it holds a `FlinkJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn flink_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::FlinkJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::ordered_job::JobType::FlinkJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
     /// to hold a `HadoopJob`.
     ///
@@ -17368,6 +17267,17 @@ impl OrderedJob {
         self.job_type =
             std::option::Option::Some(crate::model::ordered_job::JobType::HadoopJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `SparkJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::SparkJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
@@ -17384,6 +17294,17 @@ impl OrderedJob {
         self
     }
 
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `PysparkJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pyspark_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PySparkJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::PysparkJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
     /// to hold a `PysparkJob`.
     ///
@@ -17396,6 +17317,17 @@ impl OrderedJob {
         self.job_type =
             std::option::Option::Some(crate::model::ordered_job::JobType::PysparkJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `HiveJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn hive_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::HiveJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::HiveJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
@@ -17412,6 +17344,17 @@ impl OrderedJob {
         self
     }
 
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `PigJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pig_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PigJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::PigJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
     /// to hold a `PigJob`.
     ///
@@ -17424,6 +17367,17 @@ impl OrderedJob {
         self.job_type =
             std::option::Option::Some(crate::model::ordered_job::JobType::PigJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `SparkRJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_r_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::SparkRJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::SparkRJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
@@ -17440,6 +17394,19 @@ impl OrderedJob {
         self
     }
 
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `SparkSqlJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_sql_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SparkSqlJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::SparkSqlJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
     /// to hold a `SparkSqlJob`.
     ///
@@ -17452,6 +17419,17 @@ impl OrderedJob {
         self.job_type =
             std::option::Option::Some(crate::model::ordered_job::JobType::SparkSqlJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `PrestoJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn presto_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::PrestoJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::PrestoJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
@@ -17468,6 +17446,17 @@ impl OrderedJob {
         self
     }
 
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `TrinoJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn trino_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::TrinoJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::TrinoJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
     /// to hold a `TrinoJob`.
     ///
@@ -17480,6 +17469,17 @@ impl OrderedJob {
         self.job_type =
             std::option::Option::Some(crate::model::ordered_job::JobType::TrinoJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::OrderedJob::job_type]
+    /// if it holds a `FlinkJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn flink_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::FlinkJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::ordered_job::JobType::FlinkJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
@@ -17635,6 +17635,17 @@ impl TemplateParameter {
         self
     }
 
+    /// Sets the value of [fields][crate::model::TemplateParameter::fields].
+    pub fn set_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::TemplateParameter::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -17649,17 +17660,6 @@ impl TemplateParameter {
         v: T,
     ) -> Self {
         self.validation = v.into();
-        self
-    }
-
-    /// Sets the value of [fields][crate::model::TemplateParameter::fields].
-    pub fn set_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -17716,19 +17716,6 @@ impl ParameterValidation {
         })
     }
 
-    /// The value of [validation_type][crate::model::ParameterValidation::validation_type]
-    /// if it holds a `Values`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn values(&self) -> std::option::Option<&std::boxed::Box<crate::model::ValueValidation>> {
-        #[allow(unreachable_patterns)]
-        self.validation_type.as_ref().and_then(|v| match v {
-            crate::model::parameter_validation::ValidationType::Values(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [validation_type][crate::model::ParameterValidation::validation_type]
     /// to hold a `Regex`.
     ///
@@ -17742,6 +17729,19 @@ impl ParameterValidation {
             crate::model::parameter_validation::ValidationType::Regex(v.into()),
         );
         self
+    }
+
+    /// The value of [validation_type][crate::model::ParameterValidation::validation_type]
+    /// if it holds a `Values`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn values(&self) -> std::option::Option<&std::boxed::Box<crate::model::ValueValidation>> {
+        #[allow(unreachable_patterns)]
+        self.validation_type.as_ref().and_then(|v| match v {
+            crate::model::parameter_validation::ValidationType::Values(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [validation_type][crate::model::ParameterValidation::validation_type]
@@ -18008,6 +18008,18 @@ impl WorkflowMetadata {
         self
     }
 
+    /// Sets the value of [parameters][crate::model::WorkflowMetadata::parameters].
+    pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.parameters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::WorkflowMetadata::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -18056,18 +18068,6 @@ impl WorkflowMetadata {
         v: T,
     ) -> Self {
         self.dag_end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [parameters][crate::model::WorkflowMetadata::parameters].
-    pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.parameters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -18352,6 +18352,17 @@ impl WorkflowNode {
         self
     }
 
+    /// Sets the value of [prerequisite_step_ids][crate::model::WorkflowNode::prerequisite_step_ids].
+    pub fn set_prerequisite_step_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.prerequisite_step_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [job_id][crate::model::WorkflowNode::job_id].
     pub fn set_job_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.job_id = v.into();
@@ -18370,17 +18381,6 @@ impl WorkflowNode {
     /// Sets the value of [error][crate::model::WorkflowNode::error].
     pub fn set_error<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.error = v.into();
-        self
-    }
-
-    /// Sets the value of [prerequisite_step_ids][crate::model::WorkflowNode::prerequisite_step_ids].
-    pub fn set_prerequisite_step_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.prerequisite_step_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -18963,12 +18963,6 @@ impl ListWorkflowTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkflowTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [templates][crate::model::ListWorkflowTemplatesResponse::templates].
     pub fn set_templates<T, V>(mut self, v: T) -> Self
     where
@@ -18977,6 +18971,12 @@ impl ListWorkflowTemplatesResponse {
     {
         use std::iter::Iterator;
         self.templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkflowTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -104,19 +104,6 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
-    /// The value of [target][crate::model::DiscoverConnectionProfileRequest::target]
-    /// if it holds a `ConnectionProfileName`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn connection_profile_name(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_request::Target::ConnectionProfileName(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::DiscoverConnectionProfileRequest::target]
     /// to hold a `ConnectionProfile`.
     ///
@@ -132,6 +119,19 @@ impl DiscoverConnectionProfileRequest {
             crate::model::discover_connection_profile_request::Target::ConnectionProfile(v.into()),
         );
         self
+    }
+
+    /// The value of [target][crate::model::DiscoverConnectionProfileRequest::target]
+    /// if it holds a `ConnectionProfileName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn connection_profile_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_request::Target::ConnectionProfileName(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::DiscoverConnectionProfileRequest::target]
@@ -180,6 +180,18 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
+    /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
+    /// to hold a `FullHierarchy`.
+    ///
+    /// Note that all the setters affecting `hierarchy` are
+    /// mutually exclusive.
+    pub fn set_full_hierarchy<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.hierarchy = std::option::Option::Some(
+            crate::model::discover_connection_profile_request::Hierarchy::FullHierarchy(v.into()),
+        );
+        self
+    }
+
     /// The value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
     /// if it holds a `HierarchyDepth`, `None` if the field is not set or
     /// holds a different branch.
@@ -191,18 +203,6 @@ impl DiscoverConnectionProfileRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
-    /// to hold a `FullHierarchy`.
-    ///
-    /// Note that all the setters affecting `hierarchy` are
-    /// mutually exclusive.
-    pub fn set_full_hierarchy<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.hierarchy = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::Hierarchy::FullHierarchy(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
@@ -246,49 +246,6 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
-    /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// if it holds a `MysqlRdbms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mysql_rdbms(&self) -> std::option::Option<&std::boxed::Box<crate::model::MysqlRdbms>> {
-        #[allow(unreachable_patterns)]
-        self.data_object.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_request::DataObject::MysqlRdbms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// if it holds a `PostgresqlRdbms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql_rdbms(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlRdbms>> {
-        #[allow(unreachable_patterns)]
-        self.data_object.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_request::DataObject::PostgresqlRdbms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// if it holds a `SqlServerRdbms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_server_rdbms(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerRdbms>> {
-        #[allow(unreachable_patterns)]
-        self.data_object.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_request::DataObject::SqlServerRdbms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
     /// to hold a `OracleRdbms`.
     ///
@@ -304,6 +261,19 @@ impl DiscoverConnectionProfileRequest {
         self
     }
 
+    /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
+    /// if it holds a `MysqlRdbms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mysql_rdbms(&self) -> std::option::Option<&std::boxed::Box<crate::model::MysqlRdbms>> {
+        #[allow(unreachable_patterns)]
+        self.data_object.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_request::DataObject::MysqlRdbms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
     /// to hold a `MysqlRdbms`.
     ///
@@ -317,6 +287,21 @@ impl DiscoverConnectionProfileRequest {
             crate::model::discover_connection_profile_request::DataObject::MysqlRdbms(v.into()),
         );
         self
+    }
+
+    /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
+    /// if it holds a `PostgresqlRdbms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql_rdbms(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlRdbms>> {
+        #[allow(unreachable_patterns)]
+        self.data_object.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_request::DataObject::PostgresqlRdbms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
@@ -336,6 +321,21 @@ impl DiscoverConnectionProfileRequest {
             ),
         );
         self
+    }
+
+    /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
+    /// if it holds a `SqlServerRdbms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_server_rdbms(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerRdbms>> {
+        #[allow(unreachable_patterns)]
+        self.data_object.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_request::DataObject::SqlServerRdbms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
@@ -455,49 +455,6 @@ impl DiscoverConnectionProfileResponse {
         })
     }
 
-    /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// if it holds a `MysqlRdbms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mysql_rdbms(&self) -> std::option::Option<&std::boxed::Box<crate::model::MysqlRdbms>> {
-        #[allow(unreachable_patterns)]
-        self.data_object.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_response::DataObject::MysqlRdbms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// if it holds a `PostgresqlRdbms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql_rdbms(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlRdbms>> {
-        #[allow(unreachable_patterns)]
-        self.data_object.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_response::DataObject::PostgresqlRdbms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// if it holds a `SqlServerRdbms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_server_rdbms(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerRdbms>> {
-        #[allow(unreachable_patterns)]
-        self.data_object.as_ref().and_then(|v| match v {
-            crate::model::discover_connection_profile_response::DataObject::SqlServerRdbms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
     /// to hold a `OracleRdbms`.
     ///
@@ -513,6 +470,19 @@ impl DiscoverConnectionProfileResponse {
         self
     }
 
+    /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
+    /// if it holds a `MysqlRdbms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mysql_rdbms(&self) -> std::option::Option<&std::boxed::Box<crate::model::MysqlRdbms>> {
+        #[allow(unreachable_patterns)]
+        self.data_object.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_response::DataObject::MysqlRdbms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
     /// to hold a `MysqlRdbms`.
     ///
@@ -526,6 +496,21 @@ impl DiscoverConnectionProfileResponse {
             crate::model::discover_connection_profile_response::DataObject::MysqlRdbms(v.into()),
         );
         self
+    }
+
+    /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
+    /// if it holds a `PostgresqlRdbms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql_rdbms(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlRdbms>> {
+        #[allow(unreachable_patterns)]
+        self.data_object.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_response::DataObject::PostgresqlRdbms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
@@ -545,6 +530,21 @@ impl DiscoverConnectionProfileResponse {
             ),
         );
         self
+    }
+
+    /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
+    /// if it holds a `SqlServerRdbms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_server_rdbms(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerRdbms>> {
+        #[allow(unreachable_patterns)]
+        self.data_object.as_ref().and_then(|v| match v {
+            crate::model::discover_connection_profile_response::DataObject::SqlServerRdbms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
@@ -672,12 +672,6 @@ impl FetchStaticIpsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchStaticIpsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [static_ips][crate::model::FetchStaticIpsResponse::static_ips].
     pub fn set_static_ips<T, V>(mut self, v: T) -> Self
     where
@@ -686,6 +680,12 @@ impl FetchStaticIpsResponse {
     {
         use std::iter::Iterator;
         self.static_ips = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchStaticIpsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -802,12 +802,6 @@ impl ListConnectionProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connection_profiles][crate::model::ListConnectionProfilesResponse::connection_profiles].
     pub fn set_connection_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -816,6 +810,12 @@ impl ListConnectionProfilesResponse {
     {
         use std::iter::Iterator;
         self.connection_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1243,12 +1243,6 @@ impl ListStreamsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListStreamsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [streams][crate::model::ListStreamsResponse::streams].
     pub fn set_streams<T, V>(mut self, v: T) -> Self
     where
@@ -1257,6 +1251,12 @@ impl ListStreamsResponse {
     {
         use std::iter::Iterator;
         self.streams = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListStreamsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1928,12 +1928,6 @@ impl ListStreamObjectsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListStreamObjectsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [stream_objects][crate::model::ListStreamObjectsResponse::stream_objects].
     pub fn set_stream_objects<T, V>(mut self, v: T) -> Self
     where
@@ -1942,6 +1936,12 @@ impl ListStreamObjectsResponse {
     {
         use std::iter::Iterator;
         self.stream_objects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListStreamObjectsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2288,12 +2288,6 @@ impl ListPrivateConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [private_connections][crate::model::ListPrivateConnectionsResponse::private_connections].
     pub fn set_private_connections<T, V>(mut self, v: T) -> Self
     where
@@ -2302,6 +2296,12 @@ impl ListPrivateConnectionsResponse {
     {
         use std::iter::Iterator;
         self.private_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2619,12 +2619,6 @@ impl ListRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [routes][crate::model::ListRoutesResponse::routes].
     pub fn set_routes<T, V>(mut self, v: T) -> Self
     where
@@ -2633,6 +2627,12 @@ impl ListRoutesResponse {
     {
         use std::iter::Iterator;
         self.routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2840,6 +2840,18 @@ impl OracleProfile {
         self
     }
 
+    /// Sets the value of [connection_attributes][crate::model::OracleProfile::connection_attributes].
+    pub fn set_connection_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.connection_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [oracle_ssl_config][crate::model::OracleProfile::oracle_ssl_config].
     pub fn set_oracle_ssl_config<
         T: std::convert::Into<std::option::Option<crate::model::OracleSslConfig>>,
@@ -2868,18 +2880,6 @@ impl OracleProfile {
         v: T,
     ) -> Self {
         self.secret_manager_stored_password = v.into();
-        self
-    }
-
-    /// Sets the value of [connection_attributes][crate::model::OracleProfile::connection_attributes].
-    pub fn set_connection_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.connection_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2969,6 +2969,18 @@ impl OracleAsmConfig {
         self
     }
 
+    /// Sets the value of [connection_attributes][crate::model::OracleAsmConfig::connection_attributes].
+    pub fn set_connection_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.connection_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [oracle_ssl_config][crate::model::OracleAsmConfig::oracle_ssl_config].
     pub fn set_oracle_ssl_config<
         T: std::convert::Into<std::option::Option<crate::model::OracleSslConfig>>,
@@ -2986,18 +2998,6 @@ impl OracleAsmConfig {
         v: T,
     ) -> Self {
         self.secret_manager_stored_password = v.into();
-        self
-    }
-
-    /// Sets the value of [connection_attributes][crate::model::OracleAsmConfig::connection_attributes].
-    pub fn set_connection_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.connection_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3353,23 +3353,6 @@ impl SalesforceProfile {
         })
     }
 
-    /// The value of [credentials][crate::model::SalesforceProfile::credentials]
-    /// if it holds a `Oauth2ClientCredentials`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oauth2_client_credentials(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::salesforce_profile::Oauth2ClientCredentials>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.credentials.as_ref().and_then(|v| match v {
-            crate::model::salesforce_profile::Credentials::Oauth2ClientCredentials(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [credentials][crate::model::SalesforceProfile::credentials]
     /// to hold a `UserCredentials`.
     ///
@@ -3385,6 +3368,23 @@ impl SalesforceProfile {
             crate::model::salesforce_profile::Credentials::UserCredentials(v.into()),
         );
         self
+    }
+
+    /// The value of [credentials][crate::model::SalesforceProfile::credentials]
+    /// if it holds a `Oauth2ClientCredentials`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oauth2_client_credentials(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::salesforce_profile::Oauth2ClientCredentials>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.credentials.as_ref().and_then(|v| match v {
+            crate::model::salesforce_profile::Credentials::Oauth2ClientCredentials(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [credentials][crate::model::SalesforceProfile::credentials]
@@ -3752,6 +3752,18 @@ impl ForwardSshTunnelConnectivity {
         })
     }
 
+    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
+    /// to hold a `Password`.
+    ///
+    /// Note that all the setters affecting `authentication_method` are
+    /// mutually exclusive.
+    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.authentication_method = std::option::Option::Some(
+            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::Password(v.into()),
+        );
+        self
+    }
+
     /// The value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
     /// if it holds a `PrivateKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -3763,18 +3775,6 @@ impl ForwardSshTunnelConnectivity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
-    /// to hold a `Password`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::Password(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
@@ -3938,6 +3938,18 @@ impl PrivateConnection {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PrivateConnection::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::PrivateConnection::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -3988,18 +4000,6 @@ impl PrivateConnection {
         v: T,
     ) -> Self {
         self.vpc_peering_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::PrivateConnection::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4273,6 +4273,18 @@ impl Route {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Route::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::Route::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -4291,18 +4303,6 @@ impl Route {
     /// Sets the value of [destination_port][crate::model::Route::destination_port].
     pub fn set_destination_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.destination_port = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Route::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4504,23 +4504,6 @@ impl PostgresqlSslConfig {
         })
     }
 
-    /// The value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
-    /// if it holds a `ServerAndClientVerification`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn server_and_client_verification(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::postgresql_ssl_config::ServerAndClientVerification>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.encryption_setting.as_ref().and_then(|v| match v {
-            crate::model::postgresql_ssl_config::EncryptionSetting::ServerAndClientVerification(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
     /// to hold a `ServerVerification`.
     ///
@@ -4538,6 +4521,23 @@ impl PostgresqlSslConfig {
             crate::model::postgresql_ssl_config::EncryptionSetting::ServerVerification(v.into()),
         );
         self
+    }
+
+    /// The value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
+    /// if it holds a `ServerAndClientVerification`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn server_and_client_verification(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::postgresql_ssl_config::ServerAndClientVerification>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.encryption_setting.as_ref().and_then(|v| match v {
+            crate::model::postgresql_ssl_config::EncryptionSetting::ServerAndClientVerification(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
@@ -4777,6 +4777,18 @@ impl ConnectionProfile {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ConnectionProfile::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::ConnectionProfile::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -4798,18 +4810,6 @@ impl ConnectionProfile {
         v: T,
     ) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ConnectionProfile::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -4842,94 +4842,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// The value of [profile][crate::model::ConnectionProfile::profile]
-    /// if it holds a `GcsProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_profile(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsProfile>> {
-        #[allow(unreachable_patterns)]
-        self.profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Profile::GcsProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [profile][crate::model::ConnectionProfile::profile]
-    /// if it holds a `MysqlProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mysql_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlProfile>> {
-        #[allow(unreachable_patterns)]
-        self.profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Profile::MysqlProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [profile][crate::model::ConnectionProfile::profile]
-    /// if it holds a `BigqueryProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryProfile>> {
-        #[allow(unreachable_patterns)]
-        self.profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Profile::BigqueryProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [profile][crate::model::ConnectionProfile::profile]
-    /// if it holds a `PostgresqlProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlProfile>> {
-        #[allow(unreachable_patterns)]
-        self.profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Profile::PostgresqlProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [profile][crate::model::ConnectionProfile::profile]
-    /// if it holds a `SqlServerProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_server_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerProfile>> {
-        #[allow(unreachable_patterns)]
-        self.profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Profile::SqlServerProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [profile][crate::model::ConnectionProfile::profile]
-    /// if it holds a `SalesforceProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn salesforce_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceProfile>> {
-        #[allow(unreachable_patterns)]
-        self.profile.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Profile::SalesforceProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
     /// to hold a `OracleProfile`.
     ///
@@ -4947,6 +4859,19 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [profile][crate::model::ConnectionProfile::profile]
+    /// if it holds a `GcsProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_profile(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsProfile>> {
+        #[allow(unreachable_patterns)]
+        self.profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Profile::GcsProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
     /// to hold a `GcsProfile`.
     ///
@@ -4962,6 +4887,21 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [profile][crate::model::ConnectionProfile::profile]
+    /// if it holds a `MysqlProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mysql_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlProfile>> {
+        #[allow(unreachable_patterns)]
+        self.profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Profile::MysqlProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
     /// to hold a `MysqlProfile`.
     ///
@@ -4975,6 +4915,21 @@ impl ConnectionProfile {
             crate::model::connection_profile::Profile::MysqlProfile(v.into()),
         );
         self
+    }
+
+    /// The value of [profile][crate::model::ConnectionProfile::profile]
+    /// if it holds a `BigqueryProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryProfile>> {
+        #[allow(unreachable_patterns)]
+        self.profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Profile::BigqueryProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
@@ -4994,6 +4949,21 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [profile][crate::model::ConnectionProfile::profile]
+    /// if it holds a `PostgresqlProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlProfile>> {
+        #[allow(unreachable_patterns)]
+        self.profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Profile::PostgresqlProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
     /// to hold a `PostgresqlProfile`.
     ///
@@ -5011,6 +4981,21 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [profile][crate::model::ConnectionProfile::profile]
+    /// if it holds a `SqlServerProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_server_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerProfile>> {
+        #[allow(unreachable_patterns)]
+        self.profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Profile::SqlServerProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
     /// to hold a `SqlServerProfile`.
     ///
@@ -5026,6 +5011,21 @@ impl ConnectionProfile {
             crate::model::connection_profile::Profile::SqlServerProfile(v.into()),
         );
         self
+    }
+
+    /// The value of [profile][crate::model::ConnectionProfile::profile]
+    /// if it holds a `SalesforceProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn salesforce_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceProfile>> {
+        #[allow(unreachable_patterns)]
+        self.profile.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Profile::SalesforceProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
@@ -5074,36 +5074,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// The value of [connectivity][crate::model::ConnectionProfile::connectivity]
-    /// if it holds a `ForwardSshConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn forward_ssh_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ForwardSshTunnelConnectivity>> {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Connectivity::ForwardSshConnectivity(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connectivity][crate::model::ConnectionProfile::connectivity]
-    /// if it holds a `PrivateConnectivity`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn private_connectivity(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PrivateConnectivity>> {
-        #[allow(unreachable_patterns)]
-        self.connectivity.as_ref().and_then(|v| match v {
-            crate::model::connection_profile::Connectivity::PrivateConnectivity(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity]
     /// to hold a `StaticServiceIpConnectivity`.
     ///
@@ -5121,6 +5091,21 @@ impl ConnectionProfile {
         self
     }
 
+    /// The value of [connectivity][crate::model::ConnectionProfile::connectivity]
+    /// if it holds a `ForwardSshConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn forward_ssh_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ForwardSshTunnelConnectivity>> {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Connectivity::ForwardSshConnectivity(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity]
     /// to hold a `ForwardSshConnectivity`.
     ///
@@ -5136,6 +5121,21 @@ impl ConnectionProfile {
             crate::model::connection_profile::Connectivity::ForwardSshConnectivity(v.into()),
         );
         self
+    }
+
+    /// The value of [connectivity][crate::model::ConnectionProfile::connectivity]
+    /// if it holds a `PrivateConnectivity`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn private_connectivity(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PrivateConnectivity>> {
+        #[allow(unreachable_patterns)]
+        self.connectivity.as_ref().and_then(|v| match v {
+            crate::model::connection_profile::Connectivity::PrivateConnectivity(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity]
@@ -5555,22 +5555,6 @@ impl OracleSourceConfig {
         })
     }
 
-    /// The value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
-    /// if it holds a `StreamLargeObjects`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn stream_large_objects(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::oracle_source_config::StreamLargeObjects>>
-    {
-        #[allow(unreachable_patterns)]
-        self.large_objects_handling.as_ref().and_then(|v| match v {
-            crate::model::oracle_source_config::LargeObjectsHandling::StreamLargeObjects(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
     /// to hold a `DropLargeObjects`.
     ///
@@ -5586,6 +5570,22 @@ impl OracleSourceConfig {
             crate::model::oracle_source_config::LargeObjectsHandling::DropLargeObjects(v.into()),
         );
         self
+    }
+
+    /// The value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
+    /// if it holds a `StreamLargeObjects`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn stream_large_objects(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::oracle_source_config::StreamLargeObjects>>
+    {
+        #[allow(unreachable_patterns)]
+        self.large_objects_handling.as_ref().and_then(|v| match v {
+            crate::model::oracle_source_config::LargeObjectsHandling::StreamLargeObjects(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
@@ -5634,22 +5634,6 @@ impl OracleSourceConfig {
         })
     }
 
-    /// The value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
-    /// if it holds a `BinaryLogParser`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn binary_log_parser(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::oracle_source_config::BinaryLogParser>>
-    {
-        #[allow(unreachable_patterns)]
-        self.cdc_method.as_ref().and_then(|v| match v {
-            crate::model::oracle_source_config::CdcMethod::BinaryLogParser(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
     /// to hold a `LogMiner`.
     ///
@@ -5665,6 +5649,22 @@ impl OracleSourceConfig {
             crate::model::oracle_source_config::CdcMethod::LogMiner(v.into()),
         );
         self
+    }
+
+    /// The value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
+    /// if it holds a `BinaryLogParser`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn binary_log_parser(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::oracle_source_config::BinaryLogParser>>
+    {
+        #[allow(unreachable_patterns)]
+        self.cdc_method.as_ref().and_then(|v| match v {
+            crate::model::oracle_source_config::CdcMethod::BinaryLogParser(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
@@ -5818,6 +5818,20 @@ pub mod oracle_source_config {
             })
         }
 
+        /// Sets the value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
+        /// to hold a `OracleAsmLogFileAccess`.
+        ///
+        /// Note that all the setters affecting `log_file_access` are
+        /// mutually exclusive.
+        pub fn set_oracle_asm_log_file_access<T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::binary_log_parser::OracleAsmLogFileAccess>>>(mut self, v: T) -> Self{
+            self.log_file_access = std::option::Option::Some(
+                crate::model::oracle_source_config::binary_log_parser::LogFileAccess::OracleAsmLogFileAccess(
+                    v.into()
+                )
+            );
+            self
+        }
+
         /// The value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
         /// if it holds a `LogFileDirectories`, `None` if the field is not set or
         /// holds a different branch.
@@ -5833,20 +5847,6 @@ pub mod oracle_source_config {
                 crate::model::oracle_source_config::binary_log_parser::LogFileAccess::LogFileDirectories(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
-        /// to hold a `OracleAsmLogFileAccess`.
-        ///
-        /// Note that all the setters affecting `log_file_access` are
-        /// mutually exclusive.
-        pub fn set_oracle_asm_log_file_access<T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::binary_log_parser::OracleAsmLogFileAccess>>>(mut self, v: T) -> Self{
-            self.log_file_access = std::option::Option::Some(
-                crate::model::oracle_source_config::binary_log_parser::LogFileAccess::OracleAsmLogFileAccess(
-                    v.into()
-                )
-            );
-            self
         }
 
         /// Sets the value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
@@ -6654,21 +6654,6 @@ impl SqlServerSourceConfig {
         })
     }
 
-    /// The value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
-    /// if it holds a `ChangeTables`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn change_tables(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerChangeTables>> {
-        #[allow(unreachable_patterns)]
-        self.cdc_method.as_ref().and_then(|v| match v {
-            crate::model::sql_server_source_config::CdcMethod::ChangeTables(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
     /// to hold a `TransactionLogs`.
     ///
@@ -6684,6 +6669,21 @@ impl SqlServerSourceConfig {
             crate::model::sql_server_source_config::CdcMethod::TransactionLogs(v.into()),
         );
         self
+    }
+
+    /// The value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
+    /// if it holds a `ChangeTables`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn change_tables(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerChangeTables>> {
+        #[allow(unreachable_patterns)]
+        self.cdc_method.as_ref().and_then(|v| match v {
+            crate::model::sql_server_source_config::CdcMethod::ChangeTables(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
@@ -7119,19 +7119,6 @@ impl MysqlSourceConfig {
         })
     }
 
-    /// The value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
-    /// if it holds a `Gtid`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gtid(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::mysql_source_config::Gtid>> {
-        #[allow(unreachable_patterns)]
-        self.cdc_method.as_ref().and_then(|v| match v {
-            crate::model::mysql_source_config::CdcMethod::Gtid(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
     /// to hold a `BinaryLogPosition`.
     ///
@@ -7147,6 +7134,19 @@ impl MysqlSourceConfig {
             crate::model::mysql_source_config::CdcMethod::BinaryLogPosition(v.into()),
         );
         self
+    }
+
+    /// The value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
+    /// if it holds a `Gtid`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gtid(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::mysql_source_config::Gtid>> {
+        #[allow(unreachable_patterns)]
+        self.cdc_method.as_ref().and_then(|v| match v {
+            crate::model::mysql_source_config::CdcMethod::Gtid(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
@@ -7501,66 +7501,6 @@ impl SourceConfig {
         })
     }
 
-    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// if it holds a `MysqlSourceConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mysql_source_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlSourceConfig>> {
-        #[allow(unreachable_patterns)]
-        self.source_stream_config.as_ref().and_then(|v| match v {
-            crate::model::source_config::SourceStreamConfig::MysqlSourceConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// if it holds a `PostgresqlSourceConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql_source_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlSourceConfig>> {
-        #[allow(unreachable_patterns)]
-        self.source_stream_config.as_ref().and_then(|v| match v {
-            crate::model::source_config::SourceStreamConfig::PostgresqlSourceConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// if it holds a `SqlServerSourceConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_server_source_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerSourceConfig>> {
-        #[allow(unreachable_patterns)]
-        self.source_stream_config.as_ref().and_then(|v| match v {
-            crate::model::source_config::SourceStreamConfig::SqlServerSourceConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// if it holds a `SalesforceSourceConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn salesforce_source_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceSourceConfig>> {
-        #[allow(unreachable_patterns)]
-        self.source_stream_config.as_ref().and_then(|v| match v {
-            crate::model::source_config::SourceStreamConfig::SalesforceSourceConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
     /// to hold a `OracleSourceConfig`.
     ///
@@ -7576,6 +7516,21 @@ impl SourceConfig {
             crate::model::source_config::SourceStreamConfig::OracleSourceConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
+    /// if it holds a `MysqlSourceConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mysql_source_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlSourceConfig>> {
+        #[allow(unreachable_patterns)]
+        self.source_stream_config.as_ref().and_then(|v| match v {
+            crate::model::source_config::SourceStreamConfig::MysqlSourceConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
@@ -7595,6 +7550,21 @@ impl SourceConfig {
         self
     }
 
+    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
+    /// if it holds a `PostgresqlSourceConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql_source_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlSourceConfig>> {
+        #[allow(unreachable_patterns)]
+        self.source_stream_config.as_ref().and_then(|v| match v {
+            crate::model::source_config::SourceStreamConfig::PostgresqlSourceConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
     /// to hold a `PostgresqlSourceConfig`.
     ///
@@ -7612,6 +7582,21 @@ impl SourceConfig {
         self
     }
 
+    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
+    /// if it holds a `SqlServerSourceConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_server_source_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerSourceConfig>> {
+        #[allow(unreachable_patterns)]
+        self.source_stream_config.as_ref().and_then(|v| match v {
+            crate::model::source_config::SourceStreamConfig::SqlServerSourceConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
     /// to hold a `SqlServerSourceConfig`.
     ///
@@ -7627,6 +7612,21 @@ impl SourceConfig {
             crate::model::source_config::SourceStreamConfig::SqlServerSourceConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
+    /// if it holds a `SalesforceSourceConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn salesforce_source_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceSourceConfig>> {
+        #[allow(unreachable_patterns)]
+        self.source_stream_config.as_ref().and_then(|v| match v {
+            crate::model::source_config::SourceStreamConfig::SalesforceSourceConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
@@ -8101,21 +8101,6 @@ impl GcsDestinationConfig {
         })
     }
 
-    /// The value of [file_format][crate::model::GcsDestinationConfig::file_format]
-    /// if it holds a `JsonFileFormat`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn json_file_format(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::JsonFileFormat>> {
-        #[allow(unreachable_patterns)]
-        self.file_format.as_ref().and_then(|v| match v {
-            crate::model::gcs_destination_config::FileFormat::JsonFileFormat(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [file_format][crate::model::GcsDestinationConfig::file_format]
     /// to hold a `AvroFileFormat`.
     ///
@@ -8131,6 +8116,21 @@ impl GcsDestinationConfig {
             crate::model::gcs_destination_config::FileFormat::AvroFileFormat(v.into()),
         );
         self
+    }
+
+    /// The value of [file_format][crate::model::GcsDestinationConfig::file_format]
+    /// if it holds a `JsonFileFormat`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn json_file_format(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::JsonFileFormat>> {
+        #[allow(unreachable_patterns)]
+        self.file_format.as_ref().and_then(|v| match v {
+            crate::model::gcs_destination_config::FileFormat::JsonFileFormat(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [file_format][crate::model::GcsDestinationConfig::file_format]
@@ -8263,23 +8263,6 @@ impl BigQueryDestinationConfig {
         })
     }
 
-    /// The value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
-    /// if it holds a `SourceHierarchyDatasets`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn source_hierarchy_datasets(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::big_query_destination_config::SourceHierarchyDatasets>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.dataset_config.as_ref().and_then(|v| match v {
-            crate::model::big_query_destination_config::DatasetConfig::SourceHierarchyDatasets(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
     /// to hold a `SingleTargetDataset`.
     ///
@@ -8299,6 +8282,23 @@ impl BigQueryDestinationConfig {
             ),
         );
         self
+    }
+
+    /// The value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
+    /// if it holds a `SourceHierarchyDatasets`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn source_hierarchy_datasets(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::big_query_destination_config::SourceHierarchyDatasets>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.dataset_config.as_ref().and_then(|v| match v {
+            crate::model::big_query_destination_config::DatasetConfig::SourceHierarchyDatasets(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
@@ -8356,22 +8356,6 @@ impl BigQueryDestinationConfig {
         })
     }
 
-    /// The value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
-    /// if it holds a `AppendOnly`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn append_only(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::big_query_destination_config::AppendOnly>>
-    {
-        #[allow(unreachable_patterns)]
-        self.write_mode.as_ref().and_then(|v| match v {
-            crate::model::big_query_destination_config::WriteMode::AppendOnly(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
     /// to hold a `Merge`.
     ///
@@ -8387,6 +8371,22 @@ impl BigQueryDestinationConfig {
             crate::model::big_query_destination_config::WriteMode::Merge(v.into()),
         );
         self
+    }
+
+    /// The value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
+    /// if it holds a `AppendOnly`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn append_only(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::big_query_destination_config::AppendOnly>>
+    {
+        #[allow(unreachable_patterns)]
+        self.write_mode.as_ref().and_then(|v| match v {
+            crate::model::big_query_destination_config::WriteMode::AppendOnly(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
@@ -9051,19 +9051,6 @@ impl DestinationConfig {
             })
     }
 
-    /// The value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
-    /// if it holds a `BigqueryDestinationConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_destination_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestinationConfig>> {
-        #[allow(unreachable_patterns)]
-        self.destination_stream_config.as_ref().and_then(|v| match v {
-            crate::model::destination_config::DestinationStreamConfig::BigqueryDestinationConfig(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
     /// to hold a `GcsDestinationConfig`.
     ///
@@ -9081,6 +9068,19 @@ impl DestinationConfig {
             ),
         );
         self
+    }
+
+    /// The value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
+    /// if it holds a `BigqueryDestinationConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_destination_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryDestinationConfig>> {
+        #[allow(unreachable_patterns)]
+        self.destination_stream_config.as_ref().and_then(|v| match v {
+            crate::model::destination_config::DestinationStreamConfig::BigqueryDestinationConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
@@ -9224,6 +9224,18 @@ impl Stream {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Stream::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::Stream::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -9255,6 +9267,17 @@ impl Stream {
     /// Sets the value of [state][crate::model::Stream::state].
     pub fn set_state<T: std::convert::Into<crate::model::stream::State>>(mut self, v: T) -> Self {
         self.state = v.into();
+        self
+    }
+
+    /// Sets the value of [errors][crate::model::Stream::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Error>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -9296,29 +9319,6 @@ impl Stream {
         self
     }
 
-    /// Sets the value of [errors][crate::model::Stream::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Error>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Stream::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [backfill_strategy][crate::model::Stream::backfill_strategy].
     ///
     /// Note that all the setters affecting `backfill_strategy` are mutually
@@ -9346,19 +9346,6 @@ impl Stream {
         })
     }
 
-    /// The value of [backfill_strategy][crate::model::Stream::backfill_strategy]
-    /// if it holds a `BackfillNone`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn backfill_none(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::stream::BackfillNoneStrategy>> {
-        #[allow(unreachable_patterns)]
-        self.backfill_strategy.as_ref().and_then(|v| match v {
-            crate::model::stream::BackfillStrategy::BackfillNone(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [backfill_strategy][crate::model::Stream::backfill_strategy]
     /// to hold a `BackfillAll`.
     ///
@@ -9374,6 +9361,19 @@ impl Stream {
             crate::model::stream::BackfillStrategy::BackfillAll(v.into()),
         );
         self
+    }
+
+    /// The value of [backfill_strategy][crate::model::Stream::backfill_strategy]
+    /// if it holds a `BackfillNone`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn backfill_none(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::stream::BackfillNoneStrategy>> {
+        #[allow(unreachable_patterns)]
+        self.backfill_strategy.as_ref().and_then(|v| match v {
+            crate::model::stream::BackfillStrategy::BackfillNone(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [backfill_strategy][crate::model::Stream::backfill_strategy]
@@ -9457,58 +9457,6 @@ pub mod stream {
             })
         }
 
-        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// if it holds a `MysqlExcludedObjects`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn mysql_excluded_objects(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlRdbms>> {
-            #[allow(unreachable_patterns)]
-            self.excluded_objects.as_ref().and_then(|v| match v {
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::MysqlExcludedObjects(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// if it holds a `PostgresqlExcludedObjects`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn postgresql_excluded_objects(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlRdbms>> {
-            #[allow(unreachable_patterns)]
-            self.excluded_objects.as_ref().and_then(|v| match v {
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::PostgresqlExcludedObjects(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// if it holds a `SqlServerExcludedObjects`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sql_server_excluded_objects(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerRdbms>> {
-            #[allow(unreachable_patterns)]
-            self.excluded_objects.as_ref().and_then(|v| match v {
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::SqlServerExcludedObjects(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// if it holds a `SalesforceExcludedObjects`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn salesforce_excluded_objects(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceOrg>> {
-            #[allow(unreachable_patterns)]
-            self.excluded_objects.as_ref().and_then(|v| match v {
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::SalesforceExcludedObjects(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
         /// to hold a `OracleExcludedObjects`.
         ///
@@ -9526,6 +9474,19 @@ pub mod stream {
                 ),
             );
             self
+        }
+
+        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
+        /// if it holds a `MysqlExcludedObjects`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn mysql_excluded_objects(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlRdbms>> {
+            #[allow(unreachable_patterns)]
+            self.excluded_objects.as_ref().and_then(|v| match v {
+                crate::model::stream::backfill_all_strategy::ExcludedObjects::MysqlExcludedObjects(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
@@ -9547,6 +9508,19 @@ pub mod stream {
             self
         }
 
+        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
+        /// if it holds a `PostgresqlExcludedObjects`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn postgresql_excluded_objects(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::PostgresqlRdbms>> {
+            #[allow(unreachable_patterns)]
+            self.excluded_objects.as_ref().and_then(|v| match v {
+                crate::model::stream::backfill_all_strategy::ExcludedObjects::PostgresqlExcludedObjects(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
         /// to hold a `PostgresqlExcludedObjects`.
         ///
@@ -9566,6 +9540,19 @@ pub mod stream {
             self
         }
 
+        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
+        /// if it holds a `SqlServerExcludedObjects`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sql_server_excluded_objects(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerRdbms>> {
+            #[allow(unreachable_patterns)]
+            self.excluded_objects.as_ref().and_then(|v| match v {
+                crate::model::stream::backfill_all_strategy::ExcludedObjects::SqlServerExcludedObjects(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
         /// to hold a `SqlServerExcludedObjects`.
         ///
@@ -9583,6 +9570,19 @@ pub mod stream {
                 )
             );
             self
+        }
+
+        /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
+        /// if it holds a `SalesforceExcludedObjects`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn salesforce_excluded_objects(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::SalesforceOrg>> {
+            #[allow(unreachable_patterns)]
+            self.excluded_objects.as_ref().and_then(|v| match v {
+                crate::model::stream::backfill_all_strategy::ExcludedObjects::SalesforceExcludedObjects(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
@@ -9920,6 +9920,17 @@ impl StreamObject {
         self
     }
 
+    /// Sets the value of [errors][crate::model::StreamObject::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Error>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [backfill_job][crate::model::StreamObject::backfill_job].
     pub fn set_backfill_job<
         T: std::convert::Into<std::option::Option<crate::model::BackfillJob>>,
@@ -9939,17 +9950,6 @@ impl StreamObject {
         v: T,
     ) -> Self {
         self.source_object = v.into();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::StreamObject::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Error>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10013,74 +10013,6 @@ impl SourceObjectIdentifier {
         })
     }
 
-    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// if it holds a `MysqlIdentifier`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mysql_identifier(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::source_object_identifier::MysqlObjectIdentifier>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.source_identifier.as_ref().and_then(|v| match v {
-            crate::model::source_object_identifier::SourceIdentifier::MysqlIdentifier(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// if it holds a `PostgresqlIdentifier`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postgresql_identifier(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::source_object_identifier::PostgresqlObjectIdentifier>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.source_identifier.as_ref().and_then(|v| match v {
-            crate::model::source_object_identifier::SourceIdentifier::PostgresqlIdentifier(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// if it holds a `SqlServerIdentifier`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sql_server_identifier(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::source_object_identifier::SqlServerObjectIdentifier>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.source_identifier.as_ref().and_then(|v| match v {
-            crate::model::source_object_identifier::SourceIdentifier::SqlServerIdentifier(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// if it holds a `SalesforceIdentifier`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn salesforce_identifier(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::source_object_identifier::SalesforceObjectIdentifier>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.source_identifier.as_ref().and_then(|v| match v {
-            crate::model::source_object_identifier::SourceIdentifier::SalesforceIdentifier(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
     /// to hold a `OracleIdentifier`.
     ///
@@ -10100,6 +10032,23 @@ impl SourceObjectIdentifier {
         self
     }
 
+    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
+    /// if it holds a `MysqlIdentifier`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mysql_identifier(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::source_object_identifier::MysqlObjectIdentifier>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.source_identifier.as_ref().and_then(|v| match v {
+            crate::model::source_object_identifier::SourceIdentifier::MysqlIdentifier(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
     /// to hold a `MysqlIdentifier`.
     ///
@@ -10117,6 +10066,23 @@ impl SourceObjectIdentifier {
             crate::model::source_object_identifier::SourceIdentifier::MysqlIdentifier(v.into()),
         );
         self
+    }
+
+    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
+    /// if it holds a `PostgresqlIdentifier`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postgresql_identifier(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::source_object_identifier::PostgresqlObjectIdentifier>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.source_identifier.as_ref().and_then(|v| match v {
+            crate::model::source_object_identifier::SourceIdentifier::PostgresqlIdentifier(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
@@ -10140,6 +10106,23 @@ impl SourceObjectIdentifier {
         self
     }
 
+    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
+    /// if it holds a `SqlServerIdentifier`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sql_server_identifier(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::source_object_identifier::SqlServerObjectIdentifier>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.source_identifier.as_ref().and_then(|v| match v {
+            crate::model::source_object_identifier::SourceIdentifier::SqlServerIdentifier(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
     /// to hold a `SqlServerIdentifier`.
     ///
@@ -10157,6 +10140,23 @@ impl SourceObjectIdentifier {
             crate::model::source_object_identifier::SourceIdentifier::SqlServerIdentifier(v.into()),
         );
         self
+    }
+
+    /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
+    /// if it holds a `SalesforceIdentifier`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn salesforce_identifier(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::source_object_identifier::SalesforceObjectIdentifier>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.source_identifier.as_ref().and_then(|v| match v {
+            crate::model::source_object_identifier::SourceIdentifier::SalesforceIdentifier(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
@@ -10981,12 +10981,6 @@ impl Validation {
         self
     }
 
-    /// Sets the value of [code][crate::model::Validation::code].
-    pub fn set_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.code = v.into();
-        self
-    }
-
     /// Sets the value of [message][crate::model::Validation::message].
     pub fn set_message<T, V>(mut self, v: T) -> Self
     where
@@ -10995,6 +10989,12 @@ impl Validation {
     {
         use std::iter::Iterator;
         self.message = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [code][crate::model::Validation::code].
+    pub fn set_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.code = v.into();
         self
     }
 }
@@ -11202,12 +11202,6 @@ impl ValidationMessage {
         self
     }
 
-    /// Sets the value of [code][crate::model::ValidationMessage::code].
-    pub fn set_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.code = v.into();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::ValidationMessage::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -11217,6 +11211,12 @@ impl ValidationMessage {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [code][crate::model::ValidationMessage::code].
+    pub fn set_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.code = v.into();
         self
     }
 }
@@ -11416,38 +11416,6 @@ impl CdcStrategy {
         })
     }
 
-    /// The value of [start_position][crate::model::CdcStrategy::start_position]
-    /// if it holds a `NextAvailableStartPosition`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn next_available_start_position(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::cdc_strategy::NextAvailableStartPosition>>
-    {
-        #[allow(unreachable_patterns)]
-        self.start_position.as_ref().and_then(|v| match v {
-            crate::model::cdc_strategy::StartPosition::NextAvailableStartPosition(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [start_position][crate::model::CdcStrategy::start_position]
-    /// if it holds a `SpecificStartPosition`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn specific_start_position(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::cdc_strategy::SpecificStartPosition>>
-    {
-        #[allow(unreachable_patterns)]
-        self.start_position.as_ref().and_then(|v| match v {
-            crate::model::cdc_strategy::StartPosition::SpecificStartPosition(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [start_position][crate::model::CdcStrategy::start_position]
     /// to hold a `MostRecentStartPosition`.
     ///
@@ -11465,6 +11433,22 @@ impl CdcStrategy {
         self
     }
 
+    /// The value of [start_position][crate::model::CdcStrategy::start_position]
+    /// if it holds a `NextAvailableStartPosition`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn next_available_start_position(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::cdc_strategy::NextAvailableStartPosition>>
+    {
+        #[allow(unreachable_patterns)]
+        self.start_position.as_ref().and_then(|v| match v {
+            crate::model::cdc_strategy::StartPosition::NextAvailableStartPosition(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [start_position][crate::model::CdcStrategy::start_position]
     /// to hold a `NextAvailableStartPosition`.
     ///
@@ -11480,6 +11464,22 @@ impl CdcStrategy {
             crate::model::cdc_strategy::StartPosition::NextAvailableStartPosition(v.into()),
         );
         self
+    }
+
+    /// The value of [start_position][crate::model::CdcStrategy::start_position]
+    /// if it holds a `SpecificStartPosition`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn specific_start_position(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::cdc_strategy::SpecificStartPosition>>
+    {
+        #[allow(unreachable_patterns)]
+        self.start_position.as_ref().and_then(|v| match v {
+            crate::model::cdc_strategy::StartPosition::SpecificStartPosition(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [start_position][crate::model::CdcStrategy::start_position]
@@ -11609,45 +11609,6 @@ pub mod cdc_strategy {
             })
         }
 
-        /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// if it holds a `OracleScnPosition`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn oracle_scn_position(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::OracleScnPosition>> {
-            #[allow(unreachable_patterns)]
-            self.position.as_ref().and_then(|v| match v {
-                crate::model::cdc_strategy::specific_start_position::Position::OracleScnPosition(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// if it holds a `SqlServerLsnPosition`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn sql_server_lsn_position(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerLsnPosition>> {
-            #[allow(unreachable_patterns)]
-            self.position.as_ref().and_then(|v| match v {
-                crate::model::cdc_strategy::specific_start_position::Position::SqlServerLsnPosition(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// if it holds a `MysqlGtidPosition`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn mysql_gtid_position(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlGtidPosition>> {
-            #[allow(unreachable_patterns)]
-            self.position.as_ref().and_then(|v| match v {
-                crate::model::cdc_strategy::specific_start_position::Position::MysqlGtidPosition(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
         /// to hold a `MysqlLogPosition`.
         ///
@@ -11665,6 +11626,19 @@ pub mod cdc_strategy {
                 ),
             );
             self
+        }
+
+        /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
+        /// if it holds a `OracleScnPosition`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn oracle_scn_position(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::OracleScnPosition>> {
+            #[allow(unreachable_patterns)]
+            self.position.as_ref().and_then(|v| match v {
+                crate::model::cdc_strategy::specific_start_position::Position::OracleScnPosition(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
@@ -11686,6 +11660,19 @@ pub mod cdc_strategy {
             self
         }
 
+        /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
+        /// if it holds a `SqlServerLsnPosition`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn sql_server_lsn_position(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::SqlServerLsnPosition>> {
+            #[allow(unreachable_patterns)]
+            self.position.as_ref().and_then(|v| match v {
+                crate::model::cdc_strategy::specific_start_position::Position::SqlServerLsnPosition(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
         /// to hold a `SqlServerLsnPosition`.
         ///
@@ -11703,6 +11690,19 @@ pub mod cdc_strategy {
                 ),
             );
             self
+        }
+
+        /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
+        /// if it holds a `MysqlGtidPosition`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn mysql_gtid_position(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::MysqlGtidPosition>> {
+            #[allow(unreachable_patterns)]
+            self.position.as_ref().and_then(|v| match v {
+                crate::model::cdc_strategy::specific_start_position::Position::MysqlGtidPosition(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]

--- a/src/generated/cloud/deploy/v1/src/builder.rs
+++ b/src/generated/cloud/deploy/v1/src/builder.rs
@@ -2853,12 +2853,6 @@ pub mod cloud_deploy {
             self
         }
 
-        /// Sets the value of [starting_phase_id][crate::model::CreateRolloutRequest::starting_phase_id].
-        pub fn set_starting_phase_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.starting_phase_id = v.into();
-            self
-        }
-
         /// Sets the value of [override_deploy_policy][crate::model::CreateRolloutRequest::override_deploy_policy].
         pub fn set_override_deploy_policy<T, V>(mut self, v: T) -> Self
         where
@@ -2867,6 +2861,12 @@ pub mod cloud_deploy {
         {
             use std::iter::Iterator;
             self.0.request.override_deploy_policy = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [starting_phase_id][crate::model::CreateRolloutRequest::starting_phase_id].
+        pub fn set_starting_phase_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.starting_phase_id = v.into();
             self
         }
     }

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -294,6 +294,30 @@ impl DeliveryPipeline {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::DeliveryPipeline::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::DeliveryPipeline::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::DeliveryPipeline::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -332,30 +356,6 @@ impl DeliveryPipeline {
     /// Sets the value of [suspended][crate::model::DeliveryPipeline::suspended].
     pub fn set_suspended<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.suspended = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::DeliveryPipeline::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DeliveryPipeline::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -509,15 +509,6 @@ impl Stage {
         self
     }
 
-    /// Sets the value of [strategy][crate::model::Stage::strategy].
-    pub fn set_strategy<T: std::convert::Into<std::option::Option<crate::model::Strategy>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.strategy = v.into();
-        self
-    }
-
     /// Sets the value of [profiles][crate::model::Stage::profiles].
     pub fn set_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -526,6 +517,15 @@ impl Stage {
     {
         use std::iter::Iterator;
         self.profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [strategy][crate::model::Stage::strategy].
+    pub fn set_strategy<T: std::convert::Into<std::option::Option<crate::model::Strategy>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.strategy = v.into();
         self
     }
 
@@ -647,17 +647,6 @@ impl Strategy {
         })
     }
 
-    /// The value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
-    /// if it holds a `Canary`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn canary(&self) -> std::option::Option<&std::boxed::Box<crate::model::Canary>> {
-        #[allow(unreachable_patterns)]
-        self.deployment_strategy.as_ref().and_then(|v| match v {
-            crate::model::strategy::DeploymentStrategy::Canary(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
     /// to hold a `Standard`.
     ///
@@ -671,6 +660,17 @@ impl Strategy {
             crate::model::strategy::DeploymentStrategy::Standard(v.into()),
         );
         self
+    }
+
+    /// The value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
+    /// if it holds a `Canary`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn canary(&self) -> std::option::Option<&std::boxed::Box<crate::model::Canary>> {
+        #[allow(unreachable_patterns)]
+        self.deployment_strategy.as_ref().and_then(|v| match v {
+            crate::model::strategy::DeploymentStrategy::Canary(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
@@ -910,19 +910,6 @@ impl Canary {
         })
     }
 
-    /// The value of [mode][crate::model::Canary::mode]
-    /// if it holds a `CustomCanaryDeployment`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_canary_deployment(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CustomCanaryDeployment>> {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::canary::Mode::CustomCanaryDeployment(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::Canary::mode]
     /// to hold a `CanaryDeployment`.
     ///
@@ -937,6 +924,19 @@ impl Canary {
         self.mode =
             std::option::Option::Some(crate::model::canary::Mode::CanaryDeployment(v.into()));
         self
+    }
+
+    /// The value of [mode][crate::model::Canary::mode]
+    /// if it holds a `CustomCanaryDeployment`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_canary_deployment(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CustomCanaryDeployment>> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::canary::Mode::CustomCanaryDeployment(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::Canary::mode]
@@ -1018,6 +1018,17 @@ impl CanaryDeployment {
         std::default::Default::default()
     }
 
+    /// Sets the value of [percentages][crate::model::CanaryDeployment::percentages].
+    pub fn set_percentages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.percentages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [verify][crate::model::CanaryDeployment::verify].
     pub fn set_verify<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.verify = v.into();
@@ -1039,17 +1050,6 @@ impl CanaryDeployment {
         v: T,
     ) -> Self {
         self.postdeploy = v.into();
-        self
-    }
-
-    /// Sets the value of [percentages][crate::model::CanaryDeployment::percentages].
-    pub fn set_percentages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.percentages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1164,6 +1164,17 @@ pub mod custom_canary_deployment {
             self
         }
 
+        /// Sets the value of [profiles][crate::model::custom_canary_deployment::PhaseConfig::profiles].
+        pub fn set_profiles<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.profiles = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [verify][crate::model::custom_canary_deployment::PhaseConfig::verify].
         pub fn set_verify<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.verify = v.into();
@@ -1189,17 +1200,6 @@ pub mod custom_canary_deployment {
             v: T,
         ) -> Self {
             self.postdeploy = v.into();
-            self
-        }
-
-        /// Sets the value of [profiles][crate::model::custom_canary_deployment::PhaseConfig::profiles].
-        pub fn set_profiles<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.profiles = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1260,22 +1260,6 @@ impl KubernetesConfig {
         })
     }
 
-    /// The value of [service_definition][crate::model::KubernetesConfig::service_definition]
-    /// if it holds a `ServiceNetworking`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn service_networking(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::kubernetes_config::ServiceNetworking>>
-    {
-        #[allow(unreachable_patterns)]
-        self.service_definition.as_ref().and_then(|v| match v {
-            crate::model::kubernetes_config::ServiceDefinition::ServiceNetworking(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [service_definition][crate::model::KubernetesConfig::service_definition]
     /// to hold a `GatewayServiceMesh`.
     ///
@@ -1291,6 +1275,22 @@ impl KubernetesConfig {
             crate::model::kubernetes_config::ServiceDefinition::GatewayServiceMesh(v.into()),
         );
         self
+    }
+
+    /// The value of [service_definition][crate::model::KubernetesConfig::service_definition]
+    /// if it holds a `ServiceNetworking`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn service_networking(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::kubernetes_config::ServiceNetworking>>
+    {
+        #[allow(unreachable_patterns)]
+        self.service_definition.as_ref().and_then(|v| match v {
+            crate::model::kubernetes_config::ServiceDefinition::ServiceNetworking(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [service_definition][crate::model::KubernetesConfig::service_definition]
@@ -1484,12 +1484,6 @@ pub mod kubernetes_config {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [propagate_service][crate::model::kubernetes_config::gateway_service_mesh::RouteDestinations::propagate_service].
-            pub fn set_propagate_service<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.propagate_service = v.into();
-                self
-            }
-
             /// Sets the value of [destination_ids][crate::model::kubernetes_config::gateway_service_mesh::RouteDestinations::destination_ids].
             pub fn set_destination_ids<T, V>(mut self, v: T) -> Self
             where
@@ -1498,6 +1492,12 @@ pub mod kubernetes_config {
             {
                 use std::iter::Iterator;
                 self.destination_ids = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [propagate_service][crate::model::kubernetes_config::gateway_service_mesh::RouteDestinations::propagate_service].
+            pub fn set_propagate_service<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.propagate_service = v.into();
                 self
             }
         }
@@ -1726,19 +1726,6 @@ impl RuntimeConfig {
         })
     }
 
-    /// The value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
-    /// if it holds a `CloudRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_run(&self) -> std::option::Option<&std::boxed::Box<crate::model::CloudRunConfig>> {
-        #[allow(unreachable_patterns)]
-        self.runtime_config.as_ref().and_then(|v| match v {
-            crate::model::runtime_config::RuntimeConfig::CloudRun(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
     /// to hold a `Kubernetes`.
     ///
@@ -1754,6 +1741,19 @@ impl RuntimeConfig {
             crate::model::runtime_config::RuntimeConfig::Kubernetes(v.into()),
         );
         self
+    }
+
+    /// The value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
+    /// if it holds a `CloudRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_run(&self) -> std::option::Option<&std::boxed::Box<crate::model::CloudRunConfig>> {
+        #[allow(unreachable_patterns)]
+        self.runtime_config.as_ref().and_then(|v| match v {
+            crate::model::runtime_config::RuntimeConfig::CloudRun(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
@@ -1879,15 +1879,6 @@ impl TargetsPresentCondition {
         self
     }
 
-    /// Sets the value of [update_time][crate::model::TargetsPresentCondition::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [missing_targets][crate::model::TargetsPresentCondition::missing_targets].
     pub fn set_missing_targets<T, V>(mut self, v: T) -> Self
     where
@@ -1896,6 +1887,15 @@ impl TargetsPresentCondition {
     {
         use std::iter::Iterator;
         self.missing_targets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::TargetsPresentCondition::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -2128,12 +2128,6 @@ impl ListDeliveryPipelinesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeliveryPipelinesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [delivery_pipelines][crate::model::ListDeliveryPipelinesResponse::delivery_pipelines].
     pub fn set_delivery_pipelines<T, V>(mut self, v: T) -> Self
     where
@@ -2142,6 +2136,12 @@ impl ListDeliveryPipelinesResponse {
     {
         use std::iter::Iterator;
         self.delivery_pipelines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeliveryPipelinesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2841,47 +2841,6 @@ impl Target {
         self
     }
 
-    /// Sets the value of [require_approval][crate::model::Target::require_approval].
-    pub fn set_require_approval<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.require_approval = v.into();
-        self
-    }
-
-    /// Sets the value of [create_time][crate::model::Target::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [update_time][crate::model::Target::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [etag][crate::model::Target::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [execution_configs][crate::model::Target::execution_configs].
-    pub fn set_execution_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ExecutionConfig>,
-    {
-        use std::iter::Iterator;
-        self.execution_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::Target::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -2906,6 +2865,30 @@ impl Target {
         self
     }
 
+    /// Sets the value of [require_approval][crate::model::Target::require_approval].
+    pub fn set_require_approval<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.require_approval = v.into();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::Target::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::Target::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
+        self
+    }
+
     /// Sets the value of [associated_entities][crate::model::Target::associated_entities].
     pub fn set_associated_entities<T, K, V>(mut self, v: T) -> Self
     where
@@ -2915,6 +2898,23 @@ impl Target {
     {
         use std::iter::Iterator;
         self.associated_entities = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Target::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [execution_configs][crate::model::Target::execution_configs].
+    pub fn set_execution_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ExecutionConfig>,
+    {
+        use std::iter::Iterator;
+        self.execution_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2955,6 +2955,20 @@ impl Target {
         })
     }
 
+    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
+    /// to hold a `Gke`.
+    ///
+    /// Note that all the setters affecting `deployment_target` are
+    /// mutually exclusive.
+    pub fn set_gke<T: std::convert::Into<std::boxed::Box<crate::model::GkeCluster>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.deployment_target =
+            std::option::Option::Some(crate::model::target::DeploymentTarget::Gke(v.into()));
+        self
+    }
+
     /// The value of [deployment_target][crate::model::Target::deployment_target]
     /// if it holds a `AnthosCluster`, `None` if the field is not set or
     /// holds a different branch.
@@ -2968,55 +2982,6 @@ impl Target {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [deployment_target][crate::model::Target::deployment_target]
-    /// if it holds a `Run`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn run(&self) -> std::option::Option<&std::boxed::Box<crate::model::CloudRunLocation>> {
-        #[allow(unreachable_patterns)]
-        self.deployment_target.as_ref().and_then(|v| match v {
-            crate::model::target::DeploymentTarget::Run(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [deployment_target][crate::model::Target::deployment_target]
-    /// if it holds a `MultiTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn multi_target(&self) -> std::option::Option<&std::boxed::Box<crate::model::MultiTarget>> {
-        #[allow(unreachable_patterns)]
-        self.deployment_target.as_ref().and_then(|v| match v {
-            crate::model::target::DeploymentTarget::MultiTarget(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [deployment_target][crate::model::Target::deployment_target]
-    /// if it holds a `CustomTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CustomTarget>> {
-        #[allow(unreachable_patterns)]
-        self.deployment_target.as_ref().and_then(|v| match v {
-            crate::model::target::DeploymentTarget::CustomTarget(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
-    /// to hold a `Gke`.
-    ///
-    /// Note that all the setters affecting `deployment_target` are
-    /// mutually exclusive.
-    pub fn set_gke<T: std::convert::Into<std::boxed::Box<crate::model::GkeCluster>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_target =
-            std::option::Option::Some(crate::model::target::DeploymentTarget::Gke(v.into()));
-        self
     }
 
     /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
@@ -3036,6 +3001,17 @@ impl Target {
         self
     }
 
+    /// The value of [deployment_target][crate::model::Target::deployment_target]
+    /// if it holds a `Run`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn run(&self) -> std::option::Option<&std::boxed::Box<crate::model::CloudRunLocation>> {
+        #[allow(unreachable_patterns)]
+        self.deployment_target.as_ref().and_then(|v| match v {
+            crate::model::target::DeploymentTarget::Run(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
     /// to hold a `Run`.
     ///
@@ -3048,6 +3024,17 @@ impl Target {
         self.deployment_target =
             std::option::Option::Some(crate::model::target::DeploymentTarget::Run(v.into()));
         self
+    }
+
+    /// The value of [deployment_target][crate::model::Target::deployment_target]
+    /// if it holds a `MultiTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn multi_target(&self) -> std::option::Option<&std::boxed::Box<crate::model::MultiTarget>> {
+        #[allow(unreachable_patterns)]
+        self.deployment_target.as_ref().and_then(|v| match v {
+            crate::model::target::DeploymentTarget::MultiTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
@@ -3063,6 +3050,19 @@ impl Target {
             crate::model::target::DeploymentTarget::MultiTarget(v.into()),
         );
         self
+    }
+
+    /// The value of [deployment_target][crate::model::Target::deployment_target]
+    /// if it holds a `CustomTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CustomTarget>> {
+        #[allow(unreachable_patterns)]
+        self.deployment_target.as_ref().and_then(|v| match v {
+            crate::model::target::DeploymentTarget::CustomTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
@@ -3166,6 +3166,17 @@ impl ExecutionConfig {
         std::default::Default::default()
     }
 
+    /// Sets the value of [usages][crate::model::ExecutionConfig::usages].
+    pub fn set_usages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::execution_config::ExecutionEnvironmentUsage>,
+    {
+        use std::iter::Iterator;
+        self.usages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [worker_pool][crate::model::ExecutionConfig::worker_pool].
     pub fn set_worker_pool<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.worker_pool = v.into();
@@ -3202,17 +3213,6 @@ impl ExecutionConfig {
         self
     }
 
-    /// Sets the value of [usages][crate::model::ExecutionConfig::usages].
-    pub fn set_usages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::execution_config::ExecutionEnvironmentUsage>,
-    {
-        use std::iter::Iterator;
-        self.usages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [execution_environment][crate::model::ExecutionConfig::execution_environment].
     ///
     /// Note that all the setters affecting `execution_environment` are mutually
@@ -3242,19 +3242,6 @@ impl ExecutionConfig {
         })
     }
 
-    /// The value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
-    /// if it holds a `PrivatePool`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn private_pool(&self) -> std::option::Option<&std::boxed::Box<crate::model::PrivatePool>> {
-        #[allow(unreachable_patterns)]
-        self.execution_environment.as_ref().and_then(|v| match v {
-            crate::model::execution_config::ExecutionEnvironment::PrivatePool(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
     /// to hold a `DefaultPool`.
     ///
@@ -3268,6 +3255,19 @@ impl ExecutionConfig {
             crate::model::execution_config::ExecutionEnvironment::DefaultPool(v.into()),
         );
         self
+    }
+
+    /// The value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
+    /// if it holds a `PrivatePool`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn private_pool(&self) -> std::option::Option<&std::boxed::Box<crate::model::PrivatePool>> {
+        #[allow(unreachable_patterns)]
+        self.execution_environment.as_ref().and_then(|v| match v {
+            crate::model::execution_config::ExecutionEnvironment::PrivatePool(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
@@ -3953,12 +3953,6 @@ impl ListTargetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTargetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [targets][crate::model::ListTargetsResponse::targets].
     pub fn set_targets<T, V>(mut self, v: T) -> Self
     where
@@ -3967,6 +3961,12 @@ impl ListTargetsResponse {
     {
         use std::iter::Iterator;
         self.targets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTargetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4415,30 +4415,6 @@ impl CustomTargetType {
         self
     }
 
-    /// Sets the value of [create_time][crate::model::CustomTargetType::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [update_time][crate::model::CustomTargetType::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [etag][crate::model::CustomTargetType::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::CustomTargetType::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -4460,6 +4436,30 @@ impl CustomTargetType {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::CustomTargetType::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::CustomTargetType::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::CustomTargetType::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 
@@ -4655,38 +4655,6 @@ impl SkaffoldModules {
         })
     }
 
-    /// The value of [source][crate::model::SkaffoldModules::source]
-    /// if it holds a `GoogleCloudStorage`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn google_cloud_storage(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::skaffold_modules::SkaffoldGCSSource>>
-    {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::skaffold_modules::Source::GoogleCloudStorage(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::SkaffoldModules::source]
-    /// if it holds a `GoogleCloudBuildRepo`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn google_cloud_build_repo(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::skaffold_modules::SkaffoldGCBRepoSource>>
-    {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::skaffold_modules::Source::GoogleCloudBuildRepo(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::SkaffoldModules::source]
     /// to hold a `Git`.
     ///
@@ -4701,6 +4669,22 @@ impl SkaffoldModules {
         self.source =
             std::option::Option::Some(crate::model::skaffold_modules::Source::Git(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::SkaffoldModules::source]
+    /// if it holds a `GoogleCloudStorage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn google_cloud_storage(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::skaffold_modules::SkaffoldGCSSource>>
+    {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::skaffold_modules::Source::GoogleCloudStorage(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::SkaffoldModules::source]
@@ -4718,6 +4702,22 @@ impl SkaffoldModules {
             crate::model::skaffold_modules::Source::GoogleCloudStorage(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::SkaffoldModules::source]
+    /// if it holds a `GoogleCloudBuildRepo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn google_cloud_build_repo(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::skaffold_modules::SkaffoldGCBRepoSource>>
+    {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::skaffold_modules::Source::GoogleCloudBuildRepo(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::SkaffoldModules::source]
@@ -5029,12 +5029,6 @@ impl ListCustomTargetTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCustomTargetTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [custom_target_types][crate::model::ListCustomTargetTypesResponse::custom_target_types].
     pub fn set_custom_target_types<T, V>(mut self, v: T) -> Self
     where
@@ -5043,6 +5037,12 @@ impl ListCustomTargetTypesResponse {
     {
         use std::iter::Iterator;
         self.custom_target_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCustomTargetTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5507,6 +5507,30 @@ impl DeployPolicy {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::DeployPolicy::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::DeployPolicy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::DeployPolicy::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5528,12 +5552,6 @@ impl DeployPolicy {
     /// Sets the value of [suspended][crate::model::DeployPolicy::suspended].
     pub fn set_suspended<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.suspended = v.into();
-        self
-    }
-
-    /// Sets the value of [etag][crate::model::DeployPolicy::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
         self
     }
 
@@ -5559,27 +5577,9 @@ impl DeployPolicy {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::DeployPolicy::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::DeployPolicy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [etag][crate::model::DeployPolicy::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -6010,17 +6010,6 @@ impl RolloutRestriction {
         self
     }
 
-    /// Sets the value of [time_windows][crate::model::RolloutRestriction::time_windows].
-    pub fn set_time_windows<
-        T: std::convert::Into<std::option::Option<crate::model::TimeWindows>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_windows = v.into();
-        self
-    }
-
     /// Sets the value of [invokers][crate::model::RolloutRestriction::invokers].
     pub fn set_invokers<T, V>(mut self, v: T) -> Self
     where
@@ -6040,6 +6029,17 @@ impl RolloutRestriction {
     {
         use std::iter::Iterator;
         self.actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [time_windows][crate::model::RolloutRestriction::time_windows].
+    pub fn set_time_windows<
+        T: std::convert::Into<std::option::Option<crate::model::TimeWindows>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.time_windows = v.into();
         self
     }
 }
@@ -6403,6 +6403,17 @@ impl WeeklyWindow {
         std::default::Default::default()
     }
 
+    /// Sets the value of [days_of_week][crate::model::WeeklyWindow::days_of_week].
+    pub fn set_days_of_week<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<gtype::model::DayOfWeek>,
+    {
+        use std::iter::Iterator;
+        self.days_of_week = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::WeeklyWindow::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<gtype::model::TimeOfDay>>>(
         mut self,
@@ -6418,17 +6429,6 @@ impl WeeklyWindow {
         v: T,
     ) -> Self {
         self.end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [days_of_week][crate::model::WeeklyWindow::days_of_week].
-    pub fn set_days_of_week<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<gtype::model::DayOfWeek>,
-    {
-        use std::iter::Iterator;
-        self.days_of_week = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6684,6 +6684,30 @@ impl Release {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Release::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Release::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [abandoned][crate::model::Release::abandoned].
     pub fn set_abandoned<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.abandoned = v.into();
@@ -6735,6 +6759,17 @@ impl Release {
         self
     }
 
+    /// Sets the value of [build_artifacts][crate::model::Release::build_artifacts].
+    pub fn set_build_artifacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BuildArtifact>,
+    {
+        use std::iter::Iterator;
+        self.build_artifacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [delivery_pipeline_snapshot][crate::model::Release::delivery_pipeline_snapshot].
     pub fn set_delivery_pipeline_snapshot<
         T: std::convert::Into<std::option::Option<crate::model::DeliveryPipeline>>,
@@ -6743,6 +6778,28 @@ impl Release {
         v: T,
     ) -> Self {
         self.delivery_pipeline_snapshot = v.into();
+        self
+    }
+
+    /// Sets the value of [target_snapshots][crate::model::Release::target_snapshots].
+    pub fn set_target_snapshots<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Target>,
+    {
+        use std::iter::Iterator;
+        self.target_snapshots = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [custom_target_type_snapshots][crate::model::Release::custom_target_type_snapshots].
+    pub fn set_custom_target_type_snapshots<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CustomTargetType>,
+    {
+        use std::iter::Iterator;
+        self.custom_target_type_snapshots = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6770,74 +6827,6 @@ impl Release {
         self
     }
 
-    /// Sets the value of [condition][crate::model::Release::condition].
-    pub fn set_condition<
-        T: std::convert::Into<std::option::Option<crate::model::release::ReleaseCondition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition = v.into();
-        self
-    }
-
-    /// Sets the value of [build_artifacts][crate::model::Release::build_artifacts].
-    pub fn set_build_artifacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BuildArtifact>,
-    {
-        use std::iter::Iterator;
-        self.build_artifacts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [target_snapshots][crate::model::Release::target_snapshots].
-    pub fn set_target_snapshots<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Target>,
-    {
-        use std::iter::Iterator;
-        self.target_snapshots = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [custom_target_type_snapshots][crate::model::Release::custom_target_type_snapshots].
-    pub fn set_custom_target_type_snapshots<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CustomTargetType>,
-    {
-        use std::iter::Iterator;
-        self.custom_target_type_snapshots = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Release::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Release::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [target_artifacts][crate::model::Release::target_artifacts].
     pub fn set_target_artifacts<T, K, V>(mut self, v: T) -> Self
     where
@@ -6859,6 +6848,17 @@ impl Release {
     {
         use std::iter::Iterator;
         self.target_renders = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [condition][crate::model::Release::condition].
+    pub fn set_condition<
+        T: std::convert::Into<std::option::Option<crate::model::release::ReleaseCondition>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.condition = v.into();
         self
     }
 
@@ -8025,12 +8025,6 @@ impl ListDeployPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeployPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deploy_policies][crate::model::ListDeployPoliciesResponse::deploy_policies].
     pub fn set_deploy_policies<T, V>(mut self, v: T) -> Self
     where
@@ -8039,6 +8033,12 @@ impl ListDeployPoliciesResponse {
     {
         use std::iter::Iterator;
         self.deploy_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeployPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8578,12 +8578,6 @@ impl ListReleasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReleasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [releases][crate::model::ListReleasesResponse::releases].
     pub fn set_releases<T, V>(mut self, v: T) -> Self
     where
@@ -8592,6 +8586,12 @@ impl ListReleasesResponse {
     {
         use std::iter::Iterator;
         self.releases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReleasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8914,6 +8914,30 @@ impl Rollout {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Rollout::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Rollout::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Rollout::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -9007,6 +9031,17 @@ impl Rollout {
         self
     }
 
+    /// Sets the value of [phases][crate::model::Rollout::phases].
+    pub fn set_phases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Phase>,
+    {
+        use std::iter::Iterator;
+        self.phases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [metadata][crate::model::Rollout::metadata].
     pub fn set_metadata<T: std::convert::Into<std::option::Option<crate::model::Metadata>>>(
         mut self,
@@ -9034,26 +9069,6 @@ impl Rollout {
         self
     }
 
-    /// Sets the value of [active_repair_automation_run][crate::model::Rollout::active_repair_automation_run].
-    pub fn set_active_repair_automation_run<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.active_repair_automation_run = v.into();
-        self
-    }
-
-    /// Sets the value of [phases][crate::model::Rollout::phases].
-    pub fn set_phases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Phase>,
-    {
-        use std::iter::Iterator;
-        self.phases = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [rolled_back_by_rollouts][crate::model::Rollout::rolled_back_by_rollouts].
     pub fn set_rolled_back_by_rollouts<T, V>(mut self, v: T) -> Self
     where
@@ -9065,27 +9080,12 @@ impl Rollout {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::Rollout::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Rollout::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [active_repair_automation_run][crate::model::Rollout::active_repair_automation_run].
+    pub fn set_active_repair_automation_run<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.active_repair_automation_run = v.into();
         self
     }
 }
@@ -9797,6 +9797,17 @@ impl CloudRunMetadata {
         self
     }
 
+    /// Sets the value of [service_urls][crate::model::CloudRunMetadata::service_urls].
+    pub fn set_service_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.service_urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [revision][crate::model::CloudRunMetadata::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
@@ -9806,17 +9817,6 @@ impl CloudRunMetadata {
     /// Sets the value of [job][crate::model::CloudRunMetadata::job].
     pub fn set_job<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.job = v.into();
-        self
-    }
-
-    /// Sets the value of [service_urls][crate::model::CloudRunMetadata::service_urls].
-    pub fn set_service_urls<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.service_urls = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10043,19 +10043,6 @@ impl Phase {
         })
     }
 
-    /// The value of [jobs][crate::model::Phase::jobs]
-    /// if it holds a `ChildRolloutJobs`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn child_rollout_jobs(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ChildRolloutJobs>> {
-        #[allow(unreachable_patterns)]
-        self.jobs.as_ref().and_then(|v| match v {
-            crate::model::phase::Jobs::ChildRolloutJobs(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [jobs][crate::model::Phase::jobs]
     /// to hold a `DeploymentJobs`.
     ///
@@ -10069,6 +10056,19 @@ impl Phase {
     ) -> Self {
         self.jobs = std::option::Option::Some(crate::model::phase::Jobs::DeploymentJobs(v.into()));
         self
+    }
+
+    /// The value of [jobs][crate::model::Phase::jobs]
+    /// if it holds a `ChildRolloutJobs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn child_rollout_jobs(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ChildRolloutJobs>> {
+        #[allow(unreachable_patterns)]
+        self.jobs.as_ref().and_then(|v| match v {
+            crate::model::phase::Jobs::ChildRolloutJobs(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [jobs][crate::model::Phase::jobs]
@@ -10480,69 +10480,6 @@ impl Job {
         })
     }
 
-    /// The value of [job_type][crate::model::Job::job_type]
-    /// if it holds a `VerifyJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn verify_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::VerifyJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::job::JobType::VerifyJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::Job::job_type]
-    /// if it holds a `PredeployJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn predeploy_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PredeployJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::job::JobType::PredeployJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::Job::job_type]
-    /// if it holds a `PostdeployJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postdeploy_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostdeployJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::job::JobType::PostdeployJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::Job::job_type]
-    /// if it holds a `CreateChildRolloutJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_child_rollout_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateChildRolloutJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::job::JobType::CreateChildRolloutJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_type][crate::model::Job::job_type]
-    /// if it holds a `AdvanceChildRolloutJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn advance_child_rollout_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceChildRolloutJob>> {
-        #[allow(unreachable_patterns)]
-        self.job_type.as_ref().and_then(|v| match v {
-            crate::model::job::JobType::AdvanceChildRolloutJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [job_type][crate::model::Job::job_type]
     /// to hold a `DeployJob`.
     ///
@@ -10554,6 +10491,17 @@ impl Job {
     ) -> Self {
         self.job_type = std::option::Option::Some(crate::model::job::JobType::DeployJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::Job::job_type]
+    /// if it holds a `VerifyJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn verify_job(&self) -> std::option::Option<&std::boxed::Box<crate::model::VerifyJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::job::JobType::VerifyJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::Job::job_type]
@@ -10569,6 +10517,19 @@ impl Job {
         self
     }
 
+    /// The value of [job_type][crate::model::Job::job_type]
+    /// if it holds a `PredeployJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn predeploy_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PredeployJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::job::JobType::PredeployJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_type][crate::model::Job::job_type]
     /// to hold a `PredeployJob`.
     ///
@@ -10581,6 +10542,19 @@ impl Job {
         self.job_type =
             std::option::Option::Some(crate::model::job::JobType::PredeployJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::Job::job_type]
+    /// if it holds a `PostdeployJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postdeploy_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostdeployJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::job::JobType::PostdeployJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::Job::job_type]
@@ -10599,6 +10573,19 @@ impl Job {
         self
     }
 
+    /// The value of [job_type][crate::model::Job::job_type]
+    /// if it holds a `CreateChildRolloutJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_child_rollout_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateChildRolloutJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::job::JobType::CreateChildRolloutJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_type][crate::model::Job::job_type]
     /// to hold a `CreateChildRolloutJob`.
     ///
@@ -10613,6 +10600,19 @@ impl Job {
         self.job_type =
             std::option::Option::Some(crate::model::job::JobType::CreateChildRolloutJob(v.into()));
         self
+    }
+
+    /// The value of [job_type][crate::model::Job::job_type]
+    /// if it holds a `AdvanceChildRolloutJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn advance_child_rollout_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceChildRolloutJob>> {
+        #[allow(unreachable_patterns)]
+        self.job_type.as_ref().and_then(|v| match v {
+            crate::model::job::JobType::AdvanceChildRolloutJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_type][crate::model::Job::job_type]
@@ -11108,12 +11108,6 @@ impl ListRolloutsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRolloutsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rollouts][crate::model::ListRolloutsResponse::rollouts].
     pub fn set_rollouts<T, V>(mut self, v: T) -> Self
     where
@@ -11122,6 +11116,12 @@ impl ListRolloutsResponse {
     {
         use std::iter::Iterator;
         self.rollouts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRolloutsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -11283,15 +11283,6 @@ impl CreateRolloutRequest {
         self
     }
 
-    /// Sets the value of [starting_phase_id][crate::model::CreateRolloutRequest::starting_phase_id].
-    pub fn set_starting_phase_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.starting_phase_id = v.into();
-        self
-    }
-
     /// Sets the value of [override_deploy_policy][crate::model::CreateRolloutRequest::override_deploy_policy].
     pub fn set_override_deploy_policy<T, V>(mut self, v: T) -> Self
     where
@@ -11300,6 +11291,15 @@ impl CreateRolloutRequest {
     {
         use std::iter::Iterator;
         self.override_deploy_policy = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [starting_phase_id][crate::model::CreateRolloutRequest::starting_phase_id].
+    pub fn set_starting_phase_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.starting_phase_id = v.into();
         self
     }
 }
@@ -12035,75 +12035,6 @@ impl JobRun {
         })
     }
 
-    /// The value of [job_run][crate::model::JobRun::job_run]
-    /// if it holds a `VerifyJobRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn verify_job_run(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VerifyJobRun>> {
-        #[allow(unreachable_patterns)]
-        self.job_run.as_ref().and_then(|v| match v {
-            crate::model::job_run::JobRun::VerifyJobRun(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_run][crate::model::JobRun::job_run]
-    /// if it holds a `PredeployJobRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn predeploy_job_run(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PredeployJobRun>> {
-        #[allow(unreachable_patterns)]
-        self.job_run.as_ref().and_then(|v| match v {
-            crate::model::job_run::JobRun::PredeployJobRun(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_run][crate::model::JobRun::job_run]
-    /// if it holds a `PostdeployJobRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn postdeploy_job_run(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostdeployJobRun>> {
-        #[allow(unreachable_patterns)]
-        self.job_run.as_ref().and_then(|v| match v {
-            crate::model::job_run::JobRun::PostdeployJobRun(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_run][crate::model::JobRun::job_run]
-    /// if it holds a `CreateChildRolloutJobRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_child_rollout_job_run(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateChildRolloutJobRun>> {
-        #[allow(unreachable_patterns)]
-        self.job_run.as_ref().and_then(|v| match v {
-            crate::model::job_run::JobRun::CreateChildRolloutJobRun(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [job_run][crate::model::JobRun::job_run]
-    /// if it holds a `AdvanceChildRolloutJobRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn advance_child_rollout_job_run(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceChildRolloutJobRun>> {
-        #[allow(unreachable_patterns)]
-        self.job_run.as_ref().and_then(|v| match v {
-            crate::model::job_run::JobRun::AdvanceChildRolloutJobRun(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [job_run][crate::model::JobRun::job_run]
     /// to hold a `DeployJobRun`.
     ///
@@ -12118,6 +12049,19 @@ impl JobRun {
         self.job_run =
             std::option::Option::Some(crate::model::job_run::JobRun::DeployJobRun(v.into()));
         self
+    }
+
+    /// The value of [job_run][crate::model::JobRun::job_run]
+    /// if it holds a `VerifyJobRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn verify_job_run(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VerifyJobRun>> {
+        #[allow(unreachable_patterns)]
+        self.job_run.as_ref().and_then(|v| match v {
+            crate::model::job_run::JobRun::VerifyJobRun(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_run][crate::model::JobRun::job_run]
@@ -12136,6 +12080,19 @@ impl JobRun {
         self
     }
 
+    /// The value of [job_run][crate::model::JobRun::job_run]
+    /// if it holds a `PredeployJobRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn predeploy_job_run(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PredeployJobRun>> {
+        #[allow(unreachable_patterns)]
+        self.job_run.as_ref().and_then(|v| match v {
+            crate::model::job_run::JobRun::PredeployJobRun(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_run][crate::model::JobRun::job_run]
     /// to hold a `PredeployJobRun`.
     ///
@@ -12150,6 +12107,19 @@ impl JobRun {
         self.job_run =
             std::option::Option::Some(crate::model::job_run::JobRun::PredeployJobRun(v.into()));
         self
+    }
+
+    /// The value of [job_run][crate::model::JobRun::job_run]
+    /// if it holds a `PostdeployJobRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn postdeploy_job_run(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostdeployJobRun>> {
+        #[allow(unreachable_patterns)]
+        self.job_run.as_ref().and_then(|v| match v {
+            crate::model::job_run::JobRun::PostdeployJobRun(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_run][crate::model::JobRun::job_run]
@@ -12168,6 +12138,21 @@ impl JobRun {
         self
     }
 
+    /// The value of [job_run][crate::model::JobRun::job_run]
+    /// if it holds a `CreateChildRolloutJobRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_child_rollout_job_run(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateChildRolloutJobRun>> {
+        #[allow(unreachable_patterns)]
+        self.job_run.as_ref().and_then(|v| match v {
+            crate::model::job_run::JobRun::CreateChildRolloutJobRun(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [job_run][crate::model::JobRun::job_run]
     /// to hold a `CreateChildRolloutJobRun`.
     ///
@@ -12183,6 +12168,21 @@ impl JobRun {
             crate::model::job_run::JobRun::CreateChildRolloutJobRun(v.into()),
         );
         self
+    }
+
+    /// The value of [job_run][crate::model::JobRun::job_run]
+    /// if it holds a `AdvanceChildRolloutJobRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn advance_child_rollout_job_run(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceChildRolloutJobRun>> {
+        #[allow(unreachable_patterns)]
+        self.job_run.as_ref().and_then(|v| match v {
+            crate::model::job_run::JobRun::AdvanceChildRolloutJobRun(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_run][crate::model::JobRun::job_run]
@@ -13536,12 +13536,6 @@ impl ListJobRunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobRunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [job_runs][crate::model::ListJobRunsResponse::job_runs].
     pub fn set_job_runs<T, V>(mut self, v: T) -> Self
     where
@@ -13550,6 +13544,12 @@ impl ListJobRunsResponse {
     {
         use std::iter::Iterator;
         self.job_runs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobRunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -13723,15 +13723,6 @@ impl Config {
         self
     }
 
-    /// Sets the value of [default_skaffold_version][crate::model::Config::default_skaffold_version].
-    pub fn set_default_skaffold_version<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.default_skaffold_version = v.into();
-        self
-    }
-
     /// Sets the value of [supported_versions][crate::model::Config::supported_versions].
     pub fn set_supported_versions<T, V>(mut self, v: T) -> Self
     where
@@ -13740,6 +13731,15 @@ impl Config {
     {
         use std::iter::Iterator;
         self.supported_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [default_skaffold_version][crate::model::Config::default_skaffold_version].
+    pub fn set_default_skaffold_version<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.default_skaffold_version = v.into();
         self
     }
 }
@@ -13994,6 +13994,30 @@ impl Automation {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Automation::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Automation::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Automation::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -14031,30 +14055,6 @@ impl Automation {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Automation::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Automation::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -14151,51 +14151,6 @@ impl AutomationRule {
         })
     }
 
-    /// The value of [rule][crate::model::AutomationRule::rule]
-    /// if it holds a `AdvanceRolloutRule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn advance_rollout_rule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceRolloutRule>> {
-        #[allow(unreachable_patterns)]
-        self.rule.as_ref().and_then(|v| match v {
-            crate::model::automation_rule::Rule::AdvanceRolloutRule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule][crate::model::AutomationRule::rule]
-    /// if it holds a `RepairRolloutRule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn repair_rollout_rule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RepairRolloutRule>> {
-        #[allow(unreachable_patterns)]
-        self.rule.as_ref().and_then(|v| match v {
-            crate::model::automation_rule::Rule::RepairRolloutRule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [rule][crate::model::AutomationRule::rule]
-    /// if it holds a `TimedPromoteReleaseRule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn timed_promote_release_rule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TimedPromoteReleaseRule>> {
-        #[allow(unreachable_patterns)]
-        self.rule.as_ref().and_then(|v| match v {
-            crate::model::automation_rule::Rule::TimedPromoteReleaseRule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [rule][crate::model::AutomationRule::rule]
     /// to hold a `PromoteReleaseRule`.
     ///
@@ -14211,6 +14166,21 @@ impl AutomationRule {
             crate::model::automation_rule::Rule::PromoteReleaseRule(v.into()),
         );
         self
+    }
+
+    /// The value of [rule][crate::model::AutomationRule::rule]
+    /// if it holds a `AdvanceRolloutRule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn advance_rollout_rule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceRolloutRule>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::automation_rule::Rule::AdvanceRolloutRule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule][crate::model::AutomationRule::rule]
@@ -14230,6 +14200,21 @@ impl AutomationRule {
         self
     }
 
+    /// The value of [rule][crate::model::AutomationRule::rule]
+    /// if it holds a `RepairRolloutRule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn repair_rollout_rule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RepairRolloutRule>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::automation_rule::Rule::RepairRolloutRule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [rule][crate::model::AutomationRule::rule]
     /// to hold a `RepairRolloutRule`.
     ///
@@ -14245,6 +14230,21 @@ impl AutomationRule {
             crate::model::automation_rule::Rule::RepairRolloutRule(v.into()),
         );
         self
+    }
+
+    /// The value of [rule][crate::model::AutomationRule::rule]
+    /// if it holds a `TimedPromoteReleaseRule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn timed_promote_release_rule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimedPromoteReleaseRule>> {
+        #[allow(unreachable_patterns)]
+        self.rule.as_ref().and_then(|v| match v {
+            crate::model::automation_rule::Rule::TimedPromoteReleaseRule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [rule][crate::model::AutomationRule::rule]
@@ -14541,6 +14541,17 @@ impl AdvanceRolloutRule {
         self
     }
 
+    /// Sets the value of [source_phases][crate::model::AdvanceRolloutRule::source_phases].
+    pub fn set_source_phases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.source_phases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [wait][crate::model::AdvanceRolloutRule::wait].
     pub fn set_wait<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
@@ -14558,17 +14569,6 @@ impl AdvanceRolloutRule {
         v: T,
     ) -> Self {
         self.condition = v.into();
-        self
-    }
-
-    /// Sets the value of [source_phases][crate::model::AdvanceRolloutRule::source_phases].
-    pub fn set_source_phases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.source_phases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -14634,17 +14634,6 @@ impl RepairRolloutRule {
         self
     }
 
-    /// Sets the value of [condition][crate::model::RepairRolloutRule::condition].
-    pub fn set_condition<
-        T: std::convert::Into<std::option::Option<crate::model::AutomationRuleCondition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition = v.into();
-        self
-    }
-
     /// Sets the value of [phases][crate::model::RepairRolloutRule::phases].
     pub fn set_phases<T, V>(mut self, v: T) -> Self
     where
@@ -14664,6 +14653,17 @@ impl RepairRolloutRule {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [condition][crate::model::RepairRolloutRule::condition].
+    pub fn set_condition<
+        T: std::convert::Into<std::option::Option<crate::model::AutomationRuleCondition>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.condition = v.into();
         self
     }
 
@@ -14731,19 +14731,6 @@ impl RepairPhaseConfig {
         })
     }
 
-    /// The value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
-    /// if it holds a `Rollback`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn rollback(&self) -> std::option::Option<&std::boxed::Box<crate::model::Rollback>> {
-        #[allow(unreachable_patterns)]
-        self.repair_phase.as_ref().and_then(|v| match v {
-            crate::model::repair_phase_config::RepairPhase::Rollback(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
     /// to hold a `Retry`.
     ///
@@ -14757,6 +14744,19 @@ impl RepairPhaseConfig {
             crate::model::repair_phase_config::RepairPhase::Retry(v.into()),
         );
         self
+    }
+
+    /// The value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
+    /// if it holds a `Rollback`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn rollback(&self) -> std::option::Option<&std::boxed::Box<crate::model::Rollback>> {
+        #[allow(unreachable_patterns)]
+        self.repair_phase.as_ref().and_then(|v| match v {
+            crate::model::repair_phase_config::RepairPhase::Rollback(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
@@ -15507,12 +15507,6 @@ impl ListAutomationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutomationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [automations][crate::model::ListAutomationsResponse::automations].
     pub fn set_automations<T, V>(mut self, v: T) -> Self
     where
@@ -15521,6 +15515,12 @@ impl ListAutomationsResponse {
     {
         use std::iter::Iterator;
         self.automations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutomationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -15819,51 +15819,6 @@ impl AutomationRun {
         })
     }
 
-    /// The value of [operation][crate::model::AutomationRun::operation]
-    /// if it holds a `AdvanceRolloutOperation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn advance_rollout_operation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceRolloutOperation>> {
-        #[allow(unreachable_patterns)]
-        self.operation.as_ref().and_then(|v| match v {
-            crate::model::automation_run::Operation::AdvanceRolloutOperation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [operation][crate::model::AutomationRun::operation]
-    /// if it holds a `RepairRolloutOperation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn repair_rollout_operation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RepairRolloutOperation>> {
-        #[allow(unreachable_patterns)]
-        self.operation.as_ref().and_then(|v| match v {
-            crate::model::automation_run::Operation::RepairRolloutOperation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [operation][crate::model::AutomationRun::operation]
-    /// if it holds a `TimedPromoteReleaseOperation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn timed_promote_release_operation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TimedPromoteReleaseOperation>> {
-        #[allow(unreachable_patterns)]
-        self.operation.as_ref().and_then(|v| match v {
-            crate::model::automation_run::Operation::TimedPromoteReleaseOperation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [operation][crate::model::AutomationRun::operation]
     /// to hold a `PromoteReleaseOperation`.
     ///
@@ -15879,6 +15834,21 @@ impl AutomationRun {
             crate::model::automation_run::Operation::PromoteReleaseOperation(v.into()),
         );
         self
+    }
+
+    /// The value of [operation][crate::model::AutomationRun::operation]
+    /// if it holds a `AdvanceRolloutOperation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn advance_rollout_operation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AdvanceRolloutOperation>> {
+        #[allow(unreachable_patterns)]
+        self.operation.as_ref().and_then(|v| match v {
+            crate::model::automation_run::Operation::AdvanceRolloutOperation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [operation][crate::model::AutomationRun::operation]
@@ -15898,6 +15868,21 @@ impl AutomationRun {
         self
     }
 
+    /// The value of [operation][crate::model::AutomationRun::operation]
+    /// if it holds a `RepairRolloutOperation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn repair_rollout_operation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RepairRolloutOperation>> {
+        #[allow(unreachable_patterns)]
+        self.operation.as_ref().and_then(|v| match v {
+            crate::model::automation_run::Operation::RepairRolloutOperation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [operation][crate::model::AutomationRun::operation]
     /// to hold a `RepairRolloutOperation`.
     ///
@@ -15913,6 +15898,21 @@ impl AutomationRun {
             crate::model::automation_run::Operation::RepairRolloutOperation(v.into()),
         );
         self
+    }
+
+    /// The value of [operation][crate::model::AutomationRun::operation]
+    /// if it holds a `TimedPromoteReleaseOperation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn timed_promote_release_operation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimedPromoteReleaseOperation>> {
+        #[allow(unreachable_patterns)]
+        self.operation.as_ref().and_then(|v| match v {
+            crate::model::automation_run::Operation::TimedPromoteReleaseOperation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [operation][crate::model::AutomationRun::operation]
@@ -16306,6 +16306,17 @@ impl RepairRolloutOperation {
         self
     }
 
+    /// Sets the value of [repair_phases][crate::model::RepairRolloutOperation::repair_phases].
+    pub fn set_repair_phases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RepairPhase>,
+    {
+        use std::iter::Iterator;
+        self.repair_phases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [phase_id][crate::model::RepairRolloutOperation::phase_id].
     pub fn set_phase_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.phase_id = v.into();
@@ -16315,17 +16326,6 @@ impl RepairRolloutOperation {
     /// Sets the value of [job_id][crate::model::RepairRolloutOperation::job_id].
     pub fn set_job_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.job_id = v.into();
-        self
-    }
-
-    /// Sets the value of [repair_phases][crate::model::RepairRolloutOperation::repair_phases].
-    pub fn set_repair_phases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RepairPhase>,
-    {
-        use std::iter::Iterator;
-        self.repair_phases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -16435,17 +16435,6 @@ impl RepairPhase {
         })
     }
 
-    /// The value of [repair_phase][crate::model::RepairPhase::repair_phase]
-    /// if it holds a `Rollback`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn rollback(&self) -> std::option::Option<&std::boxed::Box<crate::model::RollbackAttempt>> {
-        #[allow(unreachable_patterns)]
-        self.repair_phase.as_ref().and_then(|v| match v {
-            crate::model::repair_phase::RepairPhase::Rollback(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [repair_phase][crate::model::RepairPhase::repair_phase]
     /// to hold a `Retry`.
     ///
@@ -16458,6 +16447,17 @@ impl RepairPhase {
         self.repair_phase =
             std::option::Option::Some(crate::model::repair_phase::RepairPhase::Retry(v.into()));
         self
+    }
+
+    /// The value of [repair_phase][crate::model::RepairPhase::repair_phase]
+    /// if it holds a `Rollback`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn rollback(&self) -> std::option::Option<&std::boxed::Box<crate::model::RollbackAttempt>> {
+        #[allow(unreachable_patterns)]
+        self.repair_phase.as_ref().and_then(|v| match v {
+            crate::model::repair_phase::RepairPhase::Rollback(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [repair_phase][crate::model::RepairPhase::repair_phase]
@@ -16812,12 +16812,6 @@ impl ListAutomationRunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutomationRunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [automation_runs][crate::model::ListAutomationRunsResponse::automation_runs].
     pub fn set_automation_runs<T, V>(mut self, v: T) -> Self
     where
@@ -16826,6 +16820,12 @@ impl ListAutomationRunsResponse {
     {
         use std::iter::Iterator;
         self.automation_runs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutomationRunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -141,6 +141,18 @@ impl Connection {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Connection::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [installation_state][crate::model::Connection::installation_state].
     pub fn set_installation_state<
         T: std::convert::Into<std::option::Option<crate::model::InstallationState>>,
@@ -164,6 +176,18 @@ impl Connection {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Connection::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Connection::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -184,30 +208,6 @@ impl Connection {
         v: T,
     ) -> Self {
         self.crypto_key_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Connection::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Connection::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -240,51 +240,6 @@ impl Connection {
         })
     }
 
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn github_enterprise_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GitHubEnterpriseConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `GitlabConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gitlab_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::GitlabConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `GitlabEnterpriseConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gitlab_enterprise_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabEnterpriseConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::GitlabEnterpriseConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
     /// to hold a `GithubConfig`.
     ///
@@ -298,6 +253,21 @@ impl Connection {
             crate::model::connection::ConnectionConfig::GithubConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn github_enterprise_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitHubEnterpriseConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
@@ -317,6 +287,21 @@ impl Connection {
         self
     }
 
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GitlabConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gitlab_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GitlabConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
     /// to hold a `GitlabConfig`.
     ///
@@ -330,6 +315,21 @@ impl Connection {
             crate::model::connection::ConnectionConfig::GitlabConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GitlabEnterpriseConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gitlab_enterprise_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabEnterpriseConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GitlabEnterpriseConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
@@ -1417,12 +1417,6 @@ impl ListConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connections][crate::model::ListConnectionsResponse::connections].
     pub fn set_connections<T, V>(mut self, v: T) -> Self
     where
@@ -1431,6 +1425,12 @@ impl ListConnectionsResponse {
     {
         use std::iter::Iterator;
         self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1970,30 +1970,6 @@ impl GitRepositoryLink {
         self
     }
 
-    /// Sets the value of [etag][crate::model::GitRepositoryLink::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [reconciling][crate::model::GitRepositoryLink::reconciling].
-    pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.reconciling = v.into();
-        self
-    }
-
-    /// Sets the value of [uid][crate::model::GitRepositoryLink::uid].
-    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.uid = v.into();
-        self
-    }
-
-    /// Sets the value of [webhook_id][crate::model::GitRepositoryLink::webhook_id].
-    pub fn set_webhook_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.webhook_id = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::GitRepositoryLink::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -2006,6 +1982,18 @@ impl GitRepositoryLink {
         self
     }
 
+    /// Sets the value of [etag][crate::model::GitRepositoryLink::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [reconciling][crate::model::GitRepositoryLink::reconciling].
+    pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.reconciling = v.into();
+        self
+    }
+
     /// Sets the value of [annotations][crate::model::GitRepositoryLink::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -2015,6 +2003,18 @@ impl GitRepositoryLink {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [uid][crate::model::GitRepositoryLink::uid].
+    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.uid = v.into();
+        self
+    }
+
+    /// Sets the value of [webhook_id][crate::model::GitRepositoryLink::webhook_id].
+    pub fn set_webhook_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.webhook_id = v.into();
         self
     }
 }
@@ -2296,12 +2296,6 @@ impl ListGitRepositoryLinksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGitRepositoryLinksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [git_repository_links][crate::model::ListGitRepositoryLinksResponse::git_repository_links].
     pub fn set_git_repository_links<T, V>(mut self, v: T) -> Self
     where
@@ -2310,6 +2304,12 @@ impl ListGitRepositoryLinksResponse {
     {
         use std::iter::Iterator;
         self.git_repository_links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGitRepositoryLinksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2639,12 +2639,6 @@ impl FetchLinkableGitRepositoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchLinkableGitRepositoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [linkable_git_repositories][crate::model::FetchLinkableGitRepositoriesResponse::linkable_git_repositories].
     pub fn set_linkable_git_repositories<T, V>(mut self, v: T) -> Self
     where
@@ -2653,6 +2647,12 @@ impl FetchLinkableGitRepositoriesResponse {
     {
         use std::iter::Iterator;
         self.linkable_git_repositories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchLinkableGitRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3071,12 +3071,6 @@ impl FetchGitRefsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchGitRefsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [ref_names][crate::model::FetchGitRefsResponse::ref_names].
     pub fn set_ref_names<T, V>(mut self, v: T) -> Self
     where
@@ -3085,6 +3079,12 @@ impl FetchGitRefsResponse {
     {
         use std::iter::Iterator;
         self.ref_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchGitRefsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -2543,6 +2543,19 @@ pub mod entity_types {
             self
         }
 
+        /// Sets the value of [entity_types][crate::model::ExportEntityTypesRequest::entity_types].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_entity_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.entity_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [data_format][crate::model::ExportEntityTypesRequest::data_format].
         pub fn set_data_format<T: Into<crate::model::export_entity_types_request::DataFormat>>(
             mut self,
@@ -2555,19 +2568,6 @@ pub mod entity_types {
         /// Sets the value of [language_code][crate::model::ExportEntityTypesRequest::language_code].
         pub fn set_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.language_code = v.into();
-            self
-        }
-
-        /// Sets the value of [entity_types][crate::model::ExportEntityTypesRequest::entity_types].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_entity_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.entity_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -7195,15 +7195,6 @@ pub mod intents {
             self
         }
 
-        /// Sets the value of [data_format][crate::model::ExportIntentsRequest::data_format].
-        pub fn set_data_format<T: Into<crate::model::export_intents_request::DataFormat>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.data_format = v.into();
-            self
-        }
-
         /// Sets the value of [intents][crate::model::ExportIntentsRequest::intents].
         ///
         /// This is a **required** field for requests.
@@ -7214,6 +7205,15 @@ pub mod intents {
         {
             use std::iter::Iterator;
             self.0.request.intents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [data_format][crate::model::ExportIntentsRequest::data_format].
+        pub fn set_data_format<T: Into<crate::model::export_intents_request::DataFormat>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.data_format = v.into();
             self
         }
 

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -607,6 +607,17 @@ impl Agent {
         self
     }
 
+    /// Sets the value of [supported_language_codes][crate::model::Agent::supported_language_codes].
+    pub fn set_supported_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.supported_language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [time_zone][crate::model::Agent::time_zone].
     pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time_zone = v.into();
@@ -768,17 +779,6 @@ impl Agent {
         v: T,
     ) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [supported_language_codes][crate::model::Agent::supported_language_codes].
-    pub fn set_supported_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.supported_language_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1247,12 +1247,6 @@ impl ListAgentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAgentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [agents][crate::model::ListAgentsResponse::agents].
     pub fn set_agents<T, V>(mut self, v: T) -> Self
     where
@@ -1261,6 +1255,12 @@ impl ListAgentsResponse {
     {
         use std::iter::Iterator;
         self.agents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAgentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1801,6 +1801,18 @@ impl ExportAgentResponse {
         })
     }
 
+    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
+    /// to hold a `AgentUri`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::export_agent_response::Agent::AgentUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [agent][crate::model::ExportAgentResponse::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1814,6 +1826,18 @@ impl ExportAgentResponse {
         })
     }
 
+    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
+    /// to hold a `AgentContent`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::export_agent_response::Agent::AgentContent(v.into()),
+        );
+        self
+    }
+
     /// The value of [agent][crate::model::ExportAgentResponse::agent]
     /// if it holds a `CommitSha`, `None` if the field is not set or
     /// holds a different branch.
@@ -1825,30 +1849,6 @@ impl ExportAgentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentContent(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
@@ -1973,6 +1973,18 @@ impl RestoreAgentRequest {
         })
     }
 
+    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
+    /// to hold a `AgentUri`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::restore_agent_request::Agent::AgentUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [agent][crate::model::RestoreAgentRequest::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1984,6 +1996,18 @@ impl RestoreAgentRequest {
             }
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
+    /// to hold a `AgentContent`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::restore_agent_request::Agent::AgentContent(v.into()),
+        );
+        self
     }
 
     /// The value of [agent][crate::model::RestoreAgentRequest::agent]
@@ -1999,30 +2023,6 @@ impl RestoreAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentContent(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
@@ -2747,6 +2747,17 @@ impl InputAudioConfig {
         self
     }
 
+    /// Sets the value of [phrase_hints][crate::model::InputAudioConfig::phrase_hints].
+    pub fn set_phrase_hints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.phrase_hints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [model][crate::model::InputAudioConfig::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
@@ -2785,17 +2796,6 @@ impl InputAudioConfig {
         v: T,
     ) -> Self {
         self.opt_out_conformer_model_migration = v.into();
-        self
-    }
-
-    /// Sets the value of [phrase_hints][crate::model::InputAudioConfig::phrase_hints].
-    pub fn set_phrase_hints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.phrase_hints = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2931,17 +2931,6 @@ impl SynthesizeSpeechConfig {
         self
     }
 
-    /// Sets the value of [voice][crate::model::SynthesizeSpeechConfig::voice].
-    pub fn set_voice<
-        T: std::convert::Into<std::option::Option<crate::model::VoiceSelectionParams>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.voice = v.into();
-        self
-    }
-
     /// Sets the value of [effects_profile_id][crate::model::SynthesizeSpeechConfig::effects_profile_id].
     pub fn set_effects_profile_id<T, V>(mut self, v: T) -> Self
     where
@@ -2950,6 +2939,17 @@ impl SynthesizeSpeechConfig {
     {
         use std::iter::Iterator;
         self.effects_profile_id = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [voice][crate::model::SynthesizeSpeechConfig::voice].
+    pub fn set_voice<
+        T: std::convert::Into<std::option::Option<crate::model::VoiceSelectionParams>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.voice = v.into();
         self
     }
 }
@@ -3204,12 +3204,6 @@ impl ListChangelogsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListChangelogsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [changelogs][crate::model::ListChangelogsResponse::changelogs].
     pub fn set_changelogs<T, V>(mut self, v: T) -> Self
     where
@@ -3218,6 +3212,12 @@ impl ListChangelogsResponse {
     {
         use std::iter::Iterator;
         self.changelogs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListChangelogsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3534,6 +3534,17 @@ impl DataStoreConnectionSignals {
         self
     }
 
+    /// Sets the value of [search_snippets][crate::model::DataStoreConnectionSignals::search_snippets].
+    pub fn set_search_snippets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::data_store_connection_signals::SearchSnippet>,
+    {
+        use std::iter::Iterator;
+        self.search_snippets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [answer_generation_model_call_signals][crate::model::DataStoreConnectionSignals::answer_generation_model_call_signals].
     pub fn set_answer_generation_model_call_signals<
         T: std::convert::Into<
@@ -3552,6 +3563,28 @@ impl DataStoreConnectionSignals {
     /// Sets the value of [answer][crate::model::DataStoreConnectionSignals::answer].
     pub fn set_answer<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.answer = v.into();
+        self
+    }
+
+    /// Sets the value of [answer_parts][crate::model::DataStoreConnectionSignals::answer_parts].
+    pub fn set_answer_parts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::data_store_connection_signals::AnswerPart>,
+    {
+        use std::iter::Iterator;
+        self.answer_parts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [cited_snippets][crate::model::DataStoreConnectionSignals::cited_snippets].
+    pub fn set_cited_snippets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::data_store_connection_signals::CitedSnippet>,
+    {
+        use std::iter::Iterator;
+        self.cited_snippets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3578,39 +3611,6 @@ impl DataStoreConnectionSignals {
         v: T,
     ) -> Self {
         self.safety_signals = v.into();
-        self
-    }
-
-    /// Sets the value of [search_snippets][crate::model::DataStoreConnectionSignals::search_snippets].
-    pub fn set_search_snippets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::data_store_connection_signals::SearchSnippet>,
-    {
-        use std::iter::Iterator;
-        self.search_snippets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [answer_parts][crate::model::DataStoreConnectionSignals::answer_parts].
-    pub fn set_answer_parts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::data_store_connection_signals::AnswerPart>,
-    {
-        use std::iter::Iterator;
-        self.answer_parts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [cited_snippets][crate::model::DataStoreConnectionSignals::cited_snippets].
-    pub fn set_cited_snippets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::data_store_connection_signals::CitedSnippet>,
-    {
-        use std::iter::Iterator;
-        self.cited_snippets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4732,12 +4732,6 @@ pub mod deployment {
             std::default::Default::default()
         }
 
-        /// Sets the value of [experiment][crate::model::deployment::Result::experiment].
-        pub fn set_experiment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.experiment = v.into();
-            self
-        }
-
         /// Sets the value of [deployment_test_results][crate::model::deployment::Result::deployment_test_results].
         pub fn set_deployment_test_results<T, V>(mut self, v: T) -> Self
         where
@@ -4746,6 +4740,12 @@ pub mod deployment {
         {
             use std::iter::Iterator;
             self.deployment_test_results = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [experiment][crate::model::deployment::Result::experiment].
+        pub fn set_experiment<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.experiment = v.into();
             self
         }
     }
@@ -4986,12 +4986,6 @@ impl ListDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::ListDeploymentsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -5000,6 +4994,12 @@ impl ListDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5184,18 +5184,6 @@ impl EntityType {
         self
     }
 
-    /// Sets the value of [enable_fuzzy_extraction][crate::model::EntityType::enable_fuzzy_extraction].
-    pub fn set_enable_fuzzy_extraction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_fuzzy_extraction = v.into();
-        self
-    }
-
-    /// Sets the value of [redact][crate::model::EntityType::redact].
-    pub fn set_redact<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.redact = v.into();
-        self
-    }
-
     /// Sets the value of [entities][crate::model::EntityType::entities].
     pub fn set_entities<T, V>(mut self, v: T) -> Self
     where
@@ -5215,6 +5203,18 @@ impl EntityType {
     {
         use std::iter::Iterator;
         self.excluded_phrases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enable_fuzzy_extraction][crate::model::EntityType::enable_fuzzy_extraction].
+    pub fn set_enable_fuzzy_extraction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_fuzzy_extraction = v.into();
+        self
+    }
+
+    /// Sets the value of [redact][crate::model::EntityType::redact].
+    pub fn set_redact<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.redact = v.into();
         self
     }
 }
@@ -5656,6 +5656,17 @@ impl ExportEntityTypesRequest {
         self
     }
 
+    /// Sets the value of [entity_types][crate::model::ExportEntityTypesRequest::entity_types].
+    pub fn set_entity_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [data_format][crate::model::ExportEntityTypesRequest::data_format].
     pub fn set_data_format<
         T: std::convert::Into<crate::model::export_entity_types_request::DataFormat>,
@@ -5670,17 +5681,6 @@ impl ExportEntityTypesRequest {
     /// Sets the value of [language_code][crate::model::ExportEntityTypesRequest::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [entity_types][crate::model::ExportEntityTypesRequest::entity_types].
-    pub fn set_entity_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.entity_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5713,19 +5713,6 @@ impl ExportEntityTypesRequest {
         })
     }
 
-    /// The value of [destination][crate::model::ExportEntityTypesRequest::destination]
-    /// if it holds a `EntityTypesContentInline`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity_types_content_inline(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::export_entity_types_request::Destination::EntityTypesContentInline(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::ExportEntityTypesRequest::destination]
     /// to hold a `EntityTypesUri`.
     ///
@@ -5739,6 +5726,19 @@ impl ExportEntityTypesRequest {
             crate::model::export_entity_types_request::Destination::EntityTypesUri(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::ExportEntityTypesRequest::destination]
+    /// if it holds a `EntityTypesContentInline`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity_types_content_inline(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::export_entity_types_request::Destination::EntityTypesContentInline(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::ExportEntityTypesRequest::destination]
@@ -5974,21 +5974,6 @@ impl ExportEntityTypesResponse {
         })
     }
 
-    /// The value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
-    /// if it holds a `EntityTypesContent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity_types_content(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineDestination>> {
-        #[allow(unreachable_patterns)]
-        self.exported_entity_types.as_ref().and_then(|v| match v {
-            crate::model::export_entity_types_response::ExportedEntityTypes::EntityTypesContent(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
     /// to hold a `EntityTypesUri`.
     ///
@@ -6004,6 +5989,21 @@ impl ExportEntityTypesResponse {
             ),
         );
         self
+    }
+
+    /// The value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
+    /// if it holds a `EntityTypesContent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity_types_content(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineDestination>> {
+        #[allow(unreachable_patterns)]
+        self.exported_entity_types.as_ref().and_then(|v| match v {
+            crate::model::export_entity_types_response::ExportedEntityTypes::EntityTypesContent(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
@@ -6182,21 +6182,6 @@ impl ImportEntityTypesRequest {
         })
     }
 
-    /// The value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
-    /// if it holds a `EntityTypesContent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity_types_content(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineSource>> {
-        #[allow(unreachable_patterns)]
-        self.entity_types.as_ref().and_then(|v| match v {
-            crate::model::import_entity_types_request::EntityTypes::EntityTypesContent(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
     /// to hold a `EntityTypesUri`.
     ///
@@ -6210,6 +6195,21 @@ impl ImportEntityTypesRequest {
             crate::model::import_entity_types_request::EntityTypes::EntityTypesUri(v.into()),
         );
         self
+    }
+
+    /// The value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
+    /// if it holds a `EntityTypesContent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity_types_content(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineSource>> {
+        #[allow(unreachable_patterns)]
+        self.entity_types.as_ref().and_then(|v| match v {
+            crate::model::import_entity_types_request::EntityTypes::EntityTypesContent(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
@@ -6450,6 +6450,17 @@ impl ImportEntityTypesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [entity_types][crate::model::ImportEntityTypesResponse::entity_types].
+    pub fn set_entity_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [conflicting_resources][crate::model::ImportEntityTypesResponse::conflicting_resources].
     pub fn set_conflicting_resources<
         T: std::convert::Into<
@@ -6462,17 +6473,6 @@ impl ImportEntityTypesResponse {
         v: T,
     ) -> Self {
         self.conflicting_resources = v.into();
-        self
-    }
-
-    /// Sets the value of [entity_types][crate::model::ImportEntityTypesResponse::entity_types].
-    pub fn set_entity_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.entity_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6675,12 +6675,6 @@ impl ListEntityTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntityTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entity_types][crate::model::ListEntityTypesResponse::entity_types].
     pub fn set_entity_types<T, V>(mut self, v: T) -> Self
     where
@@ -6689,6 +6683,12 @@ impl ListEntityTypesResponse {
     {
         use std::iter::Iterator;
         self.entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntityTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7049,6 +7049,17 @@ impl Environment {
         self
     }
 
+    /// Sets the value of [version_configs][crate::model::Environment::version_configs].
+    pub fn set_version_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::environment::VersionConfig>,
+    {
+        use std::iter::Iterator;
+        self.version_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [update_time][crate::model::Environment::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -7077,17 +7088,6 @@ impl Environment {
         v: T,
     ) -> Self {
         self.webhook_config = v.into();
-        self
-    }
-
-    /// Sets the value of [version_configs][crate::model::Environment::version_configs].
-    pub fn set_version_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::environment::VersionConfig>,
-    {
-        use std::iter::Iterator;
-        self.version_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7176,6 +7176,17 @@ pub mod environment {
             std::default::Default::default()
         }
 
+        /// Sets the value of [test_cases][crate::model::environment::TestCasesConfig::test_cases].
+        pub fn set_test_cases<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.test_cases = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [enable_continuous_run][crate::model::environment::TestCasesConfig::enable_continuous_run].
         pub fn set_enable_continuous_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.enable_continuous_run = v.into();
@@ -7185,17 +7196,6 @@ pub mod environment {
         /// Sets the value of [enable_predeployment_run][crate::model::environment::TestCasesConfig::enable_predeployment_run].
         pub fn set_enable_predeployment_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.enable_predeployment_run = v.into();
-            self
-        }
-
-        /// Sets the value of [test_cases][crate::model::environment::TestCasesConfig::test_cases].
-        pub fn set_test_cases<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.test_cases = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -7341,12 +7341,6 @@ impl ListEnvironmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [environments][crate::model::ListEnvironmentsResponse::environments].
     pub fn set_environments<T, V>(mut self, v: T) -> Self
     where
@@ -7355,6 +7349,12 @@ impl ListEnvironmentsResponse {
     {
         use std::iter::Iterator;
         self.environments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7654,12 +7654,6 @@ impl LookupEnvironmentHistoryResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::LookupEnvironmentHistoryResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [environments][crate::model::LookupEnvironmentHistoryResponse::environments].
     pub fn set_environments<T, V>(mut self, v: T) -> Self
     where
@@ -7668,6 +7662,12 @@ impl LookupEnvironmentHistoryResponse {
     {
         use std::iter::Iterator;
         self.environments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::LookupEnvironmentHistoryResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7741,15 +7741,6 @@ impl ContinuousTestResult {
         self
     }
 
-    /// Sets the value of [run_time][crate::model::ContinuousTestResult::run_time].
-    pub fn set_run_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.run_time = v.into();
-        self
-    }
-
     /// Sets the value of [test_case_results][crate::model::ContinuousTestResult::test_case_results].
     pub fn set_test_case_results<T, V>(mut self, v: T) -> Self
     where
@@ -7758,6 +7749,15 @@ impl ContinuousTestResult {
     {
         use std::iter::Iterator;
         self.test_case_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [run_time][crate::model::ContinuousTestResult::run_time].
+    pub fn set_run_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.run_time = v.into();
         self
     }
 }
@@ -8107,12 +8107,6 @@ impl ListContinuousTestResultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListContinuousTestResultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [continuous_test_results][crate::model::ListContinuousTestResultsResponse::continuous_test_results].
     pub fn set_continuous_test_results<T, V>(mut self, v: T) -> Self
     where
@@ -8121,6 +8115,12 @@ impl ListContinuousTestResultsResponse {
     {
         use std::iter::Iterator;
         self.continuous_test_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListContinuousTestResultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8651,15 +8651,6 @@ pub mod experiment {
             std::default::Default::default()
         }
 
-        /// Sets the value of [last_update_time][crate::model::experiment::Result::last_update_time].
-        pub fn set_last_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.last_update_time = v.into();
-            self
-        }
-
         /// Sets the value of [version_metrics][crate::model::experiment::Result::version_metrics].
         pub fn set_version_metrics<T, V>(mut self, v: T) -> Self
         where
@@ -8668,6 +8659,15 @@ pub mod experiment {
         {
             use std::iter::Iterator;
             self.version_metrics = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [last_update_time][crate::model::experiment::Result::last_update_time].
+        pub fn set_last_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.last_update_time = v.into();
             self
         }
     }
@@ -8844,6 +8844,18 @@ pub mod experiment {
                 })
             }
 
+            /// Sets the value of [value][crate::model::experiment::result::Metric::value]
+            /// to hold a `Ratio`.
+            ///
+            /// Note that all the setters affecting `value` are
+            /// mutually exclusive.
+            pub fn set_ratio<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+                self.value = std::option::Option::Some(
+                    crate::model::experiment::result::metric::Value::Ratio(v.into()),
+                );
+                self
+            }
+
             /// The value of [value][crate::model::experiment::result::Metric::value]
             /// if it holds a `Count`, `None` if the field is not set or
             /// holds a different branch.
@@ -8855,18 +8867,6 @@ pub mod experiment {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [value][crate::model::experiment::result::Metric::value]
-            /// to hold a `Ratio`.
-            ///
-            /// Note that all the setters affecting `value` are
-            /// mutually exclusive.
-            pub fn set_ratio<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-                self.value = std::option::Option::Some(
-                    crate::model::experiment::result::metric::Value::Ratio(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [value][crate::model::experiment::result::Metric::value]
@@ -8943,12 +8943,6 @@ pub mod experiment {
                 self
             }
 
-            /// Sets the value of [session_count][crate::model::experiment::result::VersionMetrics::session_count].
-            pub fn set_session_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.session_count = v.into();
-                self
-            }
-
             /// Sets the value of [metrics][crate::model::experiment::result::VersionMetrics::metrics].
             pub fn set_metrics<T, V>(mut self, v: T) -> Self
             where
@@ -8957,6 +8951,12 @@ pub mod experiment {
             {
                 use std::iter::Iterator;
                 self.metrics = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [session_count][crate::model::experiment::result::VersionMetrics::session_count].
+            pub fn set_session_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+                self.session_count = v.into();
                 self
             }
         }
@@ -9655,6 +9655,17 @@ impl RolloutConfig {
         std::default::Default::default()
     }
 
+    /// Sets the value of [rollout_steps][crate::model::RolloutConfig::rollout_steps].
+    pub fn set_rollout_steps<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::rollout_config::RolloutStep>,
+    {
+        use std::iter::Iterator;
+        self.rollout_steps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [rollout_condition][crate::model::RolloutConfig::rollout_condition].
     pub fn set_rollout_condition<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -9670,17 +9681,6 @@ impl RolloutConfig {
         v: T,
     ) -> Self {
         self.failure_condition = v.into();
-        self
-    }
-
-    /// Sets the value of [rollout_steps][crate::model::RolloutConfig::rollout_steps].
-    pub fn set_rollout_steps<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::rollout_config::RolloutStep>,
-    {
-        use std::iter::Iterator;
-        self.rollout_steps = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9903,12 +9903,6 @@ impl ListExperimentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExperimentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [experiments][crate::model::ListExperimentsResponse::experiments].
     pub fn set_experiments<T, V>(mut self, v: T) -> Self
     where
@@ -9917,6 +9911,12 @@ impl ListExperimentsResponse {
     {
         use std::iter::Iterator;
         self.experiments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExperimentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10674,6 +10674,39 @@ impl Flow {
         self
     }
 
+    /// Sets the value of [transition_routes][crate::model::Flow::transition_routes].
+    pub fn set_transition_routes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TransitionRoute>,
+    {
+        use std::iter::Iterator;
+        self.transition_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [event_handlers][crate::model::Flow::event_handlers].
+    pub fn set_event_handlers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventHandler>,
+    {
+        use std::iter::Iterator;
+        self.event_handlers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [transition_route_groups][crate::model::Flow::transition_route_groups].
+    pub fn set_transition_route_groups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.transition_route_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [nlu_settings][crate::model::Flow::nlu_settings].
     pub fn set_nlu_settings<
         T: std::convert::Into<std::option::Option<crate::model::NluSettings>>,
@@ -10721,39 +10754,6 @@ impl Flow {
     /// Sets the value of [locked][crate::model::Flow::locked].
     pub fn set_locked<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.locked = v.into();
-        self
-    }
-
-    /// Sets the value of [transition_routes][crate::model::Flow::transition_routes].
-    pub fn set_transition_routes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TransitionRoute>,
-    {
-        use std::iter::Iterator;
-        self.transition_routes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [event_handlers][crate::model::Flow::event_handlers].
-    pub fn set_event_handlers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventHandler>,
-    {
-        use std::iter::Iterator;
-        self.event_handlers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [transition_route_groups][crate::model::Flow::transition_route_groups].
-    pub fn set_transition_route_groups<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.transition_route_groups = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -11070,12 +11070,6 @@ impl ListFlowsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFlowsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [flows][crate::model::ListFlowsResponse::flows].
     pub fn set_flows<T, V>(mut self, v: T) -> Self
     where
@@ -11084,6 +11078,12 @@ impl ListFlowsResponse {
     {
         use std::iter::Iterator;
         self.flows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFlowsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11409,15 +11409,6 @@ impl FlowValidationResult {
         self
     }
 
-    /// Sets the value of [update_time][crate::model::FlowValidationResult::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [validation_messages][crate::model::FlowValidationResult::validation_messages].
     pub fn set_validation_messages<T, V>(mut self, v: T) -> Self
     where
@@ -11426,6 +11417,15 @@ impl FlowValidationResult {
     {
         use std::iter::Iterator;
         self.validation_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::FlowValidationResult::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -11524,17 +11524,6 @@ impl ImportFlowRequest {
         })
     }
 
-    /// The value of [flow][crate::model::ImportFlowRequest::flow]
-    /// if it holds a `FlowContent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn flow_content(&self) -> std::option::Option<&::bytes::Bytes> {
-        #[allow(unreachable_patterns)]
-        self.flow.as_ref().and_then(|v| match v {
-            crate::model::import_flow_request::Flow::FlowContent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [flow][crate::model::ImportFlowRequest::flow]
     /// to hold a `FlowUri`.
     ///
@@ -11544,6 +11533,17 @@ impl ImportFlowRequest {
         self.flow =
             std::option::Option::Some(crate::model::import_flow_request::Flow::FlowUri(v.into()));
         self
+    }
+
+    /// The value of [flow][crate::model::ImportFlowRequest::flow]
+    /// if it holds a `FlowContent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn flow_content(&self) -> std::option::Option<&::bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.flow.as_ref().and_then(|v| match v {
+            crate::model::import_flow_request::Flow::FlowContent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [flow][crate::model::ImportFlowRequest::flow]
@@ -11916,6 +11916,17 @@ impl ExportFlowResponse {
         })
     }
 
+    /// Sets the value of [flow][crate::model::ExportFlowResponse::flow]
+    /// to hold a `FlowUri`.
+    ///
+    /// Note that all the setters affecting `flow` are
+    /// mutually exclusive.
+    pub fn set_flow_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.flow =
+            std::option::Option::Some(crate::model::export_flow_response::Flow::FlowUri(v.into()));
+        self
+    }
+
     /// The value of [flow][crate::model::ExportFlowResponse::flow]
     /// if it holds a `FlowContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -11927,17 +11938,6 @@ impl ExportFlowResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [flow][crate::model::ExportFlowResponse::flow]
-    /// to hold a `FlowUri`.
-    ///
-    /// Note that all the setters affecting `flow` are
-    /// mutually exclusive.
-    pub fn set_flow_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.flow =
-            std::option::Option::Some(crate::model::export_flow_response::Flow::FlowUri(v.into()));
-        self
     }
 
     /// Sets the value of [flow][crate::model::ExportFlowResponse::flow]
@@ -12073,6 +12073,17 @@ impl Fulfillment {
         std::default::Default::default()
     }
 
+    /// Sets the value of [messages][crate::model::Fulfillment::messages].
+    pub fn set_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResponseMessage>,
+    {
+        use std::iter::Iterator;
+        self.messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [webhook][crate::model::Fulfillment::webhook].
     pub fn set_webhook<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.webhook = v.into();
@@ -12088,34 +12099,6 @@ impl Fulfillment {
     /// Sets the value of [tag][crate::model::Fulfillment::tag].
     pub fn set_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tag = v.into();
-        self
-    }
-
-    /// Sets the value of [advanced_settings][crate::model::Fulfillment::advanced_settings].
-    pub fn set_advanced_settings<
-        T: std::convert::Into<std::option::Option<crate::model::AdvancedSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.advanced_settings = v.into();
-        self
-    }
-
-    /// Sets the value of [enable_generative_fallback][crate::model::Fulfillment::enable_generative_fallback].
-    pub fn set_enable_generative_fallback<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_generative_fallback = v.into();
-        self
-    }
-
-    /// Sets the value of [messages][crate::model::Fulfillment::messages].
-    pub fn set_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResponseMessage>,
-    {
-        use std::iter::Iterator;
-        self.messages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -12138,6 +12121,23 @@ impl Fulfillment {
     {
         use std::iter::Iterator;
         self.conditional_cases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [advanced_settings][crate::model::Fulfillment::advanced_settings].
+    pub fn set_advanced_settings<
+        T: std::convert::Into<std::option::Option<crate::model::AdvancedSettings>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.advanced_settings = v.into();
+        self
+    }
+
+    /// Sets the value of [enable_generative_fallback][crate::model::Fulfillment::enable_generative_fallback].
+    pub fn set_enable_generative_fallback<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_generative_fallback = v.into();
         self
     }
 }
@@ -12353,21 +12353,6 @@ pub mod fulfillment {
                     })
                 }
 
-                /// The value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
-                /// if it holds a `AdditionalCases`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn additional_cases(
-                    &self,
-                ) -> std::option::Option<
-                    &std::boxed::Box<crate::model::fulfillment::ConditionalCases>,
-                > {
-                    #[allow(unreachable_patterns)]
-                    self.cases_or_message.as_ref().and_then(|v| match v {
-                        crate::model::fulfillment::conditional_cases::case::case_content::CasesOrMessage::AdditionalCases(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
                 /// to hold a `Message`.
                 ///
@@ -12385,6 +12370,21 @@ pub mod fulfillment {
                         )
                     );
                     self
+                }
+
+                /// The value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
+                /// if it holds a `AdditionalCases`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn additional_cases(
+                    &self,
+                ) -> std::option::Option<
+                    &std::boxed::Box<crate::model::fulfillment::ConditionalCases>,
+                > {
+                    #[allow(unreachable_patterns)]
+                    self.cases_or_message.as_ref().and_then(|v| match v {
+                        crate::model::fulfillment::conditional_cases::case::case_content::CasesOrMessage::AdditionalCases(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
@@ -12858,17 +12858,6 @@ impl Generator {
         self
     }
 
-    /// Sets the value of [model_parameter][crate::model::Generator::model_parameter].
-    pub fn set_model_parameter<
-        T: std::convert::Into<std::option::Option<crate::model::generator::ModelParameter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model_parameter = v.into();
-        self
-    }
-
     /// Sets the value of [placeholders][crate::model::Generator::placeholders].
     pub fn set_placeholders<T, V>(mut self, v: T) -> Self
     where
@@ -12877,6 +12866,17 @@ impl Generator {
     {
         use std::iter::Iterator;
         self.placeholders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [model_parameter][crate::model::Generator::model_parameter].
+    pub fn set_model_parameter<
+        T: std::convert::Into<std::option::Option<crate::model::generator::ModelParameter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.model_parameter = v.into();
         self
     }
 }
@@ -13142,12 +13142,6 @@ impl ListGeneratorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGeneratorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [generators][crate::model::ListGeneratorsResponse::generators].
     pub fn set_generators<T, V>(mut self, v: T) -> Self
     where
@@ -13156,6 +13150,12 @@ impl ListGeneratorsResponse {
     {
         use std::iter::Iterator;
         self.generators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGeneratorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -13577,24 +13577,6 @@ impl Intent {
         self
     }
 
-    /// Sets the value of [priority][crate::model::Intent::priority].
-    pub fn set_priority<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.priority = v.into();
-        self
-    }
-
-    /// Sets the value of [is_fallback][crate::model::Intent::is_fallback].
-    pub fn set_is_fallback<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.is_fallback = v.into();
-        self
-    }
-
-    /// Sets the value of [description][crate::model::Intent::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
     /// Sets the value of [training_phrases][crate::model::Intent::training_phrases].
     pub fn set_training_phrases<T, V>(mut self, v: T) -> Self
     where
@@ -13617,6 +13599,18 @@ impl Intent {
         self
     }
 
+    /// Sets the value of [priority][crate::model::Intent::priority].
+    pub fn set_priority<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.priority = v.into();
+        self
+    }
+
+    /// Sets the value of [is_fallback][crate::model::Intent::is_fallback].
+    pub fn set_is_fallback<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.is_fallback = v.into();
+        self
+    }
+
     /// Sets the value of [labels][crate::model::Intent::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -13626,6 +13620,12 @@ impl Intent {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::Intent::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
         self
     }
 }
@@ -13695,12 +13695,6 @@ pub mod intent {
             self
         }
 
-        /// Sets the value of [repeat_count][crate::model::intent::TrainingPhrase::repeat_count].
-        pub fn set_repeat_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.repeat_count = v.into();
-            self
-        }
-
         /// Sets the value of [parts][crate::model::intent::TrainingPhrase::parts].
         pub fn set_parts<T, V>(mut self, v: T) -> Self
         where
@@ -13709,6 +13703,12 @@ pub mod intent {
         {
             use std::iter::Iterator;
             self.parts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [repeat_count][crate::model::intent::TrainingPhrase::repeat_count].
+        pub fn set_repeat_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.repeat_count = v.into();
             self
         }
     }
@@ -13972,12 +13972,6 @@ impl ListIntentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIntentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [intents][crate::model::ListIntentsResponse::intents].
     pub fn set_intents<T, V>(mut self, v: T) -> Self
     where
@@ -13986,6 +13980,12 @@ impl ListIntentsResponse {
     {
         use std::iter::Iterator;
         self.intents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIntentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -14314,6 +14314,18 @@ impl ImportIntentsRequest {
         })
     }
 
+    /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
+    /// to hold a `IntentsUri`.
+    ///
+    /// Note that all the setters affecting `intents` are
+    /// mutually exclusive.
+    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.intents = std::option::Option::Some(
+            crate::model::import_intents_request::Intents::IntentsUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [intents][crate::model::ImportIntentsRequest::intents]
     /// if it holds a `IntentsContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -14327,18 +14339,6 @@ impl ImportIntentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
-    /// to hold a `IntentsUri`.
-    ///
-    /// Note that all the setters affecting `intents` are
-    /// mutually exclusive.
-    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.intents = std::option::Option::Some(
-            crate::model::import_intents_request::Intents::IntentsUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
@@ -14590,6 +14590,17 @@ impl ImportIntentsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [intents][crate::model::ImportIntentsResponse::intents].
+    pub fn set_intents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.intents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [conflicting_resources][crate::model::ImportIntentsResponse::conflicting_resources].
     pub fn set_conflicting_resources<
         T: std::convert::Into<
@@ -14600,17 +14611,6 @@ impl ImportIntentsResponse {
         v: T,
     ) -> Self {
         self.conflicting_resources = v.into();
-        self
-    }
-
-    /// Sets the value of [intents][crate::model::ImportIntentsResponse::intents].
-    pub fn set_intents<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.intents = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -14750,17 +14750,6 @@ impl ExportIntentsRequest {
         self
     }
 
-    /// Sets the value of [data_format][crate::model::ExportIntentsRequest::data_format].
-    pub fn set_data_format<
-        T: std::convert::Into<crate::model::export_intents_request::DataFormat>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_format = v.into();
-        self
-    }
-
     /// Sets the value of [intents][crate::model::ExportIntentsRequest::intents].
     pub fn set_intents<T, V>(mut self, v: T) -> Self
     where
@@ -14769,6 +14758,17 @@ impl ExportIntentsRequest {
     {
         use std::iter::Iterator;
         self.intents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_format][crate::model::ExportIntentsRequest::data_format].
+    pub fn set_data_format<
+        T: std::convert::Into<crate::model::export_intents_request::DataFormat>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.data_format = v.into();
         self
     }
 
@@ -14799,6 +14799,18 @@ impl ExportIntentsRequest {
         })
     }
 
+    /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
+    /// to hold a `IntentsUri`.
+    ///
+    /// Note that all the setters affecting `destination` are
+    /// mutually exclusive.
+    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.destination = std::option::Option::Some(
+            crate::model::export_intents_request::Destination::IntentsUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [destination][crate::model::ExportIntentsRequest::destination]
     /// if it holds a `IntentsContentInline`, `None` if the field is not set or
     /// holds a different branch.
@@ -14810,18 +14822,6 @@ impl ExportIntentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
-    /// to hold a `IntentsUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_intents_request::Destination::IntentsUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
@@ -15057,6 +15057,18 @@ impl ExportIntentsResponse {
         })
     }
 
+    /// Sets the value of [intents][crate::model::ExportIntentsResponse::intents]
+    /// to hold a `IntentsUri`.
+    ///
+    /// Note that all the setters affecting `intents` are
+    /// mutually exclusive.
+    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.intents = std::option::Option::Some(
+            crate::model::export_intents_response::Intents::IntentsUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [intents][crate::model::ExportIntentsResponse::intents]
     /// if it holds a `IntentsContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -15070,18 +15082,6 @@ impl ExportIntentsResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intents][crate::model::ExportIntentsResponse::intents]
-    /// to hold a `IntentsUri`.
-    ///
-    /// Note that all the setters affecting `intents` are
-    /// mutually exclusive.
-    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.intents = std::option::Option::Some(
-            crate::model::export_intents_response::Intents::IntentsUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [intents][crate::model::ExportIntentsResponse::intents]
@@ -15323,28 +15323,6 @@ impl Page {
         self
     }
 
-    /// Sets the value of [advanced_settings][crate::model::Page::advanced_settings].
-    pub fn set_advanced_settings<
-        T: std::convert::Into<std::option::Option<crate::model::AdvancedSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.advanced_settings = v.into();
-        self
-    }
-
-    /// Sets the value of [knowledge_connector_settings][crate::model::Page::knowledge_connector_settings].
-    pub fn set_knowledge_connector_settings<
-        T: std::convert::Into<std::option::Option<crate::model::KnowledgeConnectorSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.knowledge_connector_settings = v.into();
-        self
-    }
-
     /// Sets the value of [transition_route_groups][crate::model::Page::transition_route_groups].
     pub fn set_transition_route_groups<T, V>(mut self, v: T) -> Self
     where
@@ -15375,6 +15353,28 @@ impl Page {
     {
         use std::iter::Iterator;
         self.event_handlers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [advanced_settings][crate::model::Page::advanced_settings].
+    pub fn set_advanced_settings<
+        T: std::convert::Into<std::option::Option<crate::model::AdvancedSettings>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.advanced_settings = v.into();
+        self
+    }
+
+    /// Sets the value of [knowledge_connector_settings][crate::model::Page::knowledge_connector_settings].
+    pub fn set_knowledge_connector_settings<
+        T: std::convert::Into<std::option::Option<crate::model::KnowledgeConnectorSettings>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.knowledge_connector_settings = v.into();
         self
     }
 }
@@ -15770,17 +15770,6 @@ impl EventHandler {
         })
     }
 
-    /// The value of [target][crate::model::EventHandler::target]
-    /// if it holds a `TargetFlow`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn target_flow(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::event_handler::Target::TargetFlow(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::EventHandler::target]
     /// to hold a `TargetPage`.
     ///
@@ -15790,6 +15779,17 @@ impl EventHandler {
         self.target =
             std::option::Option::Some(crate::model::event_handler::Target::TargetPage(v.into()));
         self
+    }
+
+    /// The value of [target][crate::model::EventHandler::target]
+    /// if it holds a `TargetFlow`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn target_flow(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::event_handler::Target::TargetFlow(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::EventHandler::target]
@@ -15983,17 +15983,6 @@ impl TransitionRoute {
         })
     }
 
-    /// The value of [target][crate::model::TransitionRoute::target]
-    /// if it holds a `TargetFlow`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn target_flow(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::transition_route::Target::TargetFlow(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::TransitionRoute::target]
     /// to hold a `TargetPage`.
     ///
@@ -16003,6 +15992,17 @@ impl TransitionRoute {
         self.target =
             std::option::Option::Some(crate::model::transition_route::Target::TargetPage(v.into()));
         self
+    }
+
+    /// The value of [target][crate::model::TransitionRoute::target]
+    /// if it holds a `TargetFlow`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn target_flow(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::transition_route::Target::TargetFlow(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::TransitionRoute::target]
@@ -16167,12 +16167,6 @@ impl ListPagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [pages][crate::model::ListPagesResponse::pages].
     pub fn set_pages<T, V>(mut self, v: T) -> Self
     where
@@ -16181,6 +16175,12 @@ impl ListPagesResponse {
     {
         use std::iter::Iterator;
         self.pages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -16596,6 +16596,18 @@ impl KnowledgeConnectorSettings {
         })
     }
 
+    /// Sets the value of [target][crate::model::KnowledgeConnectorSettings::target]
+    /// to hold a `TargetPage`.
+    ///
+    /// Note that all the setters affecting `target` are
+    /// mutually exclusive.
+    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.target = std::option::Option::Some(
+            crate::model::knowledge_connector_settings::Target::TargetPage(v.into()),
+        );
+        self
+    }
+
     /// The value of [target][crate::model::KnowledgeConnectorSettings::target]
     /// if it holds a `TargetFlow`, `None` if the field is not set or
     /// holds a different branch.
@@ -16607,18 +16619,6 @@ impl KnowledgeConnectorSettings {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::KnowledgeConnectorSettings::target]
-    /// to hold a `TargetPage`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::knowledge_connector_settings::Target::TargetPage(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [target][crate::model::KnowledgeConnectorSettings::target]
@@ -16757,138 +16757,6 @@ impl ResponseMessage {
         })
     }
 
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `Payload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::Payload(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `ConversationSuccess`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn conversation_success(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::ConversationSuccess>>
-    {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::ConversationSuccess(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `OutputAudioText`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn output_audio_text(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::OutputAudioText>>
-    {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::OutputAudioText(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `LiveAgentHandoff`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn live_agent_handoff(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::LiveAgentHandoff>>
-    {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::LiveAgentHandoff(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `EndInteraction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn end_interaction(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::EndInteraction>> {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::EndInteraction(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `PlayAudio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn play_audio(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::PlayAudio>> {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::PlayAudio(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `MixedAudio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mixed_audio(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::MixedAudio>> {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::MixedAudio(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `TelephonyTransferCall`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn telephony_transfer_call(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::TelephonyTransferCall>>
-    {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::TelephonyTransferCall(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [message][crate::model::ResponseMessage::message]
-    /// if it holds a `KnowledgeInfoCard`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn knowledge_info_card(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::KnowledgeInfoCard>>
-    {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::response_message::Message::KnowledgeInfoCard(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [message][crate::model::ResponseMessage::message]
     /// to hold a `Text`.
     ///
@@ -16905,6 +16773,17 @@ impl ResponseMessage {
         self
     }
 
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `Payload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::Payload(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [message][crate::model::ResponseMessage::message]
     /// to hold a `Payload`.
     ///
@@ -16917,6 +16796,22 @@ impl ResponseMessage {
         self.message =
             std::option::Option::Some(crate::model::response_message::Message::Payload(v.into()));
         self
+    }
+
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `ConversationSuccess`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn conversation_success(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::ConversationSuccess>>
+    {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::ConversationSuccess(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [message][crate::model::ResponseMessage::message]
@@ -16936,6 +16831,22 @@ impl ResponseMessage {
         self
     }
 
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `OutputAudioText`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn output_audio_text(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::OutputAudioText>>
+    {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::OutputAudioText(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [message][crate::model::ResponseMessage::message]
     /// to hold a `OutputAudioText`.
     ///
@@ -16951,6 +16862,22 @@ impl ResponseMessage {
             crate::model::response_message::Message::OutputAudioText(v.into()),
         );
         self
+    }
+
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `LiveAgentHandoff`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn live_agent_handoff(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::LiveAgentHandoff>>
+    {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::LiveAgentHandoff(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [message][crate::model::ResponseMessage::message]
@@ -16970,6 +16897,21 @@ impl ResponseMessage {
         self
     }
 
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `EndInteraction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn end_interaction(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::EndInteraction>> {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::EndInteraction(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [message][crate::model::ResponseMessage::message]
     /// to hold a `EndInteraction`.
     ///
@@ -16987,6 +16929,19 @@ impl ResponseMessage {
         self
     }
 
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `PlayAudio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn play_audio(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::PlayAudio>> {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::PlayAudio(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [message][crate::model::ResponseMessage::message]
     /// to hold a `PlayAudio`.
     ///
@@ -17001,6 +16956,19 @@ impl ResponseMessage {
         self.message =
             std::option::Option::Some(crate::model::response_message::Message::PlayAudio(v.into()));
         self
+    }
+
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `MixedAudio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mixed_audio(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::MixedAudio>> {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::MixedAudio(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [message][crate::model::ResponseMessage::message]
@@ -17020,6 +16988,22 @@ impl ResponseMessage {
         self
     }
 
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `TelephonyTransferCall`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn telephony_transfer_call(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::TelephonyTransferCall>>
+    {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::TelephonyTransferCall(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [message][crate::model::ResponseMessage::message]
     /// to hold a `TelephonyTransferCall`.
     ///
@@ -17035,6 +17019,22 @@ impl ResponseMessage {
             crate::model::response_message::Message::TelephonyTransferCall(v.into()),
         );
         self
+    }
+
+    /// The value of [message][crate::model::ResponseMessage::message]
+    /// if it holds a `KnowledgeInfoCard`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn knowledge_info_card(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::response_message::KnowledgeInfoCard>>
+    {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::response_message::Message::KnowledgeInfoCard(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [message][crate::model::ResponseMessage::message]
@@ -17092,15 +17092,6 @@ pub mod response_message {
             std::default::Default::default()
         }
 
-        /// Sets the value of [allow_playback_interruption][crate::model::response_message::Text::allow_playback_interruption].
-        pub fn set_allow_playback_interruption<T: std::convert::Into<bool>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.allow_playback_interruption = v.into();
-            self
-        }
-
         /// Sets the value of [text][crate::model::response_message::Text::text].
         pub fn set_text<T, V>(mut self, v: T) -> Self
         where
@@ -17109,6 +17100,15 @@ pub mod response_message {
         {
             use std::iter::Iterator;
             self.text = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [allow_playback_interruption][crate::model::response_message::Text::allow_playback_interruption].
+        pub fn set_allow_playback_interruption<T: std::convert::Into<bool>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.allow_playback_interruption = v.into();
             self
         }
     }
@@ -17291,6 +17291,18 @@ pub mod response_message {
             })
         }
 
+        /// Sets the value of [source][crate::model::response_message::OutputAudioText::source]
+        /// to hold a `Text`.
+        ///
+        /// Note that all the setters affecting `source` are
+        /// mutually exclusive.
+        pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.source = std::option::Option::Some(
+                crate::model::response_message::output_audio_text::Source::Text(v.into()),
+            );
+            self
+        }
+
         /// The value of [source][crate::model::response_message::OutputAudioText::source]
         /// if it holds a `Ssml`, `None` if the field is not set or
         /// holds a different branch.
@@ -17302,18 +17314,6 @@ pub mod response_message {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::response_message::OutputAudioText::source]
-        /// to hold a `Text`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::response_message::output_audio_text::Source::Text(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [source][crate::model::response_message::OutputAudioText::source]
@@ -17541,6 +17541,18 @@ pub mod response_message {
                 })
             }
 
+            /// Sets the value of [content][crate::model::response_message::mixed_audio::Segment::content]
+            /// to hold a `Audio`.
+            ///
+            /// Note that all the setters affecting `content` are
+            /// mutually exclusive.
+            pub fn set_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+                self.content = std::option::Option::Some(
+                    crate::model::response_message::mixed_audio::segment::Content::Audio(v.into()),
+                );
+                self
+            }
+
             /// The value of [content][crate::model::response_message::mixed_audio::Segment::content]
             /// if it holds a `Uri`, `None` if the field is not set or
             /// holds a different branch.
@@ -17552,18 +17564,6 @@ pub mod response_message {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [content][crate::model::response_message::mixed_audio::Segment::content]
-            /// to hold a `Audio`.
-            ///
-            /// Note that all the setters affecting `content` are
-            /// mutually exclusive.
-            pub fn set_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-                self.content = std::option::Option::Some(
-                    crate::model::response_message::mixed_audio::segment::Content::Audio(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [content][crate::model::response_message::mixed_audio::Segment::content]
@@ -18183,12 +18183,6 @@ impl ListSecuritySettingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSecuritySettingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [security_settings][crate::model::ListSecuritySettingsResponse::security_settings].
     pub fn set_security_settings<T, V>(mut self, v: T) -> Self
     where
@@ -18197,6 +18191,12 @@ impl ListSecuritySettingsResponse {
     {
         use std::iter::Iterator;
         self.security_settings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSecuritySettingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -18491,6 +18491,17 @@ impl SecuritySettings {
         self
     }
 
+    /// Sets the value of [purge_data_types][crate::model::SecuritySettings::purge_data_types].
+    pub fn set_purge_data_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::security_settings::PurgeDataType>,
+    {
+        use std::iter::Iterator;
+        self.purge_data_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [audio_export_settings][crate::model::SecuritySettings::audio_export_settings].
     pub fn set_audio_export_settings<
         T: std::convert::Into<
@@ -18514,17 +18525,6 @@ impl SecuritySettings {
         v: T,
     ) -> Self {
         self.insights_export_settings = v.into();
-        self
-    }
-
-    /// Sets the value of [purge_data_types][crate::model::SecuritySettings::purge_data_types].
-    pub fn set_purge_data_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::security_settings::PurgeDataType>,
-    {
-        use std::iter::Iterator;
-        self.purge_data_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -18555,6 +18555,18 @@ impl SecuritySettings {
         })
     }
 
+    /// Sets the value of [data_retention][crate::model::SecuritySettings::data_retention]
+    /// to hold a `RetentionWindowDays`.
+    ///
+    /// Note that all the setters affecting `data_retention` are
+    /// mutually exclusive.
+    pub fn set_retention_window_days<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.data_retention = std::option::Option::Some(
+            crate::model::security_settings::DataRetention::RetentionWindowDays(v.into()),
+        );
+        self
+    }
+
     /// The value of [data_retention][crate::model::SecuritySettings::data_retention]
     /// if it holds a `RetentionStrategy`, `None` if the field is not set or
     /// holds a different branch.
@@ -18568,18 +18580,6 @@ impl SecuritySettings {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_retention][crate::model::SecuritySettings::data_retention]
-    /// to hold a `RetentionWindowDays`.
-    ///
-    /// Note that all the setters affecting `data_retention` are
-    /// mutually exclusive.
-    pub fn set_retention_window_days<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.data_retention = std::option::Option::Some(
-            crate::model::security_settings::DataRetention::RetentionWindowDays(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [data_retention][crate::model::SecuritySettings::data_retention]
@@ -19504,12 +19504,6 @@ pub mod answer_feedback {
             std::default::Default::default()
         }
 
-        /// Sets the value of [feedback][crate::model::answer_feedback::RatingReason::feedback].
-        pub fn set_feedback<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.feedback = v.into();
-            self
-        }
-
         /// Sets the value of [reason_labels][crate::model::answer_feedback::RatingReason::reason_labels].
         pub fn set_reason_labels<T, V>(mut self, v: T) -> Self
         where
@@ -19518,6 +19512,12 @@ pub mod answer_feedback {
         {
             use std::iter::Iterator;
             self.reason_labels = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [feedback][crate::model::answer_feedback::RatingReason::feedback].
+        pub fn set_feedback<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.feedback = v.into();
             self
         }
     }
@@ -20359,6 +20359,28 @@ impl CloudConversationDebuggingInfo {
         self
     }
 
+    /// Sets the value of [speech_partial_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_partial_results_end_times].
+    pub fn set_speech_partial_results_end_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.speech_partial_results_end_times = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [speech_final_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_final_results_end_times].
+    pub fn set_speech_final_results_end_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.speech_final_results_end_times = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [partial_responses][crate::model::CloudConversationDebuggingInfo::partial_responses].
     pub fn set_partial_responses<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.partial_responses = v.into();
@@ -20383,6 +20405,28 @@ impl CloudConversationDebuggingInfo {
     /// Sets the value of [speech_single_utterance][crate::model::CloudConversationDebuggingInfo::speech_single_utterance].
     pub fn set_speech_single_utterance<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.speech_single_utterance = v.into();
+        self
+    }
+
+    /// Sets the value of [dtmf_partial_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_partial_results_times].
+    pub fn set_dtmf_partial_results_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.dtmf_partial_results_times = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [dtmf_final_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_final_results_times].
+    pub fn set_dtmf_final_results_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.dtmf_final_results_times = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -20440,50 +20484,6 @@ impl CloudConversationDebuggingInfo {
         v: T,
     ) -> Self {
         self.client_half_close_streaming_time_offset = v.into();
-        self
-    }
-
-    /// Sets the value of [speech_partial_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_partial_results_end_times].
-    pub fn set_speech_partial_results_end_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.speech_partial_results_end_times = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [speech_final_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_final_results_end_times].
-    pub fn set_speech_final_results_end_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.speech_final_results_end_times = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [dtmf_partial_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_partial_results_times].
-    pub fn set_dtmf_partial_results_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.dtmf_partial_results_times = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [dtmf_final_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_final_results_times].
-    pub fn set_dtmf_final_results_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.dtmf_final_results_times = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -20585,21 +20585,6 @@ impl StreamingDetectIntentResponse {
         })
     }
 
-    /// The value of [response][crate::model::StreamingDetectIntentResponse::response]
-    /// if it holds a `DetectIntentResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn detect_intent_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DetectIntentResponse>> {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::streaming_detect_intent_response::Response::DetectIntentResponse(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response][crate::model::StreamingDetectIntentResponse::response]
     /// to hold a `RecognitionResult`.
     ///
@@ -20615,6 +20600,21 @@ impl StreamingDetectIntentResponse {
             crate::model::streaming_detect_intent_response::Response::RecognitionResult(v.into()),
         );
         self
+    }
+
+    /// The value of [response][crate::model::StreamingDetectIntentResponse::response]
+    /// if it holds a `DetectIntentResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn detect_intent_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DetectIntentResponse>> {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::streaming_detect_intent_response::Response::DetectIntentResponse(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response][crate::model::StreamingDetectIntentResponse::response]
@@ -20801,6 +20801,17 @@ impl StreamingRecognitionResult {
         self
     }
 
+    /// Sets the value of [speech_word_info][crate::model::StreamingRecognitionResult::speech_word_info].
+    pub fn set_speech_word_info<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SpeechWordInfo>,
+    {
+        use std::iter::Iterator;
+        self.speech_word_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [speech_end_offset][crate::model::StreamingRecognitionResult::speech_end_offset].
     pub fn set_speech_end_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
@@ -20813,17 +20824,6 @@ impl StreamingRecognitionResult {
     /// Sets the value of [language_code][crate::model::StreamingRecognitionResult::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [speech_word_info][crate::model::StreamingRecognitionResult::speech_word_info].
-    pub fn set_speech_word_info<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SpeechWordInfo>,
-    {
-        use std::iter::Iterator;
-        self.speech_word_info = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -21180,6 +21180,17 @@ impl QueryParameters {
         self
     }
 
+    /// Sets the value of [session_entity_types][crate::model::QueryParameters::session_entity_types].
+    pub fn set_session_entity_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SessionEntityType>,
+    {
+        use std::iter::Iterator;
+        self.session_entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [payload][crate::model::QueryParameters::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
         mut self,
@@ -21213,6 +21224,29 @@ impl QueryParameters {
     /// Sets the value of [analyze_query_text_sentiment][crate::model::QueryParameters::analyze_query_text_sentiment].
     pub fn set_analyze_query_text_sentiment<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.analyze_query_text_sentiment = v.into();
+        self
+    }
+
+    /// Sets the value of [webhook_headers][crate::model::QueryParameters::webhook_headers].
+    pub fn set_webhook_headers<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.webhook_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [flow_versions][crate::model::QueryParameters::flow_versions].
+    pub fn set_flow_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.flow_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -21258,40 +21292,6 @@ impl QueryParameters {
         v: T,
     ) -> Self {
         self.populate_data_store_connection_signals = v.into();
-        self
-    }
-
-    /// Sets the value of [session_entity_types][crate::model::QueryParameters::session_entity_types].
-    pub fn set_session_entity_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SessionEntityType>,
-    {
-        use std::iter::Iterator;
-        self.session_entity_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [flow_versions][crate::model::QueryParameters::flow_versions].
-    pub fn set_flow_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.flow_versions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_headers][crate::model::QueryParameters::webhook_headers].
-    pub fn set_webhook_headers<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.webhook_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -22002,12 +22002,6 @@ impl FilterSpecs {
         std::default::Default::default()
     }
 
-    /// Sets the value of [filter][crate::model::FilterSpecs::filter].
-    pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.filter = v.into();
-        self
-    }
-
     /// Sets the value of [data_stores][crate::model::FilterSpecs::data_stores].
     pub fn set_data_stores<T, V>(mut self, v: T) -> Self
     where
@@ -22016,6 +22010,12 @@ impl FilterSpecs {
     {
         use std::iter::Iterator;
         self.data_stores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [filter][crate::model::FilterSpecs::filter].
+    pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.filter = v.into();
         self
     }
 }
@@ -22096,50 +22096,6 @@ impl QueryInput {
         })
     }
 
-    /// The value of [input][crate::model::QueryInput::input]
-    /// if it holds a `Intent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn intent(&self) -> std::option::Option<&std::boxed::Box<crate::model::IntentInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::query_input::Input::Intent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [input][crate::model::QueryInput::input]
-    /// if it holds a `Audio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn audio(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::query_input::Input::Audio(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [input][crate::model::QueryInput::input]
-    /// if it holds a `Event`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn event(&self) -> std::option::Option<&std::boxed::Box<crate::model::EventInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::query_input::Input::Event(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [input][crate::model::QueryInput::input]
-    /// if it holds a `Dtmf`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dtmf(&self) -> std::option::Option<&std::boxed::Box<crate::model::DtmfInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::query_input::Input::Dtmf(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [input][crate::model::QueryInput::input]
     /// to hold a `Text`.
     ///
@@ -22151,6 +22107,17 @@ impl QueryInput {
     ) -> Self {
         self.input = std::option::Option::Some(crate::model::query_input::Input::Text(v.into()));
         self
+    }
+
+    /// The value of [input][crate::model::QueryInput::input]
+    /// if it holds a `Intent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn intent(&self) -> std::option::Option<&std::boxed::Box<crate::model::IntentInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::query_input::Input::Intent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [input][crate::model::QueryInput::input]
@@ -22166,6 +22133,17 @@ impl QueryInput {
         self
     }
 
+    /// The value of [input][crate::model::QueryInput::input]
+    /// if it holds a `Audio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn audio(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::query_input::Input::Audio(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [input][crate::model::QueryInput::input]
     /// to hold a `Audio`.
     ///
@@ -22179,6 +22157,17 @@ impl QueryInput {
         self
     }
 
+    /// The value of [input][crate::model::QueryInput::input]
+    /// if it holds a `Event`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn event(&self) -> std::option::Option<&std::boxed::Box<crate::model::EventInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::query_input::Input::Event(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [input][crate::model::QueryInput::input]
     /// to hold a `Event`.
     ///
@@ -22190,6 +22179,17 @@ impl QueryInput {
     ) -> Self {
         self.input = std::option::Option::Some(crate::model::query_input::Input::Event(v.into()));
         self
+    }
+
+    /// The value of [input][crate::model::QueryInput::input]
+    /// if it holds a `Dtmf`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dtmf(&self) -> std::option::Option<&std::boxed::Box<crate::model::DtmfInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::query_input::Input::Dtmf(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [input][crate::model::QueryInput::input]
@@ -22426,6 +22426,83 @@ impl QueryResult {
         self
     }
 
+    /// Sets the value of [response_messages][crate::model::QueryResult::response_messages].
+    pub fn set_response_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResponseMessage>,
+    {
+        use std::iter::Iterator;
+        self.response_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [webhook_ids][crate::model::QueryResult::webhook_ids].
+    pub fn set_webhook_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.webhook_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [webhook_display_names][crate::model::QueryResult::webhook_display_names].
+    pub fn set_webhook_display_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.webhook_display_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [webhook_latencies][crate::model::QueryResult::webhook_latencies].
+    pub fn set_webhook_latencies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.webhook_latencies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [webhook_tags][crate::model::QueryResult::webhook_tags].
+    pub fn set_webhook_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.webhook_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [webhook_statuses][crate::model::QueryResult::webhook_statuses].
+    pub fn set_webhook_statuses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.webhook_statuses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [webhook_payloads][crate::model::QueryResult::webhook_payloads].
+    pub fn set_webhook_payloads<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Struct>,
+    {
+        use std::iter::Iterator;
+        self.webhook_payloads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [current_page][crate::model::QueryResult::current_page].
     pub fn set_current_page<T: std::convert::Into<std::option::Option<crate::model::Page>>>(
         mut self,
@@ -22518,83 +22595,6 @@ impl QueryResult {
         self
     }
 
-    /// Sets the value of [response_messages][crate::model::QueryResult::response_messages].
-    pub fn set_response_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResponseMessage>,
-    {
-        use std::iter::Iterator;
-        self.response_messages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_ids][crate::model::QueryResult::webhook_ids].
-    pub fn set_webhook_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.webhook_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_display_names][crate::model::QueryResult::webhook_display_names].
-    pub fn set_webhook_display_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.webhook_display_names = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_latencies][crate::model::QueryResult::webhook_latencies].
-    pub fn set_webhook_latencies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.webhook_latencies = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_tags][crate::model::QueryResult::webhook_tags].
-    pub fn set_webhook_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.webhook_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_statuses][crate::model::QueryResult::webhook_statuses].
-    pub fn set_webhook_statuses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.webhook_statuses = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [webhook_payloads][crate::model::QueryResult::webhook_payloads].
-    pub fn set_webhook_payloads<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Struct>,
-    {
-        use std::iter::Iterator;
-        self.webhook_payloads = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [query][crate::model::QueryResult::query].
     ///
     /// Note that all the setters affecting `query` are mutually
@@ -22620,6 +22620,16 @@ impl QueryResult {
         })
     }
 
+    /// Sets the value of [query][crate::model::QueryResult::query]
+    /// to hold a `Text`.
+    ///
+    /// Note that all the setters affecting `query` are
+    /// mutually exclusive.
+    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query = std::option::Option::Some(crate::model::query_result::Query::Text(v.into()));
+        self
+    }
+
     /// The value of [query][crate::model::QueryResult::query]
     /// if it holds a `TriggerIntent`, `None` if the field is not set or
     /// holds a different branch.
@@ -22629,49 +22639,6 @@ impl QueryResult {
             crate::model::query_result::Query::TriggerIntent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [query][crate::model::QueryResult::query]
-    /// if it holds a `Transcript`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn transcript(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::query_result::Query::Transcript(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [query][crate::model::QueryResult::query]
-    /// if it holds a `TriggerEvent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn trigger_event(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::query_result::Query::TriggerEvent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [query][crate::model::QueryResult::query]
-    /// if it holds a `Dtmf`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dtmf(&self) -> std::option::Option<&std::boxed::Box<crate::model::DtmfInput>> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::query_result::Query::Dtmf(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [query][crate::model::QueryResult::query]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(crate::model::query_result::Query::Text(v.into()));
-        self
     }
 
     /// Sets the value of [query][crate::model::QueryResult::query]
@@ -22685,6 +22652,17 @@ impl QueryResult {
         self
     }
 
+    /// The value of [query][crate::model::QueryResult::query]
+    /// if it holds a `Transcript`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn transcript(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::query_result::Query::Transcript(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [query][crate::model::QueryResult::query]
     /// to hold a `Transcript`.
     ///
@@ -22696,6 +22674,17 @@ impl QueryResult {
         self
     }
 
+    /// The value of [query][crate::model::QueryResult::query]
+    /// if it holds a `TriggerEvent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn trigger_event(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::query_result::Query::TriggerEvent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [query][crate::model::QueryResult::query]
     /// to hold a `TriggerEvent`.
     ///
@@ -22705,6 +22694,17 @@ impl QueryResult {
         self.query =
             std::option::Option::Some(crate::model::query_result::Query::TriggerEvent(v.into()));
         self
+    }
+
+    /// The value of [query][crate::model::QueryResult::query]
+    /// if it holds a `Dtmf`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dtmf(&self) -> std::option::Option<&std::boxed::Box<crate::model::DtmfInput>> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::query_result::Query::Dtmf(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [query][crate::model::QueryResult::query]
@@ -23385,15 +23385,6 @@ impl MatchIntentResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [current_page][crate::model::MatchIntentResponse::current_page].
-    pub fn set_current_page<T: std::convert::Into<std::option::Option<crate::model::Page>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.current_page = v.into();
-        self
-    }
-
     /// Sets the value of [matches][crate::model::MatchIntentResponse::matches].
     pub fn set_matches<T, V>(mut self, v: T) -> Self
     where
@@ -23402,6 +23393,15 @@ impl MatchIntentResponse {
     {
         use std::iter::Iterator;
         self.matches = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [current_page][crate::model::MatchIntentResponse::current_page].
+    pub fn set_current_page<T: std::convert::Into<std::option::Option<crate::model::Page>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.current_page = v.into();
         self
     }
 
@@ -23430,6 +23430,17 @@ impl MatchIntentResponse {
         })
     }
 
+    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
+    /// to hold a `Text`.
+    ///
+    /// Note that all the setters affecting `query` are
+    /// mutually exclusive.
+    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query =
+            std::option::Option::Some(crate::model::match_intent_response::Query::Text(v.into()));
+        self
+    }
+
     /// The value of [query][crate::model::MatchIntentResponse::query]
     /// if it holds a `TriggerIntent`, `None` if the field is not set or
     /// holds a different branch.
@@ -23441,6 +23452,18 @@ impl MatchIntentResponse {
             }
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
+    /// to hold a `TriggerIntent`.
+    ///
+    /// Note that all the setters affecting `query` are
+    /// mutually exclusive.
+    pub fn set_trigger_intent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query = std::option::Option::Some(
+            crate::model::match_intent_response::Query::TriggerIntent(v.into()),
+        );
+        self
     }
 
     /// The value of [query][crate::model::MatchIntentResponse::query]
@@ -23456,6 +23479,18 @@ impl MatchIntentResponse {
         })
     }
 
+    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
+    /// to hold a `Transcript`.
+    ///
+    /// Note that all the setters affecting `query` are
+    /// mutually exclusive.
+    pub fn set_transcript<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query = std::option::Option::Some(
+            crate::model::match_intent_response::Query::Transcript(v.into()),
+        );
+        self
+    }
+
     /// The value of [query][crate::model::MatchIntentResponse::query]
     /// if it holds a `TriggerEvent`, `None` if the field is not set or
     /// holds a different branch.
@@ -23467,41 +23502,6 @@ impl MatchIntentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::match_intent_response::Query::Text(v.into()));
-        self
-    }
-
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `TriggerIntent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_intent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::match_intent_response::Query::TriggerIntent(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `Transcript`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_transcript<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::match_intent_response::Query::Transcript(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [query][crate::model::MatchIntentResponse::query]
@@ -24080,12 +24080,6 @@ impl ListSessionEntityTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionEntityTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [session_entity_types][crate::model::ListSessionEntityTypesResponse::session_entity_types].
     pub fn set_session_entity_types<T, V>(mut self, v: T) -> Self
     where
@@ -24094,6 +24088,12 @@ impl ListSessionEntityTypesResponse {
     {
         use std::iter::Iterator;
         self.session_entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionEntityTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -24378,6 +24378,17 @@ impl TestCase {
         self
     }
 
+    /// Sets the value of [tags][crate::model::TestCase::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::TestCase::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -24399,6 +24410,17 @@ impl TestCase {
         self
     }
 
+    /// Sets the value of [test_case_conversation_turns][crate::model::TestCase::test_case_conversation_turns].
+    pub fn set_test_case_conversation_turns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConversationTurn>,
+    {
+        use std::iter::Iterator;
+        self.test_case_conversation_turns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [creation_time][crate::model::TestCase::creation_time].
     pub fn set_creation_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -24416,28 +24438,6 @@ impl TestCase {
         v: T,
     ) -> Self {
         self.last_test_result = v.into();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::TestCase::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [test_case_conversation_turns][crate::model::TestCase::test_case_conversation_turns].
-    pub fn set_test_case_conversation_turns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConversationTurn>,
-    {
-        use std::iter::Iterator;
-        self.test_case_conversation_turns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -24497,6 +24497,17 @@ impl TestCaseResult {
         self
     }
 
+    /// Sets the value of [conversation_turns][crate::model::TestCaseResult::conversation_turns].
+    pub fn set_conversation_turns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConversationTurn>,
+    {
+        use std::iter::Iterator;
+        self.conversation_turns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [test_result][crate::model::TestCaseResult::test_result].
     pub fn set_test_result<T: std::convert::Into<crate::model::TestResult>>(
         mut self,
@@ -24512,17 +24523,6 @@ impl TestCaseResult {
         v: T,
     ) -> Self {
         self.test_time = v.into();
-        self
-    }
-
-    /// Sets the value of [conversation_turns][crate::model::TestCaseResult::conversation_turns].
-    pub fn set_conversation_turns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConversationTurn>,
-    {
-        use std::iter::Iterator;
-        self.conversation_turns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -24574,6 +24574,17 @@ impl TestConfig {
         std::default::Default::default()
     }
 
+    /// Sets the value of [tracking_parameters][crate::model::TestConfig::tracking_parameters].
+    pub fn set_tracking_parameters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tracking_parameters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [flow][crate::model::TestConfig::flow].
     pub fn set_flow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.flow = v.into();
@@ -24583,17 +24594,6 @@ impl TestConfig {
     /// Sets the value of [page][crate::model::TestConfig::page].
     pub fn set_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page = v.into();
-        self
-    }
-
-    /// Sets the value of [tracking_parameters][crate::model::TestConfig::tracking_parameters].
-    pub fn set_tracking_parameters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tracking_parameters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -24810,6 +24810,17 @@ pub mod conversation_turn {
             self
         }
 
+        /// Sets the value of [differences][crate::model::conversation_turn::VirtualAgentOutput::differences].
+        pub fn set_differences<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::TestRunDifference>,
+        {
+            use std::iter::Iterator;
+            self.differences = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [diagnostic_info][crate::model::conversation_turn::VirtualAgentOutput::diagnostic_info].
         pub fn set_diagnostic_info<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
             mut self,
@@ -24839,26 +24850,6 @@ pub mod conversation_turn {
             self
         }
 
-        /// Sets the value of [status][crate::model::conversation_turn::VirtualAgentOutput::status].
-        pub fn set_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.status = v.into();
-            self
-        }
-
-        /// Sets the value of [differences][crate::model::conversation_turn::VirtualAgentOutput::differences].
-        pub fn set_differences<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::TestRunDifference>,
-        {
-            use std::iter::Iterator;
-            self.differences = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
         /// Sets the value of [text_responses][crate::model::conversation_turn::VirtualAgentOutput::text_responses].
         pub fn set_text_responses<T, V>(mut self, v: T) -> Self
         where
@@ -24867,6 +24858,15 @@ pub mod conversation_turn {
         {
             use std::iter::Iterator;
             self.text_responses = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [status][crate::model::conversation_turn::VirtualAgentOutput::status].
+        pub fn set_status<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.status = v.into();
             self
         }
     }
@@ -25108,12 +25108,6 @@ impl TransitionCoverage {
         std::default::Default::default()
     }
 
-    /// Sets the value of [coverage_score][crate::model::TransitionCoverage::coverage_score].
-    pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.coverage_score = v.into();
-        self
-    }
-
     /// Sets the value of [transitions][crate::model::TransitionCoverage::transitions].
     pub fn set_transitions<T, V>(mut self, v: T) -> Self
     where
@@ -25122,6 +25116,12 @@ impl TransitionCoverage {
     {
         use std::iter::Iterator;
         self.transitions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [coverage_score][crate::model::TransitionCoverage::coverage_score].
+    pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.coverage_score = v.into();
         self
     }
 }
@@ -25185,19 +25185,6 @@ pub mod transition_coverage {
             })
         }
 
-        /// The value of [kind][crate::model::transition_coverage::TransitionNode::kind]
-        /// if it holds a `Flow`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn flow(&self) -> std::option::Option<&std::boxed::Box<crate::model::Flow>> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::transition_coverage::transition_node::Kind::Flow(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [kind][crate::model::transition_coverage::TransitionNode::kind]
         /// to hold a `Page`.
         ///
@@ -25211,6 +25198,19 @@ pub mod transition_coverage {
                 crate::model::transition_coverage::transition_node::Kind::Page(v.into()),
             );
             self
+        }
+
+        /// The value of [kind][crate::model::transition_coverage::TransitionNode::kind]
+        /// if it holds a `Flow`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn flow(&self) -> std::option::Option<&std::boxed::Box<crate::model::Flow>> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::transition_coverage::transition_node::Kind::Flow(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [kind][crate::model::transition_coverage::TransitionNode::kind]
@@ -25363,21 +25363,6 @@ pub mod transition_coverage {
             })
         }
 
-        /// The value of [detail][crate::model::transition_coverage::Transition::detail]
-        /// if it holds a `EventHandler`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn event_handler(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::EventHandler>> {
-            #[allow(unreachable_patterns)]
-            self.detail.as_ref().and_then(|v| match v {
-                crate::model::transition_coverage::transition::Detail::EventHandler(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [detail][crate::model::transition_coverage::Transition::detail]
         /// to hold a `TransitionRoute`.
         ///
@@ -25393,6 +25378,21 @@ pub mod transition_coverage {
                 crate::model::transition_coverage::transition::Detail::TransitionRoute(v.into()),
             );
             self
+        }
+
+        /// The value of [detail][crate::model::transition_coverage::Transition::detail]
+        /// if it holds a `EventHandler`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn event_handler(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::EventHandler>> {
+            #[allow(unreachable_patterns)]
+            self.detail.as_ref().and_then(|v| match v {
+                crate::model::transition_coverage::transition::Detail::EventHandler(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [detail][crate::model::transition_coverage::Transition::detail]
@@ -25463,12 +25463,6 @@ impl TransitionRouteGroupCoverage {
         std::default::Default::default()
     }
 
-    /// Sets the value of [coverage_score][crate::model::TransitionRouteGroupCoverage::coverage_score].
-    pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.coverage_score = v.into();
-        self
-    }
-
     /// Sets the value of [coverages][crate::model::TransitionRouteGroupCoverage::coverages].
     pub fn set_coverages<T, V>(mut self, v: T) -> Self
     where
@@ -25477,6 +25471,12 @@ impl TransitionRouteGroupCoverage {
     {
         use std::iter::Iterator;
         self.coverages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [coverage_score][crate::model::TransitionRouteGroupCoverage::coverage_score].
+    pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.coverage_score = v.into();
         self
     }
 }
@@ -25532,12 +25532,6 @@ pub mod transition_route_group_coverage {
             self
         }
 
-        /// Sets the value of [coverage_score][crate::model::transition_route_group_coverage::Coverage::coverage_score].
-        pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.coverage_score = v.into();
-            self
-        }
-
         /// Sets the value of [transitions][crate::model::transition_route_group_coverage::Coverage::transitions].
         pub fn set_transitions<T, V>(mut self, v: T) -> Self
         where
@@ -25548,6 +25542,12 @@ pub mod transition_route_group_coverage {
         {
             use std::iter::Iterator;
             self.transitions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [coverage_score][crate::model::transition_route_group_coverage::Coverage::coverage_score].
+        pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.coverage_score = v.into();
             self
         }
     }
@@ -25637,12 +25637,6 @@ impl IntentCoverage {
         std::default::Default::default()
     }
 
-    /// Sets the value of [coverage_score][crate::model::IntentCoverage::coverage_score].
-    pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.coverage_score = v.into();
-        self
-    }
-
     /// Sets the value of [intents][crate::model::IntentCoverage::intents].
     pub fn set_intents<T, V>(mut self, v: T) -> Self
     where
@@ -25651,6 +25645,12 @@ impl IntentCoverage {
     {
         use std::iter::Iterator;
         self.intents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [coverage_score][crate::model::IntentCoverage::coverage_score].
+    pub fn set_coverage_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.coverage_score = v.into();
         self
     }
 }
@@ -25970,36 +25970,6 @@ impl CalculateCoverageResponse {
         })
     }
 
-    /// The value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
-    /// if it holds a `TransitionCoverage`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn transition_coverage(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TransitionCoverage>> {
-        #[allow(unreachable_patterns)]
-        self.coverage_type.as_ref().and_then(|v| match v {
-            crate::model::calculate_coverage_response::CoverageType::TransitionCoverage(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
-    /// if it holds a `RouteGroupCoverage`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn route_group_coverage(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TransitionRouteGroupCoverage>> {
-        #[allow(unreachable_patterns)]
-        self.coverage_type.as_ref().and_then(|v| match v {
-            crate::model::calculate_coverage_response::CoverageType::RouteGroupCoverage(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
     /// to hold a `IntentCoverage`.
     ///
@@ -26017,6 +25987,21 @@ impl CalculateCoverageResponse {
         self
     }
 
+    /// The value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
+    /// if it holds a `TransitionCoverage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn transition_coverage(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TransitionCoverage>> {
+        #[allow(unreachable_patterns)]
+        self.coverage_type.as_ref().and_then(|v| match v {
+            crate::model::calculate_coverage_response::CoverageType::TransitionCoverage(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
     /// to hold a `TransitionCoverage`.
     ///
@@ -26032,6 +26017,21 @@ impl CalculateCoverageResponse {
             crate::model::calculate_coverage_response::CoverageType::TransitionCoverage(v.into()),
         );
         self
+    }
+
+    /// The value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
+    /// if it holds a `RouteGroupCoverage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn route_group_coverage(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TransitionRouteGroupCoverage>> {
+        #[allow(unreachable_patterns)]
+        self.coverage_type.as_ref().and_then(|v| match v {
+            crate::model::calculate_coverage_response::CoverageType::RouteGroupCoverage(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
@@ -26315,12 +26315,6 @@ impl ListTestCasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTestCasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [test_cases][crate::model::ListTestCasesResponse::test_cases].
     pub fn set_test_cases<T, V>(mut self, v: T) -> Self
     where
@@ -26329,6 +26323,12 @@ impl ListTestCasesResponse {
     {
         use std::iter::Iterator;
         self.test_cases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTestCasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -26927,6 +26927,18 @@ impl ImportTestCasesRequest {
         })
     }
 
+    /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
+    /// to hold a `GcsUri`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::import_test_cases_request::Source::GcsUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [source][crate::model::ImportTestCasesRequest::source]
     /// if it holds a `Content`, `None` if the field is not set or
     /// holds a different branch.
@@ -26938,18 +26950,6 @@ impl ImportTestCasesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
-    /// to hold a `GcsUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_test_cases_request::Source::GcsUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
@@ -27449,6 +27449,18 @@ impl ExportTestCasesResponse {
         })
     }
 
+    /// Sets the value of [destination][crate::model::ExportTestCasesResponse::destination]
+    /// to hold a `GcsUri`.
+    ///
+    /// Note that all the setters affecting `destination` are
+    /// mutually exclusive.
+    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.destination = std::option::Option::Some(
+            crate::model::export_test_cases_response::Destination::GcsUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [destination][crate::model::ExportTestCasesResponse::destination]
     /// if it holds a `Content`, `None` if the field is not set or
     /// holds a different branch.
@@ -27460,18 +27472,6 @@ impl ExportTestCasesResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportTestCasesResponse::destination]
-    /// to hold a `GcsUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_test_cases_response::Destination::GcsUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [destination][crate::model::ExportTestCasesResponse::destination]
@@ -27661,12 +27661,6 @@ impl ListTestCaseResultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTestCaseResultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [test_case_results][crate::model::ListTestCaseResultsResponse::test_case_results].
     pub fn set_test_case_results<T, V>(mut self, v: T) -> Self
     where
@@ -27675,6 +27669,12 @@ impl ListTestCaseResultsResponse {
     {
         use std::iter::Iterator;
         self.test_case_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTestCaseResultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -27918,12 +27918,6 @@ impl ListTransitionRouteGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTransitionRouteGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [transition_route_groups][crate::model::ListTransitionRouteGroupsResponse::transition_route_groups].
     pub fn set_transition_route_groups<T, V>(mut self, v: T) -> Self
     where
@@ -27932,6 +27926,12 @@ impl ListTransitionRouteGroupsResponse {
     {
         use std::iter::Iterator;
         self.transition_route_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTransitionRouteGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -28272,21 +28272,6 @@ impl ValidationMessage {
         self
     }
 
-    /// Sets the value of [severity][crate::model::ValidationMessage::severity].
-    pub fn set_severity<T: std::convert::Into<crate::model::validation_message::Severity>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.severity = v.into();
-        self
-    }
-
-    /// Sets the value of [detail][crate::model::ValidationMessage::detail].
-    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.detail = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::ValidationMessage::resources].
     #[deprecated]
     pub fn set_resources<T, V>(mut self, v: T) -> Self
@@ -28307,6 +28292,21 @@ impl ValidationMessage {
     {
         use std::iter::Iterator;
         self.resource_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [severity][crate::model::ValidationMessage::severity].
+    pub fn set_severity<T: std::convert::Into<crate::model::validation_message::Severity>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.severity = v.into();
+        self
+    }
+
+    /// Sets the value of [detail][crate::model::ValidationMessage::detail].
+    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.detail = v.into();
         self
     }
 }
@@ -29087,12 +29087,6 @@ impl ListVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [versions][crate::model::ListVersionsResponse::versions].
     pub fn set_versions<T, V>(mut self, v: T) -> Self
     where
@@ -29101,6 +29095,12 @@ impl ListVersionsResponse {
     {
         use std::iter::Iterator;
         self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -29595,19 +29595,6 @@ impl Webhook {
         })
     }
 
-    /// The value of [webhook][crate::model::Webhook::webhook]
-    /// if it holds a `ServiceDirectory`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn service_directory(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::webhook::ServiceDirectoryConfig>> {
-        #[allow(unreachable_patterns)]
-        self.webhook.as_ref().and_then(|v| match v {
-            crate::model::webhook::Webhook::ServiceDirectory(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [webhook][crate::model::Webhook::webhook]
     /// to hold a `GenericWebService`.
     ///
@@ -29622,6 +29609,19 @@ impl Webhook {
         self.webhook =
             std::option::Option::Some(crate::model::webhook::Webhook::GenericWebService(v.into()));
         self
+    }
+
+    /// The value of [webhook][crate::model::Webhook::webhook]
+    /// if it holds a `ServiceDirectory`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn service_directory(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::webhook::ServiceDirectoryConfig>> {
+        #[allow(unreachable_patterns)]
+        self.webhook.as_ref().and_then(|v| match v {
+            crate::model::webhook::Webhook::ServiceDirectory(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [webhook][crate::model::Webhook::webhook]
@@ -29756,6 +29756,29 @@ pub mod webhook {
             self
         }
 
+        /// Sets the value of [request_headers][crate::model::webhook::GenericWebService::request_headers].
+        pub fn set_request_headers<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.request_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [allowed_ca_certs][crate::model::webhook::GenericWebService::allowed_ca_certs].
+        pub fn set_allowed_ca_certs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<::bytes::Bytes>,
+        {
+            use std::iter::Iterator;
+            self.allowed_ca_certs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [oauth_config][crate::model::webhook::GenericWebService::oauth_config].
         pub fn set_oauth_config<
             T: std::convert::Into<
@@ -29808,29 +29831,6 @@ pub mod webhook {
             v: T,
         ) -> Self {
             self.request_body = v.into();
-            self
-        }
-
-        /// Sets the value of [allowed_ca_certs][crate::model::webhook::GenericWebService::allowed_ca_certs].
-        pub fn set_allowed_ca_certs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<::bytes::Bytes>,
-        {
-            use std::iter::Iterator;
-            self.allowed_ca_certs = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [request_headers][crate::model::webhook::GenericWebService::request_headers].
-        pub fn set_request_headers<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.request_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -30546,12 +30546,6 @@ impl ListWebhooksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWebhooksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [webhooks][crate::model::ListWebhooksResponse::webhooks].
     pub fn set_webhooks<T, V>(mut self, v: T) -> Self
     where
@@ -30560,6 +30554,12 @@ impl ListWebhooksResponse {
     {
         use std::iter::Iterator;
         self.webhooks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWebhooksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -30918,6 +30918,17 @@ impl WebhookRequest {
         self
     }
 
+    /// Sets the value of [messages][crate::model::WebhookRequest::messages].
+    pub fn set_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResponseMessage>,
+    {
+        use std::iter::Iterator;
+        self.messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [payload][crate::model::WebhookRequest::payload].
     pub fn set_payload<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
         mut self,
@@ -30951,17 +30962,6 @@ impl WebhookRequest {
         self
     }
 
-    /// Sets the value of [messages][crate::model::WebhookRequest::messages].
-    pub fn set_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResponseMessage>,
-    {
-        use std::iter::Iterator;
-        self.messages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [query][crate::model::WebhookRequest::query].
     ///
     /// Note that all the setters affecting `query` are mutually
@@ -30987,50 +30987,6 @@ impl WebhookRequest {
         })
     }
 
-    /// The value of [query][crate::model::WebhookRequest::query]
-    /// if it holds a `TriggerIntent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn trigger_intent(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::webhook_request::Query::TriggerIntent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [query][crate::model::WebhookRequest::query]
-    /// if it holds a `Transcript`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn transcript(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::webhook_request::Query::Transcript(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [query][crate::model::WebhookRequest::query]
-    /// if it holds a `TriggerEvent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn trigger_event(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::webhook_request::Query::TriggerEvent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [query][crate::model::WebhookRequest::query]
-    /// if it holds a `DtmfDigits`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dtmf_digits(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.query.as_ref().and_then(|v| match v {
-            crate::model::webhook_request::Query::DtmfDigits(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [query][crate::model::WebhookRequest::query]
     /// to hold a `Text`.
     ///
@@ -31040,6 +30996,17 @@ impl WebhookRequest {
         self.query =
             std::option::Option::Some(crate::model::webhook_request::Query::Text(v.into()));
         self
+    }
+
+    /// The value of [query][crate::model::WebhookRequest::query]
+    /// if it holds a `TriggerIntent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn trigger_intent(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::webhook_request::Query::TriggerIntent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [query][crate::model::WebhookRequest::query]
@@ -31054,6 +31021,17 @@ impl WebhookRequest {
         self
     }
 
+    /// The value of [query][crate::model::WebhookRequest::query]
+    /// if it holds a `Transcript`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn transcript(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::webhook_request::Query::Transcript(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [query][crate::model::WebhookRequest::query]
     /// to hold a `Transcript`.
     ///
@@ -31065,6 +31043,17 @@ impl WebhookRequest {
         self
     }
 
+    /// The value of [query][crate::model::WebhookRequest::query]
+    /// if it holds a `TriggerEvent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn trigger_event(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::webhook_request::Query::TriggerEvent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [query][crate::model::WebhookRequest::query]
     /// to hold a `TriggerEvent`.
     ///
@@ -31074,6 +31063,17 @@ impl WebhookRequest {
         self.query =
             std::option::Option::Some(crate::model::webhook_request::Query::TriggerEvent(v.into()));
         self
+    }
+
+    /// The value of [query][crate::model::WebhookRequest::query]
+    /// if it holds a `DtmfDigits`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dtmf_digits(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.query.as_ref().and_then(|v| match v {
+            crate::model::webhook_request::Query::DtmfDigits(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [query][crate::model::WebhookRequest::query]
@@ -31203,12 +31203,6 @@ pub mod webhook_request {
             self
         }
 
-        /// Sets the value of [confidence][crate::model::webhook_request::IntentInfo::confidence].
-        pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.confidence = v.into();
-            self
-        }
-
         /// Sets the value of [parameters][crate::model::webhook_request::IntentInfo::parameters].
         pub fn set_parameters<T, K, V>(mut self, v: T) -> Self
         where
@@ -31218,6 +31212,12 @@ pub mod webhook_request {
         {
             use std::iter::Iterator;
             self.parameters = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [confidence][crate::model::webhook_request::IntentInfo::confidence].
+        pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.confidence = v.into();
             self
         }
     }
@@ -31476,6 +31476,18 @@ impl WebhookResponse {
         })
     }
 
+    /// Sets the value of [transition][crate::model::WebhookResponse::transition]
+    /// to hold a `TargetPage`.
+    ///
+    /// Note that all the setters affecting `transition` are
+    /// mutually exclusive.
+    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.transition = std::option::Option::Some(
+            crate::model::webhook_response::Transition::TargetPage(v.into()),
+        );
+        self
+    }
+
     /// The value of [transition][crate::model::WebhookResponse::transition]
     /// if it holds a `TargetFlow`, `None` if the field is not set or
     /// holds a different branch.
@@ -31487,18 +31499,6 @@ impl WebhookResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transition][crate::model::WebhookResponse::transition]
-    /// to hold a `TargetPage`.
-    ///
-    /// Note that all the setters affecting `transition` are
-    /// mutually exclusive.
-    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.transition = std::option::Option::Some(
-            crate::model::webhook_response::Transition::TargetPage(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [transition][crate::model::WebhookResponse::transition]
@@ -31547,17 +31547,6 @@ pub mod webhook_response {
             std::default::Default::default()
         }
 
-        /// Sets the value of [merge_behavior][crate::model::webhook_response::FulfillmentResponse::merge_behavior].
-        pub fn set_merge_behavior<
-            T: std::convert::Into<crate::model::webhook_response::fulfillment_response::MergeBehavior>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.merge_behavior = v.into();
-            self
-        }
-
         /// Sets the value of [messages][crate::model::webhook_response::FulfillmentResponse::messages].
         pub fn set_messages<T, V>(mut self, v: T) -> Self
         where
@@ -31566,6 +31555,17 @@ pub mod webhook_response {
         {
             use std::iter::Iterator;
             self.messages = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [merge_behavior][crate::model::webhook_response::FulfillmentResponse::merge_behavior].
+        pub fn set_merge_behavior<
+            T: std::convert::Into<crate::model::webhook_response::fulfillment_response::MergeBehavior>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.merge_behavior = v.into();
             self
         }
     }

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -2851,6 +2851,18 @@ pub mod conversations {
             self
         }
 
+        /// Sets the value of [context_references][crate::model::GenerateStatelessSuggestionRequest::context_references].
+        pub fn set_context_references<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::conversation::ContextReference>,
+        {
+            self.0.request.context_references =
+                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [conversation_context][crate::model::GenerateStatelessSuggestionRequest::conversation_context].
         pub fn set_conversation_context<
             T: Into<std::option::Option<crate::model::ConversationContext>>,
@@ -2870,18 +2882,6 @@ pub mod conversations {
         {
             use std::iter::Iterator;
             self.0.request.trigger_events = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [context_references][crate::model::GenerateStatelessSuggestionRequest::context_references].
-        pub fn set_context_references<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<crate::model::conversation::ContextReference>,
-        {
-            self.0.request.context_references =
-                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -8585,12 +8585,6 @@ pub mod entity_types {
             self
         }
 
-        /// Sets the value of [language_code][crate::model::BatchCreateEntitiesRequest::language_code].
-        pub fn set_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.language_code = v.into();
-            self
-        }
-
         /// Sets the value of [entities][crate::model::BatchCreateEntitiesRequest::entities].
         ///
         /// This is a **required** field for requests.
@@ -8601,6 +8595,12 @@ pub mod entity_types {
         {
             use std::iter::Iterator;
             self.0.request.entities = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [language_code][crate::model::BatchCreateEntitiesRequest::language_code].
+        pub fn set_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.language_code = v.into();
             self
         }
     }
@@ -8689,6 +8689,19 @@ pub mod entity_types {
             self
         }
 
+        /// Sets the value of [entities][crate::model::BatchUpdateEntitiesRequest::entities].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_entities<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::entity_type::Entity>,
+        {
+            use std::iter::Iterator;
+            self.0.request.entities = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [language_code][crate::model::BatchUpdateEntitiesRequest::language_code].
         pub fn set_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.language_code = v.into();
@@ -8701,19 +8714,6 @@ pub mod entity_types {
             v: T,
         ) -> Self {
             self.0.request.update_mask = v.into();
-            self
-        }
-
-        /// Sets the value of [entities][crate::model::BatchUpdateEntitiesRequest::entities].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_entities<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::entity_type::Entity>,
-        {
-            use std::iter::Iterator;
-            self.0.request.entities = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -8802,12 +8802,6 @@ pub mod entity_types {
             self
         }
 
-        /// Sets the value of [language_code][crate::model::BatchDeleteEntitiesRequest::language_code].
-        pub fn set_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.language_code = v.into();
-            self
-        }
-
         /// Sets the value of [entity_values][crate::model::BatchDeleteEntitiesRequest::entity_values].
         ///
         /// This is a **required** field for requests.
@@ -8818,6 +8812,12 @@ pub mod entity_types {
         {
             use std::iter::Iterator;
             self.0.request.entity_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [language_code][crate::model::BatchDeleteEntitiesRequest::language_code].
+        pub fn set_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.language_code = v.into();
             self
         }
     }

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -147,6 +147,17 @@ impl Agent {
         self
     }
 
+    /// Sets the value of [supported_language_codes][crate::model::Agent::supported_language_codes].
+    pub fn set_supported_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.supported_language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [time_zone][crate::model::Agent::time_zone].
     pub fn set_time_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.time_zone = v.into();
@@ -199,17 +210,6 @@ impl Agent {
     /// Sets the value of [tier][crate::model::Agent::tier].
     pub fn set_tier<T: std::convert::Into<crate::model::agent::Tier>>(mut self, v: T) -> Self {
         self.tier = v.into();
-        self
-    }
-
-    /// Sets the value of [supported_language_codes][crate::model::Agent::supported_language_codes].
-    pub fn set_supported_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.supported_language_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -848,12 +848,6 @@ impl SearchAgentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchAgentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [agents][crate::model::SearchAgentsResponse::agents].
     pub fn set_agents<T, V>(mut self, v: T) -> Self
     where
@@ -862,6 +856,12 @@ impl SearchAgentsResponse {
     {
         use std::iter::Iterator;
         self.agents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchAgentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1024,6 +1024,18 @@ impl ExportAgentResponse {
         })
     }
 
+    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
+    /// to hold a `AgentUri`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::export_agent_response::Agent::AgentUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [agent][crate::model::ExportAgentResponse::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1035,18 +1047,6 @@ impl ExportAgentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
@@ -1144,6 +1144,18 @@ impl ImportAgentRequest {
         })
     }
 
+    /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
+    /// to hold a `AgentUri`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::import_agent_request::Agent::AgentUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [agent][crate::model::ImportAgentRequest::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1155,18 +1167,6 @@ impl ImportAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::import_agent_request::Agent::AgentUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
@@ -1270,6 +1270,18 @@ impl RestoreAgentRequest {
         })
     }
 
+    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
+    /// to hold a `AgentUri`.
+    ///
+    /// Note that all the setters affecting `agent` are
+    /// mutually exclusive.
+    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.agent = std::option::Option::Some(
+            crate::model::restore_agent_request::Agent::AgentUri(v.into()),
+        );
+        self
+    }
+
     /// The value of [agent][crate::model::RestoreAgentRequest::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1281,18 +1293,6 @@ impl RestoreAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentUri(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
@@ -1662,12 +1662,6 @@ impl ListAnswerRecordsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAnswerRecordsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [answer_records][crate::model::ListAnswerRecordsResponse::answer_records].
     pub fn set_answer_records<T, V>(mut self, v: T) -> Self
     where
@@ -1676,6 +1670,12 @@ impl ListAnswerRecordsResponse {
     {
         use std::iter::Iterator;
         self.answer_records = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAnswerRecordsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2839,34 +2839,6 @@ impl AgentAssistantRecord {
         })
     }
 
-    /// The value of [answer][crate::model::AgentAssistantRecord::answer]
-    /// if it holds a `FaqAnswer`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn faq_answer(&self) -> std::option::Option<&std::boxed::Box<crate::model::FaqAnswer>> {
-        #[allow(unreachable_patterns)]
-        self.answer.as_ref().and_then(|v| match v {
-            crate::model::agent_assistant_record::Answer::FaqAnswer(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [answer][crate::model::AgentAssistantRecord::answer]
-    /// if it holds a `DialogflowAssistAnswer`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dialogflow_assist_answer(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DialogflowAssistAnswer>> {
-        #[allow(unreachable_patterns)]
-        self.answer.as_ref().and_then(|v| match v {
-            crate::model::agent_assistant_record::Answer::DialogflowAssistAnswer(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [answer][crate::model::AgentAssistantRecord::answer]
     /// to hold a `ArticleSuggestionAnswer`.
     ///
@@ -2884,6 +2856,19 @@ impl AgentAssistantRecord {
         self
     }
 
+    /// The value of [answer][crate::model::AgentAssistantRecord::answer]
+    /// if it holds a `FaqAnswer`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn faq_answer(&self) -> std::option::Option<&std::boxed::Box<crate::model::FaqAnswer>> {
+        #[allow(unreachable_patterns)]
+        self.answer.as_ref().and_then(|v| match v {
+            crate::model::agent_assistant_record::Answer::FaqAnswer(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [answer][crate::model::AgentAssistantRecord::answer]
     /// to hold a `FaqAnswer`.
     ///
@@ -2897,6 +2882,21 @@ impl AgentAssistantRecord {
             crate::model::agent_assistant_record::Answer::FaqAnswer(v.into()),
         );
         self
+    }
+
+    /// The value of [answer][crate::model::AgentAssistantRecord::answer]
+    /// if it holds a `DialogflowAssistAnswer`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dialogflow_assist_answer(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DialogflowAssistAnswer>> {
+        #[allow(unreachable_patterns)]
+        self.answer.as_ref().and_then(|v| match v {
+            crate::model::agent_assistant_record::Answer::DialogflowAssistAnswer(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [answer][crate::model::AgentAssistantRecord::answer]
@@ -2986,12 +2986,6 @@ impl SpeechContext {
         std::default::Default::default()
     }
 
-    /// Sets the value of [boost][crate::model::SpeechContext::boost].
-    pub fn set_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.boost = v.into();
-        self
-    }
-
     /// Sets the value of [phrases][crate::model::SpeechContext::phrases].
     pub fn set_phrases<T, V>(mut self, v: T) -> Self
     where
@@ -3000,6 +2994,12 @@ impl SpeechContext {
     {
         use std::iter::Iterator;
         self.phrases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [boost][crate::model::SpeechContext::boost].
+    pub fn set_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.boost = v.into();
         self
     }
 }
@@ -3233,6 +3233,29 @@ impl InputAudioConfig {
         self
     }
 
+    /// Sets the value of [phrase_hints][crate::model::InputAudioConfig::phrase_hints].
+    #[deprecated]
+    pub fn set_phrase_hints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.phrase_hints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [speech_contexts][crate::model::InputAudioConfig::speech_contexts].
+    pub fn set_speech_contexts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SpeechContext>,
+    {
+        use std::iter::Iterator;
+        self.speech_contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [model][crate::model::InputAudioConfig::model].
     pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.model = v.into();
@@ -3269,38 +3292,6 @@ impl InputAudioConfig {
         self
     }
 
-    /// Sets the value of [opt_out_conformer_model_migration][crate::model::InputAudioConfig::opt_out_conformer_model_migration].
-    pub fn set_opt_out_conformer_model_migration<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.opt_out_conformer_model_migration = v.into();
-        self
-    }
-
-    /// Sets the value of [phrase_hints][crate::model::InputAudioConfig::phrase_hints].
-    #[deprecated]
-    pub fn set_phrase_hints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.phrase_hints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [speech_contexts][crate::model::InputAudioConfig::speech_contexts].
-    pub fn set_speech_contexts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SpeechContext>,
-    {
-        use std::iter::Iterator;
-        self.speech_contexts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [phrase_sets][crate::model::InputAudioConfig::phrase_sets].
     pub fn set_phrase_sets<T, V>(mut self, v: T) -> Self
     where
@@ -3309,6 +3300,15 @@ impl InputAudioConfig {
     {
         use std::iter::Iterator;
         self.phrase_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [opt_out_conformer_model_migration][crate::model::InputAudioConfig::opt_out_conformer_model_migration].
+    pub fn set_opt_out_conformer_model_migration<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.opt_out_conformer_model_migration = v.into();
         self
     }
 }
@@ -3441,17 +3441,6 @@ impl SynthesizeSpeechConfig {
         self
     }
 
-    /// Sets the value of [voice][crate::model::SynthesizeSpeechConfig::voice].
-    pub fn set_voice<
-        T: std::convert::Into<std::option::Option<crate::model::VoiceSelectionParams>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.voice = v.into();
-        self
-    }
-
     /// Sets the value of [effects_profile_id][crate::model::SynthesizeSpeechConfig::effects_profile_id].
     pub fn set_effects_profile_id<T, V>(mut self, v: T) -> Self
     where
@@ -3460,6 +3449,17 @@ impl SynthesizeSpeechConfig {
     {
         use std::iter::Iterator;
         self.effects_profile_id = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [voice][crate::model::SynthesizeSpeechConfig::voice].
+    pub fn set_voice<
+        T: std::convert::Into<std::option::Option<crate::model::VoiceSelectionParams>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.voice = v.into();
         self
     }
 }
@@ -3685,6 +3685,17 @@ impl SpeechToTextConfig {
         self
     }
 
+    /// Sets the value of [phrase_sets][crate::model::SpeechToTextConfig::phrase_sets].
+    pub fn set_phrase_sets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.phrase_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [audio_encoding][crate::model::SpeechToTextConfig::audio_encoding].
     pub fn set_audio_encoding<T: std::convert::Into<crate::model::AudioEncoding>>(
         mut self,
@@ -3715,17 +3726,6 @@ impl SpeechToTextConfig {
     /// Sets the value of [use_timeout_based_endpointing][crate::model::SpeechToTextConfig::use_timeout_based_endpointing].
     pub fn set_use_timeout_based_endpointing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.use_timeout_based_endpointing = v.into();
-        self
-    }
-
-    /// Sets the value of [phrase_sets][crate::model::SpeechToTextConfig::phrase_sets].
-    pub fn set_phrase_sets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.phrase_sets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3926,12 +3926,6 @@ impl ListContextsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListContextsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [contexts][crate::model::ListContextsResponse::contexts].
     pub fn set_contexts<T, V>(mut self, v: T) -> Self
     where
@@ -3940,6 +3934,12 @@ impl ListContextsResponse {
     {
         use std::iter::Iterator;
         self.contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListContextsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4579,6 +4579,17 @@ pub mod conversation {
             std::default::Default::default()
         }
 
+        /// Sets the value of [context_contents][crate::model::conversation::ContextReference::context_contents].
+        pub fn set_context_contents<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::conversation::context_reference::ContextContent>,
+        {
+            use std::iter::Iterator;
+            self.context_contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [update_mode][crate::model::conversation::ContextReference::update_mode].
         pub fn set_update_mode<
             T: std::convert::Into<crate::model::conversation::context_reference::UpdateMode>,
@@ -4605,17 +4616,6 @@ pub mod conversation {
             v: T,
         ) -> Self {
             self.create_time = v.into();
-            self
-        }
-
-        /// Sets the value of [context_contents][crate::model::conversation::ContextReference::context_contents].
-        pub fn set_context_contents<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::conversation::context_reference::ContextContent>,
-        {
-            use std::iter::Iterator;
-            self.context_contents = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5410,12 +5410,6 @@ impl ListConversationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversations][crate::model::ListConversationsResponse::conversations].
     pub fn set_conversations<T, V>(mut self, v: T) -> Self
     where
@@ -5424,6 +5418,12 @@ impl ListConversationsResponse {
     {
         use std::iter::Iterator;
         self.conversations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5626,12 +5626,6 @@ impl ListMessagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMessagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [messages][crate::model::ListMessagesResponse::messages].
     pub fn set_messages<T, V>(mut self, v: T) -> Self
     where
@@ -5640,6 +5634,12 @@ impl ListMessagesResponse {
     {
         use std::iter::Iterator;
         self.messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMessagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6005,6 +6005,18 @@ pub mod suggest_conversation_summary_response {
             self
         }
 
+        /// Sets the value of [text_sections][crate::model::suggest_conversation_summary_response::Summary::text_sections].
+        pub fn set_text_sections<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.text_sections = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [answer_record][crate::model::suggest_conversation_summary_response::Summary::answer_record].
         pub fn set_answer_record<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -6020,18 +6032,6 @@ pub mod suggest_conversation_summary_response {
             v: T,
         ) -> Self {
             self.baseline_model_version = v.into();
-            self
-        }
-
-        /// Sets the value of [text_sections][crate::model::suggest_conversation_summary_response::Summary::text_sections].
-        pub fn set_text_sections<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.text_sections = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -6165,12 +6165,6 @@ pub mod generate_stateless_summary_request {
             std::default::Default::default()
         }
 
-        /// Sets the value of [parent][crate::model::generate_stateless_summary_request::MinimalConversation::parent].
-        pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.parent = v.into();
-            self
-        }
-
         /// Sets the value of [messages][crate::model::generate_stateless_summary_request::MinimalConversation::messages].
         pub fn set_messages<T, V>(mut self, v: T) -> Self
         where
@@ -6179,6 +6173,12 @@ pub mod generate_stateless_summary_request {
         {
             use std::iter::Iterator;
             self.messages = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parent][crate::model::generate_stateless_summary_request::MinimalConversation::parent].
+        pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.parent = v.into();
             self
         }
     }
@@ -6303,15 +6303,6 @@ pub mod generate_stateless_summary_response {
             self
         }
 
-        /// Sets the value of [baseline_model_version][crate::model::generate_stateless_summary_response::Summary::baseline_model_version].
-        pub fn set_baseline_model_version<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.baseline_model_version = v.into();
-            self
-        }
-
         /// Sets the value of [text_sections][crate::model::generate_stateless_summary_response::Summary::text_sections].
         pub fn set_text_sections<T, K, V>(mut self, v: T) -> Self
         where
@@ -6321,6 +6312,15 @@ pub mod generate_stateless_summary_response {
         {
             use std::iter::Iterator;
             self.text_sections = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [baseline_model_version][crate::model::generate_stateless_summary_response::Summary::baseline_model_version].
+        pub fn set_baseline_model_version<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.baseline_model_version = v.into();
             self
         }
     }
@@ -6385,6 +6385,18 @@ impl GenerateStatelessSuggestionRequest {
         self
     }
 
+    /// Sets the value of [context_references][crate::model::GenerateStatelessSuggestionRequest::context_references].
+    pub fn set_context_references<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::conversation::ContextReference>,
+    {
+        use std::iter::Iterator;
+        self.context_references = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [conversation_context][crate::model::GenerateStatelessSuggestionRequest::conversation_context].
     pub fn set_conversation_context<
         T: std::convert::Into<std::option::Option<crate::model::ConversationContext>>,
@@ -6404,18 +6416,6 @@ impl GenerateStatelessSuggestionRequest {
     {
         use std::iter::Iterator;
         self.trigger_events = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [context_references][crate::model::GenerateStatelessSuggestionRequest::context_references].
-    pub fn set_context_references<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::conversation::ContextReference>,
-    {
-        use std::iter::Iterator;
-        self.context_references = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -6450,17 +6450,6 @@ impl GenerateStatelessSuggestionRequest {
         })
     }
 
-    /// The value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
-    /// if it holds a `GeneratorName`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn generator_name(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.generator_resource.as_ref().and_then(|v| match v {
-            crate::model::generate_stateless_suggestion_request::GeneratorResource::GeneratorName(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
     /// to hold a `Generator`.
     ///
@@ -6476,6 +6465,17 @@ impl GenerateStatelessSuggestionRequest {
             ),
         );
         self
+    }
+
+    /// The value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
+    /// if it holds a `GeneratorName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn generator_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.generator_resource.as_ref().and_then(|v| match v {
+            crate::model::generate_stateless_suggestion_request::GeneratorResource::GeneratorName(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
@@ -7480,12 +7480,6 @@ pub mod search_knowledge_request {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [filter][crate::model::search_knowledge_request::search_config::FilterSpecs::filter].
-            pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.filter = v.into();
-                self
-            }
-
             /// Sets the value of [data_stores][crate::model::search_knowledge_request::search_config::FilterSpecs::data_stores].
             pub fn set_data_stores<T, V>(mut self, v: T) -> Self
             where
@@ -7494,6 +7488,12 @@ pub mod search_knowledge_request {
             {
                 use std::iter::Iterator;
                 self.data_stores = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [filter][crate::model::search_knowledge_request::search_config::FilterSpecs::filter].
+            pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+                self.filter = v.into();
                 self
             }
         }
@@ -7674,12 +7674,6 @@ impl SearchKnowledgeResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [rewritten_query][crate::model::SearchKnowledgeResponse::rewritten_query].
-    pub fn set_rewritten_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.rewritten_query = v.into();
-        self
-    }
-
     /// Sets the value of [answers][crate::model::SearchKnowledgeResponse::answers].
     pub fn set_answers<T, V>(mut self, v: T) -> Self
     where
@@ -7688,6 +7682,12 @@ impl SearchKnowledgeResponse {
     {
         use std::iter::Iterator;
         self.answers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [rewritten_query][crate::model::SearchKnowledgeResponse::rewritten_query].
+    pub fn set_rewritten_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.rewritten_query = v.into();
         self
     }
 }
@@ -7748,12 +7748,6 @@ impl SearchKnowledgeAnswer {
         self
     }
 
-    /// Sets the value of [answer_record][crate::model::SearchKnowledgeAnswer::answer_record].
-    pub fn set_answer_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.answer_record = v.into();
-        self
-    }
-
     /// Sets the value of [answer_sources][crate::model::SearchKnowledgeAnswer::answer_sources].
     pub fn set_answer_sources<T, V>(mut self, v: T) -> Self
     where
@@ -7762,6 +7756,12 @@ impl SearchKnowledgeAnswer {
     {
         use std::iter::Iterator;
         self.answer_sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [answer_record][crate::model::SearchKnowledgeAnswer::answer_record].
+    pub fn set_answer_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.answer_record = v.into();
         self
     }
 }
@@ -8479,12 +8479,6 @@ impl ListConversationDatasetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationDatasetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversation_datasets][crate::model::ListConversationDatasetsResponse::conversation_datasets].
     pub fn set_conversation_datasets<T, V>(mut self, v: T) -> Self
     where
@@ -8493,6 +8487,12 @@ impl ListConversationDatasetsResponse {
     {
         use std::iter::Iterator;
         self.conversation_datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8650,15 +8650,6 @@ impl ImportConversationDataOperationMetadata {
         self
     }
 
-    /// Sets the value of [create_time][crate::model::ImportConversationDataOperationMetadata::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
     /// Sets the value of [partial_failures][crate::model::ImportConversationDataOperationMetadata::partial_failures].
     pub fn set_partial_failures<T, V>(mut self, v: T) -> Self
     where
@@ -8667,6 +8658,15 @@ impl ImportConversationDataOperationMetadata {
     {
         use std::iter::Iterator;
         self.partial_failures = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::ImportConversationDataOperationMetadata::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
         self
     }
 }
@@ -8875,21 +8875,6 @@ impl ConversationEvent {
         })
     }
 
-    /// The value of [payload][crate::model::ConversationEvent::payload]
-    /// if it holds a `NewRecognitionResultPayload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn new_recognition_result_payload(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StreamingRecognitionResult>> {
-        #[allow(unreachable_patterns)]
-        self.payload.as_ref().and_then(|v| match v {
-            crate::model::conversation_event::Payload::NewRecognitionResultPayload(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [payload][crate::model::ConversationEvent::payload]
     /// to hold a `NewMessagePayload`.
     ///
@@ -8905,6 +8890,21 @@ impl ConversationEvent {
             crate::model::conversation_event::Payload::NewMessagePayload(v.into()),
         );
         self
+    }
+
+    /// The value of [payload][crate::model::ConversationEvent::payload]
+    /// if it holds a `NewRecognitionResultPayload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn new_recognition_result_payload(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StreamingRecognitionResult>> {
+        #[allow(unreachable_patterns)]
+        self.payload.as_ref().and_then(|v| match v {
+            crate::model::conversation_event::Payload::NewRecognitionResultPayload(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [payload][crate::model::ConversationEvent::payload]
@@ -9210,6 +9210,17 @@ impl ConversationModel {
         self
     }
 
+    /// Sets the value of [datasets][crate::model::ConversationModel::datasets].
+    pub fn set_datasets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InputDataset>,
+    {
+        use std::iter::Iterator;
+        self.datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::ConversationModel::state].
     pub fn set_state<T: std::convert::Into<crate::model::conversation_model::State>>(
         mut self,
@@ -9243,17 +9254,6 @@ impl ConversationModel {
         self
     }
 
-    /// Sets the value of [datasets][crate::model::ConversationModel::datasets].
-    pub fn set_datasets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InputDataset>,
-    {
-        use std::iter::Iterator;
-        self.datasets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [model_metadata][crate::model::ConversationModel::model_metadata].
     ///
     /// Note that all the setters affecting `model_metadata` are mutually
@@ -9283,21 +9283,6 @@ impl ConversationModel {
         })
     }
 
-    /// The value of [model_metadata][crate::model::ConversationModel::model_metadata]
-    /// if it holds a `SmartReplyModelMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn smart_reply_model_metadata(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SmartReplyModelMetadata>> {
-        #[allow(unreachable_patterns)]
-        self.model_metadata.as_ref().and_then(|v| match v {
-            crate::model::conversation_model::ModelMetadata::SmartReplyModelMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [model_metadata][crate::model::ConversationModel::model_metadata]
     /// to hold a `ArticleSuggestionModelMetadata`.
     ///
@@ -9315,6 +9300,21 @@ impl ConversationModel {
             ),
         );
         self
+    }
+
+    /// The value of [model_metadata][crate::model::ConversationModel::model_metadata]
+    /// if it holds a `SmartReplyModelMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn smart_reply_model_metadata(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SmartReplyModelMetadata>> {
+        #[allow(unreachable_patterns)]
+        self.model_metadata.as_ref().and_then(|v| match v {
+            crate::model::conversation_model::ModelMetadata::SmartReplyModelMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [model_metadata][crate::model::ConversationModel::model_metadata]
@@ -9905,22 +9905,6 @@ impl EvaluationConfig {
         })
     }
 
-    /// The value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
-    /// if it holds a `SmartComposeConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn smart_compose_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::evaluation_config::SmartComposeConfig>>
-    {
-        #[allow(unreachable_patterns)]
-        self.model_specific_config.as_ref().and_then(|v| match v {
-            crate::model::evaluation_config::ModelSpecificConfig::SmartComposeConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
     /// to hold a `SmartReplyConfig`.
     ///
@@ -9936,6 +9920,22 @@ impl EvaluationConfig {
             crate::model::evaluation_config::ModelSpecificConfig::SmartReplyConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
+    /// if it holds a `SmartComposeConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn smart_compose_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::evaluation_config::SmartComposeConfig>>
+    {
+        #[allow(unreachable_patterns)]
+        self.model_specific_config.as_ref().and_then(|v| match v {
+            crate::model::evaluation_config::ModelSpecificConfig::SmartComposeConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
@@ -10224,12 +10224,6 @@ impl SmartReplyMetrics {
         self
     }
 
-    /// Sets the value of [conversation_count][crate::model::SmartReplyMetrics::conversation_count].
-    pub fn set_conversation_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.conversation_count = v.into();
-        self
-    }
-
     /// Sets the value of [top_n_metrics][crate::model::SmartReplyMetrics::top_n_metrics].
     pub fn set_top_n_metrics<T, V>(mut self, v: T) -> Self
     where
@@ -10238,6 +10232,12 @@ impl SmartReplyMetrics {
     {
         use std::iter::Iterator;
         self.top_n_metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [conversation_count][crate::model::SmartReplyMetrics::conversation_count].
+    pub fn set_conversation_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.conversation_count = v.into();
         self
     }
 }
@@ -10472,12 +10472,6 @@ impl ListConversationModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversation_models][crate::model::ListConversationModelsResponse::conversation_models].
     pub fn set_conversation_models<T, V>(mut self, v: T) -> Self
     where
@@ -10486,6 +10480,12 @@ impl ListConversationModelsResponse {
     {
         use std::iter::Iterator;
         self.conversation_models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10739,12 +10739,6 @@ impl ListConversationModelEvaluationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationModelEvaluationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversation_model_evaluations][crate::model::ListConversationModelEvaluationsResponse::conversation_model_evaluations].
     pub fn set_conversation_model_evaluations<T, V>(mut self, v: T) -> Self
     where
@@ -10753,6 +10747,12 @@ impl ListConversationModelEvaluationsResponse {
     {
         use std::iter::Iterator;
         self.conversation_model_evaluations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationModelEvaluationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11825,12 +11825,6 @@ impl ListConversationProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversation_profiles][crate::model::ListConversationProfilesResponse::conversation_profiles].
     pub fn set_conversation_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -11839,6 +11833,12 @@ impl ListConversationProfilesResponse {
     {
         use std::iter::Iterator;
         self.conversation_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -12500,21 +12500,6 @@ pub mod human_agent_assistant_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [group_suggestion_responses][crate::model::human_agent_assistant_config::SuggestionConfig::group_suggestion_responses].
-        pub fn set_group_suggestion_responses<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.group_suggestion_responses = v.into();
-            self
-        }
-
-        /// Sets the value of [disable_high_latency_features_sync_delivery][crate::model::human_agent_assistant_config::SuggestionConfig::disable_high_latency_features_sync_delivery].
-        pub fn set_disable_high_latency_features_sync_delivery<T: std::convert::Into<bool>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.disable_high_latency_features_sync_delivery = v.into();
-            self
-        }
-
         /// Sets the value of [feature_configs][crate::model::human_agent_assistant_config::SuggestionConfig::feature_configs].
         pub fn set_feature_configs<T, V>(mut self, v: T) -> Self
         where
@@ -12528,6 +12513,12 @@ pub mod human_agent_assistant_config {
             self
         }
 
+        /// Sets the value of [group_suggestion_responses][crate::model::human_agent_assistant_config::SuggestionConfig::group_suggestion_responses].
+        pub fn set_group_suggestion_responses<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.group_suggestion_responses = v.into();
+            self
+        }
+
         /// Sets the value of [generators][crate::model::human_agent_assistant_config::SuggestionConfig::generators].
         pub fn set_generators<T, V>(mut self, v: T) -> Self
         where
@@ -12536,6 +12527,15 @@ pub mod human_agent_assistant_config {
         {
             use std::iter::Iterator;
             self.generators = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [disable_high_latency_features_sync_delivery][crate::model::human_agent_assistant_config::SuggestionConfig::disable_high_latency_features_sync_delivery].
+        pub fn set_disable_high_latency_features_sync_delivery<T: std::convert::Into<bool>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.disable_high_latency_features_sync_delivery = v.into();
             self
         }
     }
@@ -12660,28 +12660,6 @@ pub mod human_agent_assistant_config {
             })
         }
 
-        /// The value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
-        /// if it holds a `DocumentQuerySource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn document_query_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::DocumentQuerySource>>{
-            #[allow(unreachable_patterns)]
-            self.query_source.as_ref().and_then(|v| match v {
-                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DocumentQuerySource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
-        /// if it holds a `DialogflowQuerySource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn dialogflow_query_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::DialogflowQuerySource>>{
-            #[allow(unreachable_patterns)]
-            self.query_source.as_ref().and_then(|v| match v {
-                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DialogflowQuerySource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
         /// to hold a `KnowledgeBaseQuerySource`.
         ///
@@ -12696,6 +12674,17 @@ pub mod human_agent_assistant_config {
             self
         }
 
+        /// The value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
+        /// if it holds a `DocumentQuerySource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn document_query_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::DocumentQuerySource>>{
+            #[allow(unreachable_patterns)]
+            self.query_source.as_ref().and_then(|v| match v {
+                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DocumentQuerySource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
         /// to hold a `DocumentQuerySource`.
         ///
@@ -12708,6 +12697,17 @@ pub mod human_agent_assistant_config {
                 )
             );
             self
+        }
+
+        /// The value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
+        /// if it holds a `DialogflowQuerySource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn dialogflow_query_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::DialogflowQuerySource>>{
+            #[allow(unreachable_patterns)]
+            self.query_source.as_ref().and_then(|v| match v {
+                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DialogflowQuerySource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
@@ -13434,23 +13434,6 @@ impl HumanAgentHandoffConfig {
         })
     }
 
-    /// The value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
-    /// if it holds a `SalesforceLiveAgentConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn salesforce_live_agent_config(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::human_agent_handoff_config::SalesforceLiveAgentConfig>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.agent_service.as_ref().and_then(|v| match v {
-            crate::model::human_agent_handoff_config::AgentService::SalesforceLiveAgentConfig(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
     /// to hold a `LivePersonConfig`.
     ///
@@ -13468,6 +13451,23 @@ impl HumanAgentHandoffConfig {
             crate::model::human_agent_handoff_config::AgentService::LivePersonConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
+    /// if it holds a `SalesforceLiveAgentConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn salesforce_live_agent_config(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::human_agent_handoff_config::SalesforceLiveAgentConfig>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.agent_service.as_ref().and_then(|v| match v {
+            crate::model::human_agent_handoff_config::AgentService::SalesforceLiveAgentConfig(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
@@ -14479,6 +14479,17 @@ impl Document {
         self
     }
 
+    /// Sets the value of [knowledge_types][crate::model::Document::knowledge_types].
+    pub fn set_knowledge_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::document::KnowledgeType>,
+    {
+        use std::iter::Iterator;
+        self.knowledge_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [enable_auto_reload][crate::model::Document::enable_auto_reload].
     pub fn set_enable_auto_reload<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_auto_reload = v.into();
@@ -14496,23 +14507,6 @@ impl Document {
         self
     }
 
-    /// Sets the value of [state][crate::model::Document::state].
-    pub fn set_state<T: std::convert::Into<crate::model::document::State>>(mut self, v: T) -> Self {
-        self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [knowledge_types][crate::model::Document::knowledge_types].
-    pub fn set_knowledge_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::document::KnowledgeType>,
-    {
-        use std::iter::Iterator;
-        self.knowledge_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::Document::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -14522,6 +14516,12 @@ impl Document {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Document::state].
+    pub fn set_state<T: std::convert::Into<crate::model::document::State>>(mut self, v: T) -> Self {
+        self.state = v.into();
         self
     }
 
@@ -14550,17 +14550,6 @@ impl Document {
         })
     }
 
-    /// The value of [source][crate::model::Document::source]
-    /// if it holds a `RawContent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn raw_content(&self) -> std::option::Option<&::bytes::Bytes> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::document::Source::RawContent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::Document::source]
     /// to hold a `ContentUri`.
     ///
@@ -14570,6 +14559,17 @@ impl Document {
         self.source =
             std::option::Option::Some(crate::model::document::Source::ContentUri(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::Document::source]
+    /// if it holds a `RawContent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn raw_content(&self) -> std::option::Option<&::bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::document::Source::RawContent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::Document::source]
@@ -15127,12 +15127,6 @@ impl ListDocumentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDocumentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [documents][crate::model::ListDocumentsResponse::documents].
     pub fn set_documents<T, V>(mut self, v: T) -> Self
     where
@@ -15141,6 +15135,12 @@ impl ListDocumentsResponse {
     {
         use std::iter::Iterator;
         self.documents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDocumentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -16371,12 +16371,6 @@ impl EntityType {
         self
     }
 
-    /// Sets the value of [enable_fuzzy_extraction][crate::model::EntityType::enable_fuzzy_extraction].
-    pub fn set_enable_fuzzy_extraction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_fuzzy_extraction = v.into();
-        self
-    }
-
     /// Sets the value of [entities][crate::model::EntityType::entities].
     pub fn set_entities<T, V>(mut self, v: T) -> Self
     where
@@ -16385,6 +16379,12 @@ impl EntityType {
     {
         use std::iter::Iterator;
         self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enable_fuzzy_extraction][crate::model::EntityType::enable_fuzzy_extraction].
+    pub fn set_enable_fuzzy_extraction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_fuzzy_extraction = v.into();
         self
     }
 }
@@ -16835,12 +16835,6 @@ impl ListEntityTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntityTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entity_types][crate::model::ListEntityTypesResponse::entity_types].
     pub fn set_entity_types<T, V>(mut self, v: T) -> Self
     where
@@ -16849,6 +16843,12 @@ impl ListEntityTypesResponse {
     {
         use std::iter::Iterator;
         self.entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntityTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -17182,19 +17182,6 @@ impl BatchUpdateEntityTypesRequest {
         })
     }
 
-    /// The value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
-    /// if it holds a `EntityTypeBatchInline`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn entity_type_batch_inline(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::EntityTypeBatch>> {
-        #[allow(unreachable_patterns)]
-        self.entity_type_batch.as_ref().and_then(|v| match v {
-            crate::model::batch_update_entity_types_request::EntityTypeBatch::EntityTypeBatchInline(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
     /// to hold a `EntityTypeBatchUri`.
     ///
@@ -17210,6 +17197,19 @@ impl BatchUpdateEntityTypesRequest {
             ),
         );
         self
+    }
+
+    /// The value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
+    /// if it holds a `EntityTypeBatchInline`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn entity_type_batch_inline(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::EntityTypeBatch>> {
+        #[allow(unreachable_patterns)]
+        self.entity_type_batch.as_ref().and_then(|v| match v {
+            crate::model::batch_update_entity_types_request::EntityTypeBatch::EntityTypeBatchInline(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
@@ -17396,12 +17396,6 @@ impl BatchCreateEntitiesRequest {
         self
     }
 
-    /// Sets the value of [language_code][crate::model::BatchCreateEntitiesRequest::language_code].
-    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.language_code = v.into();
-        self
-    }
-
     /// Sets the value of [entities][crate::model::BatchCreateEntitiesRequest::entities].
     pub fn set_entities<T, V>(mut self, v: T) -> Self
     where
@@ -17410,6 +17404,12 @@ impl BatchCreateEntitiesRequest {
     {
         use std::iter::Iterator;
         self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [language_code][crate::model::BatchCreateEntitiesRequest::language_code].
+    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.language_code = v.into();
         self
     }
 }
@@ -17465,6 +17465,17 @@ impl BatchUpdateEntitiesRequest {
         self
     }
 
+    /// Sets the value of [entities][crate::model::BatchUpdateEntitiesRequest::entities].
+    pub fn set_entities<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::entity_type::Entity>,
+    {
+        use std::iter::Iterator;
+        self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [language_code][crate::model::BatchUpdateEntitiesRequest::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
@@ -17477,17 +17488,6 @@ impl BatchUpdateEntitiesRequest {
         v: T,
     ) -> Self {
         self.update_mask = v.into();
-        self
-    }
-
-    /// Sets the value of [entities][crate::model::BatchUpdateEntitiesRequest::entities].
-    pub fn set_entities<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::entity_type::Entity>,
-    {
-        use std::iter::Iterator;
-        self.entities = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -17541,12 +17541,6 @@ impl BatchDeleteEntitiesRequest {
         self
     }
 
-    /// Sets the value of [language_code][crate::model::BatchDeleteEntitiesRequest::language_code].
-    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.language_code = v.into();
-        self
-    }
-
     /// Sets the value of [entity_values][crate::model::BatchDeleteEntitiesRequest::entity_values].
     pub fn set_entity_values<T, V>(mut self, v: T) -> Self
     where
@@ -17555,6 +17549,12 @@ impl BatchDeleteEntitiesRequest {
     {
         use std::iter::Iterator;
         self.entity_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [language_code][crate::model::BatchDeleteEntitiesRequest::language_code].
+    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.language_code = v.into();
         self
     }
 }
@@ -18056,12 +18056,6 @@ impl ListEnvironmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [environments][crate::model::ListEnvironmentsResponse::environments].
     pub fn set_environments<T, V>(mut self, v: T) -> Self
     where
@@ -18070,6 +18064,12 @@ impl ListEnvironmentsResponse {
     {
         use std::iter::Iterator;
         self.environments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -18419,12 +18419,6 @@ impl EnvironmentHistory {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::EnvironmentHistory::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entries][crate::model::EnvironmentHistory::entries].
     pub fn set_entries<T, V>(mut self, v: T) -> Self
     where
@@ -18433,6 +18427,12 @@ impl EnvironmentHistory {
     {
         use std::iter::Iterator;
         self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::EnvironmentHistory::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -18729,13 +18729,6 @@ pub mod fulfillment {
             self
         }
 
-        /// Sets the value of [is_cloud_function][crate::model::fulfillment::GenericWebService::is_cloud_function].
-        #[deprecated]
-        pub fn set_is_cloud_function<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.is_cloud_function = v.into();
-            self
-        }
-
         /// Sets the value of [request_headers][crate::model::fulfillment::GenericWebService::request_headers].
         pub fn set_request_headers<T, K, V>(mut self, v: T) -> Self
         where
@@ -18745,6 +18738,13 @@ pub mod fulfillment {
         {
             use std::iter::Iterator;
             self.request_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [is_cloud_function][crate::model::fulfillment::GenericWebService::is_cloud_function].
+        #[deprecated]
+        pub fn set_is_cloud_function<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.is_cloud_function = v.into();
             self
         }
     }
@@ -19276,12 +19276,6 @@ impl ListGeneratorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGeneratorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [generators][crate::model::ListGeneratorsResponse::generators].
     pub fn set_generators<T, V>(mut self, v: T) -> Self
     where
@@ -19290,6 +19284,12 @@ impl ListGeneratorsResponse {
     {
         use std::iter::Iterator;
         self.generators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGeneratorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -19730,17 +19730,6 @@ impl FewShotExample {
         self
     }
 
-    /// Sets the value of [output][crate::model::FewShotExample::output].
-    pub fn set_output<
-        T: std::convert::Into<std::option::Option<crate::model::GeneratorSuggestion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output = v.into();
-        self
-    }
-
     /// Sets the value of [extra_info][crate::model::FewShotExample::extra_info].
     pub fn set_extra_info<T, K, V>(mut self, v: T) -> Self
     where
@@ -19750,6 +19739,17 @@ impl FewShotExample {
     {
         use std::iter::Iterator;
         self.extra_info = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [output][crate::model::FewShotExample::output].
+    pub fn set_output<
+        T: std::convert::Into<std::option::Option<crate::model::GeneratorSuggestion>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output = v.into();
         self
     }
 
@@ -20196,21 +20196,6 @@ impl SummarizationContext {
         std::default::Default::default()
     }
 
-    /// Sets the value of [version][crate::model::SummarizationContext::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
-    /// Sets the value of [output_language_code][crate::model::SummarizationContext::output_language_code].
-    pub fn set_output_language_code<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_language_code = v.into();
-        self
-    }
-
     /// Sets the value of [summarization_sections][crate::model::SummarizationContext::summarization_sections].
     pub fn set_summarization_sections<T, V>(mut self, v: T) -> Self
     where
@@ -20230,6 +20215,21 @@ impl SummarizationContext {
     {
         use std::iter::Iterator;
         self.few_shot_examples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::SummarizationContext::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
+        self
+    }
+
+    /// Sets the value of [output_language_code][crate::model::SummarizationContext::output_language_code].
+    pub fn set_output_language_code<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_language_code = v.into();
         self
     }
 }
@@ -20399,21 +20399,6 @@ impl Generator {
         })
     }
 
-    /// The value of [context][crate::model::Generator::context]
-    /// if it holds a `SummarizationContext`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summarization_context(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationContext>> {
-        #[allow(unreachable_patterns)]
-        self.context.as_ref().and_then(|v| match v {
-            crate::model::generator::Context::SummarizationContext(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [context][crate::model::Generator::context]
     /// to hold a `FreeFormContext`.
     ///
@@ -20428,6 +20413,21 @@ impl Generator {
         self.context =
             std::option::Option::Some(crate::model::generator::Context::FreeFormContext(v.into()));
         self
+    }
+
+    /// The value of [context][crate::model::Generator::context]
+    /// if it holds a `SummarizationContext`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summarization_context(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarizationContext>> {
+        #[allow(unreachable_patterns)]
+        self.context.as_ref().and_then(|v| match v {
+            crate::model::generator::Context::SummarizationContext(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [context][crate::model::Generator::context]
@@ -20691,21 +20691,6 @@ impl GeneratorSuggestion {
         })
     }
 
-    /// The value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
-    /// if it holds a `SummarySuggestion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn summary_suggestion(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarySuggestion>> {
-        #[allow(unreachable_patterns)]
-        self.suggestion.as_ref().and_then(|v| match v {
-            crate::model::generator_suggestion::Suggestion::SummarySuggestion(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
     /// to hold a `FreeFormSuggestion`.
     ///
@@ -20721,6 +20706,21 @@ impl GeneratorSuggestion {
             crate::model::generator_suggestion::Suggestion::FreeFormSuggestion(v.into()),
         );
         self
+    }
+
+    /// The value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
+    /// if it holds a `SummarySuggestion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn summary_suggestion(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SummarySuggestion>> {
+        #[allow(unreachable_patterns)]
+        self.suggestion.as_ref().and_then(|v| match v {
+            crate::model::generator_suggestion::Suggestion::SummarySuggestion(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
@@ -21033,36 +21033,6 @@ impl Intent {
         self
     }
 
-    /// Sets the value of [action][crate::model::Intent::action].
-    pub fn set_action<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action = v.into();
-        self
-    }
-
-    /// Sets the value of [reset_contexts][crate::model::Intent::reset_contexts].
-    pub fn set_reset_contexts<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.reset_contexts = v.into();
-        self
-    }
-
-    /// Sets the value of [root_followup_intent_name][crate::model::Intent::root_followup_intent_name].
-    pub fn set_root_followup_intent_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.root_followup_intent_name = v.into();
-        self
-    }
-
-    /// Sets the value of [parent_followup_intent_name][crate::model::Intent::parent_followup_intent_name].
-    pub fn set_parent_followup_intent_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parent_followup_intent_name = v.into();
-        self
-    }
-
     /// Sets the value of [input_context_names][crate::model::Intent::input_context_names].
     pub fn set_input_context_names<T, V>(mut self, v: T) -> Self
     where
@@ -21096,6 +21066,12 @@ impl Intent {
         self
     }
 
+    /// Sets the value of [action][crate::model::Intent::action].
+    pub fn set_action<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.action = v.into();
+        self
+    }
+
     /// Sets the value of [output_contexts][crate::model::Intent::output_contexts].
     pub fn set_output_contexts<T, V>(mut self, v: T) -> Self
     where
@@ -21104,6 +21080,12 @@ impl Intent {
     {
         use std::iter::Iterator;
         self.output_contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [reset_contexts][crate::model::Intent::reset_contexts].
+    pub fn set_reset_contexts<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.reset_contexts = v.into();
         self
     }
 
@@ -21137,6 +21119,24 @@ impl Intent {
     {
         use std::iter::Iterator;
         self.default_response_platforms = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [root_followup_intent_name][crate::model::Intent::root_followup_intent_name].
+    pub fn set_root_followup_intent_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.root_followup_intent_name = v.into();
+        self
+    }
+
+    /// Sets the value of [parent_followup_intent_name][crate::model::Intent::parent_followup_intent_name].
+    pub fn set_parent_followup_intent_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.parent_followup_intent_name = v.into();
         self
     }
 
@@ -21233,12 +21233,6 @@ pub mod intent {
             self
         }
 
-        /// Sets the value of [times_added_count][crate::model::intent::TrainingPhrase::times_added_count].
-        pub fn set_times_added_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.times_added_count = v.into();
-            self
-        }
-
         /// Sets the value of [parts][crate::model::intent::TrainingPhrase::parts].
         pub fn set_parts<T, V>(mut self, v: T) -> Self
         where
@@ -21247,6 +21241,12 @@ pub mod intent {
         {
             use std::iter::Iterator;
             self.parts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [times_added_count][crate::model::intent::TrainingPhrase::times_added_count].
+        pub fn set_times_added_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.times_added_count = v.into();
             self
         }
     }
@@ -21582,12 +21582,6 @@ pub mod intent {
             self
         }
 
-        /// Sets the value of [is_list][crate::model::intent::Parameter::is_list].
-        pub fn set_is_list<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.is_list = v.into();
-            self
-        }
-
         /// Sets the value of [prompts][crate::model::intent::Parameter::prompts].
         pub fn set_prompts<T, V>(mut self, v: T) -> Self
         where
@@ -21596,6 +21590,12 @@ pub mod intent {
         {
             use std::iter::Iterator;
             self.prompts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [is_list][crate::model::intent::Parameter::is_list].
+        pub fn set_is_list<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.is_list = v.into();
             self
         }
     }
@@ -21668,203 +21668,6 @@ pub mod intent {
             })
         }
 
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `Image`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn image(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Image>> {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::Image(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `QuickReplies`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn quick_replies(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::QuickReplies>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::QuickReplies(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `Card`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn card(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Card>> {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::Card(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `Payload`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::Payload(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `SimpleResponses`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn simple_responses(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::SimpleResponses>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::SimpleResponses(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `BasicCard`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn basic_card(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::BasicCard>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::BasicCard(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `Suggestions`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn suggestions(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Suggestions>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::Suggestions(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `LinkOutSuggestion`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn link_out_suggestion(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::LinkOutSuggestion>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::LinkOutSuggestion(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `ListSelect`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn list_select(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::ListSelect>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::ListSelect(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `CarouselSelect`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn carousel_select(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::CarouselSelect>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::CarouselSelect(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `BrowseCarouselCard`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn browse_carousel_card(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::BrowseCarouselCard>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::BrowseCarouselCard(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `TableCard`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn table_card(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::TableCard>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::TableCard(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [message][crate::model::intent::Message::message]
-        /// if it holds a `MediaContent`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn media_content(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::MediaContent>>
-        {
-            #[allow(unreachable_patterns)]
-            self.message.as_ref().and_then(|v| match v {
-                crate::model::intent::message::Message::MediaContent(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `Text`.
         ///
@@ -21881,6 +21684,19 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `Image`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn image(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Image>> {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::Image(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `Image`.
         ///
@@ -21895,6 +21711,22 @@ pub mod intent {
             self.message =
                 std::option::Option::Some(crate::model::intent::message::Message::Image(v.into()));
             self
+        }
+
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `QuickReplies`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn quick_replies(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::QuickReplies>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::QuickReplies(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [message][crate::model::intent::Message::message]
@@ -21914,6 +21746,19 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `Card`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn card(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Card>> {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::Card(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `Card`.
         ///
@@ -21930,6 +21775,17 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `Payload`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::Payload(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `Payload`.
         ///
@@ -21943,6 +21799,22 @@ pub mod intent {
                 crate::model::intent::message::Message::Payload(v.into()),
             );
             self
+        }
+
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `SimpleResponses`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn simple_responses(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::SimpleResponses>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::SimpleResponses(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [message][crate::model::intent::Message::message]
@@ -21962,6 +21834,22 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `BasicCard`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn basic_card(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::BasicCard>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::BasicCard(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `BasicCard`.
         ///
@@ -21977,6 +21865,22 @@ pub mod intent {
                 crate::model::intent::message::Message::BasicCard(v.into()),
             );
             self
+        }
+
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `Suggestions`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn suggestions(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Suggestions>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::Suggestions(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [message][crate::model::intent::Message::message]
@@ -21996,6 +21900,22 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `LinkOutSuggestion`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn link_out_suggestion(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::LinkOutSuggestion>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::LinkOutSuggestion(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `LinkOutSuggestion`.
         ///
@@ -22011,6 +21931,22 @@ pub mod intent {
                 crate::model::intent::message::Message::LinkOutSuggestion(v.into()),
             );
             self
+        }
+
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `ListSelect`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn list_select(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::ListSelect>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::ListSelect(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [message][crate::model::intent::Message::message]
@@ -22030,6 +21966,22 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `CarouselSelect`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn carousel_select(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::CarouselSelect>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::CarouselSelect(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `CarouselSelect`.
         ///
@@ -22045,6 +21997,22 @@ pub mod intent {
                 crate::model::intent::message::Message::CarouselSelect(v.into()),
             );
             self
+        }
+
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `BrowseCarouselCard`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn browse_carousel_card(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::BrowseCarouselCard>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::BrowseCarouselCard(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [message][crate::model::intent::Message::message]
@@ -22064,6 +22032,22 @@ pub mod intent {
             self
         }
 
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `TableCard`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn table_card(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::TableCard>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::TableCard(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [message][crate::model::intent::Message::message]
         /// to hold a `TableCard`.
         ///
@@ -22079,6 +22063,22 @@ pub mod intent {
                 crate::model::intent::message::Message::TableCard(v.into()),
             );
             self
+        }
+
+        /// The value of [message][crate::model::intent::Message::message]
+        /// if it holds a `MediaContent`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn media_content(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::MediaContent>>
+        {
+            #[allow(unreachable_patterns)]
+            self.message.as_ref().and_then(|v| match v {
+                crate::model::intent::message::Message::MediaContent(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [message][crate::model::intent::Message::message]
@@ -22815,15 +22815,6 @@ pub mod intent {
                 self
             }
 
-            /// Sets the value of [subtitle][crate::model::intent::message::ListSelect::subtitle].
-            pub fn set_subtitle<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.subtitle = v.into();
-                self
-            }
-
             /// Sets the value of [items][crate::model::intent::message::ListSelect::items].
             pub fn set_items<T, V>(mut self, v: T) -> Self
             where
@@ -22832,6 +22823,15 @@ pub mod intent {
             {
                 use std::iter::Iterator;
                 self.items = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [subtitle][crate::model::intent::message::ListSelect::subtitle].
+            pub fn set_subtitle<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.subtitle = v.into();
                 self
             }
         }
@@ -23244,20 +23244,6 @@ pub mod intent {
                     })
                 }
 
-                /// The value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
-                /// if it holds a `Icon`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn icon(
-                    &self,
-                ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Image>>
-                {
-                    #[allow(unreachable_patterns)]
-                    self.image.as_ref().and_then(|v| match v {
-                        crate::model::intent::message::media_content::response_media_object::Image::Icon(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
                 /// to hold a `LargeImage`.
                 ///
@@ -23275,6 +23261,20 @@ pub mod intent {
                         )
                     );
                     self
+                }
+
+                /// The value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
+                /// if it holds a `Icon`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn icon(
+                    &self,
+                ) -> std::option::Option<&std::boxed::Box<crate::model::intent::message::Image>>
+                {
+                    #[allow(unreachable_patterns)]
+                    self.image.as_ref().and_then(|v| match v {
+                        crate::model::intent::message::media_content::response_media_object::Image::Icon(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
@@ -23480,19 +23480,6 @@ pub mod intent {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [image_display_options][crate::model::intent::message::BrowseCarouselCard::image_display_options].
-            pub fn set_image_display_options<
-                T: std::convert::Into<
-                        crate::model::intent::message::browse_carousel_card::ImageDisplayOptions,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.image_display_options = v.into();
-                self
-            }
-
             /// Sets the value of [items][crate::model::intent::message::BrowseCarouselCard::items].
             pub fn set_items<T, V>(mut self, v: T) -> Self
             where
@@ -23503,6 +23490,19 @@ pub mod intent {
             {
                 use std::iter::Iterator;
                 self.items = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [image_display_options][crate::model::intent::message::BrowseCarouselCard::image_display_options].
+            pub fn set_image_display_options<
+                T: std::convert::Into<
+                        crate::model::intent::message::browse_carousel_card::ImageDisplayOptions,
+                    >,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.image_display_options = v.into();
                 self
             }
         }
@@ -24300,12 +24300,6 @@ pub mod intent {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [divider_after][crate::model::intent::message::TableCardRow::divider_after].
-            pub fn set_divider_after<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.divider_after = v.into();
-                self
-            }
-
             /// Sets the value of [cells][crate::model::intent::message::TableCardRow::cells].
             pub fn set_cells<T, V>(mut self, v: T) -> Self
             where
@@ -24314,6 +24308,12 @@ pub mod intent {
             {
                 use std::iter::Iterator;
                 self.cells = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [divider_after][crate::model::intent::message::TableCardRow::divider_after].
+            pub fn set_divider_after<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.divider_after = v.into();
                 self
             }
         }
@@ -24887,12 +24887,6 @@ impl ListIntentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIntentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [intents][crate::model::ListIntentsResponse::intents].
     pub fn set_intents<T, V>(mut self, v: T) -> Self
     where
@@ -24901,6 +24895,12 @@ impl ListIntentsResponse {
     {
         use std::iter::Iterator;
         self.intents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIntentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -25273,21 +25273,6 @@ impl BatchUpdateIntentsRequest {
         })
     }
 
-    /// The value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
-    /// if it holds a `IntentBatchInline`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn intent_batch_inline(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IntentBatch>> {
-        #[allow(unreachable_patterns)]
-        self.intent_batch.as_ref().and_then(|v| match v {
-            crate::model::batch_update_intents_request::IntentBatch::IntentBatchInline(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
     /// to hold a `IntentBatchUri`.
     ///
@@ -25301,6 +25286,21 @@ impl BatchUpdateIntentsRequest {
             crate::model::batch_update_intents_request::IntentBatch::IntentBatchUri(v.into()),
         );
         self
+    }
+
+    /// The value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
+    /// if it holds a `IntentBatchInline`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn intent_batch_inline(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IntentBatch>> {
+        #[allow(unreachable_patterns)]
+        self.intent_batch.as_ref().and_then(|v| match v {
+            crate::model::batch_update_intents_request::IntentBatch::IntentBatchInline(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
@@ -25661,12 +25661,6 @@ impl ListKnowledgeBasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListKnowledgeBasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [knowledge_bases][crate::model::ListKnowledgeBasesResponse::knowledge_bases].
     pub fn set_knowledge_bases<T, V>(mut self, v: T) -> Self
     where
@@ -25675,6 +25669,12 @@ impl ListKnowledgeBasesResponse {
     {
         use std::iter::Iterator;
         self.knowledge_bases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListKnowledgeBasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -26498,12 +26498,6 @@ impl ListParticipantsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListParticipantsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [participants][crate::model::ListParticipantsResponse::participants].
     pub fn set_participants<T, V>(mut self, v: T) -> Self
     where
@@ -26512,6 +26506,12 @@ impl ListParticipantsResponse {
     {
         use std::iter::Iterator;
         self.participants = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListParticipantsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -26729,47 +26729,6 @@ impl AnalyzeContentRequest {
         })
     }
 
-    /// The value of [input][crate::model::AnalyzeContentRequest::input]
-    /// if it holds a `AudioInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn audio_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::analyze_content_request::Input::AudioInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [input][crate::model::AnalyzeContentRequest::input]
-    /// if it holds a `EventInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn event_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::EventInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::analyze_content_request::Input::EventInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [input][crate::model::AnalyzeContentRequest::input]
-    /// if it holds a `SuggestionInput`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suggestion_input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestionInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::analyze_content_request::Input::SuggestionInput(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
     /// to hold a `TextInput`.
     ///
@@ -26783,6 +26742,19 @@ impl AnalyzeContentRequest {
             crate::model::analyze_content_request::Input::TextInput(v.into()),
         );
         self
+    }
+
+    /// The value of [input][crate::model::AnalyzeContentRequest::input]
+    /// if it holds a `AudioInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn audio_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::analyze_content_request::Input::AudioInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
@@ -26800,6 +26772,19 @@ impl AnalyzeContentRequest {
         self
     }
 
+    /// The value of [input][crate::model::AnalyzeContentRequest::input]
+    /// if it holds a `EventInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn event_input(&self) -> std::option::Option<&std::boxed::Box<crate::model::EventInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::analyze_content_request::Input::EventInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
     /// to hold a `EventInput`.
     ///
@@ -26813,6 +26798,21 @@ impl AnalyzeContentRequest {
             crate::model::analyze_content_request::Input::EventInput(v.into()),
         );
         self
+    }
+
+    /// The value of [input][crate::model::AnalyzeContentRequest::input]
+    /// if it holds a `SuggestionInput`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suggestion_input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestionInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::analyze_content_request::Input::SuggestionInput(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
@@ -27017,17 +27017,6 @@ impl AnalyzeContentResponse {
         self
     }
 
-    /// Sets the value of [dtmf_parameters][crate::model::AnalyzeContentResponse::dtmf_parameters].
-    pub fn set_dtmf_parameters<
-        T: std::convert::Into<std::option::Option<crate::model::DtmfParameters>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dtmf_parameters = v.into();
-        self
-    }
-
     /// Sets the value of [human_agent_suggestion_results][crate::model::AnalyzeContentResponse::human_agent_suggestion_results].
     pub fn set_human_agent_suggestion_results<T, V>(mut self, v: T) -> Self
     where
@@ -27047,6 +27036,17 @@ impl AnalyzeContentResponse {
     {
         use std::iter::Iterator;
         self.end_user_suggestion_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [dtmf_parameters][crate::model::AnalyzeContentResponse::dtmf_parameters].
+    pub fn set_dtmf_parameters<
+        T: std::convert::Into<std::option::Option<crate::model::DtmfParameters>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.dtmf_parameters = v.into();
         self
     }
 }
@@ -27298,21 +27298,6 @@ impl StreamingAnalyzeContentRequest {
         })
     }
 
-    /// The value of [config][crate::model::StreamingAnalyzeContentRequest::config]
-    /// if it holds a `TextConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InputTextConfig>> {
-        #[allow(unreachable_patterns)]
-        self.config.as_ref().and_then(|v| match v {
-            crate::model::streaming_analyze_content_request::Config::TextConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [config][crate::model::StreamingAnalyzeContentRequest::config]
     /// to hold a `AudioConfig`.
     ///
@@ -27328,6 +27313,21 @@ impl StreamingAnalyzeContentRequest {
             crate::model::streaming_analyze_content_request::Config::AudioConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [config][crate::model::StreamingAnalyzeContentRequest::config]
+    /// if it holds a `TextConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InputTextConfig>> {
+        #[allow(unreachable_patterns)]
+        self.config.as_ref().and_then(|v| match v {
+            crate::model::streaming_analyze_content_request::Config::TextConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [config][crate::model::StreamingAnalyzeContentRequest::config]
@@ -27376,6 +27376,18 @@ impl StreamingAnalyzeContentRequest {
         })
     }
 
+    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
+    /// to hold a `InputAudio`.
+    ///
+    /// Note that all the setters affecting `input` are
+    /// mutually exclusive.
+    pub fn set_input_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.input = std::option::Option::Some(
+            crate::model::streaming_analyze_content_request::Input::InputAudio(v.into()),
+        );
+        self
+    }
+
     /// The value of [input][crate::model::StreamingAnalyzeContentRequest::input]
     /// if it holds a `InputText`, `None` if the field is not set or
     /// holds a different branch.
@@ -27387,6 +27399,18 @@ impl StreamingAnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
+    /// to hold a `InputText`.
+    ///
+    /// Note that all the setters affecting `input` are
+    /// mutually exclusive.
+    pub fn set_input_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.input = std::option::Option::Some(
+            crate::model::streaming_analyze_content_request::Input::InputText(v.into()),
+        );
+        self
     }
 
     /// The value of [input][crate::model::StreamingAnalyzeContentRequest::input]
@@ -27402,30 +27426,6 @@ impl StreamingAnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
-    /// to hold a `InputAudio`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_input_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Input::InputAudio(v.into()),
-        );
-        self
-    }
-
-    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
-    /// to hold a `InputText`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_input_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Input::InputText(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
@@ -27646,6 +27646,28 @@ impl StreamingAnalyzeContentResponse {
         self
     }
 
+    /// Sets the value of [human_agent_suggestion_results][crate::model::StreamingAnalyzeContentResponse::human_agent_suggestion_results].
+    pub fn set_human_agent_suggestion_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SuggestionResult>,
+    {
+        use std::iter::Iterator;
+        self.human_agent_suggestion_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [end_user_suggestion_results][crate::model::StreamingAnalyzeContentResponse::end_user_suggestion_results].
+    pub fn set_end_user_suggestion_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SuggestionResult>,
+    {
+        use std::iter::Iterator;
+        self.end_user_suggestion_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [dtmf_parameters][crate::model::StreamingAnalyzeContentResponse::dtmf_parameters].
     pub fn set_dtmf_parameters<
         T: std::convert::Into<std::option::Option<crate::model::DtmfParameters>>,
@@ -27671,28 +27693,6 @@ impl StreamingAnalyzeContentResponse {
     /// Sets the value of [speech_model][crate::model::StreamingAnalyzeContentResponse::speech_model].
     pub fn set_speech_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.speech_model = v.into();
-        self
-    }
-
-    /// Sets the value of [human_agent_suggestion_results][crate::model::StreamingAnalyzeContentResponse::human_agent_suggestion_results].
-    pub fn set_human_agent_suggestion_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SuggestionResult>,
-    {
-        use std::iter::Iterator;
-        self.human_agent_suggestion_results = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [end_user_suggestion_results][crate::model::StreamingAnalyzeContentResponse::end_user_suggestion_results].
-    pub fn set_end_user_suggestion_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SuggestionResult>,
-    {
-        use std::iter::Iterator;
-        self.end_user_suggestion_results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -27826,6 +27826,17 @@ impl SuggestArticlesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [article_answers][crate::model::SuggestArticlesResponse::article_answers].
+    pub fn set_article_answers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ArticleAnswer>,
+    {
+        use std::iter::Iterator;
+        self.article_answers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [latest_message][crate::model::SuggestArticlesResponse::latest_message].
     pub fn set_latest_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.latest_message = v.into();
@@ -27835,17 +27846,6 @@ impl SuggestArticlesResponse {
     /// Sets the value of [context_size][crate::model::SuggestArticlesResponse::context_size].
     pub fn set_context_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.context_size = v.into();
-        self
-    }
-
-    /// Sets the value of [article_answers][crate::model::SuggestArticlesResponse::article_answers].
-    pub fn set_article_answers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ArticleAnswer>,
-    {
-        use std::iter::Iterator;
-        self.article_answers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -27976,6 +27976,17 @@ impl SuggestFaqAnswersResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [faq_answers][crate::model::SuggestFaqAnswersResponse::faq_answers].
+    pub fn set_faq_answers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FaqAnswer>,
+    {
+        use std::iter::Iterator;
+        self.faq_answers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [latest_message][crate::model::SuggestFaqAnswersResponse::latest_message].
     pub fn set_latest_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.latest_message = v.into();
@@ -27985,17 +27996,6 @@ impl SuggestFaqAnswersResponse {
     /// Sets the value of [context_size][crate::model::SuggestFaqAnswersResponse::context_size].
     pub fn set_context_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.context_size = v.into();
-        self
-    }
-
-    /// Sets the value of [faq_answers][crate::model::SuggestFaqAnswersResponse::faq_answers].
-    pub fn set_faq_answers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FaqAnswer>,
-    {
-        use std::iter::Iterator;
-        self.faq_answers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -28037,12 +28037,6 @@ impl GenerateSuggestionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [latest_message][crate::model::GenerateSuggestionsResponse::latest_message].
-    pub fn set_latest_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.latest_message = v.into();
-        self
-    }
-
     /// Sets the value of [generator_suggestion_answers][crate::model::GenerateSuggestionsResponse::generator_suggestion_answers].
     pub fn set_generator_suggestion_answers<T, V>(mut self, v: T) -> Self
     where
@@ -28053,6 +28047,12 @@ impl GenerateSuggestionsResponse {
     {
         use std::iter::Iterator;
         self.generator_suggestion_answers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [latest_message][crate::model::GenerateSuggestionsResponse::latest_message].
+    pub fn set_latest_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.latest_message = v.into();
         self
     }
 }
@@ -28259,6 +28259,17 @@ impl SuggestSmartRepliesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [smart_reply_answers][crate::model::SuggestSmartRepliesResponse::smart_reply_answers].
+    pub fn set_smart_reply_answers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SmartReplyAnswer>,
+    {
+        use std::iter::Iterator;
+        self.smart_reply_answers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [latest_message][crate::model::SuggestSmartRepliesResponse::latest_message].
     pub fn set_latest_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.latest_message = v.into();
@@ -28268,17 +28279,6 @@ impl SuggestSmartRepliesResponse {
     /// Sets the value of [context_size][crate::model::SuggestSmartRepliesResponse::context_size].
     pub fn set_context_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.context_size = v.into();
-        self
-    }
-
-    /// Sets the value of [smart_reply_answers][crate::model::SuggestSmartRepliesResponse::smart_reply_answers].
-    pub fn set_smart_reply_answers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SmartReplyAnswer>,
-    {
-        use std::iter::Iterator;
-        self.smart_reply_answers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -28669,18 +28669,6 @@ impl ArticleAnswer {
         self
     }
 
-    /// Sets the value of [confidence][crate::model::ArticleAnswer::confidence].
-    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.confidence = v.into();
-        self
-    }
-
-    /// Sets the value of [answer_record][crate::model::ArticleAnswer::answer_record].
-    pub fn set_answer_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.answer_record = v.into();
-        self
-    }
-
     /// Sets the value of [snippets][crate::model::ArticleAnswer::snippets].
     pub fn set_snippets<T, V>(mut self, v: T) -> Self
     where
@@ -28689,6 +28677,12 @@ impl ArticleAnswer {
     {
         use std::iter::Iterator;
         self.snippets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [confidence][crate::model::ArticleAnswer::confidence].
+    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.confidence = v.into();
         self
     }
 
@@ -28701,6 +28695,12 @@ impl ArticleAnswer {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [answer_record][crate::model::ArticleAnswer::answer_record].
+    pub fn set_answer_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.answer_record = v.into();
         self
     }
 }
@@ -28782,12 +28782,6 @@ impl FaqAnswer {
         self
     }
 
-    /// Sets the value of [answer_record][crate::model::FaqAnswer::answer_record].
-    pub fn set_answer_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.answer_record = v.into();
-        self
-    }
-
     /// Sets the value of [metadata][crate::model::FaqAnswer::metadata].
     pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -28797,6 +28791,12 @@ impl FaqAnswer {
     {
         use std::iter::Iterator;
         self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [answer_record][crate::model::FaqAnswer::answer_record].
+    pub fn set_answer_record<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.answer_record = v.into();
         self
     }
 }
@@ -29024,21 +29024,6 @@ impl DialogflowAssistAnswer {
         })
     }
 
-    /// The value of [result][crate::model::DialogflowAssistAnswer::result]
-    /// if it holds a `IntentSuggestion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn intent_suggestion(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IntentSuggestion>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::dialogflow_assist_answer::Result::IntentSuggestion(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::DialogflowAssistAnswer::result]
     /// to hold a `QueryResult`.
     ///
@@ -29052,6 +29037,21 @@ impl DialogflowAssistAnswer {
             crate::model::dialogflow_assist_answer::Result::QueryResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::DialogflowAssistAnswer::result]
+    /// if it holds a `IntentSuggestion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn intent_suggestion(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IntentSuggestion>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::dialogflow_assist_answer::Result::IntentSuggestion(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::DialogflowAssistAnswer::result]
@@ -29153,81 +29153,6 @@ impl SuggestionResult {
         })
     }
 
-    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// if it holds a `SuggestArticlesResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suggest_articles_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestArticlesResponse>> {
-        #[allow(unreachable_patterns)]
-        self.suggestion_response.as_ref().and_then(|v| match v {
-            crate::model::suggestion_result::SuggestionResponse::SuggestArticlesResponse(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// if it holds a `SuggestKnowledgeAssistResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suggest_knowledge_assist_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestKnowledgeAssistResponse>> {
-        #[allow(unreachable_patterns)]
-        self.suggestion_response.as_ref().and_then(|v| match v {
-            crate::model::suggestion_result::SuggestionResponse::SuggestKnowledgeAssistResponse(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// if it holds a `SuggestFaqAnswersResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suggest_faq_answers_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestFaqAnswersResponse>> {
-        #[allow(unreachable_patterns)]
-        self.suggestion_response.as_ref().and_then(|v| match v {
-            crate::model::suggestion_result::SuggestionResponse::SuggestFaqAnswersResponse(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// if it holds a `SuggestSmartRepliesResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suggest_smart_replies_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestSmartRepliesResponse>> {
-        #[allow(unreachable_patterns)]
-        self.suggestion_response.as_ref().and_then(|v| match v {
-            crate::model::suggestion_result::SuggestionResponse::SuggestSmartRepliesResponse(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// if it holds a `GenerateSuggestionsResponse`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn generate_suggestions_response(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GenerateSuggestionsResponse>> {
-        #[allow(unreachable_patterns)]
-        self.suggestion_response.as_ref().and_then(|v| match v {
-            crate::model::suggestion_result::SuggestionResponse::GenerateSuggestionsResponse(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
     /// to hold a `Error`.
     ///
@@ -29241,6 +29166,21 @@ impl SuggestionResult {
             crate::model::suggestion_result::SuggestionResponse::Error(v.into()),
         );
         self
+    }
+
+    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
+    /// if it holds a `SuggestArticlesResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suggest_articles_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestArticlesResponse>> {
+        #[allow(unreachable_patterns)]
+        self.suggestion_response.as_ref().and_then(|v| match v {
+            crate::model::suggestion_result::SuggestionResponse::SuggestArticlesResponse(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
@@ -29258,6 +29198,21 @@ impl SuggestionResult {
             crate::model::suggestion_result::SuggestionResponse::SuggestArticlesResponse(v.into()),
         );
         self
+    }
+
+    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
+    /// if it holds a `SuggestKnowledgeAssistResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suggest_knowledge_assist_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestKnowledgeAssistResponse>> {
+        #[allow(unreachable_patterns)]
+        self.suggestion_response.as_ref().and_then(|v| match v {
+            crate::model::suggestion_result::SuggestionResponse::SuggestKnowledgeAssistResponse(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
@@ -29279,6 +29234,21 @@ impl SuggestionResult {
         self
     }
 
+    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
+    /// if it holds a `SuggestFaqAnswersResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suggest_faq_answers_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestFaqAnswersResponse>> {
+        #[allow(unreachable_patterns)]
+        self.suggestion_response.as_ref().and_then(|v| match v {
+            crate::model::suggestion_result::SuggestionResponse::SuggestFaqAnswersResponse(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
     /// to hold a `SuggestFaqAnswersResponse`.
     ///
@@ -29298,6 +29268,21 @@ impl SuggestionResult {
         self
     }
 
+    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
+    /// if it holds a `SuggestSmartRepliesResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suggest_smart_replies_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SuggestSmartRepliesResponse>> {
+        #[allow(unreachable_patterns)]
+        self.suggestion_response.as_ref().and_then(|v| match v {
+            crate::model::suggestion_result::SuggestionResponse::SuggestSmartRepliesResponse(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
     /// to hold a `SuggestSmartRepliesResponse`.
     ///
@@ -29315,6 +29300,21 @@ impl SuggestionResult {
             ),
         );
         self
+    }
+
+    /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
+    /// if it holds a `GenerateSuggestionsResponse`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn generate_suggestions_response(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GenerateSuggestionsResponse>> {
+        #[allow(unreachable_patterns)]
+        self.suggestion_response.as_ref().and_then(|v| match v {
+            crate::model::suggestion_result::SuggestionResponse::GenerateSuggestionsResponse(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
@@ -29493,12 +29493,6 @@ impl MessageAnnotation {
         std::default::Default::default()
     }
 
-    /// Sets the value of [contain_entities][crate::model::MessageAnnotation::contain_entities].
-    pub fn set_contain_entities<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.contain_entities = v.into();
-        self
-    }
-
     /// Sets the value of [parts][crate::model::MessageAnnotation::parts].
     pub fn set_parts<T, V>(mut self, v: T) -> Self
     where
@@ -29507,6 +29501,12 @@ impl MessageAnnotation {
     {
         use std::iter::Iterator;
         self.parts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [contain_entities][crate::model::MessageAnnotation::contain_entities].
+    pub fn set_contain_entities<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.contain_entities = v.into();
         self
     }
 }
@@ -29937,23 +29937,6 @@ pub mod knowledge_assist_answer {
             })
         }
 
-        /// The value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
-        /// if it holds a `GenerativeSource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn generative_source(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::knowledge_assist_answer::knowledge_answer::GenerativeSource,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::knowledge_assist_answer::knowledge_answer::Source::GenerativeSource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
         /// to hold a `FaqSource`.
         ///
@@ -29975,6 +29958,23 @@ pub mod knowledge_assist_answer {
                 ),
             );
             self
+        }
+
+        /// The value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
+        /// if it holds a `GenerativeSource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn generative_source(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::knowledge_assist_answer::knowledge_answer::GenerativeSource,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::knowledge_assist_answer::knowledge_answer::Source::GenerativeSource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
@@ -30511,9 +30511,31 @@ impl QueryParameters {
         self
     }
 
+    /// Sets the value of [contexts][crate::model::QueryParameters::contexts].
+    pub fn set_contexts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Context>,
+    {
+        use std::iter::Iterator;
+        self.contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [reset_contexts][crate::model::QueryParameters::reset_contexts].
     pub fn set_reset_contexts<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reset_contexts = v.into();
+        self
+    }
+
+    /// Sets the value of [session_entity_types][crate::model::QueryParameters::session_entity_types].
+    pub fn set_session_entity_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SessionEntityType>,
+    {
+        use std::iter::Iterator;
+        self.session_entity_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -30537,34 +30559,6 @@ impl QueryParameters {
         self
     }
 
-    /// Sets the value of [platform][crate::model::QueryParameters::platform].
-    pub fn set_platform<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.platform = v.into();
-        self
-    }
-
-    /// Sets the value of [contexts][crate::model::QueryParameters::contexts].
-    pub fn set_contexts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Context>,
-    {
-        use std::iter::Iterator;
-        self.contexts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [session_entity_types][crate::model::QueryParameters::session_entity_types].
-    pub fn set_session_entity_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SessionEntityType>,
-    {
-        use std::iter::Iterator;
-        self.session_entity_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [webhook_headers][crate::model::QueryParameters::webhook_headers].
     pub fn set_webhook_headers<T, K, V>(mut self, v: T) -> Self
     where
@@ -30574,6 +30568,12 @@ impl QueryParameters {
     {
         use std::iter::Iterator;
         self.webhook_headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [platform][crate::model::QueryParameters::platform].
+    pub fn set_platform<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.platform = v.into();
         self
     }
 }
@@ -30638,28 +30638,6 @@ impl QueryInput {
         })
     }
 
-    /// The value of [input][crate::model::QueryInput::input]
-    /// if it holds a `Text`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text(&self) -> std::option::Option<&std::boxed::Box<crate::model::TextInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::query_input::Input::Text(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [input][crate::model::QueryInput::input]
-    /// if it holds a `Event`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn event(&self) -> std::option::Option<&std::boxed::Box<crate::model::EventInput>> {
-        #[allow(unreachable_patterns)]
-        self.input.as_ref().and_then(|v| match v {
-            crate::model::query_input::Input::Event(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [input][crate::model::QueryInput::input]
     /// to hold a `AudioConfig`.
     ///
@@ -30676,6 +30654,17 @@ impl QueryInput {
         self
     }
 
+    /// The value of [input][crate::model::QueryInput::input]
+    /// if it holds a `Text`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text(&self) -> std::option::Option<&std::boxed::Box<crate::model::TextInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::query_input::Input::Text(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [input][crate::model::QueryInput::input]
     /// to hold a `Text`.
     ///
@@ -30687,6 +30676,17 @@ impl QueryInput {
     ) -> Self {
         self.input = std::option::Option::Some(crate::model::query_input::Input::Text(v.into()));
         self
+    }
+
+    /// The value of [input][crate::model::QueryInput::input]
+    /// if it holds a `Event`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn event(&self) -> std::option::Option<&std::boxed::Box<crate::model::EventInput>> {
+        #[allow(unreachable_patterns)]
+        self.input.as_ref().and_then(|v| match v {
+            crate::model::query_input::Input::Event(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [input][crate::model::QueryInput::input]
@@ -30923,6 +30923,17 @@ impl QueryResult {
         self
     }
 
+    /// Sets the value of [fulfillment_messages][crate::model::QueryResult::fulfillment_messages].
+    pub fn set_fulfillment_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::intent::Message>,
+    {
+        use std::iter::Iterator;
+        self.fulfillment_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [webhook_source][crate::model::QueryResult::webhook_source].
     pub fn set_webhook_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.webhook_source = v.into();
@@ -30935,6 +30946,17 @@ impl QueryResult {
         v: T,
     ) -> Self {
         self.webhook_payload = v.into();
+        self
+    }
+
+    /// Sets the value of [output_contexts][crate::model::QueryResult::output_contexts].
+    pub fn set_output_contexts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Context>,
+    {
+        use std::iter::Iterator;
+        self.output_contexts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -30970,28 +30992,6 @@ impl QueryResult {
         v: T,
     ) -> Self {
         self.sentiment_analysis_result = v.into();
-        self
-    }
-
-    /// Sets the value of [fulfillment_messages][crate::model::QueryResult::fulfillment_messages].
-    pub fn set_fulfillment_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::intent::Message>,
-    {
-        use std::iter::Iterator;
-        self.fulfillment_messages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [output_contexts][crate::model::QueryResult::output_contexts].
-    pub fn set_output_contexts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Context>,
-    {
-        use std::iter::Iterator;
-        self.output_contexts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -31341,6 +31341,28 @@ impl CloudConversationDebuggingInfo {
         self
     }
 
+    /// Sets the value of [speech_partial_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_partial_results_end_times].
+    pub fn set_speech_partial_results_end_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.speech_partial_results_end_times = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [speech_final_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_final_results_end_times].
+    pub fn set_speech_final_results_end_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.speech_final_results_end_times = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [partial_responses][crate::model::CloudConversationDebuggingInfo::partial_responses].
     pub fn set_partial_responses<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.partial_responses = v.into();
@@ -31365,6 +31387,28 @@ impl CloudConversationDebuggingInfo {
     /// Sets the value of [speech_single_utterance][crate::model::CloudConversationDebuggingInfo::speech_single_utterance].
     pub fn set_speech_single_utterance<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.speech_single_utterance = v.into();
+        self
+    }
+
+    /// Sets the value of [dtmf_partial_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_partial_results_times].
+    pub fn set_dtmf_partial_results_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.dtmf_partial_results_times = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [dtmf_final_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_final_results_times].
+    pub fn set_dtmf_final_results_times<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.dtmf_final_results_times = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -31422,50 +31466,6 @@ impl CloudConversationDebuggingInfo {
         v: T,
     ) -> Self {
         self.client_half_close_streaming_time_offset = v.into();
-        self
-    }
-
-    /// Sets the value of [speech_partial_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_partial_results_end_times].
-    pub fn set_speech_partial_results_end_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.speech_partial_results_end_times = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [speech_final_results_end_times][crate::model::CloudConversationDebuggingInfo::speech_final_results_end_times].
-    pub fn set_speech_final_results_end_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.speech_final_results_end_times = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [dtmf_partial_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_partial_results_times].
-    pub fn set_dtmf_partial_results_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.dtmf_partial_results_times = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [dtmf_final_results_times][crate::model::CloudConversationDebuggingInfo::dtmf_final_results_times].
-    pub fn set_dtmf_final_results_times<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.dtmf_final_results_times = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -31748,6 +31748,17 @@ impl StreamingRecognitionResult {
         self
     }
 
+    /// Sets the value of [speech_word_info][crate::model::StreamingRecognitionResult::speech_word_info].
+    pub fn set_speech_word_info<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SpeechWordInfo>,
+    {
+        use std::iter::Iterator;
+        self.speech_word_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [speech_end_offset][crate::model::StreamingRecognitionResult::speech_end_offset].
     pub fn set_speech_end_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
@@ -31760,17 +31771,6 @@ impl StreamingRecognitionResult {
     /// Sets the value of [language_code][crate::model::StreamingRecognitionResult::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [speech_word_info][crate::model::StreamingRecognitionResult::speech_word_info].
-    pub fn set_speech_word_info<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SpeechWordInfo>,
-    {
-        use std::iter::Iterator;
-        self.speech_word_info = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -32509,12 +32509,6 @@ impl ListSessionEntityTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionEntityTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [session_entity_types][crate::model::ListSessionEntityTypesResponse::session_entity_types].
     pub fn set_session_entity_types<T, V>(mut self, v: T) -> Self
     where
@@ -32523,6 +32517,12 @@ impl ListSessionEntityTypesResponse {
     {
         use std::iter::Iterator;
         self.session_entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionEntityTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -32785,12 +32785,6 @@ impl ValidationError {
         self
     }
 
-    /// Sets the value of [error_message][crate::model::ValidationError::error_message].
-    pub fn set_error_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.error_message = v.into();
-        self
-    }
-
     /// Sets the value of [entries][crate::model::ValidationError::entries].
     pub fn set_entries<T, V>(mut self, v: T) -> Self
     where
@@ -32799,6 +32793,12 @@ impl ValidationError {
     {
         use std::iter::Iterator;
         self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_message][crate::model::ValidationError::error_message].
+    pub fn set_error_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.error_message = v.into();
         self
     }
 }
@@ -33333,12 +33333,6 @@ impl ListVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [versions][crate::model::ListVersionsResponse::versions].
     pub fn set_versions<T, V>(mut self, v: T) -> Self
     where
@@ -33347,6 +33341,12 @@ impl ListVersionsResponse {
     {
         use std::iter::Iterator;
         self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -33751,6 +33751,17 @@ impl WebhookResponse {
         self
     }
 
+    /// Sets the value of [fulfillment_messages][crate::model::WebhookResponse::fulfillment_messages].
+    pub fn set_fulfillment_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::intent::Message>,
+    {
+        use std::iter::Iterator;
+        self.fulfillment_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [source][crate::model::WebhookResponse::source].
     pub fn set_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source = v.into();
@@ -33766,28 +33777,6 @@ impl WebhookResponse {
         self
     }
 
-    /// Sets the value of [followup_event_input][crate::model::WebhookResponse::followup_event_input].
-    pub fn set_followup_event_input<
-        T: std::convert::Into<std::option::Option<crate::model::EventInput>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.followup_event_input = v.into();
-        self
-    }
-
-    /// Sets the value of [fulfillment_messages][crate::model::WebhookResponse::fulfillment_messages].
-    pub fn set_fulfillment_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::intent::Message>,
-    {
-        use std::iter::Iterator;
-        self.fulfillment_messages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [output_contexts][crate::model::WebhookResponse::output_contexts].
     pub fn set_output_contexts<T, V>(mut self, v: T) -> Self
     where
@@ -33796,6 +33785,17 @@ impl WebhookResponse {
     {
         use std::iter::Iterator;
         self.output_contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [followup_event_input][crate::model::WebhookResponse::followup_event_input].
+    pub fn set_followup_event_input<
+        T: std::convert::Into<std::option::Option<crate::model::EventInput>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.followup_event_input = v.into();
         self
     }
 

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -1474,6 +1474,17 @@ pub mod conversational_search_service {
             self
         }
 
+        /// Sets the value of [user_labels][crate::model::ConverseConversationRequest::user_labels].
+        pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [summary_spec][crate::model::ConverseConversationRequest::summary_spec].
         pub fn set_summary_spec<
             T: Into<
@@ -1501,17 +1512,6 @@ pub mod conversational_search_service {
             v: T,
         ) -> Self {
             self.0.request.boost_spec = v.into();
-            self
-        }
-
-        /// Sets the value of [user_labels][crate::model::ConverseConversationRequest::user_labels].
-        pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -1967,17 +1967,6 @@ pub mod conversational_search_service {
             self
         }
 
-        /// Sets the value of [end_user_spec][crate::model::AnswerQueryRequest::end_user_spec].
-        pub fn set_end_user_spec<
-            T: Into<std::option::Option<crate::model::answer_query_request::EndUserSpec>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.end_user_spec = v.into();
-            self
-        }
-
         /// Sets the value of [user_labels][crate::model::AnswerQueryRequest::user_labels].
         pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
         where
@@ -1986,6 +1975,17 @@ pub mod conversational_search_service {
             V: std::convert::Into<std::string::String>,
         {
             self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [end_user_spec][crate::model::AnswerQueryRequest::end_user_spec].
+        pub fn set_end_user_spec<
+            T: Into<std::option::Option<crate::model::answer_query_request::EndUserSpec>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.end_user_spec = v.into();
             self
         }
     }
@@ -4886,6 +4886,17 @@ pub mod grounded_generation_service {
             self
         }
 
+        /// Sets the value of [contents][crate::model::GenerateGroundedContentRequest::contents].
+        pub fn set_contents<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::GroundedGenerationContent>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [generation_spec][crate::model::GenerateGroundedContentRequest::generation_spec].
         pub fn set_generation_spec<
             T: Into<
@@ -4911,17 +4922,6 @@ pub mod grounded_generation_service {
             v: T,
         ) -> Self {
             self.0.request.grounding_spec = v.into();
-            self
-        }
-
-        /// Sets the value of [contents][crate::model::GenerateGroundedContentRequest::contents].
-        pub fn set_contents<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::GroundedGenerationContent>,
-        {
-            use std::iter::Iterator;
-            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -4989,17 +4989,6 @@ pub mod grounded_generation_service {
             self
         }
 
-        /// Sets the value of [grounding_spec][crate::model::CheckGroundingRequest::grounding_spec].
-        pub fn set_grounding_spec<
-            T: Into<std::option::Option<crate::model::CheckGroundingSpec>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.grounding_spec = v.into();
-            self
-        }
-
         /// Sets the value of [facts][crate::model::CheckGroundingRequest::facts].
         pub fn set_facts<T, V>(mut self, v: T) -> Self
         where
@@ -5008,6 +4997,17 @@ pub mod grounded_generation_service {
         {
             use std::iter::Iterator;
             self.0.request.facts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [grounding_spec][crate::model::CheckGroundingRequest::grounding_spec].
+        pub fn set_grounding_spec<
+            T: Into<std::option::Option<crate::model::CheckGroundingSpec>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.grounding_spec = v.into();
             self
         }
 
@@ -5656,12 +5656,6 @@ pub mod rank_service {
             self
         }
 
-        /// Sets the value of [ignore_record_details_in_response][crate::model::RankRequest::ignore_record_details_in_response].
-        pub fn set_ignore_record_details_in_response<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.ignore_record_details_in_response = v.into();
-            self
-        }
-
         /// Sets the value of [records][crate::model::RankRequest::records].
         ///
         /// This is a **required** field for requests.
@@ -5672,6 +5666,12 @@ pub mod rank_service {
         {
             use std::iter::Iterator;
             self.0.request.records = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [ignore_record_details_in_response][crate::model::RankRequest::ignore_record_details_in_response].
+        pub fn set_ignore_record_details_in_response<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.ignore_record_details_in_response = v.into();
             self
         }
 
@@ -6990,6 +6990,17 @@ pub mod search_service {
             self
         }
 
+        /// Sets the value of [data_store_specs][crate::model::SearchRequest::data_store_specs].
+        pub fn set_data_store_specs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_request::DataStoreSpec>,
+        {
+            use std::iter::Iterator;
+            self.0.request.data_store_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [filter][crate::model::SearchRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
@@ -7023,6 +7034,17 @@ pub mod search_service {
             self
         }
 
+        /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
+        pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_request::FacetSpec>,
+        {
+            use std::iter::Iterator;
+            self.0.request.facet_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [boost_spec][crate::model::SearchRequest::boost_spec].
         pub fn set_boost_spec<
             T: Into<std::option::Option<crate::model::search_request::BoostSpec>>,
@@ -7031,6 +7053,17 @@ pub mod search_service {
             v: T,
         ) -> Self {
             self.0.request.boost_spec = v.into();
+            self
+        }
+
+        /// Sets the value of [params][crate::model::SearchRequest::params].
+        pub fn set_params<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<wkt::Value>,
+        {
+            self.0.request.params = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -7076,6 +7109,17 @@ pub mod search_service {
         /// Sets the value of [safe_search][crate::model::SearchRequest::safe_search].
         pub fn set_safe_search<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.safe_search = v.into();
+            self
+        }
+
+        /// Sets the value of [user_labels][crate::model::SearchRequest::user_labels].
+        pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -7137,50 +7181,6 @@ pub mod search_service {
             v: T,
         ) -> Self {
             self.0.request.relevance_score_spec = v.into();
-            self
-        }
-
-        /// Sets the value of [data_store_specs][crate::model::SearchRequest::data_store_specs].
-        pub fn set_data_store_specs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_request::DataStoreSpec>,
-        {
-            use std::iter::Iterator;
-            self.0.request.data_store_specs = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
-        pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_request::FacetSpec>,
-        {
-            use std::iter::Iterator;
-            self.0.request.facet_specs = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [params][crate::model::SearchRequest::params].
-        pub fn set_params<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<wkt::Value>,
-        {
-            self.0.request.params = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-            self
-        }
-
-        /// Sets the value of [user_labels][crate::model::SearchRequest::user_labels].
-        pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -7293,6 +7293,17 @@ pub mod search_service {
             self
         }
 
+        /// Sets the value of [data_store_specs][crate::model::SearchRequest::data_store_specs].
+        pub fn set_data_store_specs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_request::DataStoreSpec>,
+        {
+            use std::iter::Iterator;
+            self.0.request.data_store_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [filter][crate::model::SearchRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
@@ -7326,6 +7337,17 @@ pub mod search_service {
             self
         }
 
+        /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
+        pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_request::FacetSpec>,
+        {
+            use std::iter::Iterator;
+            self.0.request.facet_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [boost_spec][crate::model::SearchRequest::boost_spec].
         pub fn set_boost_spec<
             T: Into<std::option::Option<crate::model::search_request::BoostSpec>>,
@@ -7334,6 +7356,17 @@ pub mod search_service {
             v: T,
         ) -> Self {
             self.0.request.boost_spec = v.into();
+            self
+        }
+
+        /// Sets the value of [params][crate::model::SearchRequest::params].
+        pub fn set_params<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<wkt::Value>,
+        {
+            self.0.request.params = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -7379,6 +7412,17 @@ pub mod search_service {
         /// Sets the value of [safe_search][crate::model::SearchRequest::safe_search].
         pub fn set_safe_search<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.safe_search = v.into();
+            self
+        }
+
+        /// Sets the value of [user_labels][crate::model::SearchRequest::user_labels].
+        pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -7440,50 +7484,6 @@ pub mod search_service {
             v: T,
         ) -> Self {
             self.0.request.relevance_score_spec = v.into();
-            self
-        }
-
-        /// Sets the value of [data_store_specs][crate::model::SearchRequest::data_store_specs].
-        pub fn set_data_store_specs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_request::DataStoreSpec>,
-        {
-            use std::iter::Iterator;
-            self.0.request.data_store_specs = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
-        pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_request::FacetSpec>,
-        {
-            use std::iter::Iterator;
-            self.0.request.facet_specs = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [params][crate::model::SearchRequest::params].
-        pub fn set_params<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<wkt::Value>,
-        {
-            self.0.request.params = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-            self
-        }
-
-        /// Sets the value of [user_labels][crate::model::SearchRequest::user_labels].
-        pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -9510,12 +9510,6 @@ pub mod site_search_engine_service {
             self
         }
 
-        /// Sets the value of [site_credential][crate::model::RecrawlUrisRequest::site_credential].
-        pub fn set_site_credential<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.site_credential = v.into();
-            self
-        }
-
         /// Sets the value of [uris][crate::model::RecrawlUrisRequest::uris].
         ///
         /// This is a **required** field for requests.
@@ -9526,6 +9520,12 @@ pub mod site_search_engine_service {
         {
             use std::iter::Iterator;
             self.0.request.uris = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [site_credential][crate::model::RecrawlUrisRequest::site_credential].
+        pub fn set_site_credential<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.site_credential = v.into();
             self
         }
     }

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -135,35 +135,6 @@ impl Answer {
         self
     }
 
-    /// Sets the value of [query_understanding_info][crate::model::Answer::query_understanding_info].
-    pub fn set_query_understanding_info<
-        T: std::convert::Into<std::option::Option<crate::model::answer::QueryUnderstandingInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.query_understanding_info = v.into();
-        self
-    }
-
-    /// Sets the value of [create_time][crate::model::Answer::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [complete_time][crate::model::Answer::complete_time].
-    pub fn set_complete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.complete_time = v.into();
-        self
-    }
-
     /// Sets the value of [citations][crate::model::Answer::citations].
     pub fn set_citations<T, V>(mut self, v: T) -> Self
     where
@@ -219,6 +190,17 @@ impl Answer {
         self
     }
 
+    /// Sets the value of [query_understanding_info][crate::model::Answer::query_understanding_info].
+    pub fn set_query_understanding_info<
+        T: std::convert::Into<std::option::Option<crate::model::answer::QueryUnderstandingInfo>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.query_understanding_info = v.into();
+        self
+    }
+
     /// Sets the value of [answer_skipped_reasons][crate::model::Answer::answer_skipped_reasons].
     pub fn set_answer_skipped_reasons<T, V>(mut self, v: T) -> Self
     where
@@ -227,6 +209,24 @@ impl Answer {
     {
         use std::iter::Iterator;
         self.answer_skipped_reasons = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::Answer::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
+        self
+    }
+
+    /// Sets the value of [complete_time][crate::model::Answer::complete_time].
+    pub fn set_complete_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.complete_time = v.into();
         self
     }
 
@@ -494,39 +494,6 @@ pub mod answer {
             })
         }
 
-        /// The value of [content][crate::model::answer::Reference::content]
-        /// if it holds a `ChunkInfo`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn chunk_info(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::answer::reference::ChunkInfo>>
-        {
-            #[allow(unreachable_patterns)]
-            self.content.as_ref().and_then(|v| match v {
-                crate::model::answer::reference::Content::ChunkInfo(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [content][crate::model::answer::Reference::content]
-        /// if it holds a `StructuredDocumentInfo`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn structured_document_info(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::answer::reference::StructuredDocumentInfo>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.content.as_ref().and_then(|v| match v {
-                crate::model::answer::reference::Content::StructuredDocumentInfo(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [content][crate::model::answer::Reference::content]
         /// to hold a `UnstructuredDocumentInfo`.
         ///
@@ -546,6 +513,22 @@ pub mod answer {
             self
         }
 
+        /// The value of [content][crate::model::answer::Reference::content]
+        /// if it holds a `ChunkInfo`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn chunk_info(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::answer::reference::ChunkInfo>>
+        {
+            #[allow(unreachable_patterns)]
+            self.content.as_ref().and_then(|v| match v {
+                crate::model::answer::reference::Content::ChunkInfo(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [content][crate::model::answer::Reference::content]
         /// to hold a `ChunkInfo`.
         ///
@@ -561,6 +544,23 @@ pub mod answer {
                 crate::model::answer::reference::Content::ChunkInfo(v.into()),
             );
             self
+        }
+
+        /// The value of [content][crate::model::answer::Reference::content]
+        /// if it holds a `StructuredDocumentInfo`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn structured_document_info(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::answer::reference::StructuredDocumentInfo>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.content.as_ref().and_then(|v| match v {
+                crate::model::answer::reference::Content::StructuredDocumentInfo(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [content][crate::model::answer::Reference::content]
@@ -653,15 +653,6 @@ pub mod answer {
                 self
             }
 
-            /// Sets the value of [struct_data][crate::model::answer::reference::UnstructuredDocumentInfo::struct_data].
-            pub fn set_struct_data<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.struct_data = v.into();
-                self
-            }
-
             /// Sets the value of [chunk_contents][crate::model::answer::reference::UnstructuredDocumentInfo::chunk_contents].
             pub fn set_chunk_contents<T, V>(mut self, v: T) -> Self
             where
@@ -672,6 +663,15 @@ pub mod answer {
             {
                 use std::iter::Iterator;
                 self.chunk_contents = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [struct_data][crate::model::answer::reference::UnstructuredDocumentInfo::struct_data].
+            pub fn set_struct_data<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.struct_data = v.into();
                 self
             }
         }
@@ -1338,17 +1338,6 @@ pub mod answer {
                         self
                     }
 
-                    /// Sets the value of [struct_data][crate::model::answer::step::action::observation::SearchResult::struct_data].
-                    pub fn set_struct_data<
-                        T: std::convert::Into<std::option::Option<wkt::Struct>>,
-                    >(
-                        mut self,
-                        v: T,
-                    ) -> Self {
-                        self.struct_data = v.into();
-                        self
-                    }
-
                     /// Sets the value of [snippet_info][crate::model::answer::step::action::observation::SearchResult::snippet_info].
                     pub fn set_snippet_info<T, V>(mut self, v: T) -> Self
                     where
@@ -1368,6 +1357,17 @@ pub mod answer {
                     {
                         use std::iter::Iterator;
                         self.chunk_info = v.into_iter().map(|i| i.into()).collect();
+                        self
+                    }
+
+                    /// Sets the value of [struct_data][crate::model::answer::step::action::observation::SearchResult::struct_data].
+                    pub fn set_struct_data<
+                        T: std::convert::Into<std::option::Option<wkt::Struct>>,
+                    >(
+                        mut self,
+                        v: T,
+                    ) -> Self {
+                        self.struct_data = v.into();
                         self
                     }
                 }
@@ -2639,6 +2639,16 @@ impl Interval {
         })
     }
 
+    /// Sets the value of [min][crate::model::Interval::min]
+    /// to hold a `Minimum`.
+    ///
+    /// Note that all the setters affecting `min` are
+    /// mutually exclusive.
+    pub fn set_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.min = std::option::Option::Some(crate::model::interval::Min::Minimum(v.into()));
+        self
+    }
+
     /// The value of [min][crate::model::Interval::min]
     /// if it holds a `ExclusiveMinimum`, `None` if the field is not set or
     /// holds a different branch.
@@ -2648,16 +2658,6 @@ impl Interval {
             crate::model::interval::Min::ExclusiveMinimum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [min][crate::model::Interval::min]
-    /// to hold a `Minimum`.
-    ///
-    /// Note that all the setters affecting `min` are
-    /// mutually exclusive.
-    pub fn set_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.min = std::option::Option::Some(crate::model::interval::Min::Minimum(v.into()));
-        self
     }
 
     /// Sets the value of [min][crate::model::Interval::min]
@@ -2694,6 +2694,16 @@ impl Interval {
         })
     }
 
+    /// Sets the value of [max][crate::model::Interval::max]
+    /// to hold a `Maximum`.
+    ///
+    /// Note that all the setters affecting `max` are
+    /// mutually exclusive.
+    pub fn set_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.max = std::option::Option::Some(crate::model::interval::Max::Maximum(v.into()));
+        self
+    }
+
     /// The value of [max][crate::model::Interval::max]
     /// if it holds a `ExclusiveMaximum`, `None` if the field is not set or
     /// holds a different branch.
@@ -2703,16 +2713,6 @@ impl Interval {
             crate::model::interval::Max::ExclusiveMaximum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [max][crate::model::Interval::max]
-    /// to hold a `Maximum`.
-    ///
-    /// Note that all the setters affecting `max` are
-    /// mutually exclusive.
-    pub fn set_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.max = std::option::Option::Some(crate::model::interval::Max::Maximum(v.into()));
-        self
     }
 
     /// Sets the value of [max][crate::model::Interval::max]
@@ -3328,6 +3328,18 @@ impl CompletionSuggestion {
         })
     }
 
+    /// Sets the value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
+    /// to hold a `GlobalScore`.
+    ///
+    /// Note that all the setters affecting `ranking_info` are
+    /// mutually exclusive.
+    pub fn set_global_score<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.ranking_info = std::option::Option::Some(
+            crate::model::completion_suggestion::RankingInfo::GlobalScore(v.into()),
+        );
+        self
+    }
+
     /// The value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
     /// if it holds a `Frequency`, `None` if the field is not set or
     /// holds a different branch.
@@ -3339,18 +3351,6 @@ impl CompletionSuggestion {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
-    /// to hold a `GlobalScore`.
-    ///
-    /// Note that all the setters affecting `ranking_info` are
-    /// mutually exclusive.
-    pub fn set_global_score<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.ranking_info = std::option::Option::Some(
-            crate::model::completion_suggestion::RankingInfo::GlobalScore(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
@@ -3538,12 +3538,6 @@ impl CompleteQueryResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [tail_match_triggered][crate::model::CompleteQueryResponse::tail_match_triggered].
-    pub fn set_tail_match_triggered<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.tail_match_triggered = v.into();
-        self
-    }
-
     /// Sets the value of [query_suggestions][crate::model::CompleteQueryResponse::query_suggestions].
     pub fn set_query_suggestions<T, V>(mut self, v: T) -> Self
     where
@@ -3552,6 +3546,12 @@ impl CompleteQueryResponse {
     {
         use std::iter::Iterator;
         self.query_suggestions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [tail_match_triggered][crate::model::CompleteQueryResponse::tail_match_triggered].
+    pub fn set_tail_match_triggered<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.tail_match_triggered = v.into();
         self
     }
 }
@@ -3660,12 +3660,6 @@ impl Condition {
         std::default::Default::default()
     }
 
-    /// Sets the value of [query_regex][crate::model::Condition::query_regex].
-    pub fn set_query_regex<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query_regex = v.into();
-        self
-    }
-
     /// Sets the value of [query_terms][crate::model::Condition::query_terms].
     pub fn set_query_terms<T, V>(mut self, v: T) -> Self
     where
@@ -3685,6 +3679,12 @@ impl Condition {
     {
         use std::iter::Iterator;
         self.active_time_range = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [query_regex][crate::model::Condition::query_regex].
+    pub fn set_query_regex<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.query_regex = v.into();
         self
     }
 }
@@ -3885,15 +3885,6 @@ impl Control {
         self
     }
 
-    /// Sets the value of [solution_type][crate::model::Control::solution_type].
-    pub fn set_solution_type<T: std::convert::Into<crate::model::SolutionType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.solution_type = v.into();
-        self
-    }
-
     /// Sets the value of [associated_serving_config_ids][crate::model::Control::associated_serving_config_ids].
     pub fn set_associated_serving_config_ids<T, V>(mut self, v: T) -> Self
     where
@@ -3902,6 +3893,15 @@ impl Control {
     {
         use std::iter::Iterator;
         self.associated_serving_config_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [solution_type][crate::model::Control::solution_type].
+    pub fn set_solution_type<T: std::convert::Into<crate::model::SolutionType>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.solution_type = v.into();
         self
     }
 
@@ -3952,58 +3952,6 @@ impl Control {
         })
     }
 
-    /// The value of [action][crate::model::Control::action]
-    /// if it holds a `FilterAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filter_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::control::FilterAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::control::Action::FilterAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Control::action]
-    /// if it holds a `RedirectAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redirect_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::control::RedirectAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::control::Action::RedirectAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Control::action]
-    /// if it holds a `SynonymsAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn synonyms_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::control::SynonymsAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::control::Action::SynonymsAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Control::action]
-    /// if it holds a `PromoteAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn promote_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::control::PromoteAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::control::Action::PromoteAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [action][crate::model::Control::action]
     /// to hold a `BoostAction`.
     ///
@@ -4018,6 +3966,19 @@ impl Control {
         self.action =
             std::option::Option::Some(crate::model::control::Action::BoostAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Control::action]
+    /// if it holds a `FilterAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filter_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::control::FilterAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::control::Action::FilterAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Control::action]
@@ -4036,6 +3997,19 @@ impl Control {
         self
     }
 
+    /// The value of [action][crate::model::Control::action]
+    /// if it holds a `RedirectAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redirect_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::control::RedirectAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::control::Action::RedirectAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Control::action]
     /// to hold a `RedirectAction`.
     ///
@@ -4052,6 +4026,19 @@ impl Control {
         self
     }
 
+    /// The value of [action][crate::model::Control::action]
+    /// if it holds a `SynonymsAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn synonyms_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::control::SynonymsAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::control::Action::SynonymsAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Control::action]
     /// to hold a `SynonymsAction`.
     ///
@@ -4066,6 +4053,19 @@ impl Control {
         self.action =
             std::option::Option::Some(crate::model::control::Action::SynonymsAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Control::action]
+    /// if it holds a `PromoteAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn promote_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::control::PromoteAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::control::Action::PromoteAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Control::action]
@@ -4183,6 +4183,18 @@ pub mod control {
             })
         }
 
+        /// Sets the value of [boost_spec][crate::model::control::BoostAction::boost_spec]
+        /// to hold a `FixedBoost`.
+        ///
+        /// Note that all the setters affecting `boost_spec` are
+        /// mutually exclusive.
+        pub fn set_fixed_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.boost_spec = std::option::Option::Some(
+                crate::model::control::boost_action::BoostSpec::FixedBoost(v.into()),
+            );
+            self
+        }
+
         /// The value of [boost_spec][crate::model::control::BoostAction::boost_spec]
         /// if it holds a `InterpolationBoostSpec`, `None` if the field is not set or
         /// holds a different branch.
@@ -4198,18 +4210,6 @@ pub mod control {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [boost_spec][crate::model::control::BoostAction::boost_spec]
-        /// to hold a `FixedBoost`.
-        ///
-        /// Note that all the setters affecting `boost_spec` are
-        /// mutually exclusive.
-        pub fn set_fixed_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.boost_spec = std::option::Option::Some(
-                crate::model::control::boost_action::BoostSpec::FixedBoost(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [boost_spec][crate::model::control::BoostAction::boost_spec]
@@ -5168,12 +5168,6 @@ impl ListControlsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListControlsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [controls][crate::model::ListControlsResponse::controls].
     pub fn set_controls<T, V>(mut self, v: T) -> Self
     where
@@ -5182,6 +5176,12 @@ impl ListControlsResponse {
     {
         use std::iter::Iterator;
         self.controls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListControlsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5268,6 +5268,17 @@ impl Conversation {
         self
     }
 
+    /// Sets the value of [messages][crate::model::Conversation::messages].
+    pub fn set_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConversationMessage>,
+    {
+        use std::iter::Iterator;
+        self.messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::Conversation::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5283,17 +5294,6 @@ impl Conversation {
         v: T,
     ) -> Self {
         self.end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [messages][crate::model::Conversation::messages].
-    pub fn set_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConversationMessage>,
-    {
-        use std::iter::Iterator;
-        self.messages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5504,12 +5504,6 @@ impl ConversationContext {
         std::default::Default::default()
     }
 
-    /// Sets the value of [active_document][crate::model::ConversationContext::active_document].
-    pub fn set_active_document<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.active_document = v.into();
-        self
-    }
-
     /// Sets the value of [context_documents][crate::model::ConversationContext::context_documents].
     pub fn set_context_documents<T, V>(mut self, v: T) -> Self
     where
@@ -5518,6 +5512,12 @@ impl ConversationContext {
     {
         use std::iter::Iterator;
         self.context_documents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [active_document][crate::model::ConversationContext::active_document].
+    pub fn set_active_document<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.active_document = v.into();
         self
     }
 }
@@ -5633,17 +5633,6 @@ impl ConversationMessage {
         })
     }
 
-    /// The value of [message][crate::model::ConversationMessage::message]
-    /// if it holds a `Reply`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn reply(&self) -> std::option::Option<&std::boxed::Box<crate::model::Reply>> {
-        #[allow(unreachable_patterns)]
-        self.message.as_ref().and_then(|v| match v {
-            crate::model::conversation_message::Message::Reply(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [message][crate::model::ConversationMessage::message]
     /// to hold a `UserInput`.
     ///
@@ -5657,6 +5646,17 @@ impl ConversationMessage {
             crate::model::conversation_message::Message::UserInput(v.into()),
         );
         self
+    }
+
+    /// The value of [message][crate::model::ConversationMessage::message]
+    /// if it holds a `Reply`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn reply(&self) -> std::option::Option<&std::boxed::Box<crate::model::Reply>> {
+        #[allow(unreachable_patterns)]
+        self.message.as_ref().and_then(|v| match v {
+            crate::model::conversation_message::Message::Reply(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [message][crate::model::ConversationMessage::message]
@@ -5832,6 +5832,18 @@ impl ConverseConversationRequest {
         self
     }
 
+    /// Sets the value of [user_labels][crate::model::ConverseConversationRequest::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [summary_spec][crate::model::ConverseConversationRequest::summary_spec].
     pub fn set_summary_spec<
         T: std::convert::Into<
@@ -5859,18 +5871,6 @@ impl ConverseConversationRequest {
         v: T,
     ) -> Self {
         self.boost_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [user_labels][crate::model::ConverseConversationRequest::user_labels].
-    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6235,12 +6235,6 @@ impl ListConversationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConversationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [conversations][crate::model::ListConversationsResponse::conversations].
     pub fn set_conversations<T, V>(mut self, v: T) -> Self
     where
@@ -6249,6 +6243,12 @@ impl ListConversationsResponse {
     {
         use std::iter::Iterator;
         self.conversations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConversationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6502,17 +6502,6 @@ impl AnswerQueryRequest {
         self
     }
 
-    /// Sets the value of [end_user_spec][crate::model::AnswerQueryRequest::end_user_spec].
-    pub fn set_end_user_spec<
-        T: std::convert::Into<std::option::Option<crate::model::answer_query_request::EndUserSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.end_user_spec = v.into();
-        self
-    }
-
     /// Sets the value of [user_labels][crate::model::AnswerQueryRequest::user_labels].
     pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6522,6 +6511,17 @@ impl AnswerQueryRequest {
     {
         use std::iter::Iterator;
         self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [end_user_spec][crate::model::AnswerQueryRequest::end_user_spec].
+    pub fn set_end_user_spec<
+        T: std::convert::Into<std::option::Option<crate::model::answer_query_request::EndUserSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.end_user_spec = v.into();
         self
     }
 }
@@ -7327,23 +7327,6 @@ pub mod answer_query_request {
             })
         }
 
-        /// The value of [input][crate::model::answer_query_request::SearchSpec::input]
-        /// if it holds a `SearchResultList`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn search_result_list(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::answer_query_request::search_spec::SearchResultList>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.input.as_ref().and_then(|v| match v {
-                crate::model::answer_query_request::search_spec::Input::SearchResultList(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [input][crate::model::answer_query_request::SearchSpec::input]
         /// to hold a `SearchParams`.
         ///
@@ -7361,6 +7344,23 @@ pub mod answer_query_request {
                 crate::model::answer_query_request::search_spec::Input::SearchParams(v.into()),
             );
             self
+        }
+
+        /// The value of [input][crate::model::answer_query_request::SearchSpec::input]
+        /// if it holds a `SearchResultList`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn search_result_list(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::answer_query_request::search_spec::SearchResultList>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.input.as_ref().and_then(|v| match v {
+                crate::model::answer_query_request::search_spec::Input::SearchResultList(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [input][crate::model::answer_query_request::SearchSpec::input]
@@ -7616,17 +7616,6 @@ pub mod answer_query_request {
                     })
                 }
 
-                /// The value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
-                /// if it holds a `ChunkInfo`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn chunk_info(&self) -> std::option::Option<&std::boxed::Box<crate::model::answer_query_request::search_spec::search_result_list::search_result::ChunkInfo>>{
-                    #[allow(unreachable_patterns)]
-                    self.content.as_ref().and_then(|v| match v {
-                        crate::model::answer_query_request::search_spec::search_result_list::search_result::Content::ChunkInfo(v) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
                 /// to hold a `UnstructuredDocumentInfo`.
                 ///
@@ -7639,6 +7628,17 @@ pub mod answer_query_request {
                         )
                     );
                     self
+                }
+
+                /// The value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
+                /// if it holds a `ChunkInfo`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn chunk_info(&self) -> std::option::Option<&std::boxed::Box<crate::model::answer_query_request::search_spec::search_result_list::search_result::ChunkInfo>>{
+                    #[allow(unreachable_patterns)]
+                    self.content.as_ref().and_then(|v| match v {
+                        crate::model::answer_query_request::search_spec::search_result_list::search_result::Content::ChunkInfo(v) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
@@ -9213,12 +9213,6 @@ impl ListSessionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sessions][crate::model::ListSessionsResponse::sessions].
     pub fn set_sessions<T, V>(mut self, v: T) -> Self
     where
@@ -9227,6 +9221,12 @@ impl ListSessionsResponse {
     {
         use std::iter::Iterator;
         self.sessions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9351,12 +9351,6 @@ impl CustomTuningModel {
         self
     }
 
-    /// Sets the value of [error_message][crate::model::CustomTuningModel::error_message].
-    pub fn set_error_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.error_message = v.into();
-        self
-    }
-
     /// Sets the value of [metrics][crate::model::CustomTuningModel::metrics].
     pub fn set_metrics<T, K, V>(mut self, v: T) -> Self
     where
@@ -9366,6 +9360,12 @@ impl CustomTuningModel {
     {
         use std::iter::Iterator;
         self.metrics = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [error_message][crate::model::CustomTuningModel::error_message].
+    pub fn set_error_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.error_message = v.into();
         self
     }
 }
@@ -9684,6 +9684,17 @@ impl DataStore {
         self
     }
 
+    /// Sets the value of [solution_types][crate::model::DataStore::solution_types].
+    pub fn set_solution_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SolutionType>,
+    {
+        use std::iter::Iterator;
+        self.solution_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [default_schema_id][crate::model::DataStore::default_schema_id].
     pub fn set_default_schema_id<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -9761,17 +9772,6 @@ impl DataStore {
         v: T,
     ) -> Self {
         self.starting_schema = v.into();
-        self
-    }
-
-    /// Sets the value of [solution_types][crate::model::DataStore::solution_types].
-    pub fn set_solution_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SolutionType>,
-    {
-        use std::iter::Iterator;
-        self.solution_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10681,12 +10681,6 @@ impl ListDataStoresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataStoresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [data_stores][crate::model::ListDataStoresResponse::data_stores].
     pub fn set_data_stores<T, V>(mut self, v: T) -> Self
     where
@@ -10695,6 +10689,12 @@ impl ListDataStoresResponse {
     {
         use std::iter::Iterator;
         self.data_stores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataStoresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11061,17 +11061,6 @@ impl Document {
         })
     }
 
-    /// The value of [data][crate::model::Document::data]
-    /// if it holds a `JsonData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn json_data(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::document::Data::JsonData(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data][crate::model::Document::data]
     /// to hold a `StructData`.
     ///
@@ -11083,6 +11072,17 @@ impl Document {
     ) -> Self {
         self.data = std::option::Option::Some(crate::model::document::Data::StructData(v.into()));
         self
+    }
+
+    /// The value of [data][crate::model::Document::data]
+    /// if it holds a `JsonData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn json_data(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::document::Data::JsonData(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::Document::data]
@@ -11170,17 +11170,6 @@ pub mod document {
             })
         }
 
-        /// The value of [content][crate::model::document::Content::content]
-        /// if it holds a `Uri`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn uri(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.content.as_ref().and_then(|v| match v {
-                crate::model::document::content::Content::Uri(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [content][crate::model::document::Content::content]
         /// to hold a `RawBytes`.
         ///
@@ -11191,6 +11180,17 @@ pub mod document {
                 crate::model::document::content::Content::RawBytes(v.into()),
             );
             self
+        }
+
+        /// The value of [content][crate::model::document::Content::content]
+        /// if it holds a `Uri`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn uri(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.content.as_ref().and_then(|v| match v {
+                crate::model::document::content::Content::Uri(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [content][crate::model::document::Content::content]
@@ -11275,15 +11275,6 @@ pub mod document {
             self
         }
 
-        /// Sets the value of [pending_message][crate::model::document::IndexStatus::pending_message].
-        pub fn set_pending_message<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.pending_message = v.into();
-            self
-        }
-
         /// Sets the value of [error_samples][crate::model::document::IndexStatus::error_samples].
         pub fn set_error_samples<T, V>(mut self, v: T) -> Self
         where
@@ -11292,6 +11283,15 @@ pub mod document {
         {
             use std::iter::Iterator;
             self.error_samples = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [pending_message][crate::model::document::IndexStatus::pending_message].
+        pub fn set_pending_message<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.pending_message = v.into();
             self
         }
     }
@@ -11632,6 +11632,20 @@ pub mod document_processing_config {
             })
         }
 
+        /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
+        /// to hold a `DigitalParsingConfig`.
+        ///
+        /// Note that all the setters affecting `type_dedicated_config` are
+        /// mutually exclusive.
+        pub fn set_digital_parsing_config<T: std::convert::Into<std::boxed::Box<crate::model::document_processing_config::parsing_config::DigitalParsingConfig>>>(mut self, v: T) -> Self{
+            self.type_dedicated_config = std::option::Option::Some(
+                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::DigitalParsingConfig(
+                    v.into()
+                )
+            );
+            self
+        }
+
         /// The value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
         /// if it holds a `OcrParsingConfig`, `None` if the field is not set or
         /// holds a different branch.
@@ -11647,37 +11661,6 @@ pub mod document_processing_config {
                 crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::OcrParsingConfig(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
-        /// if it holds a `LayoutParsingConfig`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn layout_parsing_config(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::document_processing_config::parsing_config::LayoutParsingConfig,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.type_dedicated_config.as_ref().and_then(|v| match v {
-                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::LayoutParsingConfig(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
-        /// to hold a `DigitalParsingConfig`.
-        ///
-        /// Note that all the setters affecting `type_dedicated_config` are
-        /// mutually exclusive.
-        pub fn set_digital_parsing_config<T: std::convert::Into<std::boxed::Box<crate::model::document_processing_config::parsing_config::DigitalParsingConfig>>>(mut self, v: T) -> Self{
-            self.type_dedicated_config = std::option::Option::Some(
-                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::DigitalParsingConfig(
-                    v.into()
-                )
-            );
-            self
         }
 
         /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
@@ -11701,6 +11684,23 @@ pub mod document_processing_config {
                 )
             );
             self
+        }
+
+        /// The value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
+        /// if it holds a `LayoutParsingConfig`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn layout_parsing_config(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::document_processing_config::parsing_config::LayoutParsingConfig,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.type_dedicated_config.as_ref().and_then(|v| match v {
+                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::LayoutParsingConfig(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
@@ -11777,12 +11777,6 @@ pub mod document_processing_config {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [use_native_text][crate::model::document_processing_config::parsing_config::OcrParsingConfig::use_native_text].
-            pub fn set_use_native_text<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.use_native_text = v.into();
-                self
-            }
-
             /// Sets the value of [enhanced_document_elements][crate::model::document_processing_config::parsing_config::OcrParsingConfig::enhanced_document_elements].
             #[deprecated]
             pub fn set_enhanced_document_elements<T, V>(mut self, v: T) -> Self
@@ -11792,6 +11786,12 @@ pub mod document_processing_config {
             {
                 use std::iter::Iterator;
                 self.enhanced_document_elements = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [use_native_text][crate::model::document_processing_config::parsing_config::OcrParsingConfig::use_native_text].
+            pub fn set_use_native_text<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.use_native_text = v.into();
                 self
             }
         }
@@ -12017,12 +12017,6 @@ impl ListDocumentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDocumentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [documents][crate::model::ListDocumentsResponse::documents].
     pub fn set_documents<T, V>(mut self, v: T) -> Self
     where
@@ -12031,6 +12025,12 @@ impl ListDocumentsResponse {
     {
         use std::iter::Iterator;
         self.documents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDocumentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -12467,21 +12467,6 @@ pub mod batch_get_documents_metadata_request {
             })
         }
 
-        /// The value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
-        /// if it holds a `FhirMatcher`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn fhir_matcher(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::batch_get_documents_metadata_request::FhirMatcher>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.matcher.as_ref().and_then(|v| match v {
-                crate::model::batch_get_documents_metadata_request::matcher::Matcher::FhirMatcher(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
         /// to hold a `UrisMatcher`.
         ///
@@ -12503,6 +12488,21 @@ pub mod batch_get_documents_metadata_request {
                 ),
             );
             self
+        }
+
+        /// The value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
+        /// if it holds a `FhirMatcher`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn fhir_matcher(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::batch_get_documents_metadata_request::FhirMatcher>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.matcher.as_ref().and_then(|v| match v {
+                crate::model::batch_get_documents_metadata_request::matcher::Matcher::FhirMatcher(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
@@ -12754,17 +12754,6 @@ pub mod batch_get_documents_metadata_response {
                 })
             }
 
-            /// The value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
-            /// if it holds a `FhirResource`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn fhir_resource(&self) -> std::option::Option<&std::string::String> {
-                #[allow(unreachable_patterns)]
-                self.matcher_value.as_ref().and_then(|v| match v {
-                    crate::model::batch_get_documents_metadata_response::document_metadata::matcher_value::MatcherValue::FhirResource(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
             /// to hold a `Uri`.
             ///
@@ -12777,6 +12766,17 @@ pub mod batch_get_documents_metadata_response {
                     )
                 );
                 self
+            }
+
+            /// The value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
+            /// if it holds a `FhirResource`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn fhir_resource(&self) -> std::option::Option<&std::string::String> {
+                #[allow(unreachable_patterns)]
+                self.matcher_value.as_ref().and_then(|v| match v {
+                    crate::model::batch_get_documents_metadata_response::document_metadata::matcher_value::MatcherValue::FhirResource(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
@@ -13108,6 +13108,17 @@ impl Engine {
         self
     }
 
+    /// Sets the value of [data_store_ids][crate::model::Engine::data_store_ids].
+    pub fn set_data_store_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.data_store_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [solution_type][crate::model::Engine::solution_type].
     pub fn set_solution_type<T: std::convert::Into<crate::model::SolutionType>>(
         mut self,
@@ -13143,17 +13154,6 @@ impl Engine {
         self
     }
 
-    /// Sets the value of [data_store_ids][crate::model::Engine::data_store_ids].
-    pub fn set_data_store_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.data_store_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [engine_config][crate::model::Engine::engine_config].
     ///
     /// Note that all the setters affecting `engine_config` are mutually
@@ -13181,21 +13181,6 @@ impl Engine {
         })
     }
 
-    /// The value of [engine_config][crate::model::Engine::engine_config]
-    /// if it holds a `SearchEngineConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn search_engine_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::engine::SearchEngineConfig>> {
-        #[allow(unreachable_patterns)]
-        self.engine_config.as_ref().and_then(|v| match v {
-            crate::model::engine::EngineConfig::SearchEngineConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [engine_config][crate::model::Engine::engine_config]
     /// to hold a `ChatEngineConfig`.
     ///
@@ -13211,6 +13196,21 @@ impl Engine {
             crate::model::engine::EngineConfig::ChatEngineConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [engine_config][crate::model::Engine::engine_config]
+    /// if it holds a `SearchEngineConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn search_engine_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::engine::SearchEngineConfig>> {
+        #[allow(unreachable_patterns)]
+        self.engine_config.as_ref().and_then(|v| match v {
+            crate::model::engine::EngineConfig::SearchEngineConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [engine_config][crate::model::Engine::engine_config]
@@ -14030,12 +14030,6 @@ impl ListEnginesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEnginesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [engines][crate::model::ListEnginesResponse::engines].
     pub fn set_engines<T, V>(mut self, v: T) -> Self
     where
@@ -14044,6 +14038,12 @@ impl ListEnginesResponse {
     {
         use std::iter::Iterator;
         self.engines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEnginesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -14357,6 +14357,17 @@ impl GenerateGroundedContentRequest {
         self
     }
 
+    /// Sets the value of [contents][crate::model::GenerateGroundedContentRequest::contents].
+    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::GroundedGenerationContent>,
+    {
+        use std::iter::Iterator;
+        self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [generation_spec][crate::model::GenerateGroundedContentRequest::generation_spec].
     pub fn set_generation_spec<
         T: std::convert::Into<
@@ -14382,17 +14393,6 @@ impl GenerateGroundedContentRequest {
         v: T,
     ) -> Self {
         self.grounding_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [contents][crate::model::GenerateGroundedContentRequest::contents].
-    pub fn set_contents<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::GroundedGenerationContent>,
-    {
-        use std::iter::Iterator;
-        self.contents = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -14822,6 +14822,20 @@ pub mod generate_grounded_content_request {
             })
         }
 
+        /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
+        /// to hold a `InlineSource`.
+        ///
+        /// Note that all the setters affecting `source` are
+        /// mutually exclusive.
+        pub fn set_inline_source<T: std::convert::Into<std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::InlineSource>>>(mut self, v: T) -> Self{
+            self.source = std::option::Option::Some(
+                crate::model::generate_grounded_content_request::grounding_source::Source::InlineSource(
+                    v.into()
+                )
+            );
+            self
+        }
+
         /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
         /// if it holds a `SearchSource`, `None` if the field is not set or
         /// holds a different branch.
@@ -14839,42 +14853,6 @@ pub mod generate_grounded_content_request {
             })
         }
 
-        /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// if it holds a `GoogleSearchSource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn google_search_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::GoogleSearchSource>>{
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::generate_grounded_content_request::grounding_source::Source::GoogleSearchSource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// if it holds a `EnterpriseWebRetrievalSource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn enterprise_web_retrieval_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::EnterpriseWebRetrievalSource>>{
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::generate_grounded_content_request::grounding_source::Source::EnterpriseWebRetrievalSource(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<T: std::convert::Into<std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::InlineSource>>>(mut self, v: T) -> Self{
-            self.source = std::option::Option::Some(
-                crate::model::generate_grounded_content_request::grounding_source::Source::InlineSource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
         /// to hold a `SearchSource`.
         ///
@@ -14889,6 +14867,17 @@ pub mod generate_grounded_content_request {
             self
         }
 
+        /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
+        /// if it holds a `GoogleSearchSource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn google_search_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::GoogleSearchSource>>{
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::generate_grounded_content_request::grounding_source::Source::GoogleSearchSource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
         /// to hold a `GoogleSearchSource`.
         ///
@@ -14901,6 +14890,17 @@ pub mod generate_grounded_content_request {
                 )
             );
             self
+        }
+
+        /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
+        /// if it holds a `EnterpriseWebRetrievalSource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn enterprise_web_retrieval_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::EnterpriseWebRetrievalSource>>{
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::generate_grounded_content_request::grounding_source::Source::EnterpriseWebRetrievalSource(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
@@ -15337,12 +15337,6 @@ pub mod generate_grounded_content_response {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [search_entry_point][crate::model::generate_grounded_content_response::candidate::GroundingMetadata::search_entry_point].
-            pub fn set_search_entry_point<T: std::convert::Into<std::option::Option<crate::model::generate_grounded_content_response::candidate::grounding_metadata::SearchEntryPoint>>>(mut self, v: T) -> Self{
-                self.search_entry_point = v.into();
-                self
-            }
-
             /// Sets the value of [retrieval_metadata][crate::model::generate_grounded_content_response::candidate::GroundingMetadata::retrieval_metadata].
             pub fn set_retrieval_metadata<T, V>(mut self, v: T) -> Self
             where
@@ -15373,6 +15367,12 @@ pub mod generate_grounded_content_response {
             {
                 use std::iter::Iterator;
                 self.web_search_queries = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [search_entry_point][crate::model::generate_grounded_content_response::candidate::GroundingMetadata::search_entry_point].
+            pub fn set_search_entry_point<T: std::convert::Into<std::option::Option<crate::model::generate_grounded_content_response::candidate::grounding_metadata::SearchEntryPoint>>>(mut self, v: T) -> Self{
+                self.search_entry_point = v.into();
                 self
             }
 
@@ -15911,15 +15911,6 @@ pub mod generate_grounded_content_response {
                     self
                 }
 
-                /// Sets the value of [support_score][crate::model::generate_grounded_content_response::candidate::grounding_metadata::GroundingSupport::support_score].
-                pub fn set_support_score<T: std::convert::Into<std::option::Option<f32>>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.support_score = v.into();
-                    self
-                }
-
                 /// Sets the value of [support_chunk_indices][crate::model::generate_grounded_content_response::candidate::grounding_metadata::GroundingSupport::support_chunk_indices].
                 pub fn set_support_chunk_indices<T, V>(mut self, v: T) -> Self
                 where
@@ -15928,6 +15919,15 @@ pub mod generate_grounded_content_response {
                 {
                     use std::iter::Iterator;
                     self.support_chunk_indices = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [support_score][crate::model::generate_grounded_content_response::candidate::grounding_metadata::GroundingSupport::support_score].
+                pub fn set_support_score<T: std::convert::Into<std::option::Option<f32>>>(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.support_score = v.into();
                     self
                 }
             }
@@ -16221,17 +16221,6 @@ impl CheckGroundingRequest {
         self
     }
 
-    /// Sets the value of [grounding_spec][crate::model::CheckGroundingRequest::grounding_spec].
-    pub fn set_grounding_spec<
-        T: std::convert::Into<std::option::Option<crate::model::CheckGroundingSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.grounding_spec = v.into();
-        self
-    }
-
     /// Sets the value of [facts][crate::model::CheckGroundingRequest::facts].
     pub fn set_facts<T, V>(mut self, v: T) -> Self
     where
@@ -16240,6 +16229,17 @@ impl CheckGroundingRequest {
     {
         use std::iter::Iterator;
         self.facts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [grounding_spec][crate::model::CheckGroundingRequest::grounding_spec].
+    pub fn set_grounding_spec<
+        T: std::convert::Into<std::option::Option<crate::model::CheckGroundingSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.grounding_spec = v.into();
         self
     }
 
@@ -16470,15 +16470,6 @@ pub mod check_grounding_response {
             self
         }
 
-        /// Sets the value of [grounding_check_required][crate::model::check_grounding_response::Claim::grounding_check_required].
-        pub fn set_grounding_check_required<T: std::convert::Into<std::option::Option<bool>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.grounding_check_required = v.into();
-            self
-        }
-
         /// Sets the value of [citation_indices][crate::model::check_grounding_response::Claim::citation_indices].
         pub fn set_citation_indices<T, V>(mut self, v: T) -> Self
         where
@@ -16487,6 +16478,15 @@ pub mod check_grounding_response {
         {
             use std::iter::Iterator;
             self.citation_indices = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [grounding_check_required][crate::model::check_grounding_response::Claim::grounding_check_required].
+        pub fn set_grounding_check_required<T: std::convert::Into<std::option::Option<bool>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.grounding_check_required = v.into();
             self
         }
     }
@@ -16676,12 +16676,6 @@ impl GcsSource {
         std::default::Default::default()
     }
 
-    /// Sets the value of [data_schema][crate::model::GcsSource::data_schema].
-    pub fn set_data_schema<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data_schema = v.into();
-        self
-    }
-
     /// Sets the value of [input_uris][crate::model::GcsSource::input_uris].
     pub fn set_input_uris<T, V>(mut self, v: T) -> Self
     where
@@ -16690,6 +16684,12 @@ impl GcsSource {
     {
         use std::iter::Iterator;
         self.input_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_schema][crate::model::GcsSource::data_schema].
+    pub fn set_data_schema<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.data_schema = v.into();
         self
     }
 }
@@ -17600,15 +17600,6 @@ impl FhirStoreSource {
         self
     }
 
-    /// Sets the value of [update_from_latest_predefined_schema][crate::model::FhirStoreSource::update_from_latest_predefined_schema].
-    pub fn set_update_from_latest_predefined_schema<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_from_latest_predefined_schema = v.into();
-        self
-    }
-
     /// Sets the value of [resource_types][crate::model::FhirStoreSource::resource_types].
     pub fn set_resource_types<T, V>(mut self, v: T) -> Self
     where
@@ -17617,6 +17608,15 @@ impl FhirStoreSource {
     {
         use std::iter::Iterator;
         self.resource_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_from_latest_predefined_schema][crate::model::FhirStoreSource::update_from_latest_predefined_schema].
+    pub fn set_update_from_latest_predefined_schema<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_from_latest_predefined_schema = v.into();
         self
     }
 }
@@ -18044,34 +18044,6 @@ impl ImportUserEventsRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportUserEventsRequest::source]
-    /// if it holds a `GcsSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_user_events_request::Source::GcsSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportUserEventsRequest::source]
-    /// if it holds a `BigquerySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_user_events_request::Source::BigquerySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
     /// to hold a `InlineSource`.
     ///
@@ -18089,6 +18061,19 @@ impl ImportUserEventsRequest {
         self
     }
 
+    /// The value of [source][crate::model::ImportUserEventsRequest::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_user_events_request::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
     /// to hold a `GcsSource`.
     ///
@@ -18102,6 +18087,21 @@ impl ImportUserEventsRequest {
             crate::model::import_user_events_request::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportUserEventsRequest::source]
+    /// if it holds a `BigquerySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_user_events_request::Source::BigquerySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
@@ -18221,6 +18221,17 @@ impl ImportUserEventsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [error_samples][crate::model::ImportUserEventsResponse::error_samples].
+    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [error_config][crate::model::ImportUserEventsResponse::error_config].
     pub fn set_error_config<
         T: std::convert::Into<std::option::Option<crate::model::ImportErrorConfig>>,
@@ -18241,17 +18252,6 @@ impl ImportUserEventsResponse {
     /// Sets the value of [unjoined_events_count][crate::model::ImportUserEventsResponse::unjoined_events_count].
     pub fn set_unjoined_events_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.unjoined_events_count = v.into();
-        self
-    }
-
-    /// Sets the value of [error_samples][crate::model::ImportUserEventsResponse::error_samples].
-    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.error_samples = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -18639,124 +18639,6 @@ impl ImportDocumentsRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `GcsSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::GcsSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `BigquerySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::BigquerySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `FhirStoreSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fhir_store_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FhirStoreSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::FhirStoreSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `SpannerSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spanner_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SpannerSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::SpannerSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `CloudSqlSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_sql_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::CloudSqlSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `FirestoreSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn firestore_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FirestoreSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::FirestoreSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `AlloyDbSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn alloy_db_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AlloyDbSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::AlloyDbSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportDocumentsRequest::source]
-    /// if it holds a `BigtableSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigtable_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigtableSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_documents_request::Source::BigtableSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
     /// to hold a `InlineSource`.
     ///
@@ -18774,6 +18656,19 @@ impl ImportDocumentsRequest {
         self
     }
 
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
     /// to hold a `GcsSource`.
     ///
@@ -18787,6 +18682,21 @@ impl ImportDocumentsRequest {
             crate::model::import_documents_request::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `BigquerySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::BigquerySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
@@ -18806,6 +18716,21 @@ impl ImportDocumentsRequest {
         self
     }
 
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `FhirStoreSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fhir_store_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FhirStoreSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::FhirStoreSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
     /// to hold a `FhirStoreSource`.
     ///
@@ -18821,6 +18746,21 @@ impl ImportDocumentsRequest {
             crate::model::import_documents_request::Source::FhirStoreSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `SpannerSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spanner_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SpannerSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::SpannerSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
@@ -18840,6 +18780,21 @@ impl ImportDocumentsRequest {
         self
     }
 
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `CloudSqlSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_sql_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::CloudSqlSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
     /// to hold a `CloudSqlSource`.
     ///
@@ -18855,6 +18810,21 @@ impl ImportDocumentsRequest {
             crate::model::import_documents_request::Source::CloudSqlSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `FirestoreSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn firestore_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FirestoreSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::FirestoreSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
@@ -18874,6 +18844,21 @@ impl ImportDocumentsRequest {
         self
     }
 
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `AlloyDbSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn alloy_db_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AlloyDbSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::AlloyDbSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
     /// to hold a `AlloyDbSource`.
     ///
@@ -18889,6 +18874,21 @@ impl ImportDocumentsRequest {
             crate::model::import_documents_request::Source::AlloyDbSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportDocumentsRequest::source]
+    /// if it holds a `BigtableSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigtable_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigtableSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_documents_request::Source::BigtableSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
@@ -19149,17 +19149,6 @@ impl ImportDocumentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [error_config][crate::model::ImportDocumentsResponse::error_config].
-    pub fn set_error_config<
-        T: std::convert::Into<std::option::Option<crate::model::ImportErrorConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error_config = v.into();
-        self
-    }
-
     /// Sets the value of [error_samples][crate::model::ImportDocumentsResponse::error_samples].
     pub fn set_error_samples<T, V>(mut self, v: T) -> Self
     where
@@ -19168,6 +19157,17 @@ impl ImportDocumentsResponse {
     {
         use std::iter::Iterator;
         self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_config][crate::model::ImportDocumentsResponse::error_config].
+    pub fn set_error_config<
+        T: std::convert::Into<std::option::Option<crate::model::ImportErrorConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error_config = v.into();
         self
     }
 }
@@ -19248,19 +19248,6 @@ impl ImportSuggestionDenyListEntriesRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
-    /// if it holds a `GcsSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_suggestion_deny_list_entries_request::Source::GcsSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
     /// to hold a `InlineSource`.
     ///
@@ -19282,6 +19269,19 @@ impl ImportSuggestionDenyListEntriesRequest {
             ),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_suggestion_deny_list_entries_request::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
@@ -19404,6 +19404,17 @@ impl ImportSuggestionDenyListEntriesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [error_samples][crate::model::ImportSuggestionDenyListEntriesResponse::error_samples].
+    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [imported_entries_count][crate::model::ImportSuggestionDenyListEntriesResponse::imported_entries_count].
     pub fn set_imported_entries_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.imported_entries_count = v.into();
@@ -19413,17 +19424,6 @@ impl ImportSuggestionDenyListEntriesResponse {
     /// Sets the value of [failed_entries_count][crate::model::ImportSuggestionDenyListEntriesResponse::failed_entries_count].
     pub fn set_failed_entries_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.failed_entries_count = v.into();
-        self
-    }
-
-    /// Sets the value of [error_samples][crate::model::ImportSuggestionDenyListEntriesResponse::error_samples].
-    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.error_samples = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -19569,34 +19569,6 @@ impl ImportCompletionSuggestionsRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-    /// if it holds a `GcsSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_completion_suggestions_request::Source::GcsSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-    /// if it holds a `BigquerySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_completion_suggestions_request::Source::BigquerySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
     /// to hold a `InlineSource`.
     ///
@@ -19616,6 +19588,19 @@ impl ImportCompletionSuggestionsRequest {
         self
     }
 
+    /// The value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_completion_suggestions_request::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
     /// to hold a `GcsSource`.
     ///
@@ -19629,6 +19614,21 @@ impl ImportCompletionSuggestionsRequest {
             crate::model::import_completion_suggestions_request::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
+    /// if it holds a `BigquerySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_completion_suggestions_request::Source::BigquerySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
@@ -19742,17 +19742,6 @@ impl ImportCompletionSuggestionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [error_config][crate::model::ImportCompletionSuggestionsResponse::error_config].
-    pub fn set_error_config<
-        T: std::convert::Into<std::option::Option<crate::model::ImportErrorConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error_config = v.into();
-        self
-    }
-
     /// Sets the value of [error_samples][crate::model::ImportCompletionSuggestionsResponse::error_samples].
     pub fn set_error_samples<T, V>(mut self, v: T) -> Self
     where
@@ -19761,6 +19750,17 @@ impl ImportCompletionSuggestionsResponse {
     {
         use std::iter::Iterator;
         self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_config][crate::model::ImportCompletionSuggestionsResponse::error_config].
+    pub fn set_error_config<
+        T: std::convert::Into<std::option::Option<crate::model::ImportErrorConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error_config = v.into();
         self
     }
 }
@@ -20655,6 +20655,21 @@ impl PurgeDocumentsRequest {
         })
     }
 
+    /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
+    /// to hold a `GcsSource`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::purge_documents_request::Source::GcsSource(v.into()),
+        );
+        self
+    }
+
     /// The value of [source][crate::model::PurgeDocumentsRequest::source]
     /// if it holds a `InlineSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -20669,21 +20684,6 @@ impl PurgeDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::purge_documents_request::Source::GcsSource(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
@@ -21370,15 +21370,6 @@ impl RankRequest {
         self
     }
 
-    /// Sets the value of [ignore_record_details_in_response][crate::model::RankRequest::ignore_record_details_in_response].
-    pub fn set_ignore_record_details_in_response<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ignore_record_details_in_response = v.into();
-        self
-    }
-
     /// Sets the value of [records][crate::model::RankRequest::records].
     pub fn set_records<T, V>(mut self, v: T) -> Self
     where
@@ -21387,6 +21378,15 @@ impl RankRequest {
     {
         use std::iter::Iterator;
         self.records = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ignore_record_details_in_response][crate::model::RankRequest::ignore_record_details_in_response].
+    pub fn set_ignore_record_details_in_response<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.ignore_record_details_in_response = v.into();
         self
     }
 
@@ -21711,21 +21711,6 @@ impl RecommendResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [attribution_token][crate::model::RecommendResponse::attribution_token].
-    pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.attribution_token = v.into();
-        self
-    }
-
-    /// Sets the value of [validate_only][crate::model::RecommendResponse::validate_only].
-    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.validate_only = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::RecommendResponse::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -21737,6 +21722,15 @@ impl RecommendResponse {
         self
     }
 
+    /// Sets the value of [attribution_token][crate::model::RecommendResponse::attribution_token].
+    pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.attribution_token = v.into();
+        self
+    }
+
     /// Sets the value of [missing_ids][crate::model::RecommendResponse::missing_ids].
     pub fn set_missing_ids<T, V>(mut self, v: T) -> Self
     where
@@ -21745,6 +21739,12 @@ impl RecommendResponse {
     {
         use std::iter::Iterator;
         self.missing_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [validate_only][crate::model::RecommendResponse::validate_only].
+    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.validate_only = v.into();
         self
     }
 }
@@ -22280,17 +22280,6 @@ impl Schema {
         })
     }
 
-    /// The value of [schema][crate::model::Schema::schema]
-    /// if it holds a `JsonSchema`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn json_schema(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.schema.as_ref().and_then(|v| match v {
-            crate::model::schema::Schema::JsonSchema(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [schema][crate::model::Schema::schema]
     /// to hold a `StructSchema`.
     ///
@@ -22303,6 +22292,17 @@ impl Schema {
         self.schema =
             std::option::Option::Some(crate::model::schema::Schema::StructSchema(v.into()));
         self
+    }
+
+    /// The value of [schema][crate::model::Schema::schema]
+    /// if it holds a `JsonSchema`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn json_schema(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.schema.as_ref().and_then(|v| match v {
+            crate::model::schema::Schema::JsonSchema(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schema][crate::model::Schema::schema]
@@ -22489,12 +22489,6 @@ impl ListSchemasResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSchemasResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [schemas][crate::model::ListSchemasResponse::schemas].
     pub fn set_schemas<T, V>(mut self, v: T) -> Self
     where
@@ -22503,6 +22497,12 @@ impl ListSchemasResponse {
     {
         use std::iter::Iterator;
         self.schemas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSchemasResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -23221,6 +23221,17 @@ impl SearchRequest {
         self
     }
 
+    /// Sets the value of [data_store_specs][crate::model::SearchRequest::data_store_specs].
+    pub fn set_data_store_specs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_request::DataStoreSpec>,
+    {
+        use std::iter::Iterator;
+        self.data_store_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [filter][crate::model::SearchRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
@@ -23257,6 +23268,17 @@ impl SearchRequest {
         self
     }
 
+    /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
+    pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_request::FacetSpec>,
+    {
+        use std::iter::Iterator;
+        self.facet_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [boost_spec][crate::model::SearchRequest::boost_spec].
     pub fn set_boost_spec<
         T: std::convert::Into<std::option::Option<crate::model::search_request::BoostSpec>>,
@@ -23265,6 +23287,18 @@ impl SearchRequest {
         v: T,
     ) -> Self {
         self.boost_spec = v.into();
+        self
+    }
+
+    /// Sets the value of [params][crate::model::SearchRequest::params].
+    pub fn set_params<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.params = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -23310,6 +23344,18 @@ impl SearchRequest {
     /// Sets the value of [safe_search][crate::model::SearchRequest::safe_search].
     pub fn set_safe_search<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.safe_search = v.into();
+        self
+    }
+
+    /// Sets the value of [user_labels][crate::model::SearchRequest::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -23371,52 +23417,6 @@ impl SearchRequest {
         v: T,
     ) -> Self {
         self.relevance_score_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [data_store_specs][crate::model::SearchRequest::data_store_specs].
-    pub fn set_data_store_specs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_request::DataStoreSpec>,
-    {
-        use std::iter::Iterator;
-        self.data_store_specs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
-    pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_request::FacetSpec>,
-    {
-        use std::iter::Iterator;
-        self.facet_specs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [params][crate::model::SearchRequest::params].
-    pub fn set_params<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<wkt::Value>,
-    {
-        use std::iter::Iterator;
-        self.params = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [user_labels][crate::model::SearchRequest::user_labels].
-    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -23693,12 +23693,6 @@ pub mod search_request {
             self
         }
 
-        /// Sets the value of [enable_dynamic_position][crate::model::search_request::FacetSpec::enable_dynamic_position].
-        pub fn set_enable_dynamic_position<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.enable_dynamic_position = v.into();
-            self
-        }
-
         /// Sets the value of [excluded_filter_keys][crate::model::search_request::FacetSpec::excluded_filter_keys].
         pub fn set_excluded_filter_keys<T, V>(mut self, v: T) -> Self
         where
@@ -23707,6 +23701,12 @@ pub mod search_request {
         {
             use std::iter::Iterator;
             self.excluded_filter_keys = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [enable_dynamic_position][crate::model::search_request::FacetSpec::enable_dynamic_position].
+        pub fn set_enable_dynamic_position<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.enable_dynamic_position = v.into();
             self
         }
     }
@@ -23812,21 +23812,6 @@ pub mod search_request {
                 self
             }
 
-            /// Sets the value of [case_insensitive][crate::model::search_request::facet_spec::FacetKey::case_insensitive].
-            pub fn set_case_insensitive<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.case_insensitive = v.into();
-                self
-            }
-
-            /// Sets the value of [order_by][crate::model::search_request::facet_spec::FacetKey::order_by].
-            pub fn set_order_by<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.order_by = v.into();
-                self
-            }
-
             /// Sets the value of [intervals][crate::model::search_request::facet_spec::FacetKey::intervals].
             pub fn set_intervals<T, V>(mut self, v: T) -> Self
             where
@@ -23868,6 +23853,21 @@ pub mod search_request {
             {
                 use std::iter::Iterator;
                 self.contains = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [case_insensitive][crate::model::search_request::facet_spec::FacetKey::case_insensitive].
+            pub fn set_case_insensitive<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.case_insensitive = v.into();
+                self
+            }
+
+            /// Sets the value of [order_by][crate::model::search_request::facet_spec::FacetKey::order_by].
+            pub fn set_order_by<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.order_by = v.into();
                 self
             }
         }
@@ -26387,6 +26387,28 @@ impl SearchResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [results][crate::model::SearchResponse::results].
+    pub fn set_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_response::SearchResult>,
+    {
+        use std::iter::Iterator;
+        self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [facets][crate::model::SearchResponse::facets].
+    pub fn set_facets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_response::Facet>,
+    {
+        use std::iter::Iterator;
+        self.facets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [total_size][crate::model::SearchResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
@@ -26450,28 +26472,6 @@ impl SearchResponse {
         v: T,
     ) -> Self {
         self.session_info = v.into();
-        self
-    }
-
-    /// Sets the value of [results][crate::model::SearchResponse::results].
-    pub fn set_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_response::SearchResult>,
-    {
-        use std::iter::Iterator;
-        self.results = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [facets][crate::model::SearchResponse::facets].
-    pub fn set_facets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_response::Facet>,
-    {
-        use std::iter::Iterator;
-        self.facets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -26633,12 +26633,6 @@ pub mod search_response {
             self
         }
 
-        /// Sets the value of [dynamic_facet][crate::model::search_response::Facet::dynamic_facet].
-        pub fn set_dynamic_facet<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.dynamic_facet = v.into();
-            self
-        }
-
         /// Sets the value of [values][crate::model::search_response::Facet::values].
         pub fn set_values<T, V>(mut self, v: T) -> Self
         where
@@ -26647,6 +26641,12 @@ pub mod search_response {
         {
             use std::iter::Iterator;
             self.values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [dynamic_facet][crate::model::search_response::Facet::dynamic_facet].
+        pub fn set_dynamic_facet<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.dynamic_facet = v.into();
             self
         }
     }
@@ -26724,6 +26724,18 @@ pub mod search_response {
                 })
             }
 
+            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
+            /// to hold a `Value`.
+            ///
+            /// Note that all the setters affecting `facet_value` are
+            /// mutually exclusive.
+            pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+                self.facet_value = std::option::Option::Some(
+                    crate::model::search_response::facet::facet_value::FacetValue::Value(v.into()),
+                );
+                self
+            }
+
             /// The value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
             /// if it holds a `Interval`, `None` if the field is not set or
             /// holds a different branch.
@@ -26737,18 +26749,6 @@ pub mod search_response {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
-            /// to hold a `Value`.
-            ///
-            /// Note that all the setters affecting `facet_value` are
-            /// mutually exclusive.
-            pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.facet_value = std::option::Option::Some(
-                    crate::model::search_response::facet::facet_value::FacetValue::Value(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
@@ -26842,6 +26842,17 @@ pub mod search_response {
             self
         }
 
+        /// Sets the value of [summary_skipped_reasons][crate::model::search_response::Summary::summary_skipped_reasons].
+        pub fn set_summary_skipped_reasons<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_response::summary::SummarySkippedReason>,
+        {
+            use std::iter::Iterator;
+            self.summary_skipped_reasons = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [safety_attributes][crate::model::search_response::Summary::safety_attributes].
         pub fn set_safety_attributes<
             T: std::convert::Into<
@@ -26867,17 +26878,6 @@ pub mod search_response {
             v: T,
         ) -> Self {
             self.summary_with_metadata = v.into();
-            self
-        }
-
-        /// Sets the value of [summary_skipped_reasons][crate::model::search_response::Summary::summary_skipped_reasons].
-        pub fn set_summary_skipped_reasons<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_response::summary::SummarySkippedReason>,
-        {
-            use std::iter::Iterator;
-            self.summary_skipped_reasons = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -27998,6 +27998,17 @@ impl TrainCustomModelResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [error_samples][crate::model::TrainCustomModelResponse::error_samples].
+    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [error_config][crate::model::TrainCustomModelResponse::error_config].
     pub fn set_error_config<
         T: std::convert::Into<std::option::Option<crate::model::ImportErrorConfig>>,
@@ -28015,23 +28026,6 @@ impl TrainCustomModelResponse {
         self
     }
 
-    /// Sets the value of [model_name][crate::model::TrainCustomModelResponse::model_name].
-    pub fn set_model_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.model_name = v.into();
-        self
-    }
-
-    /// Sets the value of [error_samples][crate::model::TrainCustomModelResponse::error_samples].
-    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.error_samples = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [metrics][crate::model::TrainCustomModelResponse::metrics].
     pub fn set_metrics<T, K, V>(mut self, v: T) -> Self
     where
@@ -28041,6 +28035,12 @@ impl TrainCustomModelResponse {
     {
         use std::iter::Iterator;
         self.metrics = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [model_name][crate::model::TrainCustomModelResponse::model_name].
+    pub fn set_model_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.model_name = v.into();
         self
     }
 }
@@ -28499,21 +28499,6 @@ impl ServingConfig {
         })
     }
 
-    /// The value of [vertical_config][crate::model::ServingConfig::vertical_config]
-    /// if it holds a `GenericConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn generic_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::serving_config::GenericConfig>> {
-        #[allow(unreachable_patterns)]
-        self.vertical_config.as_ref().and_then(|v| match v {
-            crate::model::serving_config::VerticalConfig::GenericConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [vertical_config][crate::model::ServingConfig::vertical_config]
     /// to hold a `MediaConfig`.
     ///
@@ -28529,6 +28514,21 @@ impl ServingConfig {
             crate::model::serving_config::VerticalConfig::MediaConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [vertical_config][crate::model::ServingConfig::vertical_config]
+    /// if it holds a `GenericConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn generic_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::serving_config::GenericConfig>> {
+        #[allow(unreachable_patterns)]
+        self.vertical_config.as_ref().and_then(|v| match v {
+            crate::model::serving_config::VerticalConfig::GenericConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [vertical_config][crate::model::ServingConfig::vertical_config]
@@ -28679,17 +28679,6 @@ pub mod serving_config {
             })
         }
 
-        /// The value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
-        /// if it holds a `ContentWatchedSecondsThreshold`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn content_watched_seconds_threshold(&self) -> std::option::Option<&f32> {
-            #[allow(unreachable_patterns)]
-            self.demote_content_watched.as_ref().and_then(|v| match v {
-                crate::model::serving_config::media_config::DemoteContentWatched::ContentWatchedSecondsThreshold(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
         /// to hold a `ContentWatchedPercentageThreshold`.
         ///
@@ -28705,6 +28694,17 @@ pub mod serving_config {
                 )
             );
             self
+        }
+
+        /// The value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
+        /// if it holds a `ContentWatchedSecondsThreshold`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn content_watched_seconds_threshold(&self) -> std::option::Option<&f32> {
+            #[allow(unreachable_patterns)]
+            self.demote_content_watched.as_ref().and_then(|v| match v {
+                crate::model::serving_config::media_config::DemoteContentWatched::ContentWatchedSecondsThreshold(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
@@ -28941,6 +28941,17 @@ impl Session {
         self
     }
 
+    /// Sets the value of [turns][crate::model::Session::turns].
+    pub fn set_turns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::session::Turn>,
+    {
+        use std::iter::Iterator;
+        self.turns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [start_time][crate::model::Session::start_time].
     pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -28962,17 +28973,6 @@ impl Session {
     /// Sets the value of [is_pinned][crate::model::Session::is_pinned].
     pub fn set_is_pinned<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.is_pinned = v.into();
-        self
-    }
-
-    /// Sets the value of [turns][crate::model::Session::turns].
-    pub fn set_turns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::session::Turn>,
-    {
-        use std::iter::Iterator;
-        self.turns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -30737,6 +30737,17 @@ impl ListTargetSitesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [target_sites][crate::model::ListTargetSitesResponse::target_sites].
+    pub fn set_target_sites<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TargetSite>,
+    {
+        use std::iter::Iterator;
+        self.target_sites = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListTargetSitesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -30746,17 +30757,6 @@ impl ListTargetSitesResponse {
     /// Sets the value of [total_size][crate::model::ListTargetSitesResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [target_sites][crate::model::ListTargetSitesResponse::target_sites].
-    pub fn set_target_sites<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TargetSite>,
-    {
-        use std::iter::Iterator;
-        self.target_sites = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -31678,12 +31678,6 @@ impl RecrawlUrisRequest {
         self
     }
 
-    /// Sets the value of [site_credential][crate::model::RecrawlUrisRequest::site_credential].
-    pub fn set_site_credential<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.site_credential = v.into();
-        self
-    }
-
     /// Sets the value of [uris][crate::model::RecrawlUrisRequest::uris].
     pub fn set_uris<T, V>(mut self, v: T) -> Self
     where
@@ -31692,6 +31686,12 @@ impl RecrawlUrisRequest {
     {
         use std::iter::Iterator;
         self.uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [site_credential][crate::model::RecrawlUrisRequest::site_credential].
+    pub fn set_site_credential<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.site_credential = v.into();
         self
     }
 }
@@ -32096,15 +32096,48 @@ impl RecrawlUrisMetadata {
         self
     }
 
+    /// Sets the value of [invalid_uris][crate::model::RecrawlUrisMetadata::invalid_uris].
+    pub fn set_invalid_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.invalid_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [invalid_uris_count][crate::model::RecrawlUrisMetadata::invalid_uris_count].
     pub fn set_invalid_uris_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.invalid_uris_count = v.into();
         self
     }
 
+    /// Sets the value of [noindex_uris][crate::model::RecrawlUrisMetadata::noindex_uris].
+    pub fn set_noindex_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.noindex_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [noindex_uris_count][crate::model::RecrawlUrisMetadata::noindex_uris_count].
     pub fn set_noindex_uris_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.noindex_uris_count = v.into();
+        self
+    }
+
+    /// Sets the value of [uris_not_matching_target_sites][crate::model::RecrawlUrisMetadata::uris_not_matching_target_sites].
+    pub fn set_uris_not_matching_target_sites<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.uris_not_matching_target_sites = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -32138,39 +32171,6 @@ impl RecrawlUrisMetadata {
     /// Sets the value of [quota_exceeded_count][crate::model::RecrawlUrisMetadata::quota_exceeded_count].
     pub fn set_quota_exceeded_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.quota_exceeded_count = v.into();
-        self
-    }
-
-    /// Sets the value of [invalid_uris][crate::model::RecrawlUrisMetadata::invalid_uris].
-    pub fn set_invalid_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.invalid_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [noindex_uris][crate::model::RecrawlUrisMetadata::noindex_uris].
-    pub fn set_noindex_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.noindex_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [uris_not_matching_target_sites][crate::model::RecrawlUrisMetadata::uris_not_matching_target_sites].
-    pub fn set_uris_not_matching_target_sites<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.uris_not_matching_target_sites = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -32401,6 +32401,17 @@ impl FetchDomainVerificationStatusResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [target_sites][crate::model::FetchDomainVerificationStatusResponse::target_sites].
+    pub fn set_target_sites<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TargetSite>,
+    {
+        use std::iter::Iterator;
+        self.target_sites = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::FetchDomainVerificationStatusResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -32410,17 +32421,6 @@ impl FetchDomainVerificationStatusResponse {
     /// Sets the value of [total_size][crate::model::FetchDomainVerificationStatusResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [target_sites][crate::model::FetchDomainVerificationStatusResponse::target_sites].
-    pub fn set_target_sites<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TargetSite>,
-    {
-        use std::iter::Iterator;
-        self.target_sites = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -32842,6 +32842,17 @@ impl UserEvent {
         self
     }
 
+    /// Sets the value of [documents][crate::model::UserEvent::documents].
+    pub fn set_documents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DocumentInfo>,
+    {
+        use std::iter::Iterator;
+        self.documents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [panel][crate::model::UserEvent::panel].
     pub fn set_panel<T: std::convert::Into<std::option::Option<crate::model::PanelInfo>>>(
         mut self,
@@ -32882,26 +32893,6 @@ impl UserEvent {
         self
     }
 
-    /// Sets the value of [media_info][crate::model::UserEvent::media_info].
-    pub fn set_media_info<T: std::convert::Into<std::option::Option<crate::model::MediaInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.media_info = v.into();
-        self
-    }
-
-    /// Sets the value of [documents][crate::model::UserEvent::documents].
-    pub fn set_documents<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DocumentInfo>,
-    {
-        use std::iter::Iterator;
-        self.documents = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [tag_ids][crate::model::UserEvent::tag_ids].
     pub fn set_tag_ids<T, V>(mut self, v: T) -> Self
     where
@@ -32924,17 +32915,6 @@ impl UserEvent {
         self
     }
 
-    /// Sets the value of [panels][crate::model::UserEvent::panels].
-    pub fn set_panels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PanelInfo>,
-    {
-        use std::iter::Iterator;
-        self.panels = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [attributes][crate::model::UserEvent::attributes].
     pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
     where
@@ -32944,6 +32924,26 @@ impl UserEvent {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [media_info][crate::model::UserEvent::media_info].
+    pub fn set_media_info<T: std::convert::Into<std::option::Option<crate::model::MediaInfo>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.media_info = v.into();
+        self
+    }
+
+    /// Sets the value of [panels][crate::model::UserEvent::panels].
+    pub fn set_panels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PanelInfo>,
+    {
+        use std::iter::Iterator;
+        self.panels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -33386,6 +33386,17 @@ impl DocumentInfo {
         self
     }
 
+    /// Sets the value of [promotion_ids][crate::model::DocumentInfo::promotion_ids].
+    pub fn set_promotion_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.promotion_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [joined][crate::model::DocumentInfo::joined].
     pub fn set_joined<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.joined = v.into();
@@ -33398,17 +33409,6 @@ impl DocumentInfo {
         v: T,
     ) -> Self {
         self.conversion_value = v.into();
-        self
-    }
-
-    /// Sets the value of [promotion_ids][crate::model::DocumentInfo::promotion_ids].
-    pub fn set_promotion_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.promotion_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -33437,6 +33437,18 @@ impl DocumentInfo {
         })
     }
 
+    /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
+    /// to hold a `Id`.
+    ///
+    /// Note that all the setters affecting `document_descriptor` are
+    /// mutually exclusive.
+    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.document_descriptor = std::option::Option::Some(
+            crate::model::document_info::DocumentDescriptor::Id(v.into()),
+        );
+        self
+    }
+
     /// The value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
     /// if it holds a `Name`, `None` if the field is not set or
     /// holds a different branch.
@@ -33450,29 +33462,6 @@ impl DocumentInfo {
         })
     }
 
-    /// The value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
-    /// if it holds a `Uri`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn uri(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.document_descriptor.as_ref().and_then(|v| match v {
-            crate::model::document_info::DocumentDescriptor::Uri(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
-    /// to hold a `Id`.
-    ///
-    /// Note that all the setters affecting `document_descriptor` are
-    /// mutually exclusive.
-    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.document_descriptor = std::option::Option::Some(
-            crate::model::document_info::DocumentDescriptor::Id(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
     /// to hold a `Name`.
     ///
@@ -33483,6 +33472,17 @@ impl DocumentInfo {
             crate::model::document_info::DocumentDescriptor::Name(v.into()),
         );
         self
+    }
+
+    /// The value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
+    /// if it holds a `Uri`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn uri(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.document_descriptor.as_ref().and_then(|v| match v {
+            crate::model::document_info::DocumentDescriptor::Uri(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -131,12 +131,6 @@ pub mod document_processor_service {
             self
         }
 
-        /// Sets the value of [imageless_mode][crate::model::ProcessRequest::imageless_mode].
-        pub fn set_imageless_mode<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.imageless_mode = v.into();
-            self
-        }
-
         /// Sets the value of [labels][crate::model::ProcessRequest::labels].
         pub fn set_labels<T, K, V>(mut self, v: T) -> Self
         where
@@ -145,6 +139,12 @@ pub mod document_processor_service {
             V: std::convert::Into<std::string::String>,
         {
             self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [imageless_mode][crate::model::ProcessRequest::imageless_mode].
+        pub fn set_imageless_mode<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.imageless_mode = v.into();
             self
         }
 

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -231,48 +231,6 @@ impl Document {
         self
     }
 
-    /// Sets the value of [shard_info][crate::model::Document::shard_info].
-    pub fn set_shard_info<
-        T: std::convert::Into<std::option::Option<crate::model::document::ShardInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.shard_info = v.into();
-        self
-    }
-
-    /// Sets the value of [error][crate::model::Document::error].
-    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error = v.into();
-        self
-    }
-
-    /// Sets the value of [document_layout][crate::model::Document::document_layout].
-    pub fn set_document_layout<
-        T: std::convert::Into<std::option::Option<crate::model::document::DocumentLayout>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.document_layout = v.into();
-        self
-    }
-
-    /// Sets the value of [chunked_document][crate::model::Document::chunked_document].
-    pub fn set_chunked_document<
-        T: std::convert::Into<std::option::Option<crate::model::document::ChunkedDocument>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.chunked_document = v.into();
-        self
-    }
-
     /// Sets the value of [text_styles][crate::model::Document::text_styles].
     #[deprecated]
     pub fn set_text_styles<T, V>(mut self, v: T) -> Self
@@ -329,6 +287,26 @@ impl Document {
         self
     }
 
+    /// Sets the value of [shard_info][crate::model::Document::shard_info].
+    pub fn set_shard_info<
+        T: std::convert::Into<std::option::Option<crate::model::document::ShardInfo>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.shard_info = v.into();
+        self
+    }
+
+    /// Sets the value of [error][crate::model::Document::error].
+    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error = v.into();
+        self
+    }
+
     /// Sets the value of [revisions][crate::model::Document::revisions].
     pub fn set_revisions<T, V>(mut self, v: T) -> Self
     where
@@ -337,6 +315,28 @@ impl Document {
     {
         use std::iter::Iterator;
         self.revisions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [document_layout][crate::model::Document::document_layout].
+    pub fn set_document_layout<
+        T: std::convert::Into<std::option::Option<crate::model::document::DocumentLayout>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.document_layout = v.into();
+        self
+    }
+
+    /// Sets the value of [chunked_document][crate::model::Document::chunked_document].
+    pub fn set_chunked_document<
+        T: std::convert::Into<std::option::Option<crate::model::document::ChunkedDocument>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.chunked_document = v.into();
         self
     }
 
@@ -365,6 +365,16 @@ impl Document {
         })
     }
 
+    /// Sets the value of [source][crate::model::Document::source]
+    /// to hold a `Uri`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(crate::model::document::Source::Uri(v.into()));
+        self
+    }
+
     /// The value of [source][crate::model::Document::source]
     /// if it holds a `Content`, `None` if the field is not set or
     /// holds a different branch.
@@ -374,16 +384,6 @@ impl Document {
             crate::model::document::Source::Content(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(crate::model::document::Source::Uri(v.into()));
-        self
     }
 
     /// Sets the value of [source][crate::model::Document::source]
@@ -774,6 +774,17 @@ pub mod document {
             self
         }
 
+        /// Sets the value of [transforms][crate::model::document::Page::transforms].
+        pub fn set_transforms<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::document::page::Matrix>,
+        {
+            use std::iter::Iterator;
+            self.transforms = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [dimension][crate::model::document::Page::dimension].
         pub fn set_dimension<
             T: std::convert::Into<std::option::Option<crate::model::document::page::Dimension>>,
@@ -793,42 +804,6 @@ pub mod document {
             v: T,
         ) -> Self {
             self.layout = v.into();
-            self
-        }
-
-        /// Sets the value of [image_quality_scores][crate::model::document::Page::image_quality_scores].
-        pub fn set_image_quality_scores<
-            T: std::convert::Into<
-                    std::option::Option<crate::model::document::page::ImageQualityScores>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.image_quality_scores = v.into();
-            self
-        }
-
-        /// Sets the value of [provenance][crate::model::document::Page::provenance].
-        #[deprecated]
-        pub fn set_provenance<
-            T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.provenance = v.into();
-            self
-        }
-
-        /// Sets the value of [transforms][crate::model::document::Page::transforms].
-        pub fn set_transforms<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::document::page::Matrix>,
-        {
-            use std::iter::Iterator;
-            self.transforms = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -939,6 +914,31 @@ pub mod document {
         {
             use std::iter::Iterator;
             self.detected_barcodes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [image_quality_scores][crate::model::document::Page::image_quality_scores].
+        pub fn set_image_quality_scores<
+            T: std::convert::Into<
+                    std::option::Option<crate::model::document::page::ImageQualityScores>,
+                >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.image_quality_scores = v.into();
+            self
+        }
+
+        /// Sets the value of [provenance][crate::model::document::Page::provenance].
+        #[deprecated]
+        pub fn set_provenance<
+            T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.provenance = v.into();
             self
         }
     }
@@ -1435,6 +1435,17 @@ pub mod document {
                 self
             }
 
+            /// Sets the value of [detected_languages][crate::model::document::page::Block::detected_languages].
+            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
+            {
+                use std::iter::Iterator;
+                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [provenance][crate::model::document::page::Block::provenance].
             #[deprecated]
             pub fn set_provenance<
@@ -1444,17 +1455,6 @@ pub mod document {
                 v: T,
             ) -> Self {
                 self.provenance = v.into();
-                self
-            }
-
-            /// Sets the value of [detected_languages][crate::model::document::page::Block::detected_languages].
-            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
-            {
-                use std::iter::Iterator;
-                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -1508,6 +1508,17 @@ pub mod document {
                 self
             }
 
+            /// Sets the value of [detected_languages][crate::model::document::page::Paragraph::detected_languages].
+            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
+            {
+                use std::iter::Iterator;
+                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [provenance][crate::model::document::page::Paragraph::provenance].
             #[deprecated]
             pub fn set_provenance<
@@ -1517,17 +1528,6 @@ pub mod document {
                 v: T,
             ) -> Self {
                 self.provenance = v.into();
-                self
-            }
-
-            /// Sets the value of [detected_languages][crate::model::document::page::Paragraph::detected_languages].
-            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
-            {
-                use std::iter::Iterator;
-                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -1582,6 +1582,17 @@ pub mod document {
                 self
             }
 
+            /// Sets the value of [detected_languages][crate::model::document::page::Line::detected_languages].
+            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
+            {
+                use std::iter::Iterator;
+                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [provenance][crate::model::document::page::Line::provenance].
             #[deprecated]
             pub fn set_provenance<
@@ -1591,17 +1602,6 @@ pub mod document {
                 v: T,
             ) -> Self {
                 self.provenance = v.into();
-                self
-            }
-
-            /// Sets the value of [detected_languages][crate::model::document::page::Line::detected_languages].
-            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
-            {
-                use std::iter::Iterator;
-                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -1680,6 +1680,17 @@ pub mod document {
                 self
             }
 
+            /// Sets the value of [detected_languages][crate::model::document::page::Token::detected_languages].
+            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
+            {
+                use std::iter::Iterator;
+                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [provenance][crate::model::document::page::Token::provenance].
             #[deprecated]
             pub fn set_provenance<
@@ -1702,17 +1713,6 @@ pub mod document {
                 v: T,
             ) -> Self {
                 self.style_info = v.into();
-                self
-            }
-
-            /// Sets the value of [detected_languages][crate::model::document::page::Token::detected_languages].
-            pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
-            {
-                use std::iter::Iterator;
-                self.detected_languages = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -2290,18 +2290,6 @@ pub mod document {
                 self
             }
 
-            /// Sets the value of [provenance][crate::model::document::page::Table::provenance].
-            #[deprecated]
-            pub fn set_provenance<
-                T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.provenance = v.into();
-                self
-            }
-
             /// Sets the value of [header_rows][crate::model::document::page::Table::header_rows].
             pub fn set_header_rows<T, V>(mut self, v: T) -> Self
             where
@@ -2332,6 +2320,18 @@ pub mod document {
             {
                 use std::iter::Iterator;
                 self.detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [provenance][crate::model::document::page::Table::provenance].
+            #[deprecated]
+            pub fn set_provenance<
+                T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.provenance = v.into();
                 self
             }
         }
@@ -2551,6 +2551,28 @@ pub mod document {
                 self
             }
 
+            /// Sets the value of [name_detected_languages][crate::model::document::page::FormField::name_detected_languages].
+            pub fn set_name_detected_languages<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
+            {
+                use std::iter::Iterator;
+                self.name_detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [value_detected_languages][crate::model::document::page::FormField::value_detected_languages].
+            pub fn set_value_detected_languages<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
+            {
+                use std::iter::Iterator;
+                self.value_detected_languages = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [value_type][crate::model::document::page::FormField::value_type].
             pub fn set_value_type<T: std::convert::Into<std::string::String>>(
                 mut self,
@@ -2586,28 +2608,6 @@ pub mod document {
                 v: T,
             ) -> Self {
                 self.provenance = v.into();
-                self
-            }
-
-            /// Sets the value of [name_detected_languages][crate::model::document::page::FormField::name_detected_languages].
-            pub fn set_name_detected_languages<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
-            {
-                use std::iter::Iterator;
-                self.name_detected_languages = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [value_detected_languages][crate::model::document::page::FormField::value_detected_languages].
-            pub fn set_value_detected_languages<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::document::page::DetectedLanguage>,
-            {
-                use std::iter::Iterator;
-                self.value_detected_languages = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -2978,6 +2978,17 @@ pub mod document {
             self
         }
 
+        /// Sets the value of [properties][crate::model::document::Entity::properties].
+        pub fn set_properties<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::document::Entity>,
+        {
+            use std::iter::Iterator;
+            self.properties = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [provenance][crate::model::document::Entity::provenance].
         pub fn set_provenance<
             T: std::convert::Into<std::option::Option<crate::model::document::Provenance>>,
@@ -2992,17 +3003,6 @@ pub mod document {
         /// Sets the value of [redacted][crate::model::document::Entity::redacted].
         pub fn set_redacted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.redacted = v.into();
-            self
-        }
-
-        /// Sets the value of [properties][crate::model::document::Entity::properties].
-        pub fn set_properties<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::document::Entity>,
-        {
-            use std::iter::Iterator;
-            self.properties = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3093,76 +3093,6 @@ pub mod document {
                 })
             }
 
-            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// if it holds a `DateValue`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn date_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::Date>> {
-                #[allow(unreachable_patterns)]
-                self.structured_value.as_ref().and_then(|v| match v {
-                    crate::model::document::entity::normalized_value::StructuredValue::DateValue(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// if it holds a `DatetimeValue`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn datetime_value(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<gtype::model::DateTime>> {
-                #[allow(unreachable_patterns)]
-                self.structured_value.as_ref().and_then(|v| match v {
-                    crate::model::document::entity::normalized_value::StructuredValue::DatetimeValue(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// if it holds a `AddressValue`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn address_value(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<gtype::model::PostalAddress>> {
-                #[allow(unreachable_patterns)]
-                self.structured_value.as_ref().and_then(|v| match v {
-                    crate::model::document::entity::normalized_value::StructuredValue::AddressValue(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// if it holds a `BooleanValue`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn boolean_value(&self) -> std::option::Option<&bool> {
-                #[allow(unreachable_patterns)]
-                self.structured_value.as_ref().and_then(|v| match v {
-                    crate::model::document::entity::normalized_value::StructuredValue::BooleanValue(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// if it holds a `IntegerValue`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn integer_value(&self) -> std::option::Option<&i32> {
-                #[allow(unreachable_patterns)]
-                self.structured_value.as_ref().and_then(|v| match v {
-                    crate::model::document::entity::normalized_value::StructuredValue::IntegerValue(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// if it holds a `FloatValue`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn float_value(&self) -> std::option::Option<&f32> {
-                #[allow(unreachable_patterns)]
-                self.structured_value.as_ref().and_then(|v| match v {
-                    crate::model::document::entity::normalized_value::StructuredValue::FloatValue(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// to hold a `MoneyValue`.
             ///
@@ -3180,6 +3110,17 @@ pub mod document {
                 self
             }
 
+            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
+            /// if it holds a `DateValue`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn date_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::Date>> {
+                #[allow(unreachable_patterns)]
+                self.structured_value.as_ref().and_then(|v| match v {
+                    crate::model::document::entity::normalized_value::StructuredValue::DateValue(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// to hold a `DateValue`.
             ///
@@ -3195,6 +3136,19 @@ pub mod document {
                     ),
                 );
                 self
+            }
+
+            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
+            /// if it holds a `DatetimeValue`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn datetime_value(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<gtype::model::DateTime>> {
+                #[allow(unreachable_patterns)]
+                self.structured_value.as_ref().and_then(|v| match v {
+                    crate::model::document::entity::normalized_value::StructuredValue::DatetimeValue(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
@@ -3216,6 +3170,19 @@ pub mod document {
                 self
             }
 
+            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
+            /// if it holds a `AddressValue`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn address_value(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<gtype::model::PostalAddress>> {
+                #[allow(unreachable_patterns)]
+                self.structured_value.as_ref().and_then(|v| match v {
+                    crate::model::document::entity::normalized_value::StructuredValue::AddressValue(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// to hold a `AddressValue`.
             ///
@@ -3235,6 +3202,17 @@ pub mod document {
                 self
             }
 
+            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
+            /// if it holds a `BooleanValue`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn boolean_value(&self) -> std::option::Option<&bool> {
+                #[allow(unreachable_patterns)]
+                self.structured_value.as_ref().and_then(|v| match v {
+                    crate::model::document::entity::normalized_value::StructuredValue::BooleanValue(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// to hold a `BooleanValue`.
             ///
@@ -3249,6 +3227,17 @@ pub mod document {
                 self
             }
 
+            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
+            /// if it holds a `IntegerValue`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn integer_value(&self) -> std::option::Option<&i32> {
+                #[allow(unreachable_patterns)]
+                self.structured_value.as_ref().and_then(|v| match v {
+                    crate::model::document::entity::normalized_value::StructuredValue::IntegerValue(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// to hold a `IntegerValue`.
             ///
@@ -3261,6 +3250,17 @@ pub mod document {
                     ),
                 );
                 self
+            }
+
+            /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
+            /// if it holds a `FloatValue`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn float_value(&self) -> std::option::Option<&f32> {
+                #[allow(unreachable_patterns)]
+                self.structured_value.as_ref().and_then(|v| match v {
+                    crate::model::document::entity::normalized_value::StructuredValue::FloatValue(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
@@ -3406,12 +3406,6 @@ pub mod document {
             std::default::Default::default()
         }
 
-        /// Sets the value of [content][crate::model::document::TextAnchor::content].
-        pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.content = v.into();
-            self
-        }
-
         /// Sets the value of [text_segments][crate::model::document::TextAnchor::text_segments].
         pub fn set_text_segments<T, V>(mut self, v: T) -> Self
         where
@@ -3420,6 +3414,12 @@ pub mod document {
         {
             use std::iter::Iterator;
             self.text_segments = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [content][crate::model::document::TextAnchor::content].
+        pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.content = v.into();
             self
         }
     }
@@ -3899,17 +3899,6 @@ pub mod document {
             self
         }
 
-        /// Sets the value of [r#type][crate::model::document::Provenance::type].
-        pub fn set_type<
-            T: std::convert::Into<crate::model::document::provenance::OperationType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#type = v.into();
-            self
-        }
-
         /// Sets the value of [parents][crate::model::document::Provenance::parents].
         pub fn set_parents<T, V>(mut self, v: T) -> Self
         where
@@ -3918,6 +3907,17 @@ pub mod document {
         {
             use std::iter::Iterator;
             self.parents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [r#type][crate::model::document::Provenance::type].
+        pub fn set_type<
+            T: std::convert::Into<crate::model::document::provenance::OperationType>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.r#type = v.into();
             self
         }
     }
@@ -4221,26 +4221,6 @@ pub mod document {
             self
         }
 
-        /// Sets the value of [create_time][crate::model::document::Revision::create_time].
-        pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.create_time = v.into();
-            self
-        }
-
-        /// Sets the value of [human_review][crate::model::document::Revision::human_review].
-        pub fn set_human_review<
-            T: std::convert::Into<std::option::Option<crate::model::document::revision::HumanReview>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.human_review = v.into();
-            self
-        }
-
         /// Sets the value of [parent][crate::model::document::Revision::parent].
         #[deprecated]
         pub fn set_parent<T, V>(mut self, v: T) -> Self
@@ -4261,6 +4241,26 @@ pub mod document {
         {
             use std::iter::Iterator;
             self.parent_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [create_time][crate::model::document::Revision::create_time].
+        pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.create_time = v.into();
+            self
+        }
+
+        /// Sets the value of [human_review][crate::model::document::Revision::human_review].
+        pub fn set_human_review<
+            T: std::convert::Into<std::option::Option<crate::model::document::revision::HumanReview>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.human_review = v.into();
             self
         }
 
@@ -4289,6 +4289,18 @@ pub mod document {
             })
         }
 
+        /// Sets the value of [source][crate::model::document::Revision::source]
+        /// to hold a `Agent`.
+        ///
+        /// Note that all the setters affecting `source` are
+        /// mutually exclusive.
+        pub fn set_agent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.source = std::option::Option::Some(
+                crate::model::document::revision::Source::Agent(v.into()),
+            );
+            self
+        }
+
         /// The value of [source][crate::model::document::Revision::source]
         /// if it holds a `Processor`, `None` if the field is not set or
         /// holds a different branch.
@@ -4300,18 +4312,6 @@ pub mod document {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::document::Revision::source]
-        /// to hold a `Agent`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_agent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::document::revision::Source::Agent(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [source][crate::model::document::Revision::source]
@@ -4611,6 +4611,20 @@ pub mod document {
                 })
             }
 
+            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
+            /// to hold a `TextBlock`.
+            ///
+            /// Note that all the setters affecting `block` are
+            /// mutually exclusive.
+            pub fn set_text_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutTextBlock>>>(mut self, v: T) -> Self{
+                self.block = std::option::Option::Some(
+                    crate::model::document::document_layout::document_layout_block::Block::TextBlock(
+                        v.into()
+                    )
+                );
+                self
+            }
+
             /// The value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
             /// if it holds a `TableBlock`, `None` if the field is not set or
             /// holds a different branch.
@@ -4620,6 +4634,20 @@ pub mod document {
                     crate::model::document::document_layout::document_layout_block::Block::TableBlock(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
+            }
+
+            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
+            /// to hold a `TableBlock`.
+            ///
+            /// Note that all the setters affecting `block` are
+            /// mutually exclusive.
+            pub fn set_table_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutTableBlock>>>(mut self, v: T) -> Self{
+                self.block = std::option::Option::Some(
+                    crate::model::document::document_layout::document_layout_block::Block::TableBlock(
+                        v.into()
+                    )
+                );
+                self
             }
 
             /// The value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
@@ -4637,34 +4665,6 @@ pub mod document {
                     crate::model::document::document_layout::document_layout_block::Block::ListBlock(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
-            /// to hold a `TextBlock`.
-            ///
-            /// Note that all the setters affecting `block` are
-            /// mutually exclusive.
-            pub fn set_text_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutTextBlock>>>(mut self, v: T) -> Self{
-                self.block = std::option::Option::Some(
-                    crate::model::document::document_layout::document_layout_block::Block::TextBlock(
-                        v.into()
-                    )
-                );
-                self
-            }
-
-            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
-            /// to hold a `TableBlock`.
-            ///
-            /// Note that all the setters affecting `block` are
-            /// mutually exclusive.
-            pub fn set_table_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutTableBlock>>>(mut self, v: T) -> Self{
-                self.block = std::option::Option::Some(
-                    crate::model::document::document_layout::document_layout_block::Block::TableBlock(
-                        v.into()
-                    )
-                );
-                self
             }
 
             /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
@@ -4836,15 +4836,6 @@ pub mod document {
                     std::default::Default::default()
                 }
 
-                /// Sets the value of [caption][crate::model::document::document_layout::document_layout_block::LayoutTableBlock::caption].
-                pub fn set_caption<T: std::convert::Into<std::string::String>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.caption = v.into();
-                    self
-                }
-
                 /// Sets the value of [header_rows][crate::model::document::document_layout::document_layout_block::LayoutTableBlock::header_rows].
                 pub fn set_header_rows<T, V>(mut self, v: T) -> Self
                 where
@@ -4864,6 +4855,15 @@ pub mod document {
                 {
                     use std::iter::Iterator;
                     self.body_rows = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [caption][crate::model::document::document_layout::document_layout_block::LayoutTableBlock::caption].
+                pub fn set_caption<T: std::convert::Into<std::string::String>>(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.caption = v.into();
                     self
                 }
             }
@@ -4942,18 +4942,6 @@ pub mod document {
                     std::default::Default::default()
                 }
 
-                /// Sets the value of [row_span][crate::model::document::document_layout::document_layout_block::LayoutTableCell::row_span].
-                pub fn set_row_span<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                    self.row_span = v.into();
-                    self
-                }
-
-                /// Sets the value of [col_span][crate::model::document::document_layout::document_layout_block::LayoutTableCell::col_span].
-                pub fn set_col_span<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                    self.col_span = v.into();
-                    self
-                }
-
                 /// Sets the value of [blocks][crate::model::document::document_layout::document_layout_block::LayoutTableCell::blocks].
                 pub fn set_blocks<T, V>(mut self, v: T) -> Self
                 where
@@ -4964,6 +4952,18 @@ pub mod document {
                 {
                     use std::iter::Iterator;
                     self.blocks = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [row_span][crate::model::document::document_layout::document_layout_block::LayoutTableCell::row_span].
+                pub fn set_row_span<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+                    self.row_span = v.into();
+                    self
+                }
+
+                /// Sets the value of [col_span][crate::model::document::document_layout::document_layout_block::LayoutTableCell::col_span].
+                pub fn set_col_span<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+                    self.col_span = v.into();
                     self
                 }
             }
@@ -5001,15 +5001,6 @@ pub mod document {
                     std::default::Default::default()
                 }
 
-                /// Sets the value of [r#type][crate::model::document::document_layout::document_layout_block::LayoutListBlock::type].
-                pub fn set_type<T: std::convert::Into<std::string::String>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.r#type = v.into();
-                    self
-                }
-
                 /// Sets the value of [list_entries][crate::model::document::document_layout::document_layout_block::LayoutListBlock::list_entries].
                 pub fn set_list_entries<T, V>(mut self, v: T) -> Self
                 where
@@ -5018,6 +5009,15 @@ pub mod document {
                 {
                     use std::iter::Iterator;
                     self.list_entries = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [r#type][crate::model::document::document_layout::document_layout_block::LayoutListBlock::type].
+                pub fn set_type<T: std::convert::Into<std::string::String>>(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.r#type = v.into();
                     self
                 }
             }
@@ -5176,6 +5176,17 @@ pub mod document {
                 self
             }
 
+            /// Sets the value of [source_block_ids][crate::model::document::chunked_document::Chunk::source_block_ids].
+            pub fn set_source_block_ids<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.source_block_ids = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [content][crate::model::document::chunked_document::Chunk::content].
             pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
                 self.content = v.into();
@@ -5194,17 +5205,6 @@ pub mod document {
                 v: T,
             ) -> Self {
                 self.page_span = v.into();
-                self
-            }
-
-            /// Sets the value of [source_block_ids][crate::model::document::chunked_document::Chunk::source_block_ids].
-            pub fn set_source_block_ids<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.source_block_ids = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -5637,21 +5637,6 @@ impl BatchDocumentsInputConfig {
         })
     }
 
-    /// The value of [source][crate::model::BatchDocumentsInputConfig::source]
-    /// if it holds a `GcsDocuments`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_documents(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsDocuments>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::batch_documents_input_config::Source::GcsDocuments(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::BatchDocumentsInputConfig::source]
     /// to hold a `GcsPrefix`.
     ///
@@ -5665,6 +5650,21 @@ impl BatchDocumentsInputConfig {
             crate::model::batch_documents_input_config::Source::GcsPrefix(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::BatchDocumentsInputConfig::source]
+    /// if it holds a `GcsDocuments`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_documents(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsDocuments>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::batch_documents_input_config::Source::GcsDocuments(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::BatchDocumentsInputConfig::source]
@@ -5998,6 +5998,17 @@ impl OcrConfig {
         self
     }
 
+    /// Sets the value of [advanced_ocr_options][crate::model::OcrConfig::advanced_ocr_options].
+    pub fn set_advanced_ocr_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.advanced_ocr_options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [enable_symbol][crate::model::OcrConfig::enable_symbol].
     pub fn set_enable_symbol<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_symbol = v.into();
@@ -6028,17 +6039,6 @@ impl OcrConfig {
         v: T,
     ) -> Self {
         self.premium_features = v.into();
-        self
-    }
-
-    /// Sets the value of [advanced_ocr_options][crate::model::OcrConfig::advanced_ocr_options].
-    pub fn set_advanced_ocr_options<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.advanced_ocr_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6262,28 +6262,6 @@ impl ProcessOptions {
         })
     }
 
-    /// The value of [page_range][crate::model::ProcessOptions::page_range]
-    /// if it holds a `FromStart`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn from_start(&self) -> std::option::Option<&i32> {
-        #[allow(unreachable_patterns)]
-        self.page_range.as_ref().and_then(|v| match v {
-            crate::model::process_options::PageRange::FromStart(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [page_range][crate::model::ProcessOptions::page_range]
-    /// if it holds a `FromEnd`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn from_end(&self) -> std::option::Option<&i32> {
-        #[allow(unreachable_patterns)]
-        self.page_range.as_ref().and_then(|v| match v {
-            crate::model::process_options::PageRange::FromEnd(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [page_range][crate::model::ProcessOptions::page_range]
     /// to hold a `IndividualPageSelector`.
     ///
@@ -6301,6 +6279,17 @@ impl ProcessOptions {
         self
     }
 
+    /// The value of [page_range][crate::model::ProcessOptions::page_range]
+    /// if it holds a `FromStart`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn from_start(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.page_range.as_ref().and_then(|v| match v {
+            crate::model::process_options::PageRange::FromStart(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [page_range][crate::model::ProcessOptions::page_range]
     /// to hold a `FromStart`.
     ///
@@ -6311,6 +6300,17 @@ impl ProcessOptions {
             crate::model::process_options::PageRange::FromStart(v.into()),
         );
         self
+    }
+
+    /// The value of [page_range][crate::model::ProcessOptions::page_range]
+    /// if it holds a `FromEnd`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn from_end(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.page_range.as_ref().and_then(|v| match v {
+            crate::model::process_options::PageRange::FromEnd(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [page_range][crate::model::ProcessOptions::page_range]
@@ -6617,12 +6617,6 @@ impl ProcessRequest {
         self
     }
 
-    /// Sets the value of [imageless_mode][crate::model::ProcessRequest::imageless_mode].
-    pub fn set_imageless_mode<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.imageless_mode = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::ProcessRequest::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6632,6 +6626,12 @@ impl ProcessRequest {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [imageless_mode][crate::model::ProcessRequest::imageless_mode].
+    pub fn set_imageless_mode<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.imageless_mode = v.into();
         self
     }
 
@@ -6662,28 +6662,6 @@ impl ProcessRequest {
         })
     }
 
-    /// The value of [source][crate::model::ProcessRequest::source]
-    /// if it holds a `RawDocument`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn raw_document(&self) -> std::option::Option<&std::boxed::Box<crate::model::RawDocument>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::process_request::Source::RawDocument(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ProcessRequest::source]
-    /// if it holds a `GcsDocument`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_document(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsDocument>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::process_request::Source::GcsDocument(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ProcessRequest::source]
     /// to hold a `InlineDocument`.
     ///
@@ -6699,6 +6677,17 @@ impl ProcessRequest {
         self
     }
 
+    /// The value of [source][crate::model::ProcessRequest::source]
+    /// if it holds a `RawDocument`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn raw_document(&self) -> std::option::Option<&std::boxed::Box<crate::model::RawDocument>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::process_request::Source::RawDocument(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ProcessRequest::source]
     /// to hold a `RawDocument`.
     ///
@@ -6711,6 +6700,17 @@ impl ProcessRequest {
         self.source =
             std::option::Option::Some(crate::model::process_request::Source::RawDocument(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::ProcessRequest::source]
+    /// if it holds a `GcsDocument`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_document(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsDocument>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::process_request::Source::GcsDocument(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ProcessRequest::source]
@@ -7690,12 +7690,6 @@ impl ListProcessorTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProcessorTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [processor_types][crate::model::ListProcessorTypesResponse::processor_types].
     pub fn set_processor_types<T, V>(mut self, v: T) -> Self
     where
@@ -7704,6 +7698,12 @@ impl ListProcessorTypesResponse {
     {
         use std::iter::Iterator;
         self.processor_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProcessorTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7811,12 +7811,6 @@ impl ListProcessorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProcessorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [processors][crate::model::ListProcessorsResponse::processors].
     pub fn set_processors<T, V>(mut self, v: T) -> Self
     where
@@ -7825,6 +7819,12 @@ impl ListProcessorsResponse {
     {
         use std::iter::Iterator;
         self.processors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProcessorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8041,12 +8041,6 @@ impl ListProcessorVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProcessorVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [processor_versions][crate::model::ListProcessorVersionsResponse::processor_versions].
     pub fn set_processor_versions<T, V>(mut self, v: T) -> Self
     where
@@ -8055,6 +8049,12 @@ impl ListProcessorVersionsResponse {
     {
         use std::iter::Iterator;
         self.processor_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProcessorVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8965,23 +8965,6 @@ impl TrainProcessorVersionRequest {
         })
     }
 
-    /// The value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
-    /// if it holds a `FoundationModelTuningOptions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn foundation_model_tuning_options(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<
-            crate::model::train_processor_version_request::FoundationModelTuningOptions,
-        >,
-    > {
-        #[allow(unreachable_patterns)]
-        self.processor_flags.as_ref().and_then(|v| match v {
-            crate::model::train_processor_version_request::ProcessorFlags::FoundationModelTuningOptions(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
     /// to hold a `CustomDocumentExtractionOptions`.
     ///
@@ -9003,6 +8986,23 @@ impl TrainProcessorVersionRequest {
             )
         );
         self
+    }
+
+    /// The value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
+    /// if it holds a `FoundationModelTuningOptions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn foundation_model_tuning_options(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<
+            crate::model::train_processor_version_request::FoundationModelTuningOptions,
+        >,
+    > {
+        #[allow(unreachable_patterns)]
+        self.processor_flags.as_ref().and_then(|v| match v {
+            crate::model::train_processor_version_request::ProcessorFlags::FoundationModelTuningOptions(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
@@ -10304,12 +10304,6 @@ impl ListEvaluationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEvaluationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [evaluations][crate::model::ListEvaluationsResponse::evaluations].
     pub fn set_evaluations<T, V>(mut self, v: T) -> Self
     where
@@ -10318,6 +10312,12 @@ impl ListEvaluationsResponse {
     {
         use std::iter::Iterator;
         self.evaluations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEvaluationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10385,17 +10385,6 @@ impl DocumentSchema {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::DocumentSchema::metadata].
-    pub fn set_metadata<
-        T: std::convert::Into<std::option::Option<crate::model::document_schema::Metadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [entity_types][crate::model::DocumentSchema::entity_types].
     pub fn set_entity_types<T, V>(mut self, v: T) -> Self
     where
@@ -10404,6 +10393,17 @@ impl DocumentSchema {
     {
         use std::iter::Iterator;
         self.entity_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::DocumentSchema::metadata].
+    pub fn set_metadata<
+        T: std::convert::Into<std::option::Option<crate::model::document_schema::Metadata>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -11095,6 +11095,18 @@ impl Evaluation {
         self
     }
 
+    /// Sets the value of [entity_metrics][crate::model::Evaluation::entity_metrics].
+    pub fn set_entity_metrics<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::evaluation::MultiConfidenceMetrics>,
+    {
+        use std::iter::Iterator;
+        self.entity_metrics = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [kms_key_name][crate::model::Evaluation::kms_key_name].
     pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kms_key_name = v.into();
@@ -11107,18 +11119,6 @@ impl Evaluation {
         v: T,
     ) -> Self {
         self.kms_key_version_name = v.into();
-        self
-    }
-
-    /// Sets the value of [entity_metrics][crate::model::Evaluation::entity_metrics].
-    pub fn set_entity_metrics<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::evaluation::MultiConfidenceMetrics>,
-    {
-        use std::iter::Iterator;
-        self.entity_metrics = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -11428,6 +11428,28 @@ pub mod evaluation {
             std::default::Default::default()
         }
 
+        /// Sets the value of [confidence_level_metrics][crate::model::evaluation::MultiConfidenceMetrics::confidence_level_metrics].
+        pub fn set_confidence_level_metrics<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::evaluation::ConfidenceLevelMetrics>,
+        {
+            use std::iter::Iterator;
+            self.confidence_level_metrics = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [confidence_level_metrics_exact][crate::model::evaluation::MultiConfidenceMetrics::confidence_level_metrics_exact].
+        pub fn set_confidence_level_metrics_exact<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::evaluation::ConfidenceLevelMetrics>,
+        {
+            use std::iter::Iterator;
+            self.confidence_level_metrics_exact = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [auprc][crate::model::evaluation::MultiConfidenceMetrics::auprc].
         pub fn set_auprc<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
             self.auprc = v.into();
@@ -11463,28 +11485,6 @@ pub mod evaluation {
             v: T,
         ) -> Self {
             self.metrics_type = v.into();
-            self
-        }
-
-        /// Sets the value of [confidence_level_metrics][crate::model::evaluation::MultiConfidenceMetrics::confidence_level_metrics].
-        pub fn set_confidence_level_metrics<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::evaluation::ConfidenceLevelMetrics>,
-        {
-            use std::iter::Iterator;
-            self.confidence_level_metrics = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [confidence_level_metrics_exact][crate::model::evaluation::MultiConfidenceMetrics::confidence_level_metrics_exact].
-        pub fn set_confidence_level_metrics_exact<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::evaluation::ConfidenceLevelMetrics>,
-        {
-            use std::iter::Iterator;
-            self.confidence_level_metrics_exact = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -12321,6 +12321,20 @@ pub mod processor_version {
             })
         }
 
+        /// Sets the value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
+        /// to hold a `FoundationGenAiModelInfo`.
+        ///
+        /// Note that all the setters affecting `model_info` are
+        /// mutually exclusive.
+        pub fn set_foundation_gen_ai_model_info<T: std::convert::Into<std::boxed::Box<crate::model::processor_version::gen_ai_model_info::FoundationGenAiModelInfo>>>(mut self, v: T) -> Self{
+            self.model_info = std::option::Option::Some(
+                crate::model::processor_version::gen_ai_model_info::ModelInfo::FoundationGenAiModelInfo(
+                    v.into()
+                )
+            );
+            self
+        }
+
         /// The value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
         /// if it holds a `CustomGenAiModelInfo`, `None` if the field is not set or
         /// holds a different branch.
@@ -12336,20 +12350,6 @@ pub mod processor_version {
                 crate::model::processor_version::gen_ai_model_info::ModelInfo::CustomGenAiModelInfo(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
-        /// to hold a `FoundationGenAiModelInfo`.
-        ///
-        /// Note that all the setters affecting `model_info` are
-        /// mutually exclusive.
-        pub fn set_foundation_gen_ai_model_info<T: std::convert::Into<std::boxed::Box<crate::model::processor_version::gen_ai_model_info::FoundationGenAiModelInfo>>>(mut self, v: T) -> Self{
-            self.model_info = std::option::Option::Some(
-                crate::model::processor_version::gen_ai_model_info::ModelInfo::FoundationGenAiModelInfo(
-                    v.into()
-                )
-            );
-            self
         }
 
         /// Sets the value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
@@ -13100,6 +13100,17 @@ impl Processor {
         self
     }
 
+    /// Sets the value of [processor_version_aliases][crate::model::Processor::processor_version_aliases].
+    pub fn set_processor_version_aliases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ProcessorVersionAlias>,
+    {
+        use std::iter::Iterator;
+        self.processor_version_aliases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [process_endpoint][crate::model::Processor::process_endpoint].
     pub fn set_process_endpoint<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -13133,17 +13144,6 @@ impl Processor {
     /// Sets the value of [satisfies_pzi][crate::model::Processor::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [processor_version_aliases][crate::model::Processor::processor_version_aliases].
-    pub fn set_processor_version_aliases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ProcessorVersionAlias>,
-    {
-        use std::iter::Iterator;
-        self.processor_version_aliases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13399,6 +13399,17 @@ impl ProcessorType {
         self
     }
 
+    /// Sets the value of [available_locations][crate::model::ProcessorType::available_locations].
+    pub fn set_available_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::processor_type::LocationInfo>,
+    {
+        use std::iter::Iterator;
+        self.available_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [allow_creation][crate::model::ProcessorType::allow_creation].
     pub fn set_allow_creation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_creation = v.into();
@@ -13411,17 +13422,6 @@ impl ProcessorType {
         v: T,
     ) -> Self {
         self.launch_stage = v.into();
-        self
-    }
-
-    /// Sets the value of [available_locations][crate::model::ProcessorType::available_locations].
-    pub fn set_available_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::processor_type::LocationInfo>,
-    {
-        use std::iter::Iterator;
-        self.available_locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 

--- a/src/generated/cloud/domains/v1/src/builder.rs
+++ b/src/generated/cloud/domains/v1/src/builder.rs
@@ -263,23 +263,6 @@ pub mod domains {
             self
         }
 
-        /// Sets the value of [yearly_price][crate::model::RegisterDomainRequest::yearly_price].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_yearly_price<T: Into<std::option::Option<gtype::model::Money>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.yearly_price = v.into();
-            self
-        }
-
-        /// Sets the value of [validate_only][crate::model::RegisterDomainRequest::validate_only].
-        pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.validate_only = v.into();
-            self
-        }
-
         /// Sets the value of [domain_notices][crate::model::RegisterDomainRequest::domain_notices].
         pub fn set_domain_notices<T, V>(mut self, v: T) -> Self
         where
@@ -299,6 +282,23 @@ pub mod domains {
         {
             use std::iter::Iterator;
             self.0.request.contact_notices = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [yearly_price][crate::model::RegisterDomainRequest::yearly_price].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_yearly_price<T: Into<std::option::Option<gtype::model::Money>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.yearly_price = v.into();
+            self
+        }
+
+        /// Sets the value of [validate_only][crate::model::RegisterDomainRequest::validate_only].
+        pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.validate_only = v.into();
             self
         }
     }
@@ -454,6 +454,17 @@ pub mod domains {
             self
         }
 
+        /// Sets the value of [contact_notices][crate::model::TransferDomainRequest::contact_notices].
+        pub fn set_contact_notices<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ContactNotice>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contact_notices = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [yearly_price][crate::model::TransferDomainRequest::yearly_price].
         ///
         /// This is a **required** field for requests.
@@ -479,17 +490,6 @@ pub mod domains {
         /// Sets the value of [validate_only][crate::model::TransferDomainRequest::validate_only].
         pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.validate_only = v.into();
-            self
-        }
-
-        /// Sets the value of [contact_notices][crate::model::TransferDomainRequest::contact_notices].
-        pub fn set_contact_notices<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::ContactNotice>,
-        {
-            use std::iter::Iterator;
-            self.0.request.contact_notices = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1047,12 +1047,6 @@ pub mod domains {
             self
         }
 
-        /// Sets the value of [validate_only][crate::model::ConfigureContactSettingsRequest::validate_only].
-        pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.validate_only = v.into();
-            self
-        }
-
         /// Sets the value of [contact_notices][crate::model::ConfigureContactSettingsRequest::contact_notices].
         pub fn set_contact_notices<T, V>(mut self, v: T) -> Self
         where
@@ -1061,6 +1055,12 @@ pub mod domains {
         {
             use std::iter::Iterator;
             self.0.request.contact_notices = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [validate_only][crate::model::ConfigureContactSettingsRequest::validate_only].
+        pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.validate_only = v.into();
             self
         }
     }

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -164,6 +164,29 @@ impl Registration {
         self
     }
 
+    /// Sets the value of [issues][crate::model::Registration::issues].
+    pub fn set_issues<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::registration::Issue>,
+    {
+        use std::iter::Iterator;
+        self.issues = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Registration::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [management_settings][crate::model::Registration::management_settings].
     pub fn set_management_settings<
         T: std::convert::Into<std::option::Option<crate::model::ManagementSettings>>,
@@ -208,17 +231,6 @@ impl Registration {
         self
     }
 
-    /// Sets the value of [issues][crate::model::Registration::issues].
-    pub fn set_issues<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::registration::Issue>,
-    {
-        use std::iter::Iterator;
-        self.issues = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [supported_privacy][crate::model::Registration::supported_privacy].
     pub fn set_supported_privacy<T, V>(mut self, v: T) -> Self
     where
@@ -227,18 +239,6 @@ impl Registration {
     {
         use std::iter::Iterator;
         self.supported_privacy = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Registration::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -826,21 +826,6 @@ impl DnsSettings {
         })
     }
 
-    /// The value of [dns_provider][crate::model::DnsSettings::dns_provider]
-    /// if it holds a `GoogleDomainsDns`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn google_domains_dns(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::dns_settings::GoogleDomainsDns>> {
-        #[allow(unreachable_patterns)]
-        self.dns_provider.as_ref().and_then(|v| match v {
-            crate::model::dns_settings::DnsProvider::GoogleDomainsDns(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [dns_provider][crate::model::DnsSettings::dns_provider]
     /// to hold a `CustomDns`.
     ///
@@ -855,6 +840,21 @@ impl DnsSettings {
         self.dns_provider =
             std::option::Option::Some(crate::model::dns_settings::DnsProvider::CustomDns(v.into()));
         self
+    }
+
+    /// The value of [dns_provider][crate::model::DnsSettings::dns_provider]
+    /// if it holds a `GoogleDomainsDns`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn google_domains_dns(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::dns_settings::GoogleDomainsDns>> {
+        #[allow(unreachable_patterns)]
+        self.dns_provider.as_ref().and_then(|v| match v {
+            crate::model::dns_settings::DnsProvider::GoogleDomainsDns(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [dns_provider][crate::model::DnsSettings::dns_provider]
@@ -977,15 +977,6 @@ pub mod dns_settings {
             std::default::Default::default()
         }
 
-        /// Sets the value of [ds_state][crate::model::dns_settings::GoogleDomainsDns::ds_state].
-        pub fn set_ds_state<T: std::convert::Into<crate::model::dns_settings::DsState>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ds_state = v.into();
-            self
-        }
-
         /// Sets the value of [name_servers][crate::model::dns_settings::GoogleDomainsDns::name_servers].
         pub fn set_name_servers<T, V>(mut self, v: T) -> Self
         where
@@ -994,6 +985,15 @@ pub mod dns_settings {
         {
             use std::iter::Iterator;
             self.name_servers = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [ds_state][crate::model::dns_settings::GoogleDomainsDns::ds_state].
+        pub fn set_ds_state<T: std::convert::Into<crate::model::dns_settings::DsState>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.ds_state = v.into();
             self
         }
 
@@ -2094,21 +2094,6 @@ impl RegisterDomainRequest {
         self
     }
 
-    /// Sets the value of [yearly_price][crate::model::RegisterDomainRequest::yearly_price].
-    pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.yearly_price = v.into();
-        self
-    }
-
-    /// Sets the value of [validate_only][crate::model::RegisterDomainRequest::validate_only].
-    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.validate_only = v.into();
-        self
-    }
-
     /// Sets the value of [domain_notices][crate::model::RegisterDomainRequest::domain_notices].
     pub fn set_domain_notices<T, V>(mut self, v: T) -> Self
     where
@@ -2128,6 +2113,21 @@ impl RegisterDomainRequest {
     {
         use std::iter::Iterator;
         self.contact_notices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [yearly_price][crate::model::RegisterDomainRequest::yearly_price].
+    pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.yearly_price = v.into();
+        self
+    }
+
+    /// Sets the value of [validate_only][crate::model::RegisterDomainRequest::validate_only].
+    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.validate_only = v.into();
         self
     }
 }
@@ -2285,6 +2285,17 @@ impl TransferDomainRequest {
         self
     }
 
+    /// Sets the value of [contact_notices][crate::model::TransferDomainRequest::contact_notices].
+    pub fn set_contact_notices<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ContactNotice>,
+    {
+        use std::iter::Iterator;
+        self.contact_notices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [yearly_price][crate::model::TransferDomainRequest::yearly_price].
     pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
         mut self,
@@ -2308,17 +2319,6 @@ impl TransferDomainRequest {
     /// Sets the value of [validate_only][crate::model::TransferDomainRequest::validate_only].
     pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.validate_only = v.into();
-        self
-    }
-
-    /// Sets the value of [contact_notices][crate::model::TransferDomainRequest::contact_notices].
-    pub fn set_contact_notices<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ContactNotice>,
-    {
-        use std::iter::Iterator;
-        self.contact_notices = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2432,12 +2432,6 @@ impl ListRegistrationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRegistrationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [registrations][crate::model::ListRegistrationsResponse::registrations].
     pub fn set_registrations<T, V>(mut self, v: T) -> Self
     where
@@ -2446,6 +2440,12 @@ impl ListRegistrationsResponse {
     {
         use std::iter::Iterator;
         self.registrations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRegistrationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2762,12 +2762,6 @@ impl ConfigureContactSettingsRequest {
         self
     }
 
-    /// Sets the value of [validate_only][crate::model::ConfigureContactSettingsRequest::validate_only].
-    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.validate_only = v.into();
-        self
-    }
-
     /// Sets the value of [contact_notices][crate::model::ConfigureContactSettingsRequest::contact_notices].
     pub fn set_contact_notices<T, V>(mut self, v: T) -> Self
     where
@@ -2776,6 +2770,12 @@ impl ConfigureContactSettingsRequest {
     {
         use std::iter::Iterator;
         self.contact_notices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [validate_only][crate::model::ConfigureContactSettingsRequest::validate_only].
+    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.validate_only = v.into();
         self
     }
 }
@@ -2971,15 +2971,6 @@ impl RegisterParameters {
         self
     }
 
-    /// Sets the value of [yearly_price][crate::model::RegisterParameters::yearly_price].
-    pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.yearly_price = v.into();
-        self
-    }
-
     /// Sets the value of [supported_privacy][crate::model::RegisterParameters::supported_privacy].
     pub fn set_supported_privacy<T, V>(mut self, v: T) -> Self
     where
@@ -2999,6 +2990,15 @@ impl RegisterParameters {
     {
         use std::iter::Iterator;
         self.domain_notices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [yearly_price][crate::model::RegisterParameters::yearly_price].
+    pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.yearly_price = v.into();
         self
     }
 }
@@ -3219,24 +3219,6 @@ impl TransferParameters {
         self
     }
 
-    /// Sets the value of [transfer_lock_state][crate::model::TransferParameters::transfer_lock_state].
-    pub fn set_transfer_lock_state<T: std::convert::Into<crate::model::TransferLockState>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transfer_lock_state = v.into();
-        self
-    }
-
-    /// Sets the value of [yearly_price][crate::model::TransferParameters::yearly_price].
-    pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.yearly_price = v.into();
-        self
-    }
-
     /// Sets the value of [name_servers][crate::model::TransferParameters::name_servers].
     pub fn set_name_servers<T, V>(mut self, v: T) -> Self
     where
@@ -3248,6 +3230,15 @@ impl TransferParameters {
         self
     }
 
+    /// Sets the value of [transfer_lock_state][crate::model::TransferParameters::transfer_lock_state].
+    pub fn set_transfer_lock_state<T: std::convert::Into<crate::model::TransferLockState>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.transfer_lock_state = v.into();
+        self
+    }
+
     /// Sets the value of [supported_privacy][crate::model::TransferParameters::supported_privacy].
     pub fn set_supported_privacy<T, V>(mut self, v: T) -> Self
     where
@@ -3256,6 +3247,15 @@ impl TransferParameters {
     {
         use std::iter::Iterator;
         self.supported_privacy = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [yearly_price][crate::model::TransferParameters::yearly_price].
+    pub fn set_yearly_price<T: std::convert::Into<std::option::Option<gtype::model::Money>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.yearly_price = v.into();
         self
     }
 }

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -182,6 +182,18 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Cluster::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [fleet][crate::model::Cluster::fleet].
     pub fn set_fleet<T: std::convert::Into<std::option::Option<crate::model::Fleet>>>(
         mut self,
@@ -288,6 +300,17 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [external_load_balancer_ipv4_address_pools][crate::model::Cluster::external_load_balancer_ipv4_address_pools].
+    pub fn set_external_load_balancer_ipv4_address_pools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.external_load_balancer_ipv4_address_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [control_plane_encryption][crate::model::Cluster::control_plane_encryption].
     pub fn set_control_plane_encryption<
         T: std::convert::Into<std::option::Option<crate::model::cluster::ControlPlaneEncryption>>,
@@ -305,6 +328,17 @@ impl Cluster {
         v: T,
     ) -> Self {
         self.status = v.into();
+        self
+    }
+
+    /// Sets the value of [maintenance_events][crate::model::Cluster::maintenance_events].
+    pub fn set_maintenance_events<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::cluster::MaintenanceEvent>,
+    {
+        use std::iter::Iterator;
+        self.maintenance_events = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -334,39 +368,6 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of [connection_state][crate::model::Cluster::connection_state].
-    pub fn set_connection_state<
-        T: std::convert::Into<std::option::Option<crate::model::cluster::ConnectionState>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_state = v.into();
-        self
-    }
-
-    /// Sets the value of [external_load_balancer_ipv4_address_pools][crate::model::Cluster::external_load_balancer_ipv4_address_pools].
-    pub fn set_external_load_balancer_ipv4_address_pools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.external_load_balancer_ipv4_address_pools = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [maintenance_events][crate::model::Cluster::maintenance_events].
-    pub fn set_maintenance_events<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::cluster::MaintenanceEvent>,
-    {
-        use std::iter::Iterator;
-        self.maintenance_events = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [external_load_balancer_ipv6_address_pools][crate::model::Cluster::external_load_balancer_ipv6_address_pools].
     pub fn set_external_load_balancer_ipv6_address_pools<T, V>(mut self, v: T) -> Self
     where
@@ -378,15 +379,14 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Cluster::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [connection_state][crate::model::Cluster::connection_state].
+    pub fn set_connection_state<
+        T: std::convert::Into<std::option::Option<crate::model::cluster::ConnectionState>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connection_state = v.into();
         self
     }
 }
@@ -450,22 +450,6 @@ pub mod cluster {
             })
         }
 
-        /// The value of [config][crate::model::cluster::ControlPlane::config]
-        /// if it holds a `Local`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn local(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::cluster::control_plane::Local>>
-        {
-            #[allow(unreachable_patterns)]
-            self.config.as_ref().and_then(|v| match v {
-                crate::model::cluster::control_plane::Config::Local(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [config][crate::model::cluster::ControlPlane::config]
         /// to hold a `Remote`.
         ///
@@ -481,6 +465,22 @@ pub mod cluster {
                 crate::model::cluster::control_plane::Config::Remote(v.into()),
             );
             self
+        }
+
+        /// The value of [config][crate::model::cluster::ControlPlane::config]
+        /// if it holds a `Local`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn local(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::cluster::control_plane::Local>>
+        {
+            #[allow(unreachable_patterns)]
+            self.config.as_ref().and_then(|v| match v {
+                crate::model::cluster::control_plane::Config::Local(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [config][crate::model::cluster::ControlPlane::config]
@@ -2381,6 +2381,18 @@ impl NodePool {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NodePool::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [node_location][crate::model::NodePool::node_location].
     pub fn set_node_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.node_location = v.into();
@@ -2424,18 +2436,6 @@ impl NodePool {
         v: T,
     ) -> Self {
         self.node_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NodePool::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2570,15 +2570,6 @@ pub mod node_pool {
             std::default::Default::default()
         }
 
-        /// Sets the value of [node_storage_schema][crate::model::node_pool::NodeConfig::node_storage_schema].
-        pub fn set_node_storage_schema<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.node_storage_schema = v.into();
-            self
-        }
-
         /// Sets the value of [labels][crate::model::node_pool::NodeConfig::labels].
         pub fn set_labels<T, K, V>(mut self, v: T) -> Self
         where
@@ -2588,6 +2579,15 @@ pub mod node_pool {
         {
             use std::iter::Iterator;
             self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [node_storage_schema][crate::model::node_pool::NodeConfig::node_storage_schema].
+        pub fn set_node_storage_schema<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.node_storage_schema = v.into();
             self
         }
     }
@@ -2679,6 +2679,18 @@ impl Machine {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Machine::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [hosted_node][crate::model::Machine::hosted_node].
     pub fn set_hosted_node<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.hosted_node = v.into();
@@ -2700,18 +2712,6 @@ impl Machine {
     /// Sets the value of [disabled][crate::model::Machine::disabled].
     pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disabled = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Machine::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2814,6 +2814,18 @@ impl VpnConnection {
         self
     }
 
+    /// Sets the value of [labels][crate::model::VpnConnection::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [nat_gateway_ip][crate::model::VpnConnection::nat_gateway_ip].
     pub fn set_nat_gateway_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.nat_gateway_ip = v.into();
@@ -2875,18 +2887,6 @@ impl VpnConnection {
         v: T,
     ) -> Self {
         self.details = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::VpnConnection::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3441,15 +3441,6 @@ impl ZoneMetadata {
         std::default::Default::default()
     }
 
-    /// Sets the value of [config_data][crate::model::ZoneMetadata::config_data].
-    pub fn set_config_data<T: std::convert::Into<std::option::Option<crate::model::ConfigData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config_data = v.into();
-        self
-    }
-
     /// Sets the value of [quota][crate::model::ZoneMetadata::quota].
     pub fn set_quota<T, V>(mut self, v: T) -> Self
     where
@@ -3470,6 +3461,15 @@ impl ZoneMetadata {
     {
         use std::iter::Iterator;
         self.rack_types = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [config_data][crate::model::ZoneMetadata::config_data].
+    pub fn set_config_data<T: std::convert::Into<std::option::Option<crate::model::ConfigData>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.config_data = v.into();
         self
     }
 }
@@ -3984,9 +3984,15 @@ impl ServerConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [default_version][crate::model::ServerConfig::default_version].
-    pub fn set_default_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.default_version = v.into();
+    /// Sets the value of [channels][crate::model::ServerConfig::channels].
+    pub fn set_channels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ChannelConfig>,
+    {
+        use std::iter::Iterator;
+        self.channels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -4001,15 +4007,9 @@ impl ServerConfig {
         self
     }
 
-    /// Sets the value of [channels][crate::model::ServerConfig::channels].
-    pub fn set_channels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::ChannelConfig>,
-    {
-        use std::iter::Iterator;
-        self.channels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [default_version][crate::model::ServerConfig::default_version].
+    pub fn set_default_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.default_version = v.into();
         self
     }
 }
@@ -4188,17 +4188,6 @@ impl OperationMetadata {
         self
     }
 
-    /// Sets the value of [status_reason][crate::model::OperationMetadata::status_reason].
-    pub fn set_status_reason<
-        T: std::convert::Into<crate::model::operation_metadata::StatusReason>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.status_reason = v.into();
-        self
-    }
-
     /// Sets the value of [warnings][crate::model::OperationMetadata::warnings].
     pub fn set_warnings<T, V>(mut self, v: T) -> Self
     where
@@ -4207,6 +4196,17 @@ impl OperationMetadata {
     {
         use std::iter::Iterator;
         self.warnings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [status_reason][crate::model::OperationMetadata::status_reason].
+    pub fn set_status_reason<
+        T: std::convert::Into<crate::model::operation_metadata::StatusReason>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.status_reason = v.into();
         self
     }
 }
@@ -4448,12 +4448,6 @@ impl ListClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
     pub fn set_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -4462,6 +4456,12 @@ impl ListClustersResponse {
     {
         use std::iter::Iterator;
         self.clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5179,12 +5179,6 @@ impl ListNodePoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNodePoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [node_pools][crate::model::ListNodePoolsResponse::node_pools].
     pub fn set_node_pools<T, V>(mut self, v: T) -> Self
     where
@@ -5193,6 +5187,12 @@ impl ListNodePoolsResponse {
     {
         use std::iter::Iterator;
         self.node_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNodePoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5534,12 +5534,6 @@ impl ListMachinesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMachinesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [machines][crate::model::ListMachinesResponse::machines].
     pub fn set_machines<T, V>(mut self, v: T) -> Self
     where
@@ -5548,6 +5542,12 @@ impl ListMachinesResponse {
     {
         use std::iter::Iterator;
         self.machines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMachinesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5715,12 +5715,6 @@ impl ListVpnConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVpnConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vpn_connections][crate::model::ListVpnConnectionsResponse::vpn_connections].
     pub fn set_vpn_connections<T, V>(mut self, v: T) -> Self
     where
@@ -5729,6 +5723,12 @@ impl ListVpnConnectionsResponse {
     {
         use std::iter::Iterator;
         self.vpn_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVpnConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/edgenetwork/v1/src/model.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/model.rs
@@ -96,13 +96,6 @@ impl Zone {
         self
     }
 
-    /// Sets the value of [layout_name][crate::model::Zone::layout_name].
-    #[deprecated]
-    pub fn set_layout_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.layout_name = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Zone::labels].
     #[deprecated]
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
@@ -113,6 +106,13 @@ impl Zone {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [layout_name][crate::model::Zone::layout_name].
+    #[deprecated]
+    pub fn set_layout_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.layout_name = v.into();
         self
     }
 }
@@ -189,18 +189,6 @@ impl Network {
         self
     }
 
-    /// Sets the value of [description][crate::model::Network::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [mtu][crate::model::Network::mtu].
-    pub fn set_mtu<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.mtu = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Network::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -210,6 +198,18 @@ impl Network {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::Network::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
+        self
+    }
+
+    /// Sets the value of [mtu][crate::model::Network::mtu].
+    pub fn set_mtu<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.mtu = v.into();
         self
     }
 }
@@ -307,6 +307,18 @@ impl Subnet {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Subnet::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Subnet::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -316,27 +328,6 @@ impl Subnet {
     /// Sets the value of [network][crate::model::Subnet::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
-        self
-    }
-
-    /// Sets the value of [vlan_id][crate::model::Subnet::vlan_id].
-    pub fn set_vlan_id<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.vlan_id = v.into();
-        self
-    }
-
-    /// Sets the value of [bonding_type][crate::model::Subnet::bonding_type].
-    pub fn set_bonding_type<T: std::convert::Into<crate::model::subnet::BondingType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bonding_type = v.into();
-        self
-    }
-
-    /// Sets the value of [state][crate::model::Subnet::state].
-    pub fn set_state<T: std::convert::Into<crate::model::ResourceState>>(mut self, v: T) -> Self {
-        self.state = v.into();
         self
     }
 
@@ -362,15 +353,24 @@ impl Subnet {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Subnet::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [vlan_id][crate::model::Subnet::vlan_id].
+    pub fn set_vlan_id<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.vlan_id = v.into();
+        self
+    }
+
+    /// Sets the value of [bonding_type][crate::model::Subnet::bonding_type].
+    pub fn set_bonding_type<T: std::convert::Into<crate::model::subnet::BondingType>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.bonding_type = v.into();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Subnet::state].
+    pub fn set_state<T: std::convert::Into<crate::model::ResourceState>>(mut self, v: T) -> Self {
+        self.state = v.into();
         self
     }
 }
@@ -600,6 +600,18 @@ impl Interconnect {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Interconnect::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Interconnect::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -640,18 +652,6 @@ impl Interconnect {
     {
         use std::iter::Iterator;
         self.physical_ports = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Interconnect::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -877,6 +877,18 @@ impl InterconnectAttachment {
         self
     }
 
+    /// Sets the value of [labels][crate::model::InterconnectAttachment::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::InterconnectAttachment::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -910,18 +922,6 @@ impl InterconnectAttachment {
     /// Sets the value of [state][crate::model::InterconnectAttachment::state].
     pub fn set_state<T: std::convert::Into<crate::model::ResourceState>>(mut self, v: T) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::InterconnectAttachment::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1018,6 +1018,18 @@ impl Router {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Router::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Router::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -1027,21 +1039,6 @@ impl Router {
     /// Sets the value of [network][crate::model::Router::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
-        self
-    }
-
-    /// Sets the value of [bgp][crate::model::Router::bgp].
-    pub fn set_bgp<T: std::convert::Into<std::option::Option<crate::model::router::Bgp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bgp = v.into();
-        self
-    }
-
-    /// Sets the value of [state][crate::model::Router::state].
-    pub fn set_state<T: std::convert::Into<crate::model::ResourceState>>(mut self, v: T) -> Self {
-        self.state = v.into();
         self
     }
 
@@ -1067,6 +1064,21 @@ impl Router {
         self
     }
 
+    /// Sets the value of [bgp][crate::model::Router::bgp].
+    pub fn set_bgp<T: std::convert::Into<std::option::Option<crate::model::router::Bgp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.bgp = v.into();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Router::state].
+    pub fn set_state<T: std::convert::Into<crate::model::ResourceState>>(mut self, v: T) -> Self {
+        self.state = v.into();
+        self
+    }
+
     /// Sets the value of [route_advertisements][crate::model::Router::route_advertisements].
     pub fn set_route_advertisements<T, V>(mut self, v: T) -> Self
     where
@@ -1075,18 +1087,6 @@ impl Router {
     {
         use std::iter::Iterator;
         self.route_advertisements = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Router::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1584,6 +1584,17 @@ pub mod interconnect_diagnostics {
             self
         }
 
+        /// Sets the value of [lldp_statuses][crate::model::interconnect_diagnostics::LinkStatus::lldp_statuses].
+        pub fn set_lldp_statuses<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::interconnect_diagnostics::LinkLLDPStatus>,
+        {
+            use std::iter::Iterator;
+            self.lldp_statuses = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [packet_counts][crate::model::interconnect_diagnostics::LinkStatus::packet_counts].
         pub fn set_packet_counts<
             T: std::convert::Into<
@@ -1594,17 +1605,6 @@ pub mod interconnect_diagnostics {
             v: T,
         ) -> Self {
             self.packet_counts = v.into();
-            self
-        }
-
-        /// Sets the value of [lldp_statuses][crate::model::interconnect_diagnostics::LinkStatus::lldp_statuses].
-        pub fn set_lldp_statuses<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::interconnect_diagnostics::LinkLLDPStatus>,
-        {
-            use std::iter::Iterator;
-            self.lldp_statuses = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2552,12 +2552,6 @@ impl ListZonesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListZonesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [zones][crate::model::ListZonesResponse::zones].
     pub fn set_zones<T, V>(mut self, v: T) -> Self
     where
@@ -2566,6 +2560,12 @@ impl ListZonesResponse {
     {
         use std::iter::Iterator;
         self.zones = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListZonesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2735,12 +2735,6 @@ impl ListNetworksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNetworksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [networks][crate::model::ListNetworksResponse::networks].
     pub fn set_networks<T, V>(mut self, v: T) -> Self
     where
@@ -2749,6 +2743,12 @@ impl ListNetworksResponse {
     {
         use std::iter::Iterator;
         self.networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNetworksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3049,12 +3049,6 @@ impl ListSubnetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSubnetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [subnets][crate::model::ListSubnetsResponse::subnets].
     pub fn set_subnets<T, V>(mut self, v: T) -> Self
     where
@@ -3063,6 +3057,12 @@ impl ListSubnetsResponse {
     {
         use std::iter::Iterator;
         self.subnets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSubnetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3437,12 +3437,6 @@ impl ListInterconnectsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInterconnectsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [interconnects][crate::model::ListInterconnectsResponse::interconnects].
     pub fn set_interconnects<T, V>(mut self, v: T) -> Self
     where
@@ -3451,6 +3445,12 @@ impl ListInterconnectsResponse {
     {
         use std::iter::Iterator;
         self.interconnects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInterconnectsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3618,12 +3618,6 @@ impl ListInterconnectAttachmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInterconnectAttachmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [interconnect_attachments][crate::model::ListInterconnectAttachmentsResponse::interconnect_attachments].
     pub fn set_interconnect_attachments<T, V>(mut self, v: T) -> Self
     where
@@ -3632,6 +3626,12 @@ impl ListInterconnectAttachmentsResponse {
     {
         use std::iter::Iterator;
         self.interconnect_attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInterconnectAttachmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3937,12 +3937,6 @@ impl ListRoutersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRoutersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [routers][crate::model::ListRoutersResponse::routers].
     pub fn set_routers<T, V>(mut self, v: T) -> Self
     where
@@ -3951,6 +3945,12 @@ impl ListRoutersResponse {
     {
         use std::iter::Iterator;
         self.routers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRoutersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4442,6 +4442,17 @@ pub mod diagnose_network_response {
             std::default::Default::default()
         }
 
+        /// Sets the value of [subnet_status][crate::model::diagnose_network_response::NetworkStatus::subnet_status].
+        pub fn set_subnet_status<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::SubnetStatus>,
+        {
+            use std::iter::Iterator;
+            self.subnet_status = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [macsec_status_internal_links][crate::model::diagnose_network_response::NetworkStatus::macsec_status_internal_links].
         pub fn set_macsec_status_internal_links<
             T: std::convert::Into<
@@ -4452,17 +4463,6 @@ pub mod diagnose_network_response {
             v: T,
         ) -> Self {
             self.macsec_status_internal_links = v.into();
-            self
-        }
-
-        /// Sets the value of [subnet_status][crate::model::diagnose_network_response::NetworkStatus::subnet_status].
-        pub fn set_subnet_status<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::SubnetStatus>,
-        {
-            use std::iter::Iterator;
-            self.subnet_status = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/essentialcontacts/v1/src/builder.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builder.rs
@@ -407,6 +407,17 @@ pub mod essential_contacts_service {
             self
         }
 
+        /// Sets the value of [notification_categories][crate::model::ComputeContactsRequest::notification_categories].
+        pub fn set_notification_categories<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::NotificationCategory>,
+        {
+            use std::iter::Iterator;
+            self.0.request.notification_categories = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_size][crate::model::ComputeContactsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
@@ -416,17 +427,6 @@ pub mod essential_contacts_service {
         /// Sets the value of [page_token][crate::model::ComputeContactsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
-            self
-        }
-
-        /// Sets the value of [notification_categories][crate::model::ComputeContactsRequest::notification_categories].
-        pub fn set_notification_categories<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::NotificationCategory>,
-        {
-            use std::iter::Iterator;
-            self.0.request.notification_categories = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -469,6 +469,19 @@ pub mod essential_contacts_service {
                 .map(gax::response::Response::into_body)
         }
 
+        /// Sets the value of [contacts][crate::model::SendTestMessageRequest::contacts].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_contacts<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contacts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [resource][crate::model::SendTestMessageRequest::resource].
         ///
         /// This is a **required** field for requests.
@@ -485,19 +498,6 @@ pub mod essential_contacts_service {
             v: T,
         ) -> Self {
             self.0.request.notification_category = v.into();
-            self
-        }
-
-        /// Sets the value of [contacts][crate::model::SendTestMessageRequest::contacts].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_contacts<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.contacts = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/essentialcontacts/v1/src/model.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/model.rs
@@ -89,6 +89,17 @@ impl Contact {
         self
     }
 
+    /// Sets the value of [notification_category_subscriptions][crate::model::Contact::notification_category_subscriptions].
+    pub fn set_notification_category_subscriptions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NotificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.notification_category_subscriptions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [language_tag][crate::model::Contact::language_tag].
     pub fn set_language_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_tag = v.into();
@@ -110,17 +121,6 @@ impl Contact {
         v: T,
     ) -> Self {
         self.validate_time = v.into();
-        self
-    }
-
-    /// Sets the value of [notification_category_subscriptions][crate::model::Contact::notification_category_subscriptions].
-    pub fn set_notification_category_subscriptions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NotificationCategory>,
-    {
-        use std::iter::Iterator;
-        self.notification_category_subscriptions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -217,12 +217,6 @@ impl ListContactsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListContactsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [contacts][crate::model::ListContactsResponse::contacts].
     pub fn set_contacts<T, V>(mut self, v: T) -> Self
     where
@@ -231,6 +225,12 @@ impl ListContactsResponse {
     {
         use std::iter::Iterator;
         self.contacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListContactsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -471,6 +471,17 @@ impl ComputeContactsRequest {
         self
     }
 
+    /// Sets the value of [notification_categories][crate::model::ComputeContactsRequest::notification_categories].
+    pub fn set_notification_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NotificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.notification_categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::ComputeContactsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -480,17 +491,6 @@ impl ComputeContactsRequest {
     /// Sets the value of [page_token][crate::model::ComputeContactsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [notification_categories][crate::model::ComputeContactsRequest::notification_categories].
-    pub fn set_notification_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NotificationCategory>,
-    {
-        use std::iter::Iterator;
-        self.notification_categories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -529,12 +529,6 @@ impl ComputeContactsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ComputeContactsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [contacts][crate::model::ComputeContactsResponse::contacts].
     pub fn set_contacts<T, V>(mut self, v: T) -> Self
     where
@@ -543,6 +537,12 @@ impl ComputeContactsResponse {
     {
         use std::iter::Iterator;
         self.contacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ComputeContactsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -601,6 +601,17 @@ impl SendTestMessageRequest {
         std::default::Default::default()
     }
 
+    /// Sets the value of [contacts][crate::model::SendTestMessageRequest::contacts].
+    pub fn set_contacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.contacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [resource][crate::model::SendTestMessageRequest::resource].
     pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource = v.into();
@@ -613,17 +624,6 @@ impl SendTestMessageRequest {
         v: T,
     ) -> Self {
         self.notification_category = v.into();
-        self
-    }
-
-    /// Sets the value of [contacts][crate::model::SendTestMessageRequest::contacts].
-    pub fn set_contacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.contacts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -589,15 +589,6 @@ impl EventType {
         self
     }
 
-    /// Sets the value of [event_schema_uri][crate::model::EventType::event_schema_uri].
-    pub fn set_event_schema_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.event_schema_uri = v.into();
-        self
-    }
-
     /// Sets the value of [filtering_attributes][crate::model::EventType::filtering_attributes].
     pub fn set_filtering_attributes<T, V>(mut self, v: T) -> Self
     where
@@ -606,6 +597,15 @@ impl EventType {
     {
         use std::iter::Iterator;
         self.filtering_attributes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [event_schema_uri][crate::model::EventType::event_schema_uri].
+    pub fn set_event_schema_uri<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.event_schema_uri = v.into();
         self
     }
 }
@@ -788,30 +788,6 @@ impl Enrollment {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::Enrollment::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
-    /// Sets the value of [cel_match][crate::model::Enrollment::cel_match].
-    pub fn set_cel_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.cel_match = v.into();
-        self
-    }
-
-    /// Sets the value of [message_bus][crate::model::Enrollment::message_bus].
-    pub fn set_message_bus<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.message_bus = v.into();
-        self
-    }
-
-    /// Sets the value of [destination][crate::model::Enrollment::destination].
-    pub fn set_destination<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Enrollment::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -833,6 +809,30 @@ impl Enrollment {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::Enrollment::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
+        self
+    }
+
+    /// Sets the value of [cel_match][crate::model::Enrollment::cel_match].
+    pub fn set_cel_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.cel_match = v.into();
+        self
+    }
+
+    /// Sets the value of [message_bus][crate::model::Enrollment::message_bus].
+    pub fn set_message_bus<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.message_bus = v.into();
+        self
+    }
+
+    /// Sets the value of [destination][crate::model::Enrollment::destination].
+    pub fn set_destination<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.destination = v.into();
         self
     }
 }
@@ -986,12 +986,6 @@ impl ListTriggersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTriggersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [triggers][crate::model::ListTriggersResponse::triggers].
     pub fn set_triggers<T, V>(mut self, v: T) -> Self
     where
@@ -1000,6 +994,12 @@ impl ListTriggersResponse {
     {
         use std::iter::Iterator;
         self.triggers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTriggersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1369,12 +1369,6 @@ impl ListChannelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListChannelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [channels][crate::model::ListChannelsResponse::channels].
     pub fn set_channels<T, V>(mut self, v: T) -> Self
     where
@@ -1383,6 +1377,12 @@ impl ListChannelsResponse {
     {
         use std::iter::Iterator;
         self.channels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListChannelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1727,12 +1727,6 @@ impl ListProvidersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProvidersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [providers][crate::model::ListProvidersResponse::providers].
     pub fn set_providers<T, V>(mut self, v: T) -> Self
     where
@@ -1741,6 +1735,12 @@ impl ListProvidersResponse {
     {
         use std::iter::Iterator;
         self.providers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProvidersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1896,12 +1896,6 @@ impl ListChannelConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListChannelConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [channel_connections][crate::model::ListChannelConnectionsResponse::channel_connections].
     pub fn set_channel_connections<T, V>(mut self, v: T) -> Self
     where
@@ -1910,6 +1904,12 @@ impl ListChannelConnectionsResponse {
     {
         use std::iter::Iterator;
         self.channel_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListChannelConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2263,12 +2263,6 @@ impl ListMessageBusesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMessageBusesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [message_buses][crate::model::ListMessageBusesResponse::message_buses].
     pub fn set_message_buses<T, V>(mut self, v: T) -> Self
     where
@@ -2277,6 +2271,12 @@ impl ListMessageBusesResponse {
     {
         use std::iter::Iterator;
         self.message_buses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMessageBusesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2398,12 +2398,6 @@ impl ListMessageBusEnrollmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMessageBusEnrollmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [enrollments][crate::model::ListMessageBusEnrollmentsResponse::enrollments].
     pub fn set_enrollments<T, V>(mut self, v: T) -> Self
     where
@@ -2412,6 +2406,12 @@ impl ListMessageBusEnrollmentsResponse {
     {
         use std::iter::Iterator;
         self.enrollments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMessageBusEnrollmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2779,12 +2779,6 @@ impl ListEnrollmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEnrollmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [enrollments][crate::model::ListEnrollmentsResponse::enrollments].
     pub fn set_enrollments<T, V>(mut self, v: T) -> Self
     where
@@ -2793,6 +2787,12 @@ impl ListEnrollmentsResponse {
     {
         use std::iter::Iterator;
         self.enrollments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEnrollmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3174,12 +3174,6 @@ impl ListPipelinesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPipelinesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [pipelines][crate::model::ListPipelinesResponse::pipelines].
     pub fn set_pipelines<T, V>(mut self, v: T) -> Self
     where
@@ -3188,6 +3182,12 @@ impl ListPipelinesResponse {
     {
         use std::iter::Iterator;
         self.pipelines = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPipelinesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3568,12 +3568,6 @@ impl ListGoogleApiSourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGoogleApiSourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [google_api_sources][crate::model::ListGoogleApiSourcesResponse::google_api_sources].
     pub fn set_google_api_sources<T, V>(mut self, v: T) -> Self
     where
@@ -3582,6 +3576,12 @@ impl ListGoogleApiSourcesResponse {
     {
         use std::iter::Iterator;
         self.google_api_sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGoogleApiSourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4040,6 +4040,30 @@ impl GoogleApiSource {
         self
     }
 
+    /// Sets the value of [labels][crate::model::GoogleApiSource::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::GoogleApiSource::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::GoogleApiSource::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -4066,30 +4090,6 @@ impl GoogleApiSource {
         v: T,
     ) -> Self {
         self.logging_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::GoogleApiSource::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::GoogleApiSource::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4500,29 +4500,6 @@ impl MessageBus {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::MessageBus::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
-    /// Sets the value of [crypto_key_name][crate::model::MessageBus::crypto_key_name].
-    pub fn set_crypto_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.crypto_key_name = v.into();
-        self
-    }
-
-    /// Sets the value of [logging_config][crate::model::MessageBus::logging_config].
-    pub fn set_logging_config<
-        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.logging_config = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::MessageBus::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -4544,6 +4521,29 @@ impl MessageBus {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::MessageBus::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
+        self
+    }
+
+    /// Sets the value of [crypto_key_name][crate::model::MessageBus::crypto_key_name].
+    pub fn set_crypto_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.crypto_key_name = v.into();
+        self
+    }
+
+    /// Sets the value of [logging_config][crate::model::MessageBus::logging_config].
+    pub fn set_logging_config<
+        T: std::convert::Into<std::option::Option<crate::model::LoggingConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.logging_config = v.into();
         self
     }
 }
@@ -4713,15 +4713,61 @@ impl Pipeline {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Pipeline::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [uid][crate::model::Pipeline::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Pipeline::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::Pipeline::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
+        self
+    }
+
+    /// Sets the value of [destinations][crate::model::Pipeline::destinations].
+    pub fn set_destinations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::pipeline::Destination>,
+    {
+        use std::iter::Iterator;
+        self.destinations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [mediations][crate::model::Pipeline::mediations].
+    pub fn set_mediations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::pipeline::Mediation>,
+    {
+        use std::iter::Iterator;
+        self.mediations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4767,52 +4813,6 @@ impl Pipeline {
     /// Sets the value of [etag][crate::model::Pipeline::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [destinations][crate::model::Pipeline::destinations].
-    pub fn set_destinations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::pipeline::Destination>,
-    {
-        use std::iter::Iterator;
-        self.destinations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [mediations][crate::model::Pipeline::mediations].
-    pub fn set_mediations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::pipeline::Mediation>,
-    {
-        use std::iter::Iterator;
-        self.mediations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Pipeline::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Pipeline::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4883,40 +4883,6 @@ pub mod pipeline {
             })
         }
 
-        /// The value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
-        /// if it holds a `Avro`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn avro(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::pipeline::message_payload_format::AvroFormat>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::pipeline::message_payload_format::Kind::Avro(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
-        /// if it holds a `Json`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn json(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::pipeline::message_payload_format::JsonFormat>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::pipeline::message_payload_format::Kind::Json(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
         /// to hold a `Protobuf`.
         ///
@@ -4936,6 +4902,23 @@ pub mod pipeline {
             self
         }
 
+        /// The value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
+        /// if it holds a `Avro`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn avro(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::pipeline::message_payload_format::AvroFormat>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::pipeline::message_payload_format::Kind::Avro(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
         /// to hold a `Avro`.
         ///
@@ -4953,6 +4936,23 @@ pub mod pipeline {
                 crate::model::pipeline::message_payload_format::Kind::Avro(v.into()),
             );
             self
+        }
+
+        /// The value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
+        /// if it holds a `Json`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn json(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::pipeline::message_payload_format::JsonFormat>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::pipeline::message_payload_format::Kind::Json(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
@@ -5208,45 +5208,6 @@ pub mod pipeline {
             })
         }
 
-        /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// if it holds a `Workflow`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn workflow(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.destination_descriptor.as_ref().and_then(|v| match v {
-                crate::model::pipeline::destination::DestinationDescriptor::Workflow(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// if it holds a `MessageBus`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn message_bus(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.destination_descriptor.as_ref().and_then(|v| match v {
-                crate::model::pipeline::destination::DestinationDescriptor::MessageBus(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// if it holds a `Topic`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn topic(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.destination_descriptor.as_ref().and_then(|v| match v {
-                crate::model::pipeline::destination::DestinationDescriptor::Topic(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
         /// to hold a `HttpEndpoint`.
         ///
@@ -5264,6 +5225,19 @@ pub mod pipeline {
             self
         }
 
+        /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
+        /// if it holds a `Workflow`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn workflow(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.destination_descriptor.as_ref().and_then(|v| match v {
+                crate::model::pipeline::destination::DestinationDescriptor::Workflow(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
         /// to hold a `Workflow`.
         ///
@@ -5276,6 +5250,19 @@ pub mod pipeline {
             self
         }
 
+        /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
+        /// if it holds a `MessageBus`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn message_bus(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.destination_descriptor.as_ref().and_then(|v| match v {
+                crate::model::pipeline::destination::DestinationDescriptor::MessageBus(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
         /// to hold a `MessageBus`.
         ///
@@ -5286,6 +5273,19 @@ pub mod pipeline {
                 crate::model::pipeline::destination::DestinationDescriptor::MessageBus(v.into()),
             );
             self
+        }
+
+        /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
+        /// if it holds a `Topic`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn topic(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.destination_descriptor.as_ref().and_then(|v| match v {
+                crate::model::pipeline::destination::DestinationDescriptor::Topic(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
@@ -5614,23 +5614,6 @@ pub mod pipeline {
                 })
             }
 
-            /// The value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
-            /// if it holds a `OauthToken`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn oauth_token(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<
-                    crate::model::pipeline::destination::authentication_config::OAuthToken,
-                >,
-            > {
-                #[allow(unreachable_patterns)]
-                self.authentication_method_descriptor.as_ref().and_then(|v| match v {
-                    crate::model::pipeline::destination::authentication_config::AuthenticationMethodDescriptor::OauthToken(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
             /// to hold a `GoogleOidc`.
             ///
@@ -5652,6 +5635,23 @@ pub mod pipeline {
                     )
                 );
                 self
+            }
+
+            /// The value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
+            /// if it holds a `OauthToken`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn oauth_token(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<
+                    crate::model::pipeline::destination::authentication_config::OAuthToken,
+                >,
+            > {
+                #[allow(unreachable_patterns)]
+                self.authentication_method_descriptor.as_ref().and_then(|v| match v {
+                    crate::model::pipeline::destination::authentication_config::AuthenticationMethodDescriptor::OauthToken(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
@@ -6261,6 +6261,17 @@ impl Trigger {
         self
     }
 
+    /// Sets the value of [event_filters][crate::model::Trigger::event_filters].
+    pub fn set_event_filters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventFilter>,
+    {
+        use std::iter::Iterator;
+        self.event_filters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::Trigger::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
@@ -6287,9 +6298,33 @@ impl Trigger {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Trigger::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [channel][crate::model::Trigger::channel].
     pub fn set_channel<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.channel = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Trigger::conditions].
+    pub fn set_conditions<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::StateCondition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -6311,41 +6346,6 @@ impl Trigger {
     /// Sets the value of [etag][crate::model::Trigger::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [event_filters][crate::model::Trigger::event_filters].
-    pub fn set_event_filters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventFilter>,
-    {
-        use std::iter::Iterator;
-        self.event_filters = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Trigger::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::Trigger::conditions].
-    pub fn set_conditions<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::StateCondition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6518,52 +6518,6 @@ impl Destination {
         })
     }
 
-    /// The value of [descriptor][crate::model::Destination::descriptor]
-    /// if it holds a `CloudFunction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_function(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.descriptor.as_ref().and_then(|v| match v {
-            crate::model::destination::Descriptor::CloudFunction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [descriptor][crate::model::Destination::descriptor]
-    /// if it holds a `Gke`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gke(&self) -> std::option::Option<&std::boxed::Box<crate::model::Gke>> {
-        #[allow(unreachable_patterns)]
-        self.descriptor.as_ref().and_then(|v| match v {
-            crate::model::destination::Descriptor::Gke(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [descriptor][crate::model::Destination::descriptor]
-    /// if it holds a `Workflow`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn workflow(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.descriptor.as_ref().and_then(|v| match v {
-            crate::model::destination::Descriptor::Workflow(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [descriptor][crate::model::Destination::descriptor]
-    /// if it holds a `HttpEndpoint`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn http_endpoint(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::HttpEndpoint>> {
-        #[allow(unreachable_patterns)]
-        self.descriptor.as_ref().and_then(|v| match v {
-            crate::model::destination::Descriptor::HttpEndpoint(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [descriptor][crate::model::Destination::descriptor]
     /// to hold a `CloudRun`.
     ///
@@ -6578,6 +6532,17 @@ impl Destination {
         self
     }
 
+    /// The value of [descriptor][crate::model::Destination::descriptor]
+    /// if it holds a `CloudFunction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_function(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.descriptor.as_ref().and_then(|v| match v {
+            crate::model::destination::Descriptor::CloudFunction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [descriptor][crate::model::Destination::descriptor]
     /// to hold a `CloudFunction`.
     ///
@@ -6588,6 +6553,17 @@ impl Destination {
             crate::model::destination::Descriptor::CloudFunction(v.into()),
         );
         self
+    }
+
+    /// The value of [descriptor][crate::model::Destination::descriptor]
+    /// if it holds a `Gke`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gke(&self) -> std::option::Option<&std::boxed::Box<crate::model::Gke>> {
+        #[allow(unreachable_patterns)]
+        self.descriptor.as_ref().and_then(|v| match v {
+            crate::model::destination::Descriptor::Gke(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [descriptor][crate::model::Destination::descriptor]
@@ -6604,6 +6580,17 @@ impl Destination {
         self
     }
 
+    /// The value of [descriptor][crate::model::Destination::descriptor]
+    /// if it holds a `Workflow`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn workflow(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.descriptor.as_ref().and_then(|v| match v {
+            crate::model::destination::Descriptor::Workflow(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [descriptor][crate::model::Destination::descriptor]
     /// to hold a `Workflow`.
     ///
@@ -6613,6 +6600,19 @@ impl Destination {
         self.descriptor =
             std::option::Option::Some(crate::model::destination::Descriptor::Workflow(v.into()));
         self
+    }
+
+    /// The value of [descriptor][crate::model::Destination::descriptor]
+    /// if it holds a `HttpEndpoint`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn http_endpoint(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HttpEndpoint>> {
+        #[allow(unreachable_patterns)]
+        self.descriptor.as_ref().and_then(|v| match v {
+            crate::model::destination::Descriptor::HttpEndpoint(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [descriptor][crate::model::Destination::descriptor]

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -98,24 +98,6 @@ impl NetworkConfig {
         self
     }
 
-    /// Sets the value of [reserved_ip_range][crate::model::NetworkConfig::reserved_ip_range].
-    pub fn set_reserved_ip_range<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.reserved_ip_range = v.into();
-        self
-    }
-
-    /// Sets the value of [connect_mode][crate::model::NetworkConfig::connect_mode].
-    pub fn set_connect_mode<T: std::convert::Into<crate::model::network_config::ConnectMode>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connect_mode = v.into();
-        self
-    }
-
     /// Sets the value of [modes][crate::model::NetworkConfig::modes].
     pub fn set_modes<T, V>(mut self, v: T) -> Self
     where
@@ -127,6 +109,15 @@ impl NetworkConfig {
         self
     }
 
+    /// Sets the value of [reserved_ip_range][crate::model::NetworkConfig::reserved_ip_range].
+    pub fn set_reserved_ip_range<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.reserved_ip_range = v.into();
+        self
+    }
+
     /// Sets the value of [ip_addresses][crate::model::NetworkConfig::ip_addresses].
     pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
     where
@@ -135,6 +126,15 @@ impl NetworkConfig {
     {
         use std::iter::Iterator;
         self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [connect_mode][crate::model::NetworkConfig::connect_mode].
+    pub fn set_connect_mode<T: std::convert::Into<crate::model::network_config::ConnectMode>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.connect_mode = v.into();
         self
     }
 }
@@ -587,6 +587,17 @@ impl NfsExportOptions {
         std::default::Default::default()
     }
 
+    /// Sets the value of [ip_ranges][crate::model::NfsExportOptions::ip_ranges].
+    pub fn set_ip_ranges<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ip_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [access_mode][crate::model::NfsExportOptions::access_mode].
     pub fn set_access_mode<T: std::convert::Into<crate::model::nfs_export_options::AccessMode>>(
         mut self,
@@ -614,17 +625,6 @@ impl NfsExportOptions {
     /// Sets the value of [anon_gid][crate::model::NfsExportOptions::anon_gid].
     pub fn set_anon_gid<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.anon_gid = v.into();
-        self
-    }
-
-    /// Sets the value of [ip_ranges][crate::model::NfsExportOptions::ip_ranges].
-    pub fn set_ip_ranges<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.ip_ranges = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -946,6 +946,17 @@ impl ReplicaConfig {
         self
     }
 
+    /// Sets the value of [state_reasons][crate::model::ReplicaConfig::state_reasons].
+    pub fn set_state_reasons<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::replica_config::StateReason>,
+    {
+        use std::iter::Iterator;
+        self.state_reasons = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [peer_instance][crate::model::ReplicaConfig::peer_instance].
     pub fn set_peer_instance<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.peer_instance = v.into();
@@ -958,17 +969,6 @@ impl ReplicaConfig {
         v: T,
     ) -> Self {
         self.last_active_sync_time = v.into();
-        self
-    }
-
-    /// Sets the value of [state_reasons][crate::model::ReplicaConfig::state_reasons].
-    pub fn set_state_reasons<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::replica_config::StateReason>,
-    {
-        use std::iter::Iterator;
-        self.state_reasons = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1615,6 +1615,40 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [file_shares][crate::model::Instance::file_shares].
+    pub fn set_file_shares<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FileShareConfig>,
+    {
+        use std::iter::Iterator;
+        self.file_shares = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [networks][crate::model::Instance::networks].
+    pub fn set_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkConfig>,
+    {
+        use std::iter::Iterator;
+        self.networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Instance::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -1642,6 +1676,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [suspension_reasons][crate::model::Instance::suspension_reasons].
+    pub fn set_suspension_reasons<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::instance::SuspensionReason>,
+    {
+        use std::iter::Iterator;
+        self.suspension_reasons = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [replication][crate::model::Instance::replication].
     pub fn set_replication<
         T: std::convert::Into<std::option::Option<crate::model::Replication>>,
@@ -1650,6 +1695,18 @@ impl Instance {
         v: T,
     ) -> Self {
         self.replication = v.into();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::Instance::tags].
+    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1702,63 +1759,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.deletion_protection_reason = v.into();
-        self
-    }
-
-    /// Sets the value of [file_shares][crate::model::Instance::file_shares].
-    pub fn set_file_shares<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FileShareConfig>,
-    {
-        use std::iter::Iterator;
-        self.file_shares = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [networks][crate::model::Instance::networks].
-    pub fn set_networks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkConfig>,
-    {
-        use std::iter::Iterator;
-        self.networks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [suspension_reasons][crate::model::Instance::suspension_reasons].
-    pub fn set_suspension_reasons<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::instance::SuspensionReason>,
-    {
-        use std::iter::Iterator;
-        self.suspension_reasons = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::Instance::tags].
-    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1896,21 +1896,6 @@ pub mod instance {
             })
         }
 
-        /// The value of [mode][crate::model::instance::PerformanceConfig::mode]
-        /// if it holds a `FixedIops`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn fixed_iops(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::instance::FixedIOPS>> {
-            #[allow(unreachable_patterns)]
-            self.mode.as_ref().and_then(|v| match v {
-                crate::model::instance::performance_config::Mode::FixedIops(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [mode][crate::model::instance::PerformanceConfig::mode]
         /// to hold a `IopsPerTb`.
         ///
@@ -1926,6 +1911,21 @@ pub mod instance {
                 crate::model::instance::performance_config::Mode::IopsPerTb(v.into()),
             );
             self
+        }
+
+        /// The value of [mode][crate::model::instance::PerformanceConfig::mode]
+        /// if it holds a `FixedIops`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn fixed_iops(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::instance::FixedIOPS>> {
+            #[allow(unreachable_patterns)]
+            self.mode.as_ref().and_then(|v| match v {
+                crate::model::instance::performance_config::Mode::FixedIops(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [mode][crate::model::instance::PerformanceConfig::mode]
@@ -3161,12 +3161,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -3175,6 +3169,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3293,12 +3293,6 @@ impl Snapshot {
         self
     }
 
-    /// Sets the value of [filesystem_used_bytes][crate::model::Snapshot::filesystem_used_bytes].
-    pub fn set_filesystem_used_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.filesystem_used_bytes = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Snapshot::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -3308,6 +3302,12 @@ impl Snapshot {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [filesystem_used_bytes][crate::model::Snapshot::filesystem_used_bytes].
+    pub fn set_filesystem_used_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.filesystem_used_bytes = v.into();
         self
     }
 
@@ -3764,12 +3764,6 @@ impl ListSnapshotsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [snapshots][crate::model::ListSnapshotsResponse::snapshots].
     pub fn set_snapshots<T, V>(mut self, v: T) -> Self
     where
@@ -3778,6 +3772,12 @@ impl ListSnapshotsResponse {
     {
         use std::iter::Iterator;
         self.snapshots = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3939,6 +3939,18 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Backup::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [capacity_gb][crate::model::Backup::capacity_gb].
     pub fn set_capacity_gb<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.capacity_gb = v.into();
@@ -4002,27 +4014,6 @@ impl Backup {
         self
     }
 
-    /// Sets the value of [file_system_protocol][crate::model::Backup::file_system_protocol].
-    pub fn set_file_system_protocol<T: std::convert::Into<crate::model::instance::FileProtocol>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.file_system_protocol = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Backup::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [tags][crate::model::Backup::tags].
     pub fn set_tags<T, K, V>(mut self, v: T) -> Self
     where
@@ -4032,6 +4023,15 @@ impl Backup {
     {
         use std::iter::Iterator;
         self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [file_system_protocol][crate::model::Backup::file_system_protocol].
+    pub fn set_file_system_protocol<T: std::convert::Into<crate::model::instance::FileProtocol>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.file_system_protocol = v.into();
         self
     }
 }
@@ -4543,12 +4543,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -4557,6 +4551,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/financialservices/v1/src/builder.rs
+++ b/src/generated/cloud/financialservices/v1/src/builder.rs
@@ -575,6 +575,17 @@ pub mod aml {
             self
         }
 
+        /// Sets the value of [party_tables][crate::model::ImportRegisteredPartiesRequest::party_tables].
+        pub fn set_party_tables<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.party_tables = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [mode][crate::model::ImportRegisteredPartiesRequest::mode].
         ///
         /// This is a **required** field for requests.
@@ -597,17 +608,6 @@ pub mod aml {
         /// This is a **required** field for requests.
         pub fn set_line_of_business<T: Into<crate::model::LineOfBusiness>>(mut self, v: T) -> Self {
             self.0.request.line_of_business = v.into();
-            self
-        }
-
-        /// Sets the value of [party_tables][crate::model::ImportRegisteredPartiesRequest::party_tables].
-        pub fn set_party_tables<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.party_tables = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/financialservices/v1/src/model.rs
+++ b/src/generated/cloud/financialservices/v1/src/model.rs
@@ -127,6 +127,18 @@ impl BacktestResult {
         self
     }
 
+    /// Sets the value of [labels][crate::model::BacktestResult::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::BacktestResult::state].
     pub fn set_state<T: std::convert::Into<crate::model::backtest_result::State>>(
         mut self,
@@ -180,18 +192,6 @@ impl BacktestResult {
         v: T,
     ) -> Self {
         self.line_of_business = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::BacktestResult::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -504,12 +504,6 @@ impl ListBacktestResultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBacktestResultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backtest_results][crate::model::ListBacktestResultsResponse::backtest_results].
     pub fn set_backtest_results<T, V>(mut self, v: T) -> Self
     where
@@ -518,6 +512,12 @@ impl ListBacktestResultsResponse {
     {
         use std::iter::Iterator;
         self.backtest_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBacktestResultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1139,30 +1139,6 @@ impl Dataset {
         self
     }
 
-    /// Sets the value of [state][crate::model::Dataset::state].
-    pub fn set_state<T: std::convert::Into<crate::model::dataset::State>>(mut self, v: T) -> Self {
-        self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [date_range][crate::model::Dataset::date_range].
-    pub fn set_date_range<T: std::convert::Into<std::option::Option<gtype::model::Interval>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.date_range = v.into();
-        self
-    }
-
-    /// Sets the value of [time_zone][crate::model::Dataset::time_zone].
-    pub fn set_time_zone<T: std::convert::Into<std::option::Option<gtype::model::TimeZone>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_zone = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Dataset::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -1184,6 +1160,30 @@ impl Dataset {
     {
         use std::iter::Iterator;
         self.table_specs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Dataset::state].
+    pub fn set_state<T: std::convert::Into<crate::model::dataset::State>>(mut self, v: T) -> Self {
+        self.state = v.into();
+        self
+    }
+
+    /// Sets the value of [date_range][crate::model::Dataset::date_range].
+    pub fn set_date_range<T: std::convert::Into<std::option::Option<gtype::model::Interval>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.date_range = v.into();
+        self
+    }
+
+    /// Sets the value of [time_zone][crate::model::Dataset::time_zone].
+    pub fn set_time_zone<T: std::convert::Into<std::option::Option<gtype::model::TimeZone>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.time_zone = v.into();
         self
     }
 }
@@ -1452,12 +1452,6 @@ impl ListDatasetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [datasets][crate::model::ListDatasetsResponse::datasets].
     pub fn set_datasets<T, V>(mut self, v: T) -> Self
     where
@@ -1466,6 +1460,12 @@ impl ListDatasetsResponse {
     {
         use std::iter::Iterator;
         self.datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1832,6 +1832,18 @@ impl EngineConfig {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EngineConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::EngineConfig::state].
     pub fn set_state<T: std::convert::Into<crate::model::engine_config::State>>(
         mut self,
@@ -1897,18 +1909,6 @@ impl EngineConfig {
         v: T,
     ) -> Self {
         self.hyperparameter_source = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::EngineConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2464,12 +2464,6 @@ impl ListEngineConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEngineConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [engine_configs][crate::model::ListEngineConfigsResponse::engine_configs].
     pub fn set_engine_configs<T, V>(mut self, v: T) -> Self
     where
@@ -2478,6 +2472,12 @@ impl ListEngineConfigsResponse {
     {
         use std::iter::Iterator;
         self.engine_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEngineConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3176,12 +3176,6 @@ impl ListEngineVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEngineVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [engine_versions][crate::model::ListEngineVersionsResponse::engine_versions].
     pub fn set_engine_versions<T, V>(mut self, v: T) -> Self
     where
@@ -3190,6 +3184,12 @@ impl ListEngineVersionsResponse {
     {
         use std::iter::Iterator;
         self.engine_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEngineVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3336,12 +3336,6 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [kms_key][crate::model::Instance::kms_key].
-    pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kms_key = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Instance::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -3351,6 +3345,12 @@ impl Instance {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [kms_key][crate::model::Instance::kms_key].
+    pub fn set_kms_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.kms_key = v.into();
         self
     }
 }
@@ -3620,12 +3620,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -3634,6 +3628,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3955,6 +3955,17 @@ impl ImportRegisteredPartiesRequest {
         self
     }
 
+    /// Sets the value of [party_tables][crate::model::ImportRegisteredPartiesRequest::party_tables].
+    pub fn set_party_tables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.party_tables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [mode][crate::model::ImportRegisteredPartiesRequest::mode].
     pub fn set_mode<
         T: std::convert::Into<crate::model::import_registered_parties_request::UpdateMode>,
@@ -3978,17 +3989,6 @@ impl ImportRegisteredPartiesRequest {
         v: T,
     ) -> Self {
         self.line_of_business = v.into();
-        self
-    }
-
-    /// Sets the value of [party_tables][crate::model::ImportRegisteredPartiesRequest::party_tables].
-    pub fn set_party_tables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.party_tables = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4406,6 +4406,18 @@ impl Model {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Model::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Model::state].
     pub fn set_state<T: std::convert::Into<crate::model::model::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -4445,18 +4457,6 @@ impl Model {
         v: T,
     ) -> Self {
         self.line_of_business = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Model::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4725,12 +4725,6 @@ impl ListModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [models][crate::model::ListModelsResponse::models].
     pub fn set_models<T, V>(mut self, v: T) -> Self
     where
@@ -4739,6 +4733,12 @@ impl ListModelsResponse {
     {
         use std::iter::Iterator;
         self.models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5180,6 +5180,18 @@ impl PredictionResult {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PredictionResult::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::PredictionResult::state].
     pub fn set_state<T: std::convert::Into<crate::model::prediction_result::State>>(
         mut self,
@@ -5233,18 +5245,6 @@ impl PredictionResult {
         v: T,
     ) -> Self {
         self.line_of_business = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::PredictionResult::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5568,12 +5568,6 @@ impl ListPredictionResultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPredictionResultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [prediction_results][crate::model::ListPredictionResultsResponse::prediction_results].
     pub fn set_prediction_results<T, V>(mut self, v: T) -> Self
     where
@@ -5582,6 +5576,12 @@ impl ListPredictionResultsResponse {
     {
         use std::iter::Iterator;
         self.prediction_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPredictionResultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -174,6 +174,29 @@ impl Function {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Function::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state_messages][crate::model::Function::state_messages].
+    pub fn set_state_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::StateMessage>,
+    {
+        use std::iter::Iterator;
+        self.state_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [environment][crate::model::Function::environment].
     pub fn set_environment<T: std::convert::Into<crate::model::Environment>>(
         mut self,
@@ -207,29 +230,6 @@ impl Function {
         v: T,
     ) -> Self {
         self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [state_messages][crate::model::Function::state_messages].
-    pub fn set_state_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::StateMessage>,
-    {
-        use std::iter::Iterator;
-        self.state_messages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Function::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -765,28 +765,6 @@ impl RepoSource {
         })
     }
 
-    /// The value of [revision][crate::model::RepoSource::revision]
-    /// if it holds a `TagName`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tag_name(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.revision.as_ref().and_then(|v| match v {
-            crate::model::repo_source::Revision::TagName(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [revision][crate::model::RepoSource::revision]
-    /// if it holds a `CommitSha`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn commit_sha(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.revision.as_ref().and_then(|v| match v {
-            crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [revision][crate::model::RepoSource::revision]
     /// to hold a `BranchName`.
     ///
@@ -798,6 +776,17 @@ impl RepoSource {
         self
     }
 
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `TagName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tag_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::TagName(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [revision][crate::model::RepoSource::revision]
     /// to hold a `TagName`.
     ///
@@ -807,6 +796,17 @@ impl RepoSource {
         self.revision =
             std::option::Option::Some(crate::model::repo_source::Revision::TagName(v.into()));
         self
+    }
+
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `CommitSha`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn commit_sha(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [revision][crate::model::RepoSource::revision]
@@ -898,28 +898,6 @@ impl Source {
         })
     }
 
-    /// The value of [source][crate::model::Source::source]
-    /// if it holds a `RepoSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn repo_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::RepoSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::source::Source::RepoSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::Source::source]
-    /// if it holds a `GitUri`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn git_uri(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::source::Source::GitUri(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::Source::source]
     /// to hold a `StorageSource`.
     ///
@@ -936,6 +914,17 @@ impl Source {
         self
     }
 
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `RepoSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn repo_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::RepoSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::RepoSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::Source::source]
     /// to hold a `RepoSource`.
     ///
@@ -947,6 +936,17 @@ impl Source {
     ) -> Self {
         self.source = std::option::Option::Some(crate::model::source::Source::RepoSource(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `GitUri`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn git_uri(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::GitUri(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::Source::source]
@@ -1199,6 +1199,18 @@ impl BuildConfig {
         self
     }
 
+    /// Sets the value of [environment_variables][crate::model::BuildConfig::environment_variables].
+    pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [docker_registry][crate::model::BuildConfig::docker_registry].
     #[deprecated]
     pub fn set_docker_registry<
@@ -1223,18 +1235,6 @@ impl BuildConfig {
     /// Sets the value of [service_account][crate::model::BuildConfig::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
-        self
-    }
-
-    /// Sets the value of [environment_variables][crate::model::BuildConfig::environment_variables].
-    pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1267,21 +1267,6 @@ impl BuildConfig {
         })
     }
 
-    /// The value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
-    /// if it holds a `OnDeployUpdatePolicy`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn on_deploy_update_policy(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OnDeployUpdatePolicy>> {
-        #[allow(unreachable_patterns)]
-        self.runtime_update_policy.as_ref().and_then(|v| match v {
-            crate::model::build_config::RuntimeUpdatePolicy::OnDeployUpdatePolicy(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
     /// to hold a `AutomaticUpdatePolicy`.
     ///
@@ -1297,6 +1282,21 @@ impl BuildConfig {
             crate::model::build_config::RuntimeUpdatePolicy::AutomaticUpdatePolicy(v.into()),
         );
         self
+    }
+
+    /// The value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
+    /// if it holds a `OnDeployUpdatePolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn on_deploy_update_policy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OnDeployUpdatePolicy>> {
+        #[allow(unreachable_patterns)]
+        self.runtime_update_policy.as_ref().and_then(|v| match v {
+            crate::model::build_config::RuntimeUpdatePolicy::OnDeployUpdatePolicy(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
@@ -1636,6 +1636,18 @@ impl ServiceConfig {
         self
     }
 
+    /// Sets the value of [environment_variables][crate::model::ServiceConfig::environment_variables].
+    pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [max_instance_count][crate::model::ServiceConfig::max_instance_count].
     pub fn set_max_instance_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_instance_count = v.into();
@@ -1697,6 +1709,28 @@ impl ServiceConfig {
         self
     }
 
+    /// Sets the value of [secret_environment_variables][crate::model::ServiceConfig::secret_environment_variables].
+    pub fn set_secret_environment_variables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretEnvVar>,
+    {
+        use std::iter::Iterator;
+        self.secret_environment_variables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [secret_volumes][crate::model::ServiceConfig::secret_volumes].
+    pub fn set_secret_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVolume>,
+    {
+        use std::iter::Iterator;
+        self.secret_volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [revision][crate::model::ServiceConfig::revision].
     pub fn set_revision<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision = v.into();
@@ -1729,40 +1763,6 @@ impl ServiceConfig {
         v: T,
     ) -> Self {
         self.binary_authorization_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [secret_environment_variables][crate::model::ServiceConfig::secret_environment_variables].
-    pub fn set_secret_environment_variables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SecretEnvVar>,
-    {
-        use std::iter::Iterator;
-        self.secret_environment_variables = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [secret_volumes][crate::model::ServiceConfig::secret_volumes].
-    pub fn set_secret_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SecretVolume>,
-    {
-        use std::iter::Iterator;
-        self.secret_volumes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [environment_variables][crate::model::ServiceConfig::environment_variables].
-    pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2497,6 +2497,17 @@ impl EventTrigger {
         self
     }
 
+    /// Sets the value of [event_filters][crate::model::EventTrigger::event_filters].
+    pub fn set_event_filters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventFilter>,
+    {
+        use std::iter::Iterator;
+        self.event_filters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [pubsub_topic][crate::model::EventTrigger::pubsub_topic].
     pub fn set_pubsub_topic<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pubsub_topic = v.into();
@@ -2530,17 +2541,6 @@ impl EventTrigger {
     /// Sets the value of [service][crate::model::EventTrigger::service].
     pub fn set_service<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service = v.into();
-        self
-    }
-
-    /// Sets the value of [event_filters][crate::model::EventTrigger::event_filters].
-    pub fn set_event_filters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventFilter>,
-    {
-        use std::iter::Iterator;
-        self.event_filters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2908,12 +2908,6 @@ impl ListFunctionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFunctionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [functions][crate::model::ListFunctionsResponse::functions].
     pub fn set_functions<T, V>(mut self, v: T) -> Self
     where
@@ -2922,6 +2916,12 @@ impl ListFunctionsResponse {
     {
         use std::iter::Iterator;
         self.functions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFunctionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3446,6 +3446,17 @@ pub mod list_runtimes_response {
             self
         }
 
+        /// Sets the value of [warnings][crate::model::list_runtimes_response::Runtime::warnings].
+        pub fn set_warnings<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.warnings = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [environment][crate::model::list_runtimes_response::Runtime::environment].
         pub fn set_environment<T: std::convert::Into<crate::model::Environment>>(
             mut self,
@@ -3474,17 +3485,6 @@ pub mod list_runtimes_response {
             v: T,
         ) -> Self {
             self.decommission_date = v.into();
-            self
-        }
-
-        /// Sets the value of [warnings][crate::model::list_runtimes_response::Runtime::warnings].
-        pub fn set_warnings<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.warnings = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3840,6 +3840,17 @@ impl OperationMetadata {
         self
     }
 
+    /// Sets the value of [stages][crate::model::OperationMetadata::stages].
+    pub fn set_stages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Stage>,
+    {
+        use std::iter::Iterator;
+        self.stages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [source_token][crate::model::OperationMetadata::source_token].
     pub fn set_source_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.source_token = v.into();
@@ -3858,17 +3869,6 @@ impl OperationMetadata {
         v: T,
     ) -> Self {
         self.operation_type = v.into();
-        self
-    }
-
-    /// Sets the value of [stages][crate::model::OperationMetadata::stages].
-    pub fn set_stages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Stage>,
-    {
-        use std::iter::Iterator;
-        self.stages = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -272,6 +272,18 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Backup::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [delete_lock_days][crate::model::Backup::delete_lock_days].
     pub fn set_delete_lock_days<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.delete_lock_days = v.into();
@@ -407,18 +419,6 @@ impl Backup {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Backup::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [backup_scope][crate::model::Backup::backup_scope].
     ///
     /// Note that all the setters affecting `backup_scope` are mutually
@@ -444,6 +444,17 @@ impl Backup {
         })
     }
 
+    /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
+    /// to hold a `AllNamespaces`.
+    ///
+    /// Note that all the setters affecting `backup_scope` are
+    /// mutually exclusive.
+    pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.backup_scope =
+            std::option::Option::Some(crate::model::backup::BackupScope::AllNamespaces(v.into()));
+        self
+    }
+
     /// The value of [backup_scope][crate::model::Backup::backup_scope]
     /// if it holds a `SelectedNamespaces`, `None` if the field is not set or
     /// holds a different branch.
@@ -457,32 +468,6 @@ impl Backup {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [backup_scope][crate::model::Backup::backup_scope]
-    /// if it holds a `SelectedApplications`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn selected_applications(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::NamespacedNames>> {
-        #[allow(unreachable_patterns)]
-        self.backup_scope.as_ref().and_then(|v| match v {
-            crate::model::backup::BackupScope::SelectedApplications(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
-    /// to hold a `AllNamespaces`.
-    ///
-    /// Note that all the setters affecting `backup_scope` are
-    /// mutually exclusive.
-    pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.backup_scope =
-            std::option::Option::Some(crate::model::backup::BackupScope::AllNamespaces(v.into()));
-        self
     }
 
     /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
@@ -500,6 +485,21 @@ impl Backup {
             crate::model::backup::BackupScope::SelectedNamespaces(v.into()),
         );
         self
+    }
+
+    /// The value of [backup_scope][crate::model::Backup::backup_scope]
+    /// if it holds a `SelectedApplications`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn selected_applications(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::NamespacedNames>> {
+        #[allow(unreachable_patterns)]
+        self.backup_scope.as_ref().and_then(|v| match v {
+            crate::model::backup::BackupScope::SelectedApplications(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
@@ -628,6 +628,18 @@ pub mod backup {
             })
         }
 
+        /// Sets the value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
+        /// to hold a `GkeVersion`.
+        ///
+        /// Note that all the setters affecting `platform_version` are
+        /// mutually exclusive.
+        pub fn set_gke_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.platform_version = std::option::Option::Some(
+                crate::model::backup::cluster_metadata::PlatformVersion::GkeVersion(v.into()),
+            );
+            self
+        }
+
         /// The value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
         /// if it holds a `AnthosVersion`, `None` if the field is not set or
         /// holds a different branch.
@@ -639,18 +651,6 @@ pub mod backup {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
-        /// to hold a `GkeVersion`.
-        ///
-        /// Note that all the setters affecting `platform_version` are
-        /// mutually exclusive.
-        pub fn set_gke_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.platform_version = std::option::Option::Some(
-                crate::model::backup::cluster_metadata::PlatformVersion::GkeVersion(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
@@ -1035,6 +1035,18 @@ impl BackupPlan {
         self
     }
 
+    /// Sets the value of [labels][crate::model::BackupPlan::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [backup_schedule][crate::model::BackupPlan::backup_schedule].
     pub fn set_backup_schedule<
         T: std::convert::Into<std::option::Option<crate::model::backup_plan::Schedule>>,
@@ -1099,18 +1111,6 @@ impl BackupPlan {
     /// Sets the value of [rpo_risk_reason][crate::model::BackupPlan::rpo_risk_reason].
     pub fn set_rpo_risk_reason<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.rpo_risk_reason = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::BackupPlan::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1426,6 +1426,18 @@ pub mod backup_plan {
             })
         }
 
+        /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
+        /// to hold a `AllNamespaces`.
+        ///
+        /// Note that all the setters affecting `backup_scope` are
+        /// mutually exclusive.
+        pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.backup_scope = std::option::Option::Some(
+                crate::model::backup_plan::backup_config::BackupScope::AllNamespaces(v.into()),
+            );
+            self
+        }
+
         /// The value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
         /// if it holds a `SelectedNamespaces`, `None` if the field is not set or
         /// holds a different branch.
@@ -1439,33 +1451,6 @@ pub mod backup_plan {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
-        /// if it holds a `SelectedApplications`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn selected_applications(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::NamespacedNames>> {
-            #[allow(unreachable_patterns)]
-            self.backup_scope.as_ref().and_then(|v| match v {
-                crate::model::backup_plan::backup_config::BackupScope::SelectedApplications(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
-        /// to hold a `AllNamespaces`.
-        ///
-        /// Note that all the setters affecting `backup_scope` are
-        /// mutually exclusive.
-        pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.backup_scope = std::option::Option::Some(
-                crate::model::backup_plan::backup_config::BackupScope::AllNamespaces(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
@@ -1483,6 +1468,21 @@ pub mod backup_plan {
                 crate::model::backup_plan::backup_config::BackupScope::SelectedNamespaces(v.into()),
             );
             self
+        }
+
+        /// The value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
+        /// if it holds a `SelectedApplications`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn selected_applications(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::NamespacedNames>> {
+            #[allow(unreachable_patterns)]
+            self.backup_scope.as_ref().and_then(|v| match v {
+                crate::model::backup_plan::backup_config::BackupScope::SelectedApplications(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
@@ -1841,32 +1841,6 @@ impl ExclusionWindow {
         })
     }
 
-    /// The value of [recurrence][crate::model::ExclusionWindow::recurrence]
-    /// if it holds a `Daily`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn daily(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.recurrence.as_ref().and_then(|v| match v {
-            crate::model::exclusion_window::Recurrence::Daily(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [recurrence][crate::model::ExclusionWindow::recurrence]
-    /// if it holds a `DaysOfWeek`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn days_of_week(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::exclusion_window::DayOfWeekList>> {
-        #[allow(unreachable_patterns)]
-        self.recurrence.as_ref().and_then(|v| match v {
-            crate::model::exclusion_window::Recurrence::DaysOfWeek(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [recurrence][crate::model::ExclusionWindow::recurrence]
     /// to hold a `SingleOccurrenceDate`.
     ///
@@ -1884,6 +1858,17 @@ impl ExclusionWindow {
         self
     }
 
+    /// The value of [recurrence][crate::model::ExclusionWindow::recurrence]
+    /// if it holds a `Daily`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn daily(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.recurrence.as_ref().and_then(|v| match v {
+            crate::model::exclusion_window::Recurrence::Daily(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [recurrence][crate::model::ExclusionWindow::recurrence]
     /// to hold a `Daily`.
     ///
@@ -1893,6 +1878,21 @@ impl ExclusionWindow {
         self.recurrence =
             std::option::Option::Some(crate::model::exclusion_window::Recurrence::Daily(v.into()));
         self
+    }
+
+    /// The value of [recurrence][crate::model::ExclusionWindow::recurrence]
+    /// if it holds a `DaysOfWeek`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn days_of_week(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::exclusion_window::DayOfWeekList>> {
+        #[allow(unreachable_patterns)]
+        self.recurrence.as_ref().and_then(|v| match v {
+            crate::model::exclusion_window::Recurrence::DaysOfWeek(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [recurrence][crate::model::ExclusionWindow::recurrence]
@@ -2571,12 +2571,6 @@ impl ListBackupPlansResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupPlansResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_plans][crate::model::ListBackupPlansResponse::backup_plans].
     pub fn set_backup_plans<T, V>(mut self, v: T) -> Self
     where
@@ -2585,6 +2579,12 @@ impl ListBackupPlansResponse {
     {
         use std::iter::Iterator;
         self.backup_plans = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupPlansResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2935,12 +2935,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -2949,6 +2943,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3237,12 +3237,6 @@ impl ListVolumeBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVolumeBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [volume_backups][crate::model::ListVolumeBackupsResponse::volume_backups].
     pub fn set_volume_backups<T, V>(mut self, v: T) -> Self
     where
@@ -3251,6 +3245,12 @@ impl ListVolumeBackupsResponse {
     {
         use std::iter::Iterator;
         self.volume_backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVolumeBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3493,12 +3493,6 @@ impl ListRestorePlansResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRestorePlansResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [restore_plans][crate::model::ListRestorePlansResponse::restore_plans].
     pub fn set_restore_plans<T, V>(mut self, v: T) -> Self
     where
@@ -3507,6 +3501,12 @@ impl ListRestorePlansResponse {
     {
         use std::iter::Iterator;
         self.restore_plans = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRestorePlansResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3874,12 +3874,6 @@ impl ListRestoresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRestoresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [restores][crate::model::ListRestoresResponse::restores].
     pub fn set_restores<T, V>(mut self, v: T) -> Self
     where
@@ -3888,6 +3882,12 @@ impl ListRestoresResponse {
     {
         use std::iter::Iterator;
         self.restores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRestoresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4187,12 +4187,6 @@ impl ListVolumeRestoresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVolumeRestoresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [volume_restores][crate::model::ListVolumeRestoresResponse::volume_restores].
     pub fn set_volume_restores<T, V>(mut self, v: T) -> Self
     where
@@ -4201,6 +4195,12 @@ impl ListVolumeRestoresResponse {
     {
         use std::iter::Iterator;
         self.volume_restores = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVolumeRestoresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4517,6 +4517,18 @@ impl Restore {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Restore::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Restore::state].
     pub fn set_state<T: std::convert::Into<crate::model::restore::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -4585,18 +4597,6 @@ impl Restore {
     {
         use std::iter::Iterator;
         self.volume_data_restore_policy_overrides = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Restore::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4962,17 +4962,6 @@ impl RestoreConfig {
         self
     }
 
-    /// Sets the value of [restore_order][crate::model::RestoreConfig::restore_order].
-    pub fn set_restore_order<
-        T: std::convert::Into<std::option::Option<crate::model::restore_config::RestoreOrder>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.restore_order = v.into();
-        self
-    }
-
     /// Sets the value of [substitution_rules][crate::model::RestoreConfig::substitution_rules].
     pub fn set_substitution_rules<T, V>(mut self, v: T) -> Self
     where
@@ -5003,6 +4992,17 @@ impl RestoreConfig {
     {
         use std::iter::Iterator;
         self.volume_data_restore_policy_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [restore_order][crate::model::RestoreConfig::restore_order].
+    pub fn set_restore_order<
+        T: std::convert::Into<std::option::Option<crate::model::restore_config::RestoreOrder>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.restore_order = v.into();
         self
     }
 
@@ -5037,6 +5037,18 @@ impl RestoreConfig {
             })
     }
 
+    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
+    /// to hold a `AllNamespaces`.
+    ///
+    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
+    /// mutually exclusive.
+    pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.namespaced_resource_restore_scope = std::option::Option::Some(
+            crate::model::restore_config::NamespacedResourceRestoreScope::AllNamespaces(v.into()),
+        );
+        self
+    }
+
     /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
     /// if it holds a `SelectedNamespaces`, `None` if the field is not set or
     /// holds a different branch.
@@ -5048,59 +5060,6 @@ impl RestoreConfig {
             crate::model::restore_config::NamespacedResourceRestoreScope::SelectedNamespaces(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// if it holds a `SelectedApplications`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn selected_applications(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::NamespacedNames>> {
-        #[allow(unreachable_patterns)]
-        self.namespaced_resource_restore_scope.as_ref().and_then(|v| match v {
-            crate::model::restore_config::NamespacedResourceRestoreScope::SelectedApplications(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// if it holds a `NoNamespaces`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn no_namespaces(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.namespaced_resource_restore_scope
-            .as_ref()
-            .and_then(|v| match v {
-                crate::model::restore_config::NamespacedResourceRestoreScope::NoNamespaces(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-    }
-
-    /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// if it holds a `ExcludedNamespaces`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn excluded_namespaces(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::Namespaces>> {
-        #[allow(unreachable_patterns)]
-        self.namespaced_resource_restore_scope.as_ref().and_then(|v| match v {
-            crate::model::restore_config::NamespacedResourceRestoreScope::ExcludedNamespaces(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// to hold a `AllNamespaces`.
-    ///
-    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
-    /// mutually exclusive.
-    pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.namespaced_resource_restore_scope = std::option::Option::Some(
-            crate::model::restore_config::NamespacedResourceRestoreScope::AllNamespaces(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
@@ -5122,6 +5081,19 @@ impl RestoreConfig {
         self
     }
 
+    /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
+    /// if it holds a `SelectedApplications`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn selected_applications(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::NamespacedNames>> {
+        #[allow(unreachable_patterns)]
+        self.namespaced_resource_restore_scope.as_ref().and_then(|v| match v {
+            crate::model::restore_config::NamespacedResourceRestoreScope::SelectedApplications(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
     /// to hold a `SelectedApplications`.
     ///
@@ -5141,6 +5113,21 @@ impl RestoreConfig {
         self
     }
 
+    /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
+    /// if it holds a `NoNamespaces`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn no_namespaces(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.namespaced_resource_restore_scope
+            .as_ref()
+            .and_then(|v| match v {
+                crate::model::restore_config::NamespacedResourceRestoreScope::NoNamespaces(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+    }
+
     /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
     /// to hold a `NoNamespaces`.
     ///
@@ -5151,6 +5138,19 @@ impl RestoreConfig {
             crate::model::restore_config::NamespacedResourceRestoreScope::NoNamespaces(v.into()),
         );
         self
+    }
+
+    /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
+    /// if it holds a `ExcludedNamespaces`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn excluded_namespaces(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::Namespaces>> {
+        #[allow(unreachable_patterns)]
+        self.namespaced_resource_restore_scope.as_ref().and_then(|v| match v {
+            crate::model::restore_config::NamespacedResourceRestoreScope::ExcludedNamespaces(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
@@ -5296,18 +5296,6 @@ pub mod restore_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [all_group_kinds][crate::model::restore_config::ClusterResourceRestoreScope::all_group_kinds].
-        pub fn set_all_group_kinds<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.all_group_kinds = v.into();
-            self
-        }
-
-        /// Sets the value of [no_group_kinds][crate::model::restore_config::ClusterResourceRestoreScope::no_group_kinds].
-        pub fn set_no_group_kinds<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.no_group_kinds = v.into();
-            self
-        }
-
         /// Sets the value of [selected_group_kinds][crate::model::restore_config::ClusterResourceRestoreScope::selected_group_kinds].
         pub fn set_selected_group_kinds<T, V>(mut self, v: T) -> Self
         where
@@ -5327,6 +5315,18 @@ pub mod restore_config {
         {
             use std::iter::Iterator;
             self.excluded_group_kinds = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [all_group_kinds][crate::model::restore_config::ClusterResourceRestoreScope::all_group_kinds].
+        pub fn set_all_group_kinds<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.all_group_kinds = v.into();
+            self
+        }
+
+        /// Sets the value of [no_group_kinds][crate::model::restore_config::ClusterResourceRestoreScope::no_group_kinds].
+        pub fn set_no_group_kinds<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.no_group_kinds = v.into();
             self
         }
     }
@@ -5400,6 +5400,28 @@ pub mod restore_config {
             std::default::Default::default()
         }
 
+        /// Sets the value of [target_namespaces][crate::model::restore_config::SubstitutionRule::target_namespaces].
+        pub fn set_target_namespaces<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.target_namespaces = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [target_group_kinds][crate::model::restore_config::SubstitutionRule::target_group_kinds].
+        pub fn set_target_group_kinds<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::restore_config::GroupKind>,
+        {
+            use std::iter::Iterator;
+            self.target_group_kinds = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [target_json_path][crate::model::restore_config::SubstitutionRule::target_json_path].
         pub fn set_target_json_path<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -5421,28 +5443,6 @@ pub mod restore_config {
         /// Sets the value of [new_value][crate::model::restore_config::SubstitutionRule::new_value].
         pub fn set_new_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.new_value = v.into();
-            self
-        }
-
-        /// Sets the value of [target_namespaces][crate::model::restore_config::SubstitutionRule::target_namespaces].
-        pub fn set_target_namespaces<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.target_namespaces = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [target_group_kinds][crate::model::restore_config::SubstitutionRule::target_group_kinds].
-        pub fn set_target_group_kinds<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::restore_config::GroupKind>,
-        {
-            use std::iter::Iterator;
-            self.target_group_kinds = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5746,12 +5746,6 @@ pub mod restore_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [json_path][crate::model::restore_config::ResourceFilter::json_path].
-        pub fn set_json_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.json_path = v.into();
-            self
-        }
-
         /// Sets the value of [namespaces][crate::model::restore_config::ResourceFilter::namespaces].
         pub fn set_namespaces<T, V>(mut self, v: T) -> Self
         where
@@ -5771,6 +5765,12 @@ pub mod restore_config {
         {
             use std::iter::Iterator;
             self.group_kinds = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [json_path][crate::model::restore_config::ResourceFilter::json_path].
+        pub fn set_json_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.json_path = v.into();
             self
         }
     }
@@ -5817,6 +5817,17 @@ pub mod restore_config {
             std::default::Default::default()
         }
 
+        /// Sets the value of [field_actions][crate::model::restore_config::TransformationRule::field_actions].
+        pub fn set_field_actions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::restore_config::TransformationRuleAction>,
+        {
+            use std::iter::Iterator;
+            self.field_actions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [resource_filter][crate::model::restore_config::TransformationRule::resource_filter].
         pub fn set_resource_filter<
             T: std::convert::Into<std::option::Option<crate::model::restore_config::ResourceFilter>>,
@@ -5831,17 +5842,6 @@ pub mod restore_config {
         /// Sets the value of [description][crate::model::restore_config::TransformationRule::description].
         pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.description = v.into();
-            self
-        }
-
-        /// Sets the value of [field_actions][crate::model::restore_config::TransformationRule::field_actions].
-        pub fn set_field_actions<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::restore_config::TransformationRuleAction>,
-        {
-            use std::iter::Iterator;
-            self.field_actions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6925,6 +6925,18 @@ impl RestorePlan {
         self
     }
 
+    /// Sets the value of [labels][crate::model::RestorePlan::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::RestorePlan::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -6943,18 +6955,6 @@ impl RestorePlan {
     /// Sets the value of [state_reason][crate::model::RestorePlan::state_reason].
     pub fn set_state_reason<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.state_reason = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::RestorePlan::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/configmanagement/v1/src/model.rs
@@ -739,6 +739,17 @@ impl PolicyController {
         self
     }
 
+    /// Sets the value of [exemptable_namespaces][crate::model::PolicyController::exemptable_namespaces].
+    pub fn set_exemptable_namespaces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.exemptable_namespaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [referential_rules_enabled][crate::model::PolicyController::referential_rules_enabled].
     pub fn set_referential_rules_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.referential_rules_enabled = v.into();
@@ -748,17 +759,6 @@ impl PolicyController {
     /// Sets the value of [log_denies_enabled][crate::model::PolicyController::log_denies_enabled].
     pub fn set_log_denies_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.log_denies_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [exemptable_namespaces][crate::model::PolicyController::exemptable_namespaces].
-    pub fn set_exemptable_namespaces<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.exemptable_namespaces = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1125,6 +1125,17 @@ impl ConfigSyncState {
         self
     }
 
+    /// Sets the value of [errors][crate::model::ConfigSyncState::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ConfigSyncError>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [rootsync_crd][crate::model::ConfigSyncState::rootsync_crd].
     pub fn set_rootsync_crd<T: std::convert::Into<crate::model::config_sync_state::CRDState>>(
         mut self,
@@ -1149,17 +1160,6 @@ impl ConfigSyncState {
         v: T,
     ) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::ConfigSyncState::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ConfigSyncError>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -128,6 +128,18 @@ impl Feature {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Feature::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [resource_state][crate::model::Feature::resource_state].
     pub fn set_resource_state<
         T: std::convert::Into<std::option::Option<crate::model::FeatureResourceState>>,
@@ -148,6 +160,18 @@ impl Feature {
         self
     }
 
+    /// Sets the value of [membership_specs][crate::model::Feature::membership_specs].
+    pub fn set_membership_specs<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::MembershipFeatureSpec>,
+    {
+        use std::iter::Iterator;
+        self.membership_specs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Feature::state].
     pub fn set_state<
         T: std::convert::Into<std::option::Option<crate::model::CommonFeatureState>>,
@@ -156,6 +180,18 @@ impl Feature {
         v: T,
     ) -> Self {
         self.state = v.into();
+        self
+    }
+
+    /// Sets the value of [membership_states][crate::model::Feature::membership_states].
+    pub fn set_membership_states<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::MembershipFeatureState>,
+    {
+        use std::iter::Iterator;
+        self.membership_states = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -183,42 +219,6 @@ impl Feature {
         v: T,
     ) -> Self {
         self.delete_time = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Feature::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [membership_specs][crate::model::Feature::membership_specs].
-    pub fn set_membership_specs<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::MembershipFeatureSpec>,
-    {
-        use std::iter::Iterator;
-        self.membership_specs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [membership_states][crate::model::Feature::membership_states].
-    pub fn set_membership_states<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::MembershipFeatureState>,
-    {
-        use std::iter::Iterator;
-        self.membership_states = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1048,6 +1048,18 @@ impl Membership {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Membership::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Membership::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -1128,18 +1140,6 @@ impl Membership {
         v: T,
     ) -> Self {
         self.monitoring_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Membership::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1350,17 +1350,6 @@ impl KubernetesResource {
         self
     }
 
-    /// Sets the value of [resource_options][crate::model::KubernetesResource::resource_options].
-    pub fn set_resource_options<
-        T: std::convert::Into<std::option::Option<crate::model::ResourceOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource_options = v.into();
-        self
-    }
-
     /// Sets the value of [membership_resources][crate::model::KubernetesResource::membership_resources].
     pub fn set_membership_resources<T, V>(mut self, v: T) -> Self
     where
@@ -1380,6 +1369,17 @@ impl KubernetesResource {
     {
         use std::iter::Iterator;
         self.connect_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [resource_options][crate::model::KubernetesResource::resource_options].
+    pub fn set_resource_options<
+        T: std::convert::Into<std::option::Option<crate::model::ResourceOptions>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.resource_options = v.into();
         self
     }
 }
@@ -2143,12 +2143,6 @@ impl ListMembershipsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMembershipsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::ListMembershipsResponse::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -2157,6 +2151,12 @@ impl ListMembershipsResponse {
     {
         use std::iter::Iterator;
         self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMembershipsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2826,12 +2826,6 @@ impl ListFeaturesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFeaturesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::ListFeaturesResponse::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -2840,6 +2834,12 @@ impl ListFeaturesResponse {
     {
         use std::iter::Iterator;
         self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFeaturesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/gkemulticloud/v1/src/model.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/model.rs
@@ -292,6 +292,18 @@ impl AttachedCluster {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::AttachedCluster::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [workload_identity_config][crate::model::AttachedCluster::workload_identity_config].
     pub fn set_workload_identity_config<
         T: std::convert::Into<std::option::Option<crate::model::WorkloadIdentityConfig>>,
@@ -311,6 +323,17 @@ impl AttachedCluster {
         v: T,
     ) -> Self {
         self.logging_config = v.into();
+        self
+    }
+
+    /// Sets the value of [errors][crate::model::AttachedCluster::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AttachedClusterError>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -366,29 +389,6 @@ impl AttachedCluster {
         v: T,
     ) -> Self {
         self.security_posture_config = v.into();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::AttachedCluster::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AttachedClusterError>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::AttachedCluster::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1527,12 +1527,6 @@ impl ListAttachedClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAttachedClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [attached_clusters][crate::model::ListAttachedClustersResponse::attached_clusters].
     pub fn set_attached_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -1541,6 +1535,12 @@ impl ListAttachedClustersResponse {
     {
         use std::iter::Iterator;
         self.attached_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAttachedClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2105,6 +2105,18 @@ impl AwsCluster {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::AwsCluster::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [workload_identity_config][crate::model::AwsCluster::workload_identity_config].
     pub fn set_workload_identity_config<
         T: std::convert::Into<std::option::Option<crate::model::WorkloadIdentityConfig>>,
@@ -2145,6 +2157,17 @@ impl AwsCluster {
         self
     }
 
+    /// Sets the value of [errors][crate::model::AwsCluster::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AwsClusterError>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [monitoring_config][crate::model::AwsCluster::monitoring_config].
     pub fn set_monitoring_config<
         T: std::convert::Into<std::option::Option<crate::model::MonitoringConfig>>,
@@ -2164,29 +2187,6 @@ impl AwsCluster {
         v: T,
     ) -> Self {
         self.binary_authorization = v.into();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::AwsCluster::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AwsClusterError>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::AwsCluster::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2496,6 +2496,28 @@ impl AwsControlPlane {
         self
     }
 
+    /// Sets the value of [subnet_ids][crate::model::AwsControlPlane::subnet_ids].
+    pub fn set_subnet_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.subnet_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [security_group_ids][crate::model::AwsControlPlane::security_group_ids].
+    pub fn set_security_group_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.security_group_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [iam_instance_profile][crate::model::AwsControlPlane::iam_instance_profile].
     pub fn set_iam_instance_profile<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -2535,6 +2557,18 @@ impl AwsControlPlane {
         v: T,
     ) -> Self {
         self.database_encryption = v.into();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::AwsControlPlane::tags].
+    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2579,40 +2613,6 @@ impl AwsControlPlane {
         v: T,
     ) -> Self {
         self.instance_placement = v.into();
-        self
-    }
-
-    /// Sets the value of [subnet_ids][crate::model::AwsControlPlane::subnet_ids].
-    pub fn set_subnet_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.subnet_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [security_group_ids][crate::model::AwsControlPlane::security_group_ids].
-    pub fn set_security_group_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.security_group_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::AwsControlPlane::tags].
-    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3108,15 +3108,6 @@ impl AwsClusterNetworking {
         self
     }
 
-    /// Sets the value of [per_node_pool_sg_rules_disabled][crate::model::AwsClusterNetworking::per_node_pool_sg_rules_disabled].
-    pub fn set_per_node_pool_sg_rules_disabled<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.per_node_pool_sg_rules_disabled = v.into();
-        self
-    }
-
     /// Sets the value of [pod_address_cidr_blocks][crate::model::AwsClusterNetworking::pod_address_cidr_blocks].
     pub fn set_pod_address_cidr_blocks<T, V>(mut self, v: T) -> Self
     where
@@ -3136,6 +3127,15 @@ impl AwsClusterNetworking {
     {
         use std::iter::Iterator;
         self.service_address_cidr_blocks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [per_node_pool_sg_rules_disabled][crate::model::AwsClusterNetworking::per_node_pool_sg_rules_disabled].
+    pub fn set_per_node_pool_sg_rules_disabled<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.per_node_pool_sg_rules_disabled = v.into();
         self
     }
 }
@@ -3338,6 +3338,18 @@ impl AwsNodePool {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::AwsNodePool::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [max_pods_constraint][crate::model::AwsNodePool::max_pods_constraint].
     pub fn set_max_pods_constraint<
         T: std::convert::Into<std::option::Option<crate::model::MaxPodsConstraint>>,
@@ -3346,6 +3358,17 @@ impl AwsNodePool {
         v: T,
     ) -> Self {
         self.max_pods_constraint = v.into();
+        self
+    }
+
+    /// Sets the value of [errors][crate::model::AwsNodePool::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AwsNodePoolError>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3379,29 +3402,6 @@ impl AwsNodePool {
         v: T,
     ) -> Self {
         self.update_settings = v.into();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::AwsNodePool::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AwsNodePoolError>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::AwsNodePool::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3837,6 +3837,41 @@ impl AwsNodeConfig {
         self
     }
 
+    /// Sets the value of [taints][crate::model::AwsNodeConfig::taints].
+    pub fn set_taints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NodeTaint>,
+    {
+        use std::iter::Iterator;
+        self.taints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::AwsNodeConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::AwsNodeConfig::tags].
+    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [iam_instance_profile][crate::model::AwsNodeConfig::iam_instance_profile].
     pub fn set_iam_instance_profile<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -3860,6 +3895,17 @@ impl AwsNodeConfig {
         v: T,
     ) -> Self {
         self.ssh_config = v.into();
+        self
+    }
+
+    /// Sets the value of [security_group_ids][crate::model::AwsNodeConfig::security_group_ids].
+    pub fn set_security_group_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.security_group_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3913,52 +3959,6 @@ impl AwsNodeConfig {
         v: T,
     ) -> Self {
         self.spot_config = v.into();
-        self
-    }
-
-    /// Sets the value of [taints][crate::model::AwsNodeConfig::taints].
-    pub fn set_taints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NodeTaint>,
-    {
-        use std::iter::Iterator;
-        self.taints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [security_group_ids][crate::model::AwsNodeConfig::security_group_ids].
-    pub fn set_security_group_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.security_group_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AwsNodeConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::AwsNodeConfig::tags].
-    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5090,12 +5090,6 @@ impl ListAwsClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAwsClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [aws_clusters][crate::model::ListAwsClustersResponse::aws_clusters].
     pub fn set_aws_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -5104,6 +5098,12 @@ impl ListAwsClustersResponse {
     {
         use std::iter::Iterator;
         self.aws_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAwsClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5616,12 +5616,6 @@ impl ListAwsNodePoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAwsNodePoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [aws_node_pools][crate::model::ListAwsNodePoolsResponse::aws_node_pools].
     pub fn set_aws_node_pools<T, V>(mut self, v: T) -> Self
     where
@@ -5630,6 +5624,12 @@ impl ListAwsNodePoolsResponse {
     {
         use std::iter::Iterator;
         self.aws_node_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAwsNodePoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6418,6 +6418,18 @@ impl AzureCluster {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::AzureCluster::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [workload_identity_config][crate::model::AzureCluster::workload_identity_config].
     pub fn set_workload_identity_config<
         T: std::convert::Into<std::option::Option<crate::model::WorkloadIdentityConfig>>,
@@ -6469,17 +6481,6 @@ impl AzureCluster {
         self
     }
 
-    /// Sets the value of [monitoring_config][crate::model::AzureCluster::monitoring_config].
-    pub fn set_monitoring_config<
-        T: std::convert::Into<std::option::Option<crate::model::MonitoringConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.monitoring_config = v.into();
-        self
-    }
-
     /// Sets the value of [errors][crate::model::AzureCluster::errors].
     pub fn set_errors<T, V>(mut self, v: T) -> Self
     where
@@ -6491,15 +6492,14 @@ impl AzureCluster {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::AzureCluster::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [monitoring_config][crate::model::AzureCluster::monitoring_config].
+    pub fn set_monitoring_config<
+        T: std::convert::Into<std::option::Option<crate::model::MonitoringConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.monitoring_config = v.into();
         self
     }
 }
@@ -6746,15 +6746,6 @@ impl AzureClusterNetworking {
         self
     }
 
-    /// Sets the value of [service_load_balancer_subnet_id][crate::model::AzureClusterNetworking::service_load_balancer_subnet_id].
-    pub fn set_service_load_balancer_subnet_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_load_balancer_subnet_id = v.into();
-        self
-    }
-
     /// Sets the value of [pod_address_cidr_blocks][crate::model::AzureClusterNetworking::pod_address_cidr_blocks].
     pub fn set_pod_address_cidr_blocks<T, V>(mut self, v: T) -> Self
     where
@@ -6774,6 +6765,15 @@ impl AzureClusterNetworking {
     {
         use std::iter::Iterator;
         self.service_address_cidr_blocks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service_load_balancer_subnet_id][crate::model::AzureClusterNetworking::service_load_balancer_subnet_id].
+    pub fn set_service_load_balancer_subnet_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.service_load_balancer_subnet_id = v.into();
         self
     }
 }
@@ -6969,12 +6969,15 @@ impl AzureControlPlane {
         self
     }
 
-    /// Sets the value of [endpoint_subnet_id][crate::model::AzureControlPlane::endpoint_subnet_id].
-    pub fn set_endpoint_subnet_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.endpoint_subnet_id = v.into();
+    /// Sets the value of [tags][crate::model::AzureControlPlane::tags].
+    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -6989,15 +6992,12 @@ impl AzureControlPlane {
         self
     }
 
-    /// Sets the value of [tags][crate::model::AzureControlPlane::tags].
-    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [endpoint_subnet_id][crate::model::AzureControlPlane::endpoint_subnet_id].
+    pub fn set_endpoint_subnet_id<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.endpoint_subnet_id = v.into();
         self
     }
 }
@@ -7342,6 +7342,18 @@ impl AzureClient {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::AzureClient::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [pem_certificate][crate::model::AzureClient::pem_certificate].
     pub fn set_pem_certificate<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pem_certificate = v.into();
@@ -7369,18 +7381,6 @@ impl AzureClient {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::AzureClient::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7744,6 +7744,18 @@ impl AzureNodePool {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::AzureNodePool::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [max_pods_constraint][crate::model::AzureNodePool::max_pods_constraint].
     pub fn set_max_pods_constraint<
         T: std::convert::Into<std::option::Option<crate::model::MaxPodsConstraint>>,
@@ -7764,17 +7776,6 @@ impl AzureNodePool {
         self
     }
 
-    /// Sets the value of [management][crate::model::AzureNodePool::management].
-    pub fn set_management<
-        T: std::convert::Into<std::option::Option<crate::model::AzureNodeManagement>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.management = v.into();
-        self
-    }
-
     /// Sets the value of [errors][crate::model::AzureNodePool::errors].
     pub fn set_errors<T, V>(mut self, v: T) -> Self
     where
@@ -7786,15 +7787,14 @@ impl AzureNodePool {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::AzureNodePool::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [management][crate::model::AzureNodePool::management].
+    pub fn set_management<
+        T: std::convert::Into<std::option::Option<crate::model::AzureNodeManagement>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.management = v.into();
         self
     }
 }
@@ -8097,6 +8097,18 @@ impl AzureNodeConfig {
         self
     }
 
+    /// Sets the value of [tags][crate::model::AzureNodeConfig::tags].
+    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [image_type][crate::model::AzureNodeConfig::image_type].
     pub fn set_image_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.image_type = v.into();
@@ -8144,18 +8156,6 @@ impl AzureNodeConfig {
     {
         use std::iter::Iterator;
         self.taints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::AzureNodeConfig::tags].
-    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -9007,12 +9007,6 @@ impl ListAzureClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAzureClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [azure_clusters][crate::model::ListAzureClustersResponse::azure_clusters].
     pub fn set_azure_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -9021,6 +9015,12 @@ impl ListAzureClustersResponse {
     {
         use std::iter::Iterator;
         self.azure_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAzureClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9458,12 +9458,6 @@ impl ListAzureNodePoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAzureNodePoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [azure_node_pools][crate::model::ListAzureNodePoolsResponse::azure_node_pools].
     pub fn set_azure_node_pools<T, V>(mut self, v: T) -> Self
     where
@@ -9472,6 +9466,12 @@ impl ListAzureNodePoolsResponse {
     {
         use std::iter::Iterator;
         self.azure_node_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAzureNodePoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9945,12 +9945,6 @@ impl ListAzureClientsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAzureClientsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [azure_clients][crate::model::ListAzureClientsResponse::azure_clients].
     pub fn set_azure_clients<T, V>(mut self, v: T) -> Self
     where
@@ -9959,6 +9953,12 @@ impl ListAzureClientsResponse {
     {
         use std::iter::Iterator;
         self.azure_clients = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAzureClientsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/gsuiteaddons/v1/src/model.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/model.rs
@@ -342,12 +342,6 @@ impl ListDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::ListDeploymentsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -356,6 +350,12 @@ impl ListDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -615,6 +615,17 @@ impl Deployment {
         self
     }
 
+    /// Sets the value of [oauth_scopes][crate::model::Deployment::oauth_scopes].
+    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [add_ons][crate::model::Deployment::add_ons].
     pub fn set_add_ons<T: std::convert::Into<std::option::Option<crate::model::AddOns>>>(
         mut self,
@@ -627,17 +638,6 @@ impl Deployment {
     /// Sets the value of [etag][crate::model::Deployment::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [oauth_scopes][crate::model::Deployment::oauth_scopes].
-    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/iap/v1/src/model.rs
+++ b/src/generated/cloud/iap/v1/src/model.rs
@@ -118,12 +118,6 @@ impl ListTunnelDestGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTunnelDestGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tunnel_dest_groups][crate::model::ListTunnelDestGroupsResponse::tunnel_dest_groups].
     pub fn set_tunnel_dest_groups<T, V>(mut self, v: T) -> Self
     where
@@ -132,6 +126,12 @@ impl ListTunnelDestGroupsResponse {
     {
         use std::iter::Iterator;
         self.tunnel_dest_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTunnelDestGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -856,15 +856,6 @@ impl GcipSettings {
         std::default::Default::default()
     }
 
-    /// Sets the value of [login_page_uri][crate::model::GcipSettings::login_page_uri].
-    pub fn set_login_page_uri<T: std::convert::Into<std::option::Option<wkt::StringValue>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.login_page_uri = v.into();
-        self
-    }
-
     /// Sets the value of [tenant_ids][crate::model::GcipSettings::tenant_ids].
     pub fn set_tenant_ids<T, V>(mut self, v: T) -> Self
     where
@@ -873,6 +864,15 @@ impl GcipSettings {
     {
         use std::iter::Iterator;
         self.tenant_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [login_page_uri][crate::model::GcipSettings::login_page_uri].
+    pub fn set_login_page_uri<T: std::convert::Into<std::option::Option<wkt::StringValue>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.login_page_uri = v.into();
         self
     }
 }
@@ -1001,15 +1001,6 @@ impl WorkforceIdentitySettings {
         std::default::Default::default()
     }
 
-    /// Sets the value of [oauth2][crate::model::WorkforceIdentitySettings::oauth2].
-    pub fn set_oauth2<T: std::convert::Into<std::option::Option<crate::model::OAuth2>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.oauth2 = v.into();
-        self
-    }
-
     /// Sets the value of [workforce_pools][crate::model::WorkforceIdentitySettings::workforce_pools].
     pub fn set_workforce_pools<T, V>(mut self, v: T) -> Self
     where
@@ -1018,6 +1009,15 @@ impl WorkforceIdentitySettings {
     {
         use std::iter::Iterator;
         self.workforce_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [oauth2][crate::model::WorkforceIdentitySettings::oauth2].
+    pub fn set_oauth2<T: std::convert::Into<std::option::Option<crate::model::OAuth2>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.oauth2 = v.into();
         self
     }
 }
@@ -1744,12 +1744,6 @@ impl AttributePropagationSettings {
         self
     }
 
-    /// Sets the value of [enable][crate::model::AttributePropagationSettings::enable].
-    pub fn set_enable<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
-        self.enable = v.into();
-        self
-    }
-
     /// Sets the value of [output_credentials][crate::model::AttributePropagationSettings::output_credentials].
     pub fn set_output_credentials<T, V>(mut self, v: T) -> Self
     where
@@ -1758,6 +1752,12 @@ impl AttributePropagationSettings {
     {
         use std::iter::Iterator;
         self.output_credentials = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enable][crate::model::AttributePropagationSettings::enable].
+    pub fn set_enable<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
+        self.enable = v.into();
         self
     }
 }
@@ -2217,12 +2217,6 @@ impl ListIdentityAwareProxyClientsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIdentityAwareProxyClientsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [identity_aware_proxy_clients][crate::model::ListIdentityAwareProxyClientsResponse::identity_aware_proxy_clients].
     pub fn set_identity_aware_proxy_clients<T, V>(mut self, v: T) -> Self
     where
@@ -2231,6 +2225,12 @@ impl ListIdentityAwareProxyClientsResponse {
     {
         use std::iter::Iterator;
         self.identity_aware_proxy_clients = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIdentityAwareProxyClientsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/ids/v1/src/model.rs
+++ b/src/generated/cloud/ids/v1/src/model.rs
@@ -115,6 +115,18 @@ impl Endpoint {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Endpoint::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [network][crate::model::Endpoint::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
@@ -160,18 +172,6 @@ impl Endpoint {
     /// Sets the value of [traffic_logs][crate::model::Endpoint::traffic_logs].
     pub fn set_traffic_logs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.traffic_logs = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Endpoint::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -585,12 +585,6 @@ impl ListEndpointsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEndpointsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [endpoints][crate::model::ListEndpointsResponse::endpoints].
     pub fn set_endpoints<T, V>(mut self, v: T) -> Self
     where
@@ -599,6 +593,12 @@ impl ListEndpointsResponse {
     {
         use std::iter::Iterator;
         self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEndpointsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/kms/inventory/v1/src/model.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/model.rs
@@ -119,12 +119,6 @@ impl ListCryptoKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCryptoKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [crypto_keys][crate::model::ListCryptoKeysResponse::crypto_keys].
     pub fn set_crypto_keys<T, V>(mut self, v: T) -> Self
     where
@@ -133,6 +127,12 @@ impl ListCryptoKeysResponse {
     {
         use std::iter::Iterator;
         self.crypto_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCryptoKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -439,12 +439,6 @@ impl SearchProtectedResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchProtectedResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [protected_resources][crate::model::SearchProtectedResourcesResponse::protected_resources].
     pub fn set_protected_resources<T, V>(mut self, v: T) -> Self
     where
@@ -453,6 +447,12 @@ impl SearchProtectedResourcesResponse {
     {
         use std::iter::Iterator;
         self.protected_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchProtectedResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -584,21 +584,24 @@ impl ProtectedResource {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ProtectedResource::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [crypto_key_version][crate::model::ProtectedResource::crypto_key_version].
     pub fn set_crypto_key_version<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.crypto_key_version = v.into();
-        self
-    }
-
-    /// Sets the value of [create_time][crate::model::ProtectedResource::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
         self
     }
 
@@ -613,15 +616,12 @@ impl ProtectedResource {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ProtectedResource::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [create_time][crate::model::ProtectedResource::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
         self
     }
 }

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -365,12 +365,6 @@ impl ListKeyHandlesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListKeyHandlesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [key_handles][crate::model::ListKeyHandlesResponse::key_handles].
     pub fn set_key_handles<T, V>(mut self, v: T) -> Self
     where
@@ -379,6 +373,12 @@ impl ListKeyHandlesResponse {
     {
         use std::iter::Iterator;
         self.key_handles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListKeyHandlesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -928,6 +928,17 @@ impl ListEkmConnectionsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [ekm_connections][crate::model::ListEkmConnectionsResponse::ekm_connections].
+    pub fn set_ekm_connections<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EkmConnection>,
+    {
+        use std::iter::Iterator;
+        self.ekm_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListEkmConnectionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -937,17 +948,6 @@ impl ListEkmConnectionsResponse {
     /// Sets the value of [total_size][crate::model::ListEkmConnectionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [ekm_connections][crate::model::ListEkmConnectionsResponse::ekm_connections].
-    pub fn set_ekm_connections<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EkmConnection>,
-    {
-        use std::iter::Iterator;
-        self.ekm_connections = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1330,6 +1330,17 @@ impl Certificate {
         self
     }
 
+    /// Sets the value of [subject_alternative_dns_names][crate::model::Certificate::subject_alternative_dns_names].
+    pub fn set_subject_alternative_dns_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.subject_alternative_dns_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [not_before_time][crate::model::Certificate::not_before_time].
     pub fn set_not_before_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1360,17 +1371,6 @@ impl Certificate {
         v: T,
     ) -> Self {
         self.sha256_fingerprint = v.into();
-        self
-    }
-
-    /// Sets the value of [subject_alternative_dns_names][crate::model::Certificate::subject_alternative_dns_names].
-    pub fn set_subject_alternative_dns_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.subject_alternative_dns_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1476,6 +1476,17 @@ impl EkmConnection {
         self
     }
 
+    /// Sets the value of [service_resolvers][crate::model::EkmConnection::service_resolvers].
+    pub fn set_service_resolvers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ekm_connection::ServiceResolver>,
+    {
+        use std::iter::Iterator;
+        self.service_resolvers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::EkmConnection::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -1499,17 +1510,6 @@ impl EkmConnection {
         v: T,
     ) -> Self {
         self.crypto_space_path = v.into();
-        self
-    }
-
-    /// Sets the value of [service_resolvers][crate::model::EkmConnection::service_resolvers].
-    pub fn set_service_resolvers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ekm_connection::ServiceResolver>,
-    {
-        use std::iter::Iterator;
-        self.service_resolvers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2188,6 +2188,18 @@ impl CryptoKey {
         self
     }
 
+    /// Sets the value of [labels][crate::model::CryptoKey::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [import_only][crate::model::CryptoKey::import_only].
     pub fn set_import_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.import_only = v.into();
@@ -2222,18 +2234,6 @@ impl CryptoKey {
         v: T,
     ) -> Self {
         self.key_access_justifications_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::CryptoKey::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5659,6 +5659,17 @@ impl ListKeyRingsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [key_rings][crate::model::ListKeyRingsResponse::key_rings].
+    pub fn set_key_rings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::KeyRing>,
+    {
+        use std::iter::Iterator;
+        self.key_rings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListKeyRingsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -5668,17 +5679,6 @@ impl ListKeyRingsResponse {
     /// Sets the value of [total_size][crate::model::ListKeyRingsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [key_rings][crate::model::ListKeyRingsResponse::key_rings].
-    pub fn set_key_rings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::KeyRing>,
-    {
-        use std::iter::Iterator;
-        self.key_rings = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5742,6 +5742,17 @@ impl ListCryptoKeysResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [crypto_keys][crate::model::ListCryptoKeysResponse::crypto_keys].
+    pub fn set_crypto_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CryptoKey>,
+    {
+        use std::iter::Iterator;
+        self.crypto_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListCryptoKeysResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -5751,17 +5762,6 @@ impl ListCryptoKeysResponse {
     /// Sets the value of [total_size][crate::model::ListCryptoKeysResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [crypto_keys][crate::model::ListCryptoKeysResponse::crypto_keys].
-    pub fn set_crypto_keys<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CryptoKey>,
-    {
-        use std::iter::Iterator;
-        self.crypto_keys = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5826,6 +5826,17 @@ impl ListCryptoKeyVersionsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [crypto_key_versions][crate::model::ListCryptoKeyVersionsResponse::crypto_key_versions].
+    pub fn set_crypto_key_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CryptoKeyVersion>,
+    {
+        use std::iter::Iterator;
+        self.crypto_key_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListCryptoKeyVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -5835,17 +5846,6 @@ impl ListCryptoKeyVersionsResponse {
     /// Sets the value of [total_size][crate::model::ListCryptoKeyVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [crypto_key_versions][crate::model::ListCryptoKeyVersionsResponse::crypto_key_versions].
-    pub fn set_crypto_key_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CryptoKeyVersion>,
-    {
-        use std::iter::Iterator;
-        self.crypto_key_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5909,6 +5909,17 @@ impl ListImportJobsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [import_jobs][crate::model::ListImportJobsResponse::import_jobs].
+    pub fn set_import_jobs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ImportJob>,
+    {
+        use std::iter::Iterator;
+        self.import_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListImportJobsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -5918,17 +5929,6 @@ impl ListImportJobsResponse {
     /// Sets the value of [total_size][crate::model::ListImportJobsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [import_jobs][crate::model::ListImportJobsResponse::import_jobs].
-    pub fn set_import_jobs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ImportJob>,
-    {
-        use std::iter::Iterator;
-        self.import_jobs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9512,6 +9512,16 @@ impl Digest {
         })
     }
 
+    /// Sets the value of [digest][crate::model::Digest::digest]
+    /// to hold a `Sha256`.
+    ///
+    /// Note that all the setters affecting `digest` are
+    /// mutually exclusive.
+    pub fn set_sha256<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha256(v.into()));
+        self
+    }
+
     /// The value of [digest][crate::model::Digest::digest]
     /// if it holds a `Sha384`, `None` if the field is not set or
     /// holds a different branch.
@@ -9523,6 +9533,16 @@ impl Digest {
         })
     }
 
+    /// Sets the value of [digest][crate::model::Digest::digest]
+    /// to hold a `Sha384`.
+    ///
+    /// Note that all the setters affecting `digest` are
+    /// mutually exclusive.
+    pub fn set_sha384<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha384(v.into()));
+        self
+    }
+
     /// The value of [digest][crate::model::Digest::digest]
     /// if it holds a `Sha512`, `None` if the field is not set or
     /// holds a different branch.
@@ -9532,26 +9552,6 @@ impl Digest {
             crate::model::digest::Digest::Sha512(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [digest][crate::model::Digest::digest]
-    /// to hold a `Sha256`.
-    ///
-    /// Note that all the setters affecting `digest` are
-    /// mutually exclusive.
-    pub fn set_sha256<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha256(v.into()));
-        self
-    }
-
-    /// Sets the value of [digest][crate::model::Digest::digest]
-    /// to hold a `Sha384`.
-    ///
-    /// Note that all the setters affecting `digest` are
-    /// mutually exclusive.
-    pub fn set_sha384<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha384(v.into()));
-        self
     }
 
     /// Sets the value of [digest][crate::model::Digest::digest]

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -103,6 +103,16 @@ impl Document {
         })
     }
 
+    /// Sets the value of [source][crate::model::Document::source]
+    /// to hold a `Content`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(crate::model::document::Source::Content(v.into()));
+        self
+    }
+
     /// The value of [source][crate::model::Document::source]
     /// if it holds a `GcsContentUri`, `None` if the field is not set or
     /// holds a different branch.
@@ -112,16 +122,6 @@ impl Document {
             crate::model::document::Source::GcsContentUri(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(crate::model::document::Source::Content(v.into()));
-        self
     }
 
     /// Sets the value of [source][crate::model::Document::source]
@@ -404,12 +404,15 @@ impl Entity {
         self
     }
 
-    /// Sets the value of [sentiment][crate::model::Entity::sentiment].
-    pub fn set_sentiment<T: std::convert::Into<std::option::Option<crate::model::Sentiment>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sentiment = v.into();
+    /// Sets the value of [metadata][crate::model::Entity::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -424,15 +427,12 @@ impl Entity {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::Entity::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [sentiment][crate::model::Entity::sentiment].
+    pub fn set_sentiment<T: std::convert::Into<std::option::Option<crate::model::Sentiment>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.sentiment = v.into();
         self
     }
 }
@@ -1150,12 +1150,6 @@ impl AnalyzeSentimentResponse {
         self
     }
 
-    /// Sets the value of [language_supported][crate::model::AnalyzeSentimentResponse::language_supported].
-    pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.language_supported = v.into();
-        self
-    }
-
     /// Sets the value of [sentences][crate::model::AnalyzeSentimentResponse::sentences].
     pub fn set_sentences<T, V>(mut self, v: T) -> Self
     where
@@ -1164,6 +1158,12 @@ impl AnalyzeSentimentResponse {
     {
         use std::iter::Iterator;
         self.sentences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [language_supported][crate::model::AnalyzeSentimentResponse::language_supported].
+    pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.language_supported = v.into();
         self
     }
 }
@@ -1252,6 +1252,17 @@ impl AnalyzeEntitiesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [entities][crate::model::AnalyzeEntitiesResponse::entities].
+    pub fn set_entities<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Entity>,
+    {
+        use std::iter::Iterator;
+        self.entities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [language_code][crate::model::AnalyzeEntitiesResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
@@ -1261,17 +1272,6 @@ impl AnalyzeEntitiesResponse {
     /// Sets the value of [language_supported][crate::model::AnalyzeEntitiesResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
-        self
-    }
-
-    /// Sets the value of [entities][crate::model::AnalyzeEntitiesResponse::entities].
-    pub fn set_entities<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Entity>,
-    {
-        use std::iter::Iterator;
-        self.entities = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1348,6 +1348,17 @@ impl ClassifyTextResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [categories][crate::model::ClassifyTextResponse::categories].
+    pub fn set_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClassificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [language_code][crate::model::ClassifyTextResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
@@ -1357,17 +1368,6 @@ impl ClassifyTextResponse {
     /// Sets the value of [language_supported][crate::model::ClassifyTextResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
-        self
-    }
-
-    /// Sets the value of [categories][crate::model::ClassifyTextResponse::categories].
-    pub fn set_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClassificationCategory>,
-    {
-        use std::iter::Iterator;
-        self.categories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1600,6 +1600,17 @@ impl ModerateTextResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [moderation_categories][crate::model::ModerateTextResponse::moderation_categories].
+    pub fn set_moderation_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClassificationCategory>,
+    {
+        use std::iter::Iterator;
+        self.moderation_categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [language_code][crate::model::ModerateTextResponse::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
@@ -1609,17 +1620,6 @@ impl ModerateTextResponse {
     /// Sets the value of [language_supported][crate::model::ModerateTextResponse::language_supported].
     pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.language_supported = v.into();
-        self
-    }
-
-    /// Sets the value of [moderation_categories][crate::model::ModerateTextResponse::moderation_categories].
-    pub fn set_moderation_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClassificationCategory>,
-    {
-        use std::iter::Iterator;
-        self.moderation_categories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1821,29 +1821,6 @@ impl AnnotateTextResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [document_sentiment][crate::model::AnnotateTextResponse::document_sentiment].
-    pub fn set_document_sentiment<
-        T: std::convert::Into<std::option::Option<crate::model::Sentiment>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.document_sentiment = v.into();
-        self
-    }
-
-    /// Sets the value of [language_code][crate::model::AnnotateTextResponse::language_code].
-    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [language_supported][crate::model::AnnotateTextResponse::language_supported].
-    pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.language_supported = v.into();
-        self
-    }
-
     /// Sets the value of [sentences][crate::model::AnnotateTextResponse::sentences].
     pub fn set_sentences<T, V>(mut self, v: T) -> Self
     where
@@ -1866,6 +1843,23 @@ impl AnnotateTextResponse {
         self
     }
 
+    /// Sets the value of [document_sentiment][crate::model::AnnotateTextResponse::document_sentiment].
+    pub fn set_document_sentiment<
+        T: std::convert::Into<std::option::Option<crate::model::Sentiment>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.document_sentiment = v.into();
+        self
+    }
+
+    /// Sets the value of [language_code][crate::model::AnnotateTextResponse::language_code].
+    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.language_code = v.into();
+        self
+    }
+
     /// Sets the value of [categories][crate::model::AnnotateTextResponse::categories].
     pub fn set_categories<T, V>(mut self, v: T) -> Self
     where
@@ -1885,6 +1879,12 @@ impl AnnotateTextResponse {
     {
         use std::iter::Iterator;
         self.moderation_categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [language_supported][crate::model::AnnotateTextResponse::language_supported].
+    pub fn set_language_supported<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.language_supported = v.into();
         self
     }
 }

--- a/src/generated/cloud/licensemanager/v1/src/model.rs
+++ b/src/generated/cloud/licensemanager/v1/src/model.rs
@@ -153,15 +153,6 @@ impl Configuration {
         self
     }
 
-    /// Sets the value of [state][crate::model::Configuration::state].
-    pub fn set_state<T: std::convert::Into<crate::model::configuration::State>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Configuration::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -171,6 +162,15 @@ impl Configuration {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Configuration::state].
+    pub fn set_state<T: std::convert::Into<crate::model::configuration::State>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.state = v.into();
         self
     }
 }
@@ -823,6 +823,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Instance::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -832,6 +844,18 @@ impl Instance {
     /// Sets the value of [region][crate::model::Instance::region].
     pub fn set_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region = v.into();
+        self
+    }
+
+    /// Sets the value of [product_activation][crate::model::Instance::product_activation].
+    pub fn set_product_activation<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ActivationState>,
+    {
+        use std::iter::Iterator;
+        self.product_activation = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -850,30 +874,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.compute_instance = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [product_activation][crate::model::Instance::product_activation].
-    pub fn set_product_activation<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::ActivationState>,
-    {
-        use std::iter::Iterator;
-        self.product_activation = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1202,12 +1202,6 @@ impl ListConfigurationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConfigurationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [configurations][crate::model::ListConfigurationsResponse::configurations].
     pub fn set_configurations<T, V>(mut self, v: T) -> Self
     where
@@ -1216,6 +1210,12 @@ impl ListConfigurationsResponse {
     {
         use std::iter::Iterator;
         self.configurations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConfigurationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1595,12 +1595,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -1609,6 +1603,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2068,12 +2068,6 @@ impl AggregateUsageResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::AggregateUsageResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [usages][crate::model::AggregateUsageResponse::usages].
     pub fn set_usages<T, V>(mut self, v: T) -> Self
     where
@@ -2082,6 +2076,12 @@ impl AggregateUsageResponse {
     {
         use std::iter::Iterator;
         self.usages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::AggregateUsageResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2217,12 +2217,6 @@ impl ListProductsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProductsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [products][crate::model::ListProductsResponse::products].
     pub fn set_products<T, V>(mut self, v: T) -> Self
     where
@@ -2231,6 +2225,12 @@ impl ListProductsResponse {
     {
         use std::iter::Iterator;
         self.products = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProductsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/location/src/model.rs
+++ b/src/generated/cloud/location/src/model.rs
@@ -119,12 +119,6 @@ impl ListLocationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [locations][crate::model::ListLocationsResponse::locations].
     pub fn set_locations<T, V>(mut self, v: T) -> Self
     where
@@ -133,6 +127,12 @@ impl ListLocationsResponse {
     {
         use std::iter::Iterator;
         self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -251,15 +251,6 @@ impl Location {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::Location::metadata].
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Location::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -269,6 +260,15 @@ impl Location {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::Location::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }

--- a/src/generated/cloud/lustre/v1/src/model.rs
+++ b/src/generated/cloud/lustre/v1/src/model.rs
@@ -167,18 +167,6 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [per_unit_storage_throughput][crate::model::Instance::per_unit_storage_throughput].
-    pub fn set_per_unit_storage_throughput<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.per_unit_storage_throughput = v.into();
-        self
-    }
-
-    /// Sets the value of [gke_support_enabled][crate::model::Instance::gke_support_enabled].
-    pub fn set_gke_support_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.gke_support_enabled = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Instance::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -188,6 +176,18 @@ impl Instance {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [per_unit_storage_throughput][crate::model::Instance::per_unit_storage_throughput].
+    pub fn set_per_unit_storage_throughput<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.per_unit_storage_throughput = v.into();
+        self
+    }
+
+    /// Sets the value of [gke_support_enabled][crate::model::Instance::gke_support_enabled].
+    pub fn set_gke_support_enabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.gke_support_enabled = v.into();
         self
     }
 }
@@ -470,12 +470,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -484,6 +478,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1870,19 +1870,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// The value of [source][crate::model::TransferOperationMetadata::source]
-    /// if it holds a `SourceGcsPath`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn source_gcs_path(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsPath>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::transfer_operation_metadata::Source::SourceGcsPath(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
     /// to hold a `SourceLustrePath`.
     ///
@@ -1898,6 +1885,19 @@ impl TransferOperationMetadata {
             crate::model::transfer_operation_metadata::Source::SourceLustrePath(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::TransferOperationMetadata::source]
+    /// if it holds a `SourceGcsPath`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn source_gcs_path(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsPath>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::transfer_operation_metadata::Source::SourceGcsPath(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
@@ -1946,21 +1946,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// The value of [destination][crate::model::TransferOperationMetadata::destination]
-    /// if it holds a `DestinationLustrePath`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn destination_lustre_path(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::LustrePath>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::transfer_operation_metadata::Destination::DestinationLustrePath(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]
     /// to hold a `DestinationGcsPath`.
     ///
@@ -1976,6 +1961,21 @@ impl TransferOperationMetadata {
             crate::model::transfer_operation_metadata::Destination::DestinationGcsPath(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::TransferOperationMetadata::destination]
+    /// if it holds a `DestinationLustrePath`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn destination_lustre_path(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::LustrePath>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::transfer_operation_metadata::Destination::DestinationLustrePath(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]

--- a/src/generated/cloud/managedidentities/v1/src/model.rs
+++ b/src/generated/cloud/managedidentities/v1/src/model.rs
@@ -377,12 +377,6 @@ impl ListDomainsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDomainsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [domains][crate::model::ListDomainsResponse::domains].
     pub fn set_domains<T, V>(mut self, v: T) -> Self
     where
@@ -391,6 +385,12 @@ impl ListDomainsResponse {
     {
         use std::iter::Iterator;
         self.domains = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDomainsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -840,12 +840,46 @@ impl Domain {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Domain::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [authorized_networks][crate::model::Domain::authorized_networks].
+    pub fn set_authorized_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.authorized_networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [reserved_ip_range][crate::model::Domain::reserved_ip_range].
     pub fn set_reserved_ip_range<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.reserved_ip_range = v.into();
+        self
+    }
+
+    /// Sets the value of [locations][crate::model::Domain::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -891,28 +925,6 @@ impl Domain {
         self
     }
 
-    /// Sets the value of [authorized_networks][crate::model::Domain::authorized_networks].
-    pub fn set_authorized_networks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.authorized_networks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [locations][crate::model::Domain::locations].
-    pub fn set_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.locations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [trusts][crate::model::Domain::trusts].
     pub fn set_trusts<T, V>(mut self, v: T) -> Self
     where
@@ -921,18 +933,6 @@ impl Domain {
     {
         use std::iter::Iterator;
         self.trusts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Domain::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1213,6 +1213,17 @@ impl Trust {
         self
     }
 
+    /// Sets the value of [target_dns_ip_addresses][crate::model::Trust::target_dns_ip_addresses].
+    pub fn set_target_dns_ip_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.target_dns_ip_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [trust_handshake_secret][crate::model::Trust::trust_handshake_secret].
     pub fn set_trust_handshake_secret<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -1263,17 +1274,6 @@ impl Trust {
         v: T,
     ) -> Self {
         self.last_trust_heartbeat_time = v.into();
-        self
-    }
-
-    /// Sets the value of [target_dns_ip_addresses][crate::model::Trust::target_dns_ip_addresses].
-    pub fn set_target_dns_ip_addresses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.target_dns_ip_addresses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/memcache/v1/src/builder.rs
+++ b/src/generated/cloud/memcache/v1/src/builder.rs
@@ -671,12 +671,6 @@ pub mod cloud_memcache {
             self
         }
 
-        /// Sets the value of [apply_all][crate::model::ApplyParametersRequest::apply_all].
-        pub fn set_apply_all<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.apply_all = v.into();
-            self
-        }
-
         /// Sets the value of [node_ids][crate::model::ApplyParametersRequest::node_ids].
         pub fn set_node_ids<T, V>(mut self, v: T) -> Self
         where
@@ -685,6 +679,12 @@ pub mod cloud_memcache {
         {
             use std::iter::Iterator;
             self.0.request.node_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [apply_all][crate::model::ApplyParametersRequest::apply_all].
+        pub fn set_apply_all<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.apply_all = v.into();
             self
         }
     }

--- a/src/generated/cloud/memcache/v1/src/model.rs
+++ b/src/generated/cloud/memcache/v1/src/model.rs
@@ -162,12 +162,35 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [authorized_network][crate::model::Instance::authorized_network].
     pub fn set_authorized_network<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.authorized_network = v.into();
+        self
+    }
+
+    /// Sets the value of [zones][crate::model::Instance::zones].
+    pub fn set_zones<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.zones = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -208,6 +231,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [memcache_nodes][crate::model::Instance::memcache_nodes].
+    pub fn set_memcache_nodes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::instance::Node>,
+    {
+        use std::iter::Iterator;
+        self.memcache_nodes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Instance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -241,6 +275,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [instance_messages][crate::model::Instance::instance_messages].
+    pub fn set_instance_messages<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::instance::InstanceMessage>,
+    {
+        use std::iter::Iterator;
+        self.instance_messages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [discovery_endpoint][crate::model::Instance::discovery_endpoint].
     pub fn set_discovery_endpoint<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -269,51 +314,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.maintenance_schedule = v.into();
-        self
-    }
-
-    /// Sets the value of [zones][crate::model::Instance::zones].
-    pub fn set_zones<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.zones = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [memcache_nodes][crate::model::Instance::memcache_nodes].
-    pub fn set_memcache_nodes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::instance::Node>,
-    {
-        use std::iter::Iterator;
-        self.memcache_nodes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [instance_messages][crate::model::Instance::instance_messages].
-    pub fn set_instance_messages<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::instance::InstanceMessage>,
-    {
-        use std::iter::Iterator;
-        self.instance_messages = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1476,12 +1476,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -1490,6 +1484,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1756,12 +1756,6 @@ impl ApplyParametersRequest {
         self
     }
 
-    /// Sets the value of [apply_all][crate::model::ApplyParametersRequest::apply_all].
-    pub fn set_apply_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.apply_all = v.into();
-        self
-    }
-
     /// Sets the value of [node_ids][crate::model::ApplyParametersRequest::node_ids].
     pub fn set_node_ids<T, V>(mut self, v: T) -> Self
     where
@@ -1770,6 +1764,12 @@ impl ApplyParametersRequest {
     {
         use std::iter::Iterator;
         self.node_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [apply_all][crate::model::ApplyParametersRequest::apply_all].
+    pub fn set_apply_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.apply_all = v.into();
         self
     }
 }

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -160,6 +160,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Instance::state].
     pub fn set_state<T: std::convert::Into<crate::model::instance::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -220,6 +232,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [discovery_endpoints][crate::model::Instance::discovery_endpoints].
+    pub fn set_discovery_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DiscoveryEndpoint>,
+    {
+        use std::iter::Iterator;
+        self.discovery_endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [node_type][crate::model::Instance::node_type].
     pub fn set_node_type<T: std::convert::Into<crate::model::instance::NodeType>>(
         mut self,
@@ -243,6 +266,18 @@ impl Instance {
     /// Sets the value of [engine_version][crate::model::Instance::engine_version].
     pub fn set_engine_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.engine_version = v.into();
+        self
+    }
+
+    /// Sets the value of [engine_configs][crate::model::Instance::engine_configs].
+    pub fn set_engine_configs<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.engine_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -275,23 +310,6 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [mode][crate::model::Instance::mode].
-    pub fn set_mode<T: std::convert::Into<crate::model::instance::Mode>>(mut self, v: T) -> Self {
-        self.mode = v.into();
-        self
-    }
-
-    /// Sets the value of [discovery_endpoints][crate::model::Instance::discovery_endpoints].
-    pub fn set_discovery_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DiscoveryEndpoint>,
-    {
-        use std::iter::Iterator;
-        self.discovery_endpoints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [psc_auto_connections][crate::model::Instance::psc_auto_connections].
     pub fn set_psc_auto_connections<T, V>(mut self, v: T) -> Self
     where
@@ -314,27 +332,9 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [engine_configs][crate::model::Instance::engine_configs].
-    pub fn set_engine_configs<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.engine_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [mode][crate::model::Instance::mode].
+    pub fn set_mode<T: std::convert::Into<crate::model::instance::Mode>>(mut self, v: T) -> Self {
+        self.mode = v.into();
         self
     }
 }
@@ -576,21 +576,6 @@ pub mod instance {
             })
         }
 
-        /// The value of [connection][crate::model::instance::ConnectionDetail::connection]
-        /// if it holds a `PscConnection`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn psc_connection(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::PscConnection>> {
-            #[allow(unreachable_patterns)]
-            self.connection.as_ref().and_then(|v| match v {
-                crate::model::instance::connection_detail::Connection::PscConnection(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [connection][crate::model::instance::ConnectionDetail::connection]
         /// to hold a `PscAutoConnection`.
         ///
@@ -606,6 +591,21 @@ pub mod instance {
                 crate::model::instance::connection_detail::Connection::PscAutoConnection(v.into()),
             );
             self
+        }
+
+        /// The value of [connection][crate::model::instance::ConnectionDetail::connection]
+        /// if it holds a `PscConnection`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn psc_connection(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::PscConnection>> {
+            #[allow(unreachable_patterns)]
+            self.connection.as_ref().and_then(|v| match v {
+                crate::model::instance::connection_detail::Connection::PscConnection(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [connection][crate::model::instance::ConnectionDetail::connection]
@@ -2640,12 +2640,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -2654,6 +2648,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -171,6 +171,18 @@ impl Service {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Service::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [network][crate::model::Service::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
@@ -303,18 +315,6 @@ impl Service {
         v: T,
     ) -> Self {
         self.scaling_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Service::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1064,6 +1064,18 @@ impl HiveMetastoreConfig {
         self
     }
 
+    /// Sets the value of [config_overrides][crate::model::HiveMetastoreConfig::config_overrides].
+    pub fn set_config_overrides<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.config_overrides = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [kerberos_config][crate::model::HiveMetastoreConfig::kerberos_config].
     pub fn set_kerberos_config<
         T: std::convert::Into<std::option::Option<crate::model::KerberosConfig>>,
@@ -1083,18 +1095,6 @@ impl HiveMetastoreConfig {
         v: T,
     ) -> Self {
         self.endpoint_protocol = v.into();
-        self
-    }
-
-    /// Sets the value of [config_overrides][crate::model::HiveMetastoreConfig::config_overrides].
-    pub fn set_config_overrides<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.config_overrides = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1467,17 +1467,6 @@ impl AuxiliaryVersionConfig {
         self
     }
 
-    /// Sets the value of [network_config][crate::model::AuxiliaryVersionConfig::network_config].
-    pub fn set_network_config<
-        T: std::convert::Into<std::option::Option<crate::model::NetworkConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.network_config = v.into();
-        self
-    }
-
     /// Sets the value of [config_overrides][crate::model::AuxiliaryVersionConfig::config_overrides].
     pub fn set_config_overrides<T, K, V>(mut self, v: T) -> Self
     where
@@ -1487,6 +1476,17 @@ impl AuxiliaryVersionConfig {
     {
         use std::iter::Iterator;
         self.config_overrides = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [network_config][crate::model::AuxiliaryVersionConfig::network_config].
+    pub fn set_network_config<
+        T: std::convert::Into<std::option::Option<crate::model::NetworkConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.network_config = v.into();
         self
     }
 }
@@ -3378,19 +3378,6 @@ impl ScalingConfig {
         })
     }
 
-    /// The value of [scaling_model][crate::model::ScalingConfig::scaling_model]
-    /// if it holds a `ScalingFactor`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn scaling_factor(&self) -> std::option::Option<&f32> {
-        #[allow(unreachable_patterns)]
-        self.scaling_model.as_ref().and_then(|v| match v {
-            crate::model::scaling_config::ScalingModel::ScalingFactor(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [scaling_model][crate::model::ScalingConfig::scaling_model]
     /// to hold a `InstanceSize`.
     ///
@@ -3404,6 +3391,19 @@ impl ScalingConfig {
             crate::model::scaling_config::ScalingModel::InstanceSize(v.into()),
         );
         self
+    }
+
+    /// The value of [scaling_model][crate::model::ScalingConfig::scaling_model]
+    /// if it holds a `ScalingFactor`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn scaling_factor(&self) -> std::option::Option<&f32> {
+        #[allow(unreachable_patterns)]
+        self.scaling_model.as_ref().and_then(|v| match v {
+            crate::model::scaling_config::ScalingModel::ScalingFactor(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [scaling_model][crate::model::ScalingConfig::scaling_model]
@@ -3722,12 +3722,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -3736,6 +3730,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4159,12 +4159,6 @@ impl ListMetadataImportsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMetadataImportsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [metadata_imports][crate::model::ListMetadataImportsResponse::metadata_imports].
     pub fn set_metadata_imports<T, V>(mut self, v: T) -> Self
     where
@@ -4173,6 +4167,12 @@ impl ListMetadataImportsResponse {
     {
         use std::iter::Iterator;
         self.metadata_imports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMetadataImportsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4544,12 +4544,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -4558,6 +4552,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5754,9 +5754,33 @@ impl Federation {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Federation::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [version][crate::model::Federation::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
+        self
+    }
+
+    /// Sets the value of [backend_metastores][crate::model::Federation::backend_metastores].
+    pub fn set_backend_metastores<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<i32>,
+        V: std::convert::Into<crate::model::BackendMetastore>,
+    {
+        use std::iter::Iterator;
+        self.backend_metastores = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5784,30 +5808,6 @@ impl Federation {
     /// Sets the value of [uid][crate::model::Federation::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Federation::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [backend_metastores][crate::model::Federation::backend_metastores].
-    pub fn set_backend_metastores<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<i32>,
-        V: std::convert::Into<crate::model::BackendMetastore>,
-    {
-        use std::iter::Iterator;
-        self.backend_metastores = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6284,12 +6284,6 @@ impl ListFederationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFederationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [federations][crate::model::ListFederationsResponse::federations].
     pub fn set_federations<T, V>(mut self, v: T) -> Self
     where
@@ -6298,6 +6292,12 @@ impl ListFederationsResponse {
     {
         use std::iter::Iterator;
         self.federations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFederationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/migrationcenter/v1/src/builder.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builder.rs
@@ -438,12 +438,6 @@ pub mod migration_center {
             self
         }
 
-        /// Sets the value of [allow_missing][crate::model::BatchDeleteAssetsRequest::allow_missing].
-        pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.allow_missing = v.into();
-            self
-        }
-
         /// Sets the value of [names][crate::model::BatchDeleteAssetsRequest::names].
         ///
         /// This is a **required** field for requests.
@@ -454,6 +448,12 @@ pub mod migration_center {
         {
             use std::iter::Iterator;
             self.0.request.names = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [allow_missing][crate::model::BatchDeleteAssetsRequest::allow_missing].
+        pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.allow_missing = v.into();
             self
         }
     }
@@ -574,12 +574,6 @@ pub mod migration_center {
             self
         }
 
-        /// Sets the value of [filter][crate::model::AggregateAssetsValuesRequest::filter].
-        pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.filter = v.into();
-            self
-        }
-
         /// Sets the value of [aggregations][crate::model::AggregateAssetsValuesRequest::aggregations].
         pub fn set_aggregations<T, V>(mut self, v: T) -> Self
         where
@@ -588,6 +582,12 @@ pub mod migration_center {
         {
             use std::iter::Iterator;
             self.0.request.aggregations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [filter][crate::model::AggregateAssetsValuesRequest::filter].
+        pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.filter = v.into();
             self
         }
     }

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -115,6 +115,30 @@ impl Asset {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Asset::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [attributes][crate::model::Asset::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [insight_list][crate::model::Asset::insight_list].
     pub fn set_insight_list<
         T: std::convert::Into<std::option::Option<crate::model::InsightList>>,
@@ -156,30 +180,6 @@ impl Asset {
     {
         use std::iter::Iterator;
         self.assigned_groups = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Asset::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [attributes][crate::model::Asset::attributes].
-    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -441,12 +441,6 @@ impl ImportJob {
         self
     }
 
-    /// Sets the value of [asset_source][crate::model::ImportJob::asset_source].
-    pub fn set_asset_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.asset_source = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::ImportJob::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -456,6 +450,12 @@ impl ImportJob {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [asset_source][crate::model::ImportJob::asset_source].
+    pub fn set_asset_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.asset_source = v.into();
         self
     }
 
@@ -486,19 +486,6 @@ impl ImportJob {
         })
     }
 
-    /// The value of [report][crate::model::ImportJob::report]
-    /// if it holds a `ExecutionReport`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn execution_report(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExecutionReport>> {
-        #[allow(unreachable_patterns)]
-        self.report.as_ref().and_then(|v| match v {
-            crate::model::import_job::Report::ExecutionReport(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [report][crate::model::ImportJob::report]
     /// to hold a `ValidationReport`.
     ///
@@ -513,6 +500,19 @@ impl ImportJob {
         self.report =
             std::option::Option::Some(crate::model::import_job::Report::ValidationReport(v.into()));
         self
+    }
+
+    /// The value of [report][crate::model::ImportJob::report]
+    /// if it holds a `ExecutionReport`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn execution_report(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExecutionReport>> {
+        #[allow(unreachable_patterns)]
+        self.report.as_ref().and_then(|v| match v {
+            crate::model::import_job::Report::ExecutionReport(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [report][crate::model::ImportJob::report]
@@ -1064,18 +1064,6 @@ impl Group {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::Group::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
-    /// Sets the value of [description][crate::model::Group::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Group::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -1085,6 +1073,18 @@ impl Group {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::Group::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::Group::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
         self
     }
 }
@@ -1132,6 +1132,17 @@ impl ErrorFrame {
         self
     }
 
+    /// Sets the value of [violations][crate::model::ErrorFrame::violations].
+    pub fn set_violations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FrameViolationEntry>,
+    {
+        use std::iter::Iterator;
+        self.violations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [original_frame][crate::model::ErrorFrame::original_frame].
     pub fn set_original_frame<
         T: std::convert::Into<std::option::Option<crate::model::AssetFrame>>,
@@ -1149,17 +1160,6 @@ impl ErrorFrame {
         v: T,
     ) -> Self {
         self.ingestion_time = v.into();
-        self
-    }
-
-    /// Sets the value of [violations][crate::model::ErrorFrame::violations].
-    pub fn set_violations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FrameViolationEntry>,
-    {
-        use std::iter::Iterator;
-        self.violations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2343,12 +2343,6 @@ impl ListAssetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assets][crate::model::ListAssetsResponse::assets].
     pub fn set_assets<T, V>(mut self, v: T) -> Self
     where
@@ -2357,6 +2351,12 @@ impl ListAssetsResponse {
     {
         use std::iter::Iterator;
         self.assets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2685,12 +2685,6 @@ impl BatchDeleteAssetsRequest {
         self
     }
 
-    /// Sets the value of [allow_missing][crate::model::BatchDeleteAssetsRequest::allow_missing].
-    pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.allow_missing = v.into();
-        self
-    }
-
     /// Sets the value of [names][crate::model::BatchDeleteAssetsRequest::names].
     pub fn set_names<T, V>(mut self, v: T) -> Self
     where
@@ -2699,6 +2693,12 @@ impl BatchDeleteAssetsRequest {
     {
         use std::iter::Iterator;
         self.names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [allow_missing][crate::model::BatchDeleteAssetsRequest::allow_missing].
+    pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.allow_missing = v.into();
         self
     }
 }
@@ -2820,12 +2820,6 @@ impl AggregateAssetsValuesRequest {
         self
     }
 
-    /// Sets the value of [filter][crate::model::AggregateAssetsValuesRequest::filter].
-    pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.filter = v.into();
-        self
-    }
-
     /// Sets the value of [aggregations][crate::model::AggregateAssetsValuesRequest::aggregations].
     pub fn set_aggregations<T, V>(mut self, v: T) -> Self
     where
@@ -2834,6 +2828,12 @@ impl AggregateAssetsValuesRequest {
     {
         use std::iter::Iterator;
         self.aggregations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [filter][crate::model::AggregateAssetsValuesRequest::filter].
+    pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.filter = v.into();
         self
     }
 }
@@ -3068,12 +3068,6 @@ impl ListImportJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListImportJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [import_jobs][crate::model::ListImportJobsResponse::import_jobs].
     pub fn set_import_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -3082,6 +3076,12 @@ impl ListImportJobsResponse {
     {
         use std::iter::Iterator;
         self.import_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListImportJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3547,12 +3547,6 @@ impl ListImportDataFilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListImportDataFilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [import_data_files][crate::model::ListImportDataFilesResponse::import_data_files].
     pub fn set_import_data_files<T, V>(mut self, v: T) -> Self
     where
@@ -3561,6 +3555,12 @@ impl ListImportDataFilesResponse {
     {
         use std::iter::Iterator;
         self.import_data_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListImportDataFilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3832,12 +3832,6 @@ impl ListGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [groups][crate::model::ListGroupsResponse::groups].
     pub fn set_groups<T, V>(mut self, v: T) -> Self
     where
@@ -3846,6 +3840,12 @@ impl ListGroupsResponse {
     {
         use std::iter::Iterator;
         self.groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4379,12 +4379,6 @@ impl ListErrorFramesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListErrorFramesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [error_frames][crate::model::ListErrorFramesResponse::error_frames].
     pub fn set_error_frames<T, V>(mut self, v: T) -> Self
     where
@@ -4393,6 +4387,12 @@ impl ListErrorFramesResponse {
     {
         use std::iter::Iterator;
         self.error_frames = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListErrorFramesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4571,12 +4571,6 @@ impl ListSourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sources][crate::model::ListSourcesResponse::sources].
     pub fn set_sources<T, V>(mut self, v: T) -> Self
     where
@@ -4585,6 +4579,12 @@ impl ListSourcesResponse {
     {
         use std::iter::Iterator;
         self.sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4953,12 +4953,6 @@ impl ListPreferenceSetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPreferenceSetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [preference_sets][crate::model::ListPreferenceSetsResponse::preference_sets].
     pub fn set_preference_sets<T, V>(mut self, v: T) -> Self
     where
@@ -4967,6 +4961,12 @@ impl ListPreferenceSetsResponse {
     {
         use std::iter::Iterator;
         self.preference_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPreferenceSetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5661,12 +5661,6 @@ impl ListReportsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReportsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [reports][crate::model::ListReportsResponse::reports].
     pub fn set_reports<T, V>(mut self, v: T) -> Self
     where
@@ -5675,6 +5669,12 @@ impl ListReportsResponse {
     {
         use std::iter::Iterator;
         self.reports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReportsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5896,12 +5896,6 @@ impl ListReportConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReportConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [report_configs][crate::model::ListReportConfigsResponse::report_configs].
     pub fn set_report_configs<T, V>(mut self, v: T) -> Self
     where
@@ -5910,6 +5904,12 @@ impl ListReportConfigsResponse {
     {
         use std::iter::Iterator;
         self.report_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReportConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6114,23 +6114,6 @@ impl AssetFrame {
         self
     }
 
-    /// Sets the value of [trace_token][crate::model::AssetFrame::trace_token].
-    pub fn set_trace_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.trace_token = v.into();
-        self
-    }
-
-    /// Sets the value of [performance_samples][crate::model::AssetFrame::performance_samples].
-    pub fn set_performance_samples<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PerformanceSample>,
-    {
-        use std::iter::Iterator;
-        self.performance_samples = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::AssetFrame::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6152,6 +6135,23 @@ impl AssetFrame {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [performance_samples][crate::model::AssetFrame::performance_samples].
+    pub fn set_performance_samples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PerformanceSample>,
+    {
+        use std::iter::Iterator;
+        self.performance_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [trace_token][crate::model::AssetFrame::trace_token].
+    pub fn set_trace_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.trace_token = v.into();
         self
     }
 
@@ -10422,66 +10422,6 @@ impl PlatformDetails {
         })
     }
 
-    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// if it holds a `AwsEc2Details`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws_ec2_details(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsEc2PlatformDetails>> {
-        #[allow(unreachable_patterns)]
-        self.vendor_details.as_ref().and_then(|v| match v {
-            crate::model::platform_details::VendorDetails::AwsEc2Details(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// if it holds a `AzureVmDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn azure_vm_details(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureVmPlatformDetails>> {
-        #[allow(unreachable_patterns)]
-        self.vendor_details.as_ref().and_then(|v| match v {
-            crate::model::platform_details::VendorDetails::AzureVmDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// if it holds a `GenericDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn generic_details(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GenericPlatformDetails>> {
-        #[allow(unreachable_patterns)]
-        self.vendor_details.as_ref().and_then(|v| match v {
-            crate::model::platform_details::VendorDetails::GenericDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// if it holds a `PhysicalDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn physical_details(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PhysicalPlatformDetails>> {
-        #[allow(unreachable_patterns)]
-        self.vendor_details.as_ref().and_then(|v| match v {
-            crate::model::platform_details::VendorDetails::PhysicalDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
     /// to hold a `VmwareDetails`.
     ///
@@ -10497,6 +10437,21 @@ impl PlatformDetails {
             crate::model::platform_details::VendorDetails::VmwareDetails(v.into()),
         );
         self
+    }
+
+    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
+    /// if it holds a `AwsEc2Details`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws_ec2_details(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsEc2PlatformDetails>> {
+        #[allow(unreachable_patterns)]
+        self.vendor_details.as_ref().and_then(|v| match v {
+            crate::model::platform_details::VendorDetails::AwsEc2Details(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
@@ -10516,6 +10471,21 @@ impl PlatformDetails {
         self
     }
 
+    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
+    /// if it holds a `AzureVmDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn azure_vm_details(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureVmPlatformDetails>> {
+        #[allow(unreachable_patterns)]
+        self.vendor_details.as_ref().and_then(|v| match v {
+            crate::model::platform_details::VendorDetails::AzureVmDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
     /// to hold a `AzureVmDetails`.
     ///
@@ -10533,6 +10503,21 @@ impl PlatformDetails {
         self
     }
 
+    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
+    /// if it holds a `GenericDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn generic_details(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GenericPlatformDetails>> {
+        #[allow(unreachable_patterns)]
+        self.vendor_details.as_ref().and_then(|v| match v {
+            crate::model::platform_details::VendorDetails::GenericDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
     /// to hold a `GenericDetails`.
     ///
@@ -10548,6 +10533,21 @@ impl PlatformDetails {
             crate::model::platform_details::VendorDetails::GenericDetails(v.into()),
         );
         self
+    }
+
+    /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
+    /// if it holds a `PhysicalDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn physical_details(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PhysicalPlatformDetails>> {
+        #[allow(unreachable_patterns)]
+        self.vendor_details.as_ref().and_then(|v| match v {
+            crate::model::platform_details::VendorDetails::PhysicalDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
@@ -11492,15 +11492,6 @@ impl InsightList {
         std::default::Default::default()
     }
 
-    /// Sets the value of [update_time][crate::model::InsightList::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [insights][crate::model::InsightList::insights].
     pub fn set_insights<T, V>(mut self, v: T) -> Self
     where
@@ -11509,6 +11500,15 @@ impl InsightList {
     {
         use std::iter::Iterator;
         self.insights = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::InsightList::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -11564,19 +11564,6 @@ impl Insight {
         })
     }
 
-    /// The value of [insight][crate::model::Insight::insight]
-    /// if it holds a `GenericInsight`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn generic_insight(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GenericInsight>> {
-        #[allow(unreachable_patterns)]
-        self.insight.as_ref().and_then(|v| match v {
-            crate::model::insight::Insight::GenericInsight(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [insight][crate::model::Insight::insight]
     /// to hold a `MigrationInsight`.
     ///
@@ -11591,6 +11578,19 @@ impl Insight {
         self.insight =
             std::option::Option::Some(crate::model::insight::Insight::MigrationInsight(v.into()));
         self
+    }
+
+    /// The value of [insight][crate::model::Insight::insight]
+    /// if it holds a `GenericInsight`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn generic_insight(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GenericInsight>> {
+        #[allow(unreachable_patterns)]
+        self.insight.as_ref().and_then(|v| match v {
+            crate::model::insight::Insight::GenericInsight(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [insight][crate::model::Insight::insight]
@@ -12200,47 +12200,6 @@ impl Aggregation {
         })
     }
 
-    /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// if it holds a `Sum`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sum(&self) -> std::option::Option<&std::boxed::Box<crate::model::aggregation::Sum>> {
-        #[allow(unreachable_patterns)]
-        self.aggregation_function.as_ref().and_then(|v| match v {
-            crate::model::aggregation::AggregationFunction::Sum(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// if it holds a `Histogram`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn histogram(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation::Histogram>> {
-        #[allow(unreachable_patterns)]
-        self.aggregation_function.as_ref().and_then(|v| match v {
-            crate::model::aggregation::AggregationFunction::Histogram(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// if it holds a `Frequency`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn frequency(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation::Frequency>> {
-        #[allow(unreachable_patterns)]
-        self.aggregation_function.as_ref().and_then(|v| match v {
-            crate::model::aggregation::AggregationFunction::Frequency(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
     /// to hold a `Count`.
     ///
@@ -12254,6 +12213,17 @@ impl Aggregation {
             crate::model::aggregation::AggregationFunction::Count(v.into()),
         );
         self
+    }
+
+    /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
+    /// if it holds a `Sum`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sum(&self) -> std::option::Option<&std::boxed::Box<crate::model::aggregation::Sum>> {
+        #[allow(unreachable_patterns)]
+        self.aggregation_function.as_ref().and_then(|v| match v {
+            crate::model::aggregation::AggregationFunction::Sum(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
@@ -12271,6 +12241,21 @@ impl Aggregation {
         self
     }
 
+    /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
+    /// if it holds a `Histogram`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn histogram(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation::Histogram>> {
+        #[allow(unreachable_patterns)]
+        self.aggregation_function.as_ref().and_then(|v| match v {
+            crate::model::aggregation::AggregationFunction::Histogram(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
     /// to hold a `Histogram`.
     ///
@@ -12286,6 +12271,21 @@ impl Aggregation {
             crate::model::aggregation::AggregationFunction::Histogram(v.into()),
         );
         self
+    }
+
+    /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
+    /// if it holds a `Frequency`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn frequency(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation::Frequency>> {
+        #[allow(unreachable_patterns)]
+        self.aggregation_function.as_ref().and_then(|v| match v {
+            crate::model::aggregation::AggregationFunction::Frequency(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
@@ -12497,45 +12497,6 @@ impl AggregationResult {
         })
     }
 
-    /// The value of [result][crate::model::AggregationResult::result]
-    /// if it holds a `Sum`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sum(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation_result::Sum>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::aggregation_result::Result::Sum(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::AggregationResult::result]
-    /// if it holds a `Histogram`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn histogram(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation_result::Histogram>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::aggregation_result::Result::Histogram(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::AggregationResult::result]
-    /// if it holds a `Frequency`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn frequency(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation_result::Frequency>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::aggregation_result::Result::Frequency(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::AggregationResult::result]
     /// to hold a `Count`.
     ///
@@ -12550,6 +12511,19 @@ impl AggregationResult {
         self.result =
             std::option::Option::Some(crate::model::aggregation_result::Result::Count(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::AggregationResult::result]
+    /// if it holds a `Sum`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sum(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation_result::Sum>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::aggregation_result::Result::Sum(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::AggregationResult::result]
@@ -12568,6 +12542,19 @@ impl AggregationResult {
         self
     }
 
+    /// The value of [result][crate::model::AggregationResult::result]
+    /// if it holds a `Histogram`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn histogram(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation_result::Histogram>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::aggregation_result::Result::Histogram(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [result][crate::model::AggregationResult::result]
     /// to hold a `Histogram`.
     ///
@@ -12583,6 +12570,19 @@ impl AggregationResult {
             crate::model::aggregation_result::Result::Histogram(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::AggregationResult::result]
+    /// if it holds a `Frequency`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn frequency(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::aggregation_result::Frequency>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::aggregation_result::Result::Frequency(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::AggregationResult::result]
@@ -12867,12 +12867,6 @@ impl FileValidationReport {
         self
     }
 
-    /// Sets the value of [partial_report][crate::model::FileValidationReport::partial_report].
-    pub fn set_partial_report<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.partial_report = v.into();
-        self
-    }
-
     /// Sets the value of [row_errors][crate::model::FileValidationReport::row_errors].
     pub fn set_row_errors<T, V>(mut self, v: T) -> Self
     where
@@ -12881,6 +12875,12 @@ impl FileValidationReport {
     {
         use std::iter::Iterator;
         self.row_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [partial_report][crate::model::FileValidationReport::partial_report].
+    pub fn set_partial_report<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.partial_report = v.into();
         self
     }
 
@@ -13299,15 +13299,6 @@ impl UploadFileInfo {
         self
     }
 
-    /// Sets the value of [uri_expiration_time][crate::model::UploadFileInfo::uri_expiration_time].
-    pub fn set_uri_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.uri_expiration_time = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::UploadFileInfo::headers].
     pub fn set_headers<T, K, V>(mut self, v: T) -> Self
     where
@@ -13317,6 +13308,15 @@ impl UploadFileInfo {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [uri_expiration_time][crate::model::UploadFileInfo::uri_expiration_time].
+    pub fn set_uri_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.uri_expiration_time = v.into();
         self
     }
 }
@@ -14953,12 +14953,6 @@ pub mod report_summary {
             std::default::Default::default()
         }
 
-        /// Sets the value of [allocated_asset_count][crate::model::report_summary::ComputeEngineFinding::allocated_asset_count].
-        pub fn set_allocated_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.allocated_asset_count = v.into();
-            self
-        }
-
         /// Sets the value of [allocated_regions][crate::model::report_summary::ComputeEngineFinding::allocated_regions].
         pub fn set_allocated_regions<T, V>(mut self, v: T) -> Self
         where
@@ -14967,6 +14961,12 @@ pub mod report_summary {
         {
             use std::iter::Iterator;
             self.allocated_regions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [allocated_asset_count][crate::model::report_summary::ComputeEngineFinding::allocated_asset_count].
+        pub fn set_allocated_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.allocated_asset_count = v.into();
             self
         }
 
@@ -15027,12 +15027,6 @@ pub mod report_summary {
             std::default::Default::default()
         }
 
-        /// Sets the value of [allocated_asset_count][crate::model::report_summary::VmwareEngineFinding::allocated_asset_count].
-        pub fn set_allocated_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.allocated_asset_count = v.into();
-            self
-        }
-
         /// Sets the value of [allocated_regions][crate::model::report_summary::VmwareEngineFinding::allocated_regions].
         pub fn set_allocated_regions<T, V>(mut self, v: T) -> Self
         where
@@ -15041,6 +15035,12 @@ pub mod report_summary {
         {
             use std::iter::Iterator;
             self.allocated_regions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [allocated_asset_count][crate::model::report_summary::VmwareEngineFinding::allocated_asset_count].
+        pub fn set_allocated_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.allocated_asset_count = v.into();
             self
         }
 
@@ -15183,12 +15183,6 @@ pub mod report_summary {
             std::default::Default::default()
         }
 
-        /// Sets the value of [allocated_asset_count][crate::model::report_summary::SoleTenantFinding::allocated_asset_count].
-        pub fn set_allocated_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.allocated_asset_count = v.into();
-            self
-        }
-
         /// Sets the value of [allocated_regions][crate::model::report_summary::SoleTenantFinding::allocated_regions].
         pub fn set_allocated_regions<T, V>(mut self, v: T) -> Self
         where
@@ -15197,6 +15191,12 @@ pub mod report_summary {
         {
             use std::iter::Iterator;
             self.allocated_regions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [allocated_asset_count][crate::model::report_summary::SoleTenantFinding::allocated_asset_count].
+        pub fn set_allocated_asset_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.allocated_asset_count = v.into();
             self
         }
 

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -94,6 +94,18 @@ impl Template {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Template::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [filter_config][crate::model::Template::filter_config].
     pub fn set_filter_config<
         T: std::convert::Into<std::option::Option<crate::model::FilterConfig>>,
@@ -113,18 +125,6 @@ impl Template {
         v: T,
     ) -> Self {
         self.template_metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Template::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -445,12 +445,6 @@ impl ListTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [templates][crate::model::ListTemplatesResponse::templates].
     pub fn set_templates<T, V>(mut self, v: T) -> Self
     where
@@ -459,6 +453,12 @@ impl ListTemplatesResponse {
     {
         use std::iter::Iterator;
         self.templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1423,21 +1423,6 @@ impl SdpFilterSettings {
         })
     }
 
-    /// The value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
-    /// if it holds a `AdvancedConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn advanced_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SdpAdvancedConfig>> {
-        #[allow(unreachable_patterns)]
-        self.sdp_configuration.as_ref().and_then(|v| match v {
-            crate::model::sdp_filter_settings::SdpConfiguration::AdvancedConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
     /// to hold a `BasicConfig`.
     ///
@@ -1453,6 +1438,21 @@ impl SdpFilterSettings {
             crate::model::sdp_filter_settings::SdpConfiguration::BasicConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
+    /// if it holds a `AdvancedConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn advanced_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SdpAdvancedConfig>> {
+        #[allow(unreachable_patterns)]
+        self.sdp_configuration.as_ref().and_then(|v| match v {
+            crate::model::sdp_filter_settings::SdpConfiguration::AdvancedConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
@@ -1979,6 +1979,18 @@ impl SanitizationResult {
         self
     }
 
+    /// Sets the value of [filter_results][crate::model::SanitizationResult::filter_results].
+    pub fn set_filter_results<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::FilterResult>,
+    {
+        use std::iter::Iterator;
+        self.filter_results = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [invocation_result][crate::model::SanitizationResult::invocation_result].
     pub fn set_invocation_result<T: std::convert::Into<crate::model::InvocationResult>>(
         mut self,
@@ -1998,18 +2010,6 @@ impl SanitizationResult {
         v: T,
     ) -> Self {
         self.sanitization_metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [filter_results][crate::model::SanitizationResult::filter_results].
-    pub fn set_filter_results<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::FilterResult>,
-    {
-        use std::iter::Iterator;
-        self.filter_results = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2122,81 +2122,6 @@ impl FilterResult {
         })
     }
 
-    /// The value of [filter_result][crate::model::FilterResult::filter_result]
-    /// if it holds a `SdpFilterResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sdp_filter_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SdpFilterResult>> {
-        #[allow(unreachable_patterns)]
-        self.filter_result.as_ref().and_then(|v| match v {
-            crate::model::filter_result::FilterResult::SdpFilterResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter_result][crate::model::FilterResult::filter_result]
-    /// if it holds a `PiAndJailbreakFilterResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pi_and_jailbreak_filter_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PiAndJailbreakFilterResult>> {
-        #[allow(unreachable_patterns)]
-        self.filter_result.as_ref().and_then(|v| match v {
-            crate::model::filter_result::FilterResult::PiAndJailbreakFilterResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter_result][crate::model::FilterResult::filter_result]
-    /// if it holds a `MaliciousUriFilterResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn malicious_uri_filter_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MaliciousUriFilterResult>> {
-        #[allow(unreachable_patterns)]
-        self.filter_result.as_ref().and_then(|v| match v {
-            crate::model::filter_result::FilterResult::MaliciousUriFilterResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter_result][crate::model::FilterResult::filter_result]
-    /// if it holds a `CsamFilterFilterResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn csam_filter_filter_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CsamFilterResult>> {
-        #[allow(unreachable_patterns)]
-        self.filter_result.as_ref().and_then(|v| match v {
-            crate::model::filter_result::FilterResult::CsamFilterFilterResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter_result][crate::model::FilterResult::filter_result]
-    /// if it holds a `VirusScanFilterResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn virus_scan_filter_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VirusScanFilterResult>> {
-        #[allow(unreachable_patterns)]
-        self.filter_result.as_ref().and_then(|v| match v {
-            crate::model::filter_result::FilterResult::VirusScanFilterResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
     /// to hold a `RaiFilterResult`.
     ///
@@ -2212,6 +2137,21 @@ impl FilterResult {
             crate::model::filter_result::FilterResult::RaiFilterResult(v.into()),
         );
         self
+    }
+
+    /// The value of [filter_result][crate::model::FilterResult::filter_result]
+    /// if it holds a `SdpFilterResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sdp_filter_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SdpFilterResult>> {
+        #[allow(unreachable_patterns)]
+        self.filter_result.as_ref().and_then(|v| match v {
+            crate::model::filter_result::FilterResult::SdpFilterResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
@@ -2231,6 +2171,21 @@ impl FilterResult {
         self
     }
 
+    /// The value of [filter_result][crate::model::FilterResult::filter_result]
+    /// if it holds a `PiAndJailbreakFilterResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pi_and_jailbreak_filter_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PiAndJailbreakFilterResult>> {
+        #[allow(unreachable_patterns)]
+        self.filter_result.as_ref().and_then(|v| match v {
+            crate::model::filter_result::FilterResult::PiAndJailbreakFilterResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
     /// to hold a `PiAndJailbreakFilterResult`.
     ///
@@ -2246,6 +2201,21 @@ impl FilterResult {
             crate::model::filter_result::FilterResult::PiAndJailbreakFilterResult(v.into()),
         );
         self
+    }
+
+    /// The value of [filter_result][crate::model::FilterResult::filter_result]
+    /// if it holds a `MaliciousUriFilterResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn malicious_uri_filter_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MaliciousUriFilterResult>> {
+        #[allow(unreachable_patterns)]
+        self.filter_result.as_ref().and_then(|v| match v {
+            crate::model::filter_result::FilterResult::MaliciousUriFilterResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
@@ -2265,6 +2235,21 @@ impl FilterResult {
         self
     }
 
+    /// The value of [filter_result][crate::model::FilterResult::filter_result]
+    /// if it holds a `CsamFilterFilterResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn csam_filter_filter_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CsamFilterResult>> {
+        #[allow(unreachable_patterns)]
+        self.filter_result.as_ref().and_then(|v| match v {
+            crate::model::filter_result::FilterResult::CsamFilterFilterResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
     /// to hold a `CsamFilterFilterResult`.
     ///
@@ -2280,6 +2265,21 @@ impl FilterResult {
             crate::model::filter_result::FilterResult::CsamFilterFilterResult(v.into()),
         );
         self
+    }
+
+    /// The value of [filter_result][crate::model::FilterResult::filter_result]
+    /// if it holds a `VirusScanFilterResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn virus_scan_filter_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VirusScanFilterResult>> {
+        #[allow(unreachable_patterns)]
+        self.filter_result.as_ref().and_then(|v| match v {
+            crate::model::filter_result::FilterResult::VirusScanFilterResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
@@ -2381,15 +2381,6 @@ impl RaiFilterResult {
         self
     }
 
-    /// Sets the value of [match_state][crate::model::RaiFilterResult::match_state].
-    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.match_state = v.into();
-        self
-    }
-
     /// Sets the value of [message_items][crate::model::RaiFilterResult::message_items].
     pub fn set_message_items<T, V>(mut self, v: T) -> Self
     where
@@ -2398,6 +2389,15 @@ impl RaiFilterResult {
     {
         use std::iter::Iterator;
         self.message_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [match_state][crate::model::RaiFilterResult::match_state].
+    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.match_state = v.into();
         self
     }
 
@@ -2534,21 +2534,6 @@ impl SdpFilterResult {
         })
     }
 
-    /// The value of [result][crate::model::SdpFilterResult::result]
-    /// if it holds a `DeidentifyResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deidentify_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SdpDeidentifyResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::sdp_filter_result::Result::DeidentifyResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::SdpFilterResult::result]
     /// to hold a `InspectResult`.
     ///
@@ -2564,6 +2549,21 @@ impl SdpFilterResult {
             crate::model::sdp_filter_result::Result::InspectResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::SdpFilterResult::result]
+    /// if it holds a `DeidentifyResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deidentify_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SdpDeidentifyResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::sdp_filter_result::Result::DeidentifyResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::SdpFilterResult::result]
@@ -2660,21 +2660,6 @@ impl SdpInspectResult {
         self
     }
 
-    /// Sets the value of [match_state][crate::model::SdpInspectResult::match_state].
-    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.match_state = v.into();
-        self
-    }
-
-    /// Sets the value of [findings_truncated][crate::model::SdpInspectResult::findings_truncated].
-    pub fn set_findings_truncated<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.findings_truncated = v.into();
-        self
-    }
-
     /// Sets the value of [message_items][crate::model::SdpInspectResult::message_items].
     pub fn set_message_items<T, V>(mut self, v: T) -> Self
     where
@@ -2686,6 +2671,15 @@ impl SdpInspectResult {
         self
     }
 
+    /// Sets the value of [match_state][crate::model::SdpInspectResult::match_state].
+    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.match_state = v.into();
+        self
+    }
+
     /// Sets the value of [findings][crate::model::SdpInspectResult::findings].
     pub fn set_findings<T, V>(mut self, v: T) -> Self
     where
@@ -2694,6 +2688,12 @@ impl SdpInspectResult {
     {
         use std::iter::Iterator;
         self.findings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [findings_truncated][crate::model::SdpInspectResult::findings_truncated].
+    pub fn set_findings_truncated<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.findings_truncated = v.into();
         self
     }
 }
@@ -2748,17 +2748,6 @@ impl DataItem {
         })
     }
 
-    /// The value of [data_item][crate::model::DataItem::data_item]
-    /// if it holds a `ByteItem`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn byte_item(&self) -> std::option::Option<&std::boxed::Box<crate::model::ByteDataItem>> {
-        #[allow(unreachable_patterns)]
-        self.data_item.as_ref().and_then(|v| match v {
-            crate::model::data_item::DataItem::ByteItem(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_item][crate::model::DataItem::data_item]
     /// to hold a `Text`.
     ///
@@ -2768,6 +2757,17 @@ impl DataItem {
         self.data_item =
             std::option::Option::Some(crate::model::data_item::DataItem::Text(v.into()));
         self
+    }
+
+    /// The value of [data_item][crate::model::DataItem::data_item]
+    /// if it holds a `ByteItem`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn byte_item(&self) -> std::option::Option<&std::boxed::Box<crate::model::ByteDataItem>> {
+        #[allow(unreachable_patterns)]
+        self.data_item.as_ref().and_then(|v| match v {
+            crate::model::data_item::DataItem::ByteItem(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_item][crate::model::DataItem::data_item]
@@ -3043,6 +3043,17 @@ impl SdpDeidentifyResult {
         self
     }
 
+    /// Sets the value of [message_items][crate::model::SdpDeidentifyResult::message_items].
+    pub fn set_message_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MessageItem>,
+    {
+        use std::iter::Iterator;
+        self.message_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [match_state][crate::model::SdpDeidentifyResult::match_state].
     pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
         mut self,
@@ -3064,17 +3075,6 @@ impl SdpDeidentifyResult {
     /// Sets the value of [transformed_bytes][crate::model::SdpDeidentifyResult::transformed_bytes].
     pub fn set_transformed_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.transformed_bytes = v.into();
-        self
-    }
-
-    /// Sets the value of [message_items][crate::model::SdpDeidentifyResult::message_items].
-    pub fn set_message_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MessageItem>,
-    {
-        use std::iter::Iterator;
-        self.message_items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3259,6 +3259,17 @@ impl PiAndJailbreakFilterResult {
         self
     }
 
+    /// Sets the value of [message_items][crate::model::PiAndJailbreakFilterResult::message_items].
+    pub fn set_message_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MessageItem>,
+    {
+        use std::iter::Iterator;
+        self.message_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [match_state][crate::model::PiAndJailbreakFilterResult::match_state].
     pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
         mut self,
@@ -3274,17 +3285,6 @@ impl PiAndJailbreakFilterResult {
         v: T,
     ) -> Self {
         self.confidence_level = v.into();
-        self
-    }
-
-    /// Sets the value of [message_items][crate::model::PiAndJailbreakFilterResult::message_items].
-    pub fn set_message_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MessageItem>,
-    {
-        use std::iter::Iterator;
-        self.message_items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3339,15 +3339,6 @@ impl MaliciousUriFilterResult {
         self
     }
 
-    /// Sets the value of [match_state][crate::model::MaliciousUriFilterResult::match_state].
-    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.match_state = v.into();
-        self
-    }
-
     /// Sets the value of [message_items][crate::model::MaliciousUriFilterResult::message_items].
     pub fn set_message_items<T, V>(mut self, v: T) -> Self
     where
@@ -3356,6 +3347,15 @@ impl MaliciousUriFilterResult {
     {
         use std::iter::Iterator;
         self.message_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [match_state][crate::model::MaliciousUriFilterResult::match_state].
+    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.match_state = v.into();
         self
     }
 
@@ -3484,6 +3484,17 @@ impl VirusScanFilterResult {
         self
     }
 
+    /// Sets the value of [message_items][crate::model::VirusScanFilterResult::message_items].
+    pub fn set_message_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MessageItem>,
+    {
+        use std::iter::Iterator;
+        self.message_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [match_state][crate::model::VirusScanFilterResult::match_state].
     pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
         mut self,
@@ -3510,17 +3521,6 @@ impl VirusScanFilterResult {
         v: T,
     ) -> Self {
         self.scanned_size = v.into();
-        self
-    }
-
-    /// Sets the value of [message_items][crate::model::VirusScanFilterResult::message_items].
-    pub fn set_message_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MessageItem>,
-    {
-        use std::iter::Iterator;
-        self.message_items = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3720,15 +3720,6 @@ impl VirusDetail {
         self
     }
 
-    /// Sets the value of [threat_type][crate::model::VirusDetail::threat_type].
-    pub fn set_threat_type<T: std::convert::Into<crate::model::virus_detail::ThreatType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.threat_type = v.into();
-        self
-    }
-
     /// Sets the value of [names][crate::model::VirusDetail::names].
     pub fn set_names<T, V>(mut self, v: T) -> Self
     where
@@ -3737,6 +3728,15 @@ impl VirusDetail {
     {
         use std::iter::Iterator;
         self.names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [threat_type][crate::model::VirusDetail::threat_type].
+    pub fn set_threat_type<T: std::convert::Into<crate::model::virus_detail::ThreatType>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.threat_type = v.into();
         self
     }
 }
@@ -3948,15 +3948,6 @@ impl CsamFilterResult {
         self
     }
 
-    /// Sets the value of [match_state][crate::model::CsamFilterResult::match_state].
-    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.match_state = v.into();
-        self
-    }
-
     /// Sets the value of [message_items][crate::model::CsamFilterResult::message_items].
     pub fn set_message_items<T, V>(mut self, v: T) -> Self
     where
@@ -3965,6 +3956,15 @@ impl CsamFilterResult {
     {
         use std::iter::Iterator;
         self.message_items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [match_state][crate::model::CsamFilterResult::match_state].
+    pub fn set_match_state<T: std::convert::Into<crate::model::FilterMatchState>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.match_state = v.into();
         self
     }
 }

--- a/src/generated/cloud/netapp/v1/src/builder.rs
+++ b/src/generated/cloud/netapp/v1/src/builder.rs
@@ -3316,14 +3316,6 @@ pub mod net_app {
             self
         }
 
-        /// Sets the value of [peer_volume_name][crate::model::EstablishPeeringRequest::peer_volume_name].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_peer_volume_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.peer_volume_name = v.into();
-            self
-        }
-
         /// Sets the value of [peer_ip_addresses][crate::model::EstablishPeeringRequest::peer_ip_addresses].
         pub fn set_peer_ip_addresses<T, V>(mut self, v: T) -> Self
         where
@@ -3332,6 +3324,14 @@ pub mod net_app {
         {
             use std::iter::Iterator;
             self.0.request.peer_ip_addresses = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [peer_volume_name][crate::model::EstablishPeeringRequest::peer_volume_name].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_peer_volume_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.peer_volume_name = v.into();
             self
         }
     }

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -133,12 +133,6 @@ impl ListActiveDirectoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListActiveDirectoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [active_directories][crate::model::ListActiveDirectoriesResponse::active_directories].
     pub fn set_active_directories<T, V>(mut self, v: T) -> Self
     where
@@ -147,6 +141,12 @@ impl ListActiveDirectoriesResponse {
     {
         use std::iter::Iterator;
         self.active_directories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListActiveDirectoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -549,6 +549,39 @@ impl ActiveDirectory {
         self
     }
 
+    /// Sets the value of [backup_operators][crate::model::ActiveDirectory::backup_operators].
+    pub fn set_backup_operators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.backup_operators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [administrators][crate::model::ActiveDirectory::administrators].
+    pub fn set_administrators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.administrators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [security_operators][crate::model::ActiveDirectory::security_operators].
+    pub fn set_security_operators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.security_operators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [kdc_hostname][crate::model::ActiveDirectory::kdc_hostname].
     pub fn set_kdc_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kdc_hostname = v.into();
@@ -585,45 +618,6 @@ impl ActiveDirectory {
         self
     }
 
-    /// Sets the value of [state_details][crate::model::ActiveDirectory::state_details].
-    pub fn set_state_details<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.state_details = v.into();
-        self
-    }
-
-    /// Sets the value of [backup_operators][crate::model::ActiveDirectory::backup_operators].
-    pub fn set_backup_operators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.backup_operators = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [administrators][crate::model::ActiveDirectory::administrators].
-    pub fn set_administrators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.administrators = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [security_operators][crate::model::ActiveDirectory::security_operators].
-    pub fn set_security_operators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.security_operators = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::ActiveDirectory::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -633,6 +627,12 @@ impl ActiveDirectory {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state_details][crate::model::ActiveDirectory::state_details].
+    pub fn set_state_details<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.state_details = v.into();
         self
     }
 }
@@ -948,6 +948,18 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Backup::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [chain_storage_bytes][crate::model::Backup::chain_storage_bytes].
     pub fn set_chain_storage_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.chain_storage_bytes = v.into();
@@ -963,18 +975,6 @@ impl Backup {
     /// Sets the value of [satisfies_pzi][crate::model::Backup::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Backup::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1401,12 +1401,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -1415,6 +1409,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1755,15 +1755,6 @@ impl BackupPolicy {
         self
     }
 
-    /// Sets the value of [state][crate::model::BackupPolicy::state].
-    pub fn set_state<T: std::convert::Into<crate::model::backup_policy::State>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::BackupPolicy::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -1773,6 +1764,15 @@ impl BackupPolicy {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::BackupPolicy::state].
+    pub fn set_state<T: std::convert::Into<crate::model::backup_policy::State>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.state = v.into();
         self
     }
 }
@@ -2139,12 +2139,6 @@ impl ListBackupPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_policies][crate::model::ListBackupPoliciesResponse::backup_policies].
     pub fn set_backup_policies<T, V>(mut self, v: T) -> Self
     where
@@ -2153,6 +2147,12 @@ impl ListBackupPoliciesResponse {
     {
         use std::iter::Iterator;
         self.backup_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2655,12 +2655,6 @@ impl ListBackupVaultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupVaultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_vaults][crate::model::ListBackupVaultsResponse::backup_vaults].
     pub fn set_backup_vaults<T, V>(mut self, v: T) -> Self
     where
@@ -2669,6 +2663,12 @@ impl ListBackupVaultsResponse {
     {
         use std::iter::Iterator;
         self.backup_vaults = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupVaultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3144,12 +3144,6 @@ impl ListKmsConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListKmsConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [kms_configs][crate::model::ListKmsConfigsResponse::kms_configs].
     pub fn set_kms_configs<T, V>(mut self, v: T) -> Self
     where
@@ -3158,6 +3152,12 @@ impl ListKmsConfigsResponse {
     {
         use std::iter::Iterator;
         self.kms_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListKmsConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3549,18 +3549,6 @@ impl KmsConfig {
         self
     }
 
-    /// Sets the value of [instructions][crate::model::KmsConfig::instructions].
-    pub fn set_instructions<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.instructions = v.into();
-        self
-    }
-
-    /// Sets the value of [service_account][crate::model::KmsConfig::service_account].
-    pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.service_account = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::KmsConfig::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -3570,6 +3558,18 @@ impl KmsConfig {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [instructions][crate::model::KmsConfig::instructions].
+    pub fn set_instructions<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.instructions = v.into();
+        self
+    }
+
+    /// Sets the value of [service_account][crate::model::KmsConfig::service_account].
+    pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.service_account = v.into();
         self
     }
 }
@@ -3883,12 +3883,6 @@ impl ListQuotaRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListQuotaRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [quota_rules][crate::model::ListQuotaRulesResponse::quota_rules].
     pub fn set_quota_rules<T, V>(mut self, v: T) -> Self
     where
@@ -3897,6 +3891,12 @@ impl ListQuotaRulesResponse {
     {
         use std::iter::Iterator;
         self.quota_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListQuotaRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4849,6 +4849,18 @@ impl Replication {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Replication::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Replication::description].
     pub fn set_description<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
@@ -4903,18 +4915,6 @@ impl Replication {
         v: T,
     ) -> Self {
         self.hybrid_replication_type = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Replication::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5878,12 +5878,6 @@ impl ListReplicationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReplicationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [replications][crate::model::ListReplicationsResponse::replications].
     pub fn set_replications<T, V>(mut self, v: T) -> Self
     where
@@ -5892,6 +5886,12 @@ impl ListReplicationsResponse {
     {
         use std::iter::Iterator;
         self.replications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReplicationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6366,15 +6366,6 @@ impl EstablishPeeringRequest {
         self
     }
 
-    /// Sets the value of [peer_volume_name][crate::model::EstablishPeeringRequest::peer_volume_name].
-    pub fn set_peer_volume_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.peer_volume_name = v.into();
-        self
-    }
-
     /// Sets the value of [peer_ip_addresses][crate::model::EstablishPeeringRequest::peer_ip_addresses].
     pub fn set_peer_ip_addresses<T, V>(mut self, v: T) -> Self
     where
@@ -6383,6 +6374,15 @@ impl EstablishPeeringRequest {
     {
         use std::iter::Iterator;
         self.peer_ip_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [peer_volume_name][crate::model::EstablishPeeringRequest::peer_volume_name].
+    pub fn set_peer_volume_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.peer_volume_name = v.into();
         self
     }
 }
@@ -6529,12 +6529,6 @@ impl ListSnapshotsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [snapshots][crate::model::ListSnapshotsResponse::snapshots].
     pub fn set_snapshots<T, V>(mut self, v: T) -> Self
     where
@@ -6543,6 +6537,12 @@ impl ListSnapshotsResponse {
     {
         use std::iter::Iterator;
         self.snapshots = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSnapshotsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7154,12 +7154,6 @@ impl ListStoragePoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListStoragePoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [storage_pools][crate::model::ListStoragePoolsResponse::storage_pools].
     pub fn set_storage_pools<T, V>(mut self, v: T) -> Self
     where
@@ -7168,6 +7162,12 @@ impl ListStoragePoolsResponse {
     {
         use std::iter::Iterator;
         self.storage_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListStoragePoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7556,6 +7556,18 @@ impl StoragePool {
         self
     }
 
+    /// Sets the value of [labels][crate::model::StoragePool::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [network][crate::model::StoragePool::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
@@ -7635,18 +7647,6 @@ impl StoragePool {
     /// Sets the value of [satisfies_pzi][crate::model::StoragePool::satisfies_pzi].
     pub fn set_satisfies_pzi<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzi = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::StoragePool::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7975,12 +7975,6 @@ impl ListVolumesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVolumesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [volumes][crate::model::ListVolumesResponse::volumes].
     pub fn set_volumes<T, V>(mut self, v: T) -> Self
     where
@@ -7989,6 +7983,12 @@ impl ListVolumesResponse {
     {
         use std::iter::Iterator;
         self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVolumesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8511,12 +8511,57 @@ impl Volume {
         self
     }
 
+    /// Sets the value of [protocols][crate::model::Volume::protocols].
+    pub fn set_protocols<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Protocols>,
+    {
+        use std::iter::Iterator;
+        self.protocols = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [smb_settings][crate::model::Volume::smb_settings].
+    pub fn set_smb_settings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SMBSettings>,
+    {
+        use std::iter::Iterator;
+        self.smb_settings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [mount_options][crate::model::Volume::mount_options].
+    pub fn set_mount_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::MountOption>,
+    {
+        use std::iter::Iterator;
+        self.mount_options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [unix_permissions][crate::model::Volume::unix_permissions].
     pub fn set_unix_permissions<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.unix_permissions = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Volume::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -8628,6 +8673,17 @@ impl Volume {
         self
     }
 
+    /// Sets the value of [restricted_actions][crate::model::Volume::restricted_actions].
+    pub fn set_restricted_actions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RestrictedAction>,
+    {
+        use std::iter::Iterator;
+        self.restricted_actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [large_capacity][crate::model::Volume::large_capacity].
     pub fn set_large_capacity<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.large_capacity = v.into();
@@ -8677,62 +8733,6 @@ impl Volume {
         v: T,
     ) -> Self {
         self.hybrid_replication_parameters = v.into();
-        self
-    }
-
-    /// Sets the value of [protocols][crate::model::Volume::protocols].
-    pub fn set_protocols<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Protocols>,
-    {
-        use std::iter::Iterator;
-        self.protocols = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [smb_settings][crate::model::Volume::smb_settings].
-    pub fn set_smb_settings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SMBSettings>,
-    {
-        use std::iter::Iterator;
-        self.smb_settings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [mount_options][crate::model::Volume::mount_options].
-    pub fn set_mount_options<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::MountOption>,
-    {
-        use std::iter::Iterator;
-        self.mount_options = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [restricted_actions][crate::model::Volume::restricted_actions].
-    pub fn set_restricted_actions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RestrictedAction>,
-    {
-        use std::iter::Iterator;
-        self.restricted_actions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Volume::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -9600,6 +9600,18 @@ impl RestoreParameters {
         })
     }
 
+    /// Sets the value of [source][crate::model::RestoreParameters::source]
+    /// to hold a `SourceSnapshot`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_source_snapshot<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::restore_parameters::Source::SourceSnapshot(v.into()),
+        );
+        self
+    }
+
     /// The value of [source][crate::model::RestoreParameters::source]
     /// if it holds a `SourceBackup`, `None` if the field is not set or
     /// holds a different branch.
@@ -9611,18 +9623,6 @@ impl RestoreParameters {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::RestoreParameters::source]
-    /// to hold a `SourceSnapshot`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_snapshot<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_parameters::Source::SourceSnapshot(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [source][crate::model::RestoreParameters::source]
@@ -9702,6 +9702,17 @@ impl BackupConfig {
         std::default::Default::default()
     }
 
+    /// Sets the value of [backup_policies][crate::model::BackupConfig::backup_policies].
+    pub fn set_backup_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.backup_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [backup_vault][crate::model::BackupConfig::backup_vault].
     pub fn set_backup_vault<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backup_vault = v.into();
@@ -9723,17 +9734,6 @@ impl BackupConfig {
         v: T,
     ) -> Self {
         self.backup_chain_bytes = v.into();
-        self
-    }
-
-    /// Sets the value of [backup_policies][crate::model::BackupConfig::backup_policies].
-    pub fn set_backup_policies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.backup_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10016,6 +10016,17 @@ impl HybridReplicationParameters {
         self
     }
 
+    /// Sets the value of [peer_ip_addresses][crate::model::HybridReplicationParameters::peer_ip_addresses].
+    pub fn set_peer_ip_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.peer_ip_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cluster_location][crate::model::HybridReplicationParameters::cluster_location].
     pub fn set_cluster_location<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -10028,17 +10039,6 @@ impl HybridReplicationParameters {
     /// Sets the value of [description][crate::model::HybridReplicationParameters::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [peer_ip_addresses][crate::model::HybridReplicationParameters::peer_ip_addresses].
-    pub fn set_peer_ip_addresses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.peer_ip_addresses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 

--- a/src/generated/cloud/networkconnectivity/v1/src/builder.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builder.rs
@@ -2793,6 +2793,17 @@ pub mod hub_service {
             self
         }
 
+        /// Sets the value of [spoke_locations][crate::model::ListHubSpokesRequest::spoke_locations].
+        pub fn set_spoke_locations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.spoke_locations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_size][crate::model::ListHubSpokesRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
@@ -2823,17 +2834,6 @@ pub mod hub_service {
             v: T,
         ) -> Self {
             self.0.request.view = v.into();
-            self
-        }
-
-        /// Sets the value of [spoke_locations][crate::model::ListHubSpokesRequest::spoke_locations].
-        pub fn set_spoke_locations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.spoke_locations = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -244,6 +244,18 @@ impl ServiceConnectionMap {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ServiceConnectionMap::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::ServiceConnectionMap::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -271,21 +283,6 @@ impl ServiceConnectionMap {
         v: T,
     ) -> Self {
         self.infrastructure = v.into();
-        self
-    }
-
-    /// Sets the value of [token][crate::model::ServiceConnectionMap::token].
-    pub fn set_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.token = v.into();
-        self
-    }
-
-    /// Sets the value of [etag][crate::model::ServiceConnectionMap::etag].
-    pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.etag = v.into();
         self
     }
 
@@ -322,15 +319,18 @@ impl ServiceConnectionMap {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ServiceConnectionMap::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [token][crate::model::ServiceConnectionMap::token].
+    pub fn set_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.token = v.into();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::ServiceConnectionMap::etag].
+    pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -489,26 +489,6 @@ pub mod service_connection_map {
             self
         }
 
-        /// Sets the value of [consumer_instance_project][crate::model::service_connection_map::ConsumerPscConfig::consumer_instance_project].
-        pub fn set_consumer_instance_project<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.consumer_instance_project = v.into();
-            self
-        }
-
-        /// Sets the value of [ip_version][crate::model::service_connection_map::ConsumerPscConfig::ip_version].
-        pub fn set_ip_version<
-            T: std::convert::Into<std::option::Option<crate::model::IPVersion>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ip_version = v.into();
-            self
-        }
-
         /// Sets the value of [service_attachment_ip_address_map][crate::model::service_connection_map::ConsumerPscConfig::service_attachment_ip_address_map].
         pub fn set_service_attachment_ip_address_map<T, K, V>(mut self, v: T) -> Self
         where
@@ -522,6 +502,15 @@ pub mod service_connection_map {
             self
         }
 
+        /// Sets the value of [consumer_instance_project][crate::model::service_connection_map::ConsumerPscConfig::consumer_instance_project].
+        pub fn set_consumer_instance_project<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.consumer_instance_project = v.into();
+            self
+        }
+
         /// Sets the value of [producer_instance_metadata][crate::model::service_connection_map::ConsumerPscConfig::producer_instance_metadata].
         pub fn set_producer_instance_metadata<T, K, V>(mut self, v: T) -> Self
         where
@@ -532,6 +521,17 @@ pub mod service_connection_map {
             use std::iter::Iterator;
             self.producer_instance_metadata =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [ip_version][crate::model::service_connection_map::ConsumerPscConfig::ip_version].
+        pub fn set_ip_version<
+            T: std::convert::Into<std::option::Option<crate::model::IPVersion>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.ip_version = v.into();
             self
         }
     }
@@ -913,17 +913,6 @@ pub mod service_connection_map {
             self
         }
 
-        /// Sets the value of [ip_version][crate::model::service_connection_map::ConsumerPscConnection::ip_version].
-        pub fn set_ip_version<
-            T: std::convert::Into<std::option::Option<crate::model::IPVersion>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ip_version = v.into();
-            self
-        }
-
         /// Sets the value of [producer_instance_metadata][crate::model::service_connection_map::ConsumerPscConnection::producer_instance_metadata].
         pub fn set_producer_instance_metadata<T, K, V>(mut self, v: T) -> Self
         where
@@ -934,6 +923,17 @@ pub mod service_connection_map {
             use std::iter::Iterator;
             self.producer_instance_metadata =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [ip_version][crate::model::service_connection_map::ConsumerPscConnection::ip_version].
+        pub fn set_ip_version<
+            T: std::convert::Into<std::option::Option<crate::model::IPVersion>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.ip_version = v.into();
             self
         }
     }
@@ -1219,12 +1219,6 @@ impl ListServiceConnectionMapsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceConnectionMapsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_connection_maps][crate::model::ListServiceConnectionMapsResponse::service_connection_maps].
     pub fn set_service_connection_maps<T, V>(mut self, v: T) -> Self
     where
@@ -1233,6 +1227,12 @@ impl ListServiceConnectionMapsResponse {
     {
         use std::iter::Iterator;
         self.service_connection_maps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceConnectionMapsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1630,6 +1630,18 @@ impl ServiceConnectionPolicy {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ServiceConnectionPolicy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::ServiceConnectionPolicy::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -1668,15 +1680,6 @@ impl ServiceConnectionPolicy {
         self
     }
 
-    /// Sets the value of [etag][crate::model::ServiceConnectionPolicy::etag].
-    pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [psc_connections][crate::model::ServiceConnectionPolicy::psc_connections].
     pub fn set_psc_connections<T, V>(mut self, v: T) -> Self
     where
@@ -1688,15 +1691,12 @@ impl ServiceConnectionPolicy {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ServiceConnectionPolicy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [etag][crate::model::ServiceConnectionPolicy::etag].
+    pub fn set_etag<T: std::convert::Into<std::option::Option<std::string::String>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -1763,6 +1763,17 @@ pub mod service_connection_policy {
             std::default::Default::default()
         }
 
+        /// Sets the value of [subnetworks][crate::model::service_connection_policy::PscConfig::subnetworks].
+        pub fn set_subnetworks<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.subnetworks = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [limit][crate::model::service_connection_policy::PscConfig::limit].
         pub fn set_limit<T: std::convert::Into<std::option::Option<i64>>>(mut self, v: T) -> Self {
             self.limit = v.into();
@@ -1779,17 +1790,6 @@ pub mod service_connection_policy {
             v: T,
         ) -> Self {
             self.producer_instance_location = v.into();
-            self
-        }
-
-        /// Sets the value of [subnetworks][crate::model::service_connection_policy::PscConfig::subnetworks].
-        pub fn set_subnetworks<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.subnetworks = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -2139,6 +2139,19 @@ pub mod service_connection_policy {
             self
         }
 
+        /// Sets the value of [producer_instance_metadata][crate::model::service_connection_policy::PscConnection::producer_instance_metadata].
+        pub fn set_producer_instance_metadata<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.producer_instance_metadata =
+                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [service_class][crate::model::service_connection_policy::PscConnection::service_class].
         pub fn set_service_class<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -2156,19 +2169,6 @@ pub mod service_connection_policy {
             v: T,
         ) -> Self {
             self.ip_version = v.into();
-            self
-        }
-
-        /// Sets the value of [producer_instance_metadata][crate::model::service_connection_policy::PscConnection::producer_instance_metadata].
-        pub fn set_producer_instance_metadata<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.producer_instance_metadata =
-                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -2446,12 +2446,6 @@ impl ListServiceConnectionPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceConnectionPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_connection_policies][crate::model::ListServiceConnectionPoliciesResponse::service_connection_policies].
     pub fn set_service_connection_policies<T, V>(mut self, v: T) -> Self
     where
@@ -2460,6 +2454,12 @@ impl ListServiceConnectionPoliciesResponse {
     {
         use std::iter::Iterator;
         self.service_connection_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceConnectionPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2838,6 +2838,18 @@ impl ServiceClass {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ServiceClass::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::ServiceClass::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -2850,18 +2862,6 @@ impl ServiceClass {
         v: T,
     ) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ServiceClass::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2972,12 +2972,6 @@ impl ListServiceClassesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceClassesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_classes][crate::model::ListServiceClassesResponse::service_classes].
     pub fn set_service_classes<T, V>(mut self, v: T) -> Self
     where
@@ -2986,6 +2980,12 @@ impl ListServiceClassesResponse {
     {
         use std::iter::Iterator;
         self.service_classes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceClassesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3280,6 +3280,18 @@ impl ServiceConnectionToken {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ServiceConnectionToken::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::ServiceConnectionToken::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -3313,18 +3325,6 @@ impl ServiceConnectionToken {
         v: T,
     ) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ServiceConnectionToken::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3435,12 +3435,6 @@ impl ListServiceConnectionTokensResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceConnectionTokensResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_connection_tokens][crate::model::ListServiceConnectionTokensResponse::service_connection_tokens].
     pub fn set_service_connection_tokens<T, V>(mut self, v: T) -> Self
     where
@@ -3449,6 +3443,12 @@ impl ListServiceConnectionTokensResponse {
     {
         use std::iter::Iterator;
         self.service_connection_tokens = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceConnectionTokensResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3792,6 +3792,18 @@ impl Hub {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Hub::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Hub::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -3807,6 +3819,28 @@ impl Hub {
     /// Sets the value of [state][crate::model::Hub::state].
     pub fn set_state<T: std::convert::Into<crate::model::State>>(mut self, v: T) -> Self {
         self.state = v.into();
+        self
+    }
+
+    /// Sets the value of [routing_vpcs][crate::model::Hub::routing_vpcs].
+    pub fn set_routing_vpcs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RoutingVPC>,
+    {
+        use std::iter::Iterator;
+        self.routing_vpcs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [route_tables][crate::model::Hub::route_tables].
+    pub fn set_route_tables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.route_tables = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3845,40 +3879,6 @@ impl Hub {
         v: T,
     ) -> Self {
         self.export_psc = v.into();
-        self
-    }
-
-    /// Sets the value of [routing_vpcs][crate::model::Hub::routing_vpcs].
-    pub fn set_routing_vpcs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RoutingVPC>,
-    {
-        use std::iter::Iterator;
-        self.routing_vpcs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [route_tables][crate::model::Hub::route_tables].
-    pub fn set_route_tables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.route_tables = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Hub::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4067,6 +4067,18 @@ impl Spoke {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Spoke::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Spoke::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4152,6 +4164,17 @@ impl Spoke {
         self
     }
 
+    /// Sets the value of [reasons][crate::model::Spoke::reasons].
+    pub fn set_reasons<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::spoke::StateReason>,
+    {
+        use std::iter::Iterator;
+        self.reasons = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [spoke_type][crate::model::Spoke::spoke_type].
     pub fn set_spoke_type<T: std::convert::Into<crate::model::SpokeType>>(mut self, v: T) -> Self {
         self.spoke_type = v.into();
@@ -4164,17 +4187,6 @@ impl Spoke {
         self
     }
 
-    /// Sets the value of [reasons][crate::model::Spoke::reasons].
-    pub fn set_reasons<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::spoke::StateReason>,
-    {
-        use std::iter::Iterator;
-        self.reasons = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [field_paths_pending_update][crate::model::Spoke::field_paths_pending_update].
     pub fn set_field_paths_pending_update<T, V>(mut self, v: T) -> Self
     where
@@ -4183,18 +4195,6 @@ impl Spoke {
     {
         use std::iter::Iterator;
         self.field_paths_pending_update = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Spoke::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4518,6 +4518,18 @@ impl RouteTable {
         self
     }
 
+    /// Sets the value of [labels][crate::model::RouteTable::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::RouteTable::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4533,18 +4545,6 @@ impl RouteTable {
     /// Sets the value of [state][crate::model::RouteTable::state].
     pub fn set_state<T: std::convert::Into<crate::model::State>>(mut self, v: T) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::RouteTable::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4698,6 +4698,18 @@ impl Route {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Route::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Route::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4764,18 +4776,6 @@ impl Route {
         v: T,
     ) -> Self {
         self.next_hop_interconnect_attachment = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Route::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4869,6 +4869,18 @@ impl Group {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Group::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Group::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4899,18 +4911,6 @@ impl Group {
     /// Sets the value of [route_table][crate::model::Group::route_table].
     pub fn set_route_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.route_table = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Group::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5075,12 +5075,6 @@ impl ListHubsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHubsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [hubs][crate::model::ListHubsResponse::hubs].
     pub fn set_hubs<T, V>(mut self, v: T) -> Self
     where
@@ -5089,6 +5083,12 @@ impl ListHubsResponse {
     {
         use std::iter::Iterator;
         self.hubs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHubsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5439,6 +5439,17 @@ impl ListHubSpokesRequest {
         self
     }
 
+    /// Sets the value of [spoke_locations][crate::model::ListHubSpokesRequest::spoke_locations].
+    pub fn set_spoke_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.spoke_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::ListHubSpokesRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -5469,17 +5480,6 @@ impl ListHubSpokesRequest {
         v: T,
     ) -> Self {
         self.view = v.into();
-        self
-    }
-
-    /// Sets the value of [spoke_locations][crate::model::ListHubSpokesRequest::spoke_locations].
-    pub fn set_spoke_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.spoke_locations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5666,12 +5666,6 @@ impl ListHubSpokesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHubSpokesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [spokes][crate::model::ListHubSpokesResponse::spokes].
     pub fn set_spokes<T, V>(mut self, v: T) -> Self
     where
@@ -5680,6 +5674,12 @@ impl ListHubSpokesResponse {
     {
         use std::iter::Iterator;
         self.spokes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHubSpokesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5855,12 +5855,6 @@ impl QueryHubStatusResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::QueryHubStatusResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [hub_status_entries][crate::model::QueryHubStatusResponse::hub_status_entries].
     pub fn set_hub_status_entries<T, V>(mut self, v: T) -> Self
     where
@@ -5869,6 +5863,12 @@ impl QueryHubStatusResponse {
     {
         use std::iter::Iterator;
         self.hub_status_entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::QueryHubStatusResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6349,12 +6349,6 @@ impl ListSpokesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSpokesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [spokes][crate::model::ListSpokesResponse::spokes].
     pub fn set_spokes<T, V>(mut self, v: T) -> Self
     where
@@ -6363,6 +6357,12 @@ impl ListSpokesResponse {
     {
         use std::iter::Iterator;
         self.spokes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSpokesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7294,12 +7294,6 @@ impl ListRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [routes][crate::model::ListRoutesResponse::routes].
     pub fn set_routes<T, V>(mut self, v: T) -> Self
     where
@@ -7308,6 +7302,12 @@ impl ListRoutesResponse {
     {
         use std::iter::Iterator;
         self.routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7452,12 +7452,6 @@ impl ListRouteTablesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRouteTablesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [route_tables][crate::model::ListRouteTablesResponse::route_tables].
     pub fn set_route_tables<T, V>(mut self, v: T) -> Self
     where
@@ -7466,6 +7460,12 @@ impl ListRouteTablesResponse {
     {
         use std::iter::Iterator;
         self.route_tables = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRouteTablesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7610,12 +7610,6 @@ impl ListGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [groups][crate::model::ListGroupsResponse::groups].
     pub fn set_groups<T, V>(mut self, v: T) -> Self
     where
@@ -7624,6 +7618,12 @@ impl ListGroupsResponse {
     {
         use std::iter::Iterator;
         self.groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7697,6 +7697,17 @@ impl LinkedVpnTunnels {
         std::default::Default::default()
     }
 
+    /// Sets the value of [uris][crate::model::LinkedVpnTunnels::uris].
+    pub fn set_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [site_to_site_data_transfer][crate::model::LinkedVpnTunnels::site_to_site_data_transfer].
     pub fn set_site_to_site_data_transfer<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.site_to_site_data_transfer = v.into();
@@ -7706,17 +7717,6 @@ impl LinkedVpnTunnels {
     /// Sets the value of [vpc_network][crate::model::LinkedVpnTunnels::vpc_network].
     pub fn set_vpc_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.vpc_network = v.into();
-        self
-    }
-
-    /// Sets the value of [uris][crate::model::LinkedVpnTunnels::uris].
-    pub fn set_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.uris = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7776,6 +7776,17 @@ impl LinkedInterconnectAttachments {
         std::default::Default::default()
     }
 
+    /// Sets the value of [uris][crate::model::LinkedInterconnectAttachments::uris].
+    pub fn set_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [site_to_site_data_transfer][crate::model::LinkedInterconnectAttachments::site_to_site_data_transfer].
     pub fn set_site_to_site_data_transfer<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.site_to_site_data_transfer = v.into();
@@ -7785,17 +7796,6 @@ impl LinkedInterconnectAttachments {
     /// Sets the value of [vpc_network][crate::model::LinkedInterconnectAttachments::vpc_network].
     pub fn set_vpc_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.vpc_network = v.into();
-        self
-    }
-
-    /// Sets the value of [uris][crate::model::LinkedInterconnectAttachments::uris].
-    pub fn set_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.uris = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7856,6 +7856,17 @@ impl LinkedRouterApplianceInstances {
         std::default::Default::default()
     }
 
+    /// Sets the value of [instances][crate::model::LinkedRouterApplianceInstances::instances].
+    pub fn set_instances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RouterApplianceInstance>,
+    {
+        use std::iter::Iterator;
+        self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [site_to_site_data_transfer][crate::model::LinkedRouterApplianceInstances::site_to_site_data_transfer].
     pub fn set_site_to_site_data_transfer<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.site_to_site_data_transfer = v.into();
@@ -7865,17 +7876,6 @@ impl LinkedRouterApplianceInstances {
     /// Sets the value of [vpc_network][crate::model::LinkedRouterApplianceInstances::vpc_network].
     pub fn set_vpc_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.vpc_network = v.into();
-        self
-    }
-
-    /// Sets the value of [instances][crate::model::LinkedRouterApplianceInstances::instances].
-    pub fn set_instances<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RouterApplianceInstance>,
-    {
-        use std::iter::Iterator;
-        self.instances = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8859,6 +8859,18 @@ impl PolicyBasedRoute {
         self
     }
 
+    /// Sets the value of [labels][crate::model::PolicyBasedRoute::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::PolicyBasedRoute::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -8888,18 +8900,6 @@ impl PolicyBasedRoute {
         self
     }
 
-    /// Sets the value of [self_link][crate::model::PolicyBasedRoute::self_link].
-    pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.self_link = v.into();
-        self
-    }
-
-    /// Sets the value of [kind][crate::model::PolicyBasedRoute::kind].
-    pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kind = v.into();
-        self
-    }
-
     /// Sets the value of [warnings][crate::model::PolicyBasedRoute::warnings].
     pub fn set_warnings<T, V>(mut self, v: T) -> Self
     where
@@ -8911,15 +8911,15 @@ impl PolicyBasedRoute {
         self
     }
 
-    /// Sets the value of [labels][crate::model::PolicyBasedRoute::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [self_link][crate::model::PolicyBasedRoute::self_link].
+    pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.self_link = v.into();
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::PolicyBasedRoute::kind].
+    pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.kind = v.into();
         self
     }
 
@@ -8953,23 +8953,6 @@ impl PolicyBasedRoute {
         })
     }
 
-    /// The value of [target][crate::model::PolicyBasedRoute::target]
-    /// if it holds a `InterconnectAttachment`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn interconnect_attachment(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::policy_based_route::InterconnectAttachment>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::policy_based_route::Target::InterconnectAttachment(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::PolicyBasedRoute::target]
     /// to hold a `VirtualMachine`.
     ///
@@ -8985,6 +8968,23 @@ impl PolicyBasedRoute {
             crate::model::policy_based_route::Target::VirtualMachine(v.into()),
         );
         self
+    }
+
+    /// The value of [target][crate::model::PolicyBasedRoute::target]
+    /// if it holds a `InterconnectAttachment`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn interconnect_attachment(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::policy_based_route::InterconnectAttachment>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::policy_based_route::Target::InterconnectAttachment(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::PolicyBasedRoute::target]
@@ -9033,6 +9033,18 @@ impl PolicyBasedRoute {
         })
     }
 
+    /// Sets the value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
+    /// to hold a `NextHopIlbIp`.
+    ///
+    /// Note that all the setters affecting `next_hop` are
+    /// mutually exclusive.
+    pub fn set_next_hop_ilb_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_hop = std::option::Option::Some(
+            crate::model::policy_based_route::NextHop::NextHopIlbIp(v.into()),
+        );
+        self
+    }
+
     /// The value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
     /// if it holds a `NextHopOtherRoutes`, `None` if the field is not set or
     /// holds a different branch.
@@ -9046,18 +9058,6 @@ impl PolicyBasedRoute {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
-    /// to hold a `NextHopIlbIp`.
-    ///
-    /// Note that all the setters affecting `next_hop` are
-    /// mutually exclusive.
-    pub fn set_next_hop_ilb_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_hop = std::option::Option::Some(
-            crate::model::policy_based_route::NextHop::NextHopIlbIp(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
@@ -9405,15 +9405,6 @@ pub mod policy_based_route {
             self
         }
 
-        /// Sets the value of [warning_message][crate::model::policy_based_route::Warnings::warning_message].
-        pub fn set_warning_message<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.warning_message = v.into();
-            self
-        }
-
         /// Sets the value of [data][crate::model::policy_based_route::Warnings::data].
         pub fn set_data<T, K, V>(mut self, v: T) -> Self
         where
@@ -9423,6 +9414,15 @@ pub mod policy_based_route {
         {
             use std::iter::Iterator;
             self.data = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [warning_message][crate::model::policy_based_route::Warnings::warning_message].
+        pub fn set_warning_message<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.warning_message = v.into();
             self
         }
     }
@@ -9846,12 +9846,6 @@ impl ListPolicyBasedRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPolicyBasedRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policy_based_routes][crate::model::ListPolicyBasedRoutesResponse::policy_based_routes].
     pub fn set_policy_based_routes<T, V>(mut self, v: T) -> Self
     where
@@ -9860,6 +9854,12 @@ impl ListPolicyBasedRoutesResponse {
     {
         use std::iter::Iterator;
         self.policy_based_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPolicyBasedRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -172,9 +172,32 @@ impl ConnectivityTest {
         self
     }
 
+    /// Sets the value of [related_projects][crate::model::ConnectivityTest::related_projects].
+    pub fn set_related_projects<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.related_projects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::ConnectivityTest::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::ConnectivityTest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -238,29 +261,6 @@ impl ConnectivityTest {
     /// Sets the value of [bypass_firewall_checks][crate::model::ConnectivityTest::bypass_firewall_checks].
     pub fn set_bypass_firewall_checks<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.bypass_firewall_checks = v.into();
-        self
-    }
-
-    /// Sets the value of [related_projects][crate::model::ConnectivityTest::related_projects].
-    pub fn set_related_projects<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.related_projects = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ConnectivityTest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1855,12 +1855,6 @@ impl ListConnectivityTestsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectivityTestsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::ListConnectivityTestsResponse::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -1869,6 +1863,12 @@ impl ListConnectivityTestsResponse {
     {
         use std::iter::Iterator;
         self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectivityTestsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2279,12 +2279,6 @@ impl Trace {
         self
     }
 
-    /// Sets the value of [forward_trace_id][crate::model::Trace::forward_trace_id].
-    pub fn set_forward_trace_id<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.forward_trace_id = v.into();
-        self
-    }
-
     /// Sets the value of [steps][crate::model::Trace::steps].
     pub fn set_steps<T, V>(mut self, v: T) -> Self
     where
@@ -2293,6 +2287,12 @@ impl Trace {
     {
         use std::iter::Iterator;
         self.steps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [forward_trace_id][crate::model::Trace::forward_trace_id].
+    pub fn set_forward_trace_id<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.forward_trace_id = v.into();
         self
     }
 }
@@ -2391,355 +2391,6 @@ impl Step {
         })
     }
 
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Firewall`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn firewall(&self) -> std::option::Option<&std::boxed::Box<crate::model::FirewallInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Firewall(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Route`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn route(&self) -> std::option::Option<&std::boxed::Box<crate::model::RouteInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Route(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Endpoint`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn endpoint(&self) -> std::option::Option<&std::boxed::Box<crate::model::EndpointInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Endpoint(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `GoogleService`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn google_service(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GoogleServiceInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::GoogleService(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `ForwardingRule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn forwarding_rule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ForwardingRuleInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::ForwardingRule(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `VpnGateway`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vpn_gateway(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VpnGatewayInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::VpnGateway(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `VpnTunnel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vpn_tunnel(&self) -> std::option::Option<&std::boxed::Box<crate::model::VpnTunnelInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::VpnTunnel(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `VpcConnector`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vpc_connector(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VpcConnectorInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::VpcConnector(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `DirectVpcEgressConnection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn direct_vpc_egress_connection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DirectVpcEgressConnectionInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::DirectVpcEgressConnection(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `ServerlessExternalConnection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn serverless_external_connection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ServerlessExternalConnectionInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::ServerlessExternalConnection(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Deliver`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deliver(&self) -> std::option::Option<&std::boxed::Box<crate::model::DeliverInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Deliver(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Forward`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn forward(&self) -> std::option::Option<&std::boxed::Box<crate::model::ForwardInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Forward(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Abort`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn abort(&self) -> std::option::Option<&std::boxed::Box<crate::model::AbortInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Abort(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Drop`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn drop(&self) -> std::option::Option<&std::boxed::Box<crate::model::DropInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Drop(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `LoadBalancer`, `None` if the field is not set or
-    /// holds a different branch.
-    #[deprecated]
-    pub fn load_balancer(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::LoadBalancerInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::LoadBalancer(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Network`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn network(&self) -> std::option::Option<&std::boxed::Box<crate::model::NetworkInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Network(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `GkeMaster`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gke_master(&self) -> std::option::Option<&std::boxed::Box<crate::model::GKEMasterInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::GkeMaster(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `CloudSqlInstance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_sql_instance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSQLInstanceInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::CloudSqlInstance(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `RedisInstance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redis_instance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RedisInstanceInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::RedisInstance(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `RedisCluster`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redis_cluster(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RedisClusterInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::RedisCluster(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `CloudFunction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_function(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudFunctionInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::CloudFunction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `AppEngineVersion`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn app_engine_version(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AppEngineVersionInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::AppEngineVersion(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `CloudRunRevision`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_run_revision(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudRunRevisionInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::CloudRunRevision(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `Nat`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn nat(&self) -> std::option::Option<&std::boxed::Box<crate::model::NatInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::Nat(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `ProxyConnection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn proxy_connection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ProxyConnectionInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::ProxyConnection(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `LoadBalancerBackendInfo`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn load_balancer_backend_info(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::LoadBalancerBackendInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::LoadBalancerBackendInfo(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `StorageBucket`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn storage_bucket(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StorageBucketInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::StorageBucket(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step_info][crate::model::Step::step_info]
-    /// if it holds a `ServerlessNeg`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn serverless_neg(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ServerlessNegInfo>> {
-        #[allow(unreachable_patterns)]
-        self.step_info.as_ref().and_then(|v| match v {
-            crate::model::step::StepInfo::ServerlessNeg(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Instance`.
     ///
@@ -2752,6 +2403,17 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::Instance(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Firewall`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn firewall(&self) -> std::option::Option<&std::boxed::Box<crate::model::FirewallInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Firewall(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2768,6 +2430,17 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Route`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn route(&self) -> std::option::Option<&std::boxed::Box<crate::model::RouteInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Route(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Route`.
     ///
@@ -2779,6 +2452,17 @@ impl Step {
     ) -> Self {
         self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Route(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Endpoint`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn endpoint(&self) -> std::option::Option<&std::boxed::Box<crate::model::EndpointInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Endpoint(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2793,6 +2477,19 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::Endpoint(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `GoogleService`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn google_service(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GoogleServiceInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::GoogleService(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2811,6 +2508,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `ForwardingRule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn forwarding_rule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ForwardingRuleInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::ForwardingRule(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `ForwardingRule`.
     ///
@@ -2827,6 +2537,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `VpnGateway`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vpn_gateway(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VpnGatewayInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::VpnGateway(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `VpnGateway`.
     ///
@@ -2839,6 +2562,17 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::VpnGateway(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `VpnTunnel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vpn_tunnel(&self) -> std::option::Option<&std::boxed::Box<crate::model::VpnTunnelInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::VpnTunnel(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2855,6 +2589,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `VpcConnector`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vpc_connector(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VpcConnectorInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::VpcConnector(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `VpcConnector`.
     ///
@@ -2869,6 +2616,21 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::VpcConnector(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `DirectVpcEgressConnection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn direct_vpc_egress_connection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DirectVpcEgressConnectionInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::DirectVpcEgressConnection(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2888,6 +2650,21 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `ServerlessExternalConnection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn serverless_external_connection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ServerlessExternalConnectionInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::ServerlessExternalConnection(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `ServerlessExternalConnection`.
     ///
@@ -2905,6 +2682,17 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Deliver`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deliver(&self) -> std::option::Option<&std::boxed::Box<crate::model::DeliverInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Deliver(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Deliver`.
     ///
@@ -2916,6 +2704,17 @@ impl Step {
     ) -> Self {
         self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Deliver(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Forward`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn forward(&self) -> std::option::Option<&std::boxed::Box<crate::model::ForwardInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Forward(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2931,6 +2730,17 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Abort`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn abort(&self) -> std::option::Option<&std::boxed::Box<crate::model::AbortInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Abort(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Abort`.
     ///
@@ -2944,6 +2754,17 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Drop`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn drop(&self) -> std::option::Option<&std::boxed::Box<crate::model::DropInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Drop(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Drop`.
     ///
@@ -2955,6 +2776,20 @@ impl Step {
     ) -> Self {
         self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Drop(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `LoadBalancer`, `None` if the field is not set or
+    /// holds a different branch.
+    #[deprecated]
+    pub fn load_balancer(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::LoadBalancerInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::LoadBalancer(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2974,6 +2809,17 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Network`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn network(&self) -> std::option::Option<&std::boxed::Box<crate::model::NetworkInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Network(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Network`.
     ///
@@ -2985,6 +2831,17 @@ impl Step {
     ) -> Self {
         self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Network(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `GkeMaster`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gke_master(&self) -> std::option::Option<&std::boxed::Box<crate::model::GKEMasterInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::GkeMaster(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -2999,6 +2856,19 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::GkeMaster(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `CloudSqlInstance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_sql_instance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSQLInstanceInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::CloudSqlInstance(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -3017,6 +2887,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `RedisInstance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redis_instance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RedisInstanceInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::RedisInstance(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `RedisInstance`.
     ///
@@ -3031,6 +2914,19 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::RedisInstance(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `RedisCluster`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redis_cluster(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RedisClusterInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::RedisCluster(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -3049,6 +2945,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `CloudFunction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_function(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudFunctionInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::CloudFunction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `CloudFunction`.
     ///
@@ -3063,6 +2972,19 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::CloudFunction(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `AppEngineVersion`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn app_engine_version(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AppEngineVersionInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::AppEngineVersion(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -3081,6 +3003,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `CloudRunRevision`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_run_revision(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudRunRevisionInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::CloudRunRevision(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `CloudRunRevision`.
     ///
@@ -3097,6 +3032,17 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `Nat`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn nat(&self) -> std::option::Option<&std::boxed::Box<crate::model::NatInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::Nat(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `Nat`.
     ///
@@ -3108,6 +3054,19 @@ impl Step {
     ) -> Self {
         self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Nat(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `ProxyConnection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn proxy_connection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ProxyConnectionInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::ProxyConnection(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -3124,6 +3083,21 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::ProxyConnection(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `LoadBalancerBackendInfo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn load_balancer_backend_info(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::LoadBalancerBackendInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::LoadBalancerBackendInfo(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -3143,6 +3117,19 @@ impl Step {
         self
     }
 
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `StorageBucket`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn storage_bucket(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StorageBucketInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::StorageBucket(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step_info][crate::model::Step::step_info]
     /// to hold a `StorageBucket`.
     ///
@@ -3157,6 +3144,19 @@ impl Step {
         self.step_info =
             std::option::Option::Some(crate::model::step::StepInfo::StorageBucket(v.into()));
         self
+    }
+
+    /// The value of [step_info][crate::model::Step::step_info]
+    /// if it holds a `ServerlessNeg`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn serverless_neg(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ServerlessNegInfo>> {
+        #[allow(unreachable_patterns)]
+        self.step_info.as_ref().and_then(|v| match v {
+            crate::model::step::StepInfo::ServerlessNeg(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_info][crate::model::Step::step_info]
@@ -3785,6 +3785,17 @@ impl InstanceInfo {
         self
     }
 
+    /// Sets the value of [network_tags][crate::model::InstanceInfo::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::InstanceInfo::service_account].
     #[deprecated]
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
@@ -3798,17 +3809,6 @@ impl InstanceInfo {
         v: T,
     ) -> Self {
         self.psc_network_attachment_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [network_tags][crate::model::InstanceInfo::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4001,6 +4001,28 @@ impl FirewallInfo {
         self
     }
 
+    /// Sets the value of [target_tags][crate::model::FirewallInfo::target_tags].
+    pub fn set_target_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.target_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [target_service_accounts][crate::model::FirewallInfo::target_service_accounts].
+    pub fn set_target_service_accounts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.target_service_accounts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [policy][crate::model::FirewallInfo::policy].
     pub fn set_policy<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.policy = v.into();
@@ -4021,28 +4043,6 @@ impl FirewallInfo {
         v: T,
     ) -> Self {
         self.firewall_rule_type = v.into();
-        self
-    }
-
-    /// Sets the value of [target_tags][crate::model::FirewallInfo::target_tags].
-    pub fn set_target_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.target_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [target_service_accounts][crate::model::FirewallInfo::target_service_accounts].
-    pub fn set_target_service_accounts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.target_service_accounts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4472,9 +4472,53 @@ impl RouteInfo {
         self
     }
 
+    /// Sets the value of [instance_tags][crate::model::RouteInfo::instance_tags].
+    pub fn set_instance_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.instance_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [src_ip_range][crate::model::RouteInfo::src_ip_range].
     pub fn set_src_ip_range<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.src_ip_range = v.into();
+        self
+    }
+
+    /// Sets the value of [dest_port_ranges][crate::model::RouteInfo::dest_port_ranges].
+    pub fn set_dest_port_ranges<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.dest_port_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [src_port_ranges][crate::model::RouteInfo::src_port_ranges].
+    pub fn set_src_port_ranges<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.src_port_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [protocols][crate::model::RouteInfo::protocols].
+    pub fn set_protocols<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.protocols = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4558,50 +4602,6 @@ impl RouteInfo {
         v: T,
     ) -> Self {
         self.ncc_hub_route_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [instance_tags][crate::model::RouteInfo::instance_tags].
-    pub fn set_instance_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.instance_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [dest_port_ranges][crate::model::RouteInfo::dest_port_ranges].
-    pub fn set_dest_port_ranges<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.dest_port_ranges = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [src_port_ranges][crate::model::RouteInfo::src_port_ranges].
-    pub fn set_src_port_ranges<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.src_port_ranges = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [protocols][crate::model::RouteInfo::protocols].
-    pub fn set_protocols<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.protocols = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5583,6 +5583,17 @@ impl LoadBalancerInfo {
         self
     }
 
+    /// Sets the value of [backends][crate::model::LoadBalancerInfo::backends].
+    pub fn set_backends<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LoadBalancerBackend>,
+    {
+        use std::iter::Iterator;
+        self.backends = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [backend_type][crate::model::LoadBalancerInfo::backend_type].
     pub fn set_backend_type<
         T: std::convert::Into<crate::model::load_balancer_info::BackendType>,
@@ -5597,17 +5608,6 @@ impl LoadBalancerInfo {
     /// Sets the value of [backend_uri][crate::model::LoadBalancerInfo::backend_uri].
     pub fn set_backend_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.backend_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [backends][crate::model::LoadBalancerInfo::backends].
-    pub fn set_backends<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LoadBalancerBackend>,
-    {
-        use std::iter::Iterator;
-        self.backends = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10463,12 +10463,6 @@ impl ListVpcFlowLogsConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVpcFlowLogsConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vpc_flow_logs_configs][crate::model::ListVpcFlowLogsConfigsResponse::vpc_flow_logs_configs].
     pub fn set_vpc_flow_logs_configs<T, V>(mut self, v: T) -> Self
     where
@@ -10477,6 +10471,12 @@ impl ListVpcFlowLogsConfigsResponse {
     {
         use std::iter::Iterator;
         self.vpc_flow_logs_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVpcFlowLogsConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -10832,6 +10832,17 @@ impl VpcFlowLogsConfig {
         self
     }
 
+    /// Sets the value of [metadata_fields][crate::model::VpcFlowLogsConfig::metadata_fields].
+    pub fn set_metadata_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata_fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [filter_expr][crate::model::VpcFlowLogsConfig::filter_expr].
     pub fn set_filter_expr<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
@@ -10854,6 +10865,18 @@ impl VpcFlowLogsConfig {
         self
     }
 
+    /// Sets the value of [labels][crate::model::VpcFlowLogsConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::VpcFlowLogsConfig::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -10869,29 +10892,6 @@ impl VpcFlowLogsConfig {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [metadata_fields][crate::model::VpcFlowLogsConfig::metadata_fields].
-    pub fn set_metadata_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata_fields = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::VpcFlowLogsConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -10922,19 +10922,6 @@ impl VpcFlowLogsConfig {
         })
     }
 
-    /// The value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]
-    /// if it holds a `VpnTunnel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vpn_tunnel(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.target_resource.as_ref().and_then(|v| match v {
-            crate::model::vpc_flow_logs_config::TargetResource::VpnTunnel(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]
     /// to hold a `InterconnectAttachment`.
     ///
@@ -10948,6 +10935,19 @@ impl VpcFlowLogsConfig {
             crate::model::vpc_flow_logs_config::TargetResource::InterconnectAttachment(v.into()),
         );
         self
+    }
+
+    /// The value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]
+    /// if it holds a `VpnTunnel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vpn_tunnel(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.target_resource.as_ref().and_then(|v| match v {
+            crate::model::vpc_flow_logs_config::TargetResource::VpnTunnel(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -114,6 +114,18 @@ impl AuthorizationPolicy {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AuthorizationPolicy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [action][crate::model::AuthorizationPolicy::action].
     pub fn set_action<T: std::convert::Into<crate::model::authorization_policy::Action>>(
         mut self,
@@ -131,18 +143,6 @@ impl AuthorizationPolicy {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AuthorizationPolicy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -324,21 +324,6 @@ pub mod authorization_policy {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [http_header_match][crate::model::authorization_policy::rule::Destination::http_header_match].
-            pub fn set_http_header_match<
-                T: std::convert::Into<
-                        std::option::Option<
-                            crate::model::authorization_policy::rule::destination::HttpHeaderMatch,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.http_header_match = v.into();
-                self
-            }
-
             /// Sets the value of [hosts][crate::model::authorization_policy::rule::Destination::hosts].
             pub fn set_hosts<T, V>(mut self, v: T) -> Self
             where
@@ -369,6 +354,21 @@ pub mod authorization_policy {
             {
                 use std::iter::Iterator;
                 self.methods = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [http_header_match][crate::model::authorization_policy::rule::Destination::http_header_match].
+            pub fn set_http_header_match<
+                T: std::convert::Into<
+                        std::option::Option<
+                            crate::model::authorization_policy::rule::destination::HttpHeaderMatch,
+                        >,
+                    >,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.http_header_match = v.into();
                 self
             }
         }
@@ -704,12 +704,6 @@ impl ListAuthorizationPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAuthorizationPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [authorization_policies][crate::model::ListAuthorizationPoliciesResponse::authorization_policies].
     pub fn set_authorization_policies<T, V>(mut self, v: T) -> Self
     where
@@ -718,6 +712,12 @@ impl ListAuthorizationPoliciesResponse {
     {
         use std::iter::Iterator;
         self.authorization_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAuthorizationPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1010,6 +1010,18 @@ impl ClientTlsPolicy {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ClientTlsPolicy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [sni][crate::model::ClientTlsPolicy::sni].
     pub fn set_sni<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.sni = v.into();
@@ -1035,18 +1047,6 @@ impl ClientTlsPolicy {
     {
         use std::iter::Iterator;
         self.server_validation_ca = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ClientTlsPolicy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1138,12 +1138,6 @@ impl ListClientTlsPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClientTlsPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [client_tls_policies][crate::model::ListClientTlsPoliciesResponse::client_tls_policies].
     pub fn set_client_tls_policies<T, V>(mut self, v: T) -> Self
     where
@@ -1152,6 +1146,12 @@ impl ListClientTlsPoliciesResponse {
     {
         use std::iter::Iterator;
         self.client_tls_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClientTlsPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1557,6 +1557,18 @@ impl ServerTlsPolicy {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ServerTlsPolicy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [allow_open][crate::model::ServerTlsPolicy::allow_open].
     pub fn set_allow_open<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_open = v.into();
@@ -1582,18 +1594,6 @@ impl ServerTlsPolicy {
         v: T,
     ) -> Self {
         self.mtls_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ServerTlsPolicy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1729,12 +1729,6 @@ impl ListServerTlsPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServerTlsPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [server_tls_policies][crate::model::ListServerTlsPoliciesResponse::server_tls_policies].
     pub fn set_server_tls_policies<T, V>(mut self, v: T) -> Self
     where
@@ -1743,6 +1737,12 @@ impl ListServerTlsPoliciesResponse {
     {
         use std::iter::Iterator;
         self.server_tls_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServerTlsPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2031,6 +2031,20 @@ impl ValidationCA {
         })
     }
 
+    /// Sets the value of [r#type][crate::model::ValidationCA::r#type]
+    /// to hold a `GrpcEndpoint`.
+    ///
+    /// Note that all the setters affecting `r#type` are
+    /// mutually exclusive.
+    pub fn set_grpc_endpoint<T: std::convert::Into<std::boxed::Box<crate::model::GrpcEndpoint>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.r#type =
+            std::option::Option::Some(crate::model::validation_ca::Type::GrpcEndpoint(v.into()));
+        self
+    }
+
     /// The value of [r#type][crate::model::ValidationCA::r#type]
     /// if it holds a `CertificateProviderInstance`, `None` if the field is not set or
     /// holds a different branch.
@@ -2044,20 +2058,6 @@ impl ValidationCA {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::ValidationCA::r#type]
-    /// to hold a `GrpcEndpoint`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_grpc_endpoint<T: std::convert::Into<std::boxed::Box<crate::model::GrpcEndpoint>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::validation_ca::Type::GrpcEndpoint(v.into()));
-        self
     }
 
     /// Sets the value of [r#type][crate::model::ValidationCA::r#type]
@@ -2191,21 +2191,6 @@ impl CertificateProvider {
         })
     }
 
-    /// The value of [r#type][crate::model::CertificateProvider::r#type]
-    /// if it holds a `CertificateProviderInstance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn certificate_provider_instance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CertificateProviderInstance>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::certificate_provider::Type::CertificateProviderInstance(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::CertificateProvider::r#type]
     /// to hold a `GrpcEndpoint`.
     ///
@@ -2219,6 +2204,21 @@ impl CertificateProvider {
             crate::model::certificate_provider::Type::GrpcEndpoint(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::CertificateProvider::r#type]
+    /// if it holds a `CertificateProviderInstance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn certificate_provider_instance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CertificateProviderInstance>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::certificate_provider::Type::CertificateProviderInstance(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::CertificateProvider::r#type]

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -755,6 +755,17 @@ pub mod extension_chain {
             self
         }
 
+        /// Sets the value of [supported_events][crate::model::extension_chain::Extension::supported_events].
+        pub fn set_supported_events<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::EventType>,
+        {
+            use std::iter::Iterator;
+            self.supported_events = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [timeout][crate::model::extension_chain::Extension::timeout].
         pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
@@ -767,17 +778,6 @@ pub mod extension_chain {
         /// Sets the value of [fail_open][crate::model::extension_chain::Extension::fail_open].
         pub fn set_fail_open<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.fail_open = v.into();
-            self
-        }
-
-        /// Sets the value of [supported_events][crate::model::extension_chain::Extension::supported_events].
-        pub fn set_supported_events<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::EventType>,
-        {
-            use std::iter::Iterator;
-            self.supported_events = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -907,21 +907,15 @@ impl LbTrafficExtension {
         self
     }
 
-    /// Sets the value of [load_balancing_scheme][crate::model::LbTrafficExtension::load_balancing_scheme].
-    pub fn set_load_balancing_scheme<T: std::convert::Into<crate::model::LoadBalancingScheme>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.load_balancing_scheme = v.into();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::LbTrafficExtension::metadata].
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
+    /// Sets the value of [labels][crate::model::LbTrafficExtension::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -947,15 +941,21 @@ impl LbTrafficExtension {
         self
     }
 
-    /// Sets the value of [labels][crate::model::LbTrafficExtension::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [load_balancing_scheme][crate::model::LbTrafficExtension::load_balancing_scheme].
+    pub fn set_load_balancing_scheme<T: std::convert::Into<crate::model::LoadBalancingScheme>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.load_balancing_scheme = v.into();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::LbTrafficExtension::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -1068,12 +1068,6 @@ impl ListLbTrafficExtensionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLbTrafficExtensionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [lb_traffic_extensions][crate::model::ListLbTrafficExtensionsResponse::lb_traffic_extensions].
     pub fn set_lb_traffic_extensions<T, V>(mut self, v: T) -> Self
     where
@@ -1082,6 +1076,12 @@ impl ListLbTrafficExtensionsResponse {
     {
         use std::iter::Iterator;
         self.lb_traffic_extensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLbTrafficExtensionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1473,21 +1473,15 @@ impl LbRouteExtension {
         self
     }
 
-    /// Sets the value of [load_balancing_scheme][crate::model::LbRouteExtension::load_balancing_scheme].
-    pub fn set_load_balancing_scheme<T: std::convert::Into<crate::model::LoadBalancingScheme>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.load_balancing_scheme = v.into();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::LbRouteExtension::metadata].
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
+    /// Sets the value of [labels][crate::model::LbRouteExtension::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1513,15 +1507,21 @@ impl LbRouteExtension {
         self
     }
 
-    /// Sets the value of [labels][crate::model::LbRouteExtension::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [load_balancing_scheme][crate::model::LbRouteExtension::load_balancing_scheme].
+    pub fn set_load_balancing_scheme<T: std::convert::Into<crate::model::LoadBalancingScheme>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.load_balancing_scheme = v.into();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::LbRouteExtension::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -1634,12 +1634,6 @@ impl ListLbRouteExtensionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLbRouteExtensionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [lb_route_extensions][crate::model::ListLbRouteExtensionsResponse::lb_route_extensions].
     pub fn set_lb_route_extensions<T, V>(mut self, v: T) -> Self
     where
@@ -1648,6 +1642,12 @@ impl ListLbRouteExtensionsResponse {
     {
         use std::iter::Iterator;
         self.lb_route_extensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLbRouteExtensionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2038,6 +2038,18 @@ impl EndpointPolicy {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EndpointPolicy::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [r#type][crate::model::EndpointPolicy::type].
     pub fn set_type<T: std::convert::Into<crate::model::endpoint_policy::EndpointPolicyType>>(
         mut self,
@@ -2099,18 +2111,6 @@ impl EndpointPolicy {
         v: T,
     ) -> Self {
         self.client_tls_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::EndpointPolicy::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2340,12 +2340,6 @@ impl ListEndpointPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEndpointPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [endpoint_policies][crate::model::ListEndpointPoliciesResponse::endpoint_policies].
     pub fn set_endpoint_policies<T, V>(mut self, v: T) -> Self
     where
@@ -2354,6 +2348,12 @@ impl ListEndpointPoliciesResponse {
     {
         use std::iter::Iterator;
         self.endpoint_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEndpointPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2661,6 +2661,18 @@ impl Gateway {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Gateway::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::Gateway::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -2670,6 +2682,17 @@ impl Gateway {
     /// Sets the value of [r#type][crate::model::Gateway::type].
     pub fn set_type<T: std::convert::Into<crate::model::gateway::Type>>(mut self, v: T) -> Self {
         self.r#type = v.into();
+        self
+    }
+
+    /// Sets the value of [ports][crate::model::Gateway::ports].
+    pub fn set_ports<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.ports = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2685,29 +2708,6 @@ impl Gateway {
         v: T,
     ) -> Self {
         self.server_tls_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [ports][crate::model::Gateway::ports].
-    pub fn set_ports<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.ports = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Gateway::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2941,12 +2941,6 @@ impl ListGatewaysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGatewaysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [gateways][crate::model::ListGatewaysResponse::gateways].
     pub fn set_gateways<T, V>(mut self, v: T) -> Self
     where
@@ -2955,6 +2949,12 @@ impl ListGatewaysResponse {
     {
         use std::iter::Iterator;
         self.gateways = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGatewaysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3285,6 +3285,18 @@ impl GrpcRoute {
         self
     }
 
+    /// Sets the value of [labels][crate::model::GrpcRoute::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::GrpcRoute::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -3332,18 +3344,6 @@ impl GrpcRoute {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::GrpcRoute::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -4150,12 +4150,6 @@ pub mod grpc_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [num_retries][crate::model::grpc_route::RetryPolicy::num_retries].
-        pub fn set_num_retries<T: std::convert::Into<u32>>(mut self, v: T) -> Self {
-            self.num_retries = v.into();
-            self
-        }
-
         /// Sets the value of [retry_conditions][crate::model::grpc_route::RetryPolicy::retry_conditions].
         pub fn set_retry_conditions<T, V>(mut self, v: T) -> Self
         where
@@ -4164,6 +4158,12 @@ pub mod grpc_route {
         {
             use std::iter::Iterator;
             self.retry_conditions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [num_retries][crate::model::grpc_route::RetryPolicy::num_retries].
+        pub fn set_num_retries<T: std::convert::Into<u32>>(mut self, v: T) -> Self {
+            self.num_retries = v.into();
             self
         }
     }
@@ -4219,6 +4219,17 @@ pub mod grpc_route {
             std::default::Default::default()
         }
 
+        /// Sets the value of [destinations][crate::model::grpc_route::RouteAction::destinations].
+        pub fn set_destinations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::grpc_route::Destination>,
+        {
+            use std::iter::Iterator;
+            self.destinations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [fault_injection_policy][crate::model::grpc_route::RouteAction::fault_injection_policy].
         pub fn set_fault_injection_policy<
             T: std::convert::Into<std::option::Option<crate::model::grpc_route::FaultInjectionPolicy>>,
@@ -4247,17 +4258,6 @@ pub mod grpc_route {
             v: T,
         ) -> Self {
             self.retry_policy = v.into();
-            self
-        }
-
-        /// Sets the value of [destinations][crate::model::grpc_route::RouteAction::destinations].
-        pub fn set_destinations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::grpc_route::Destination>,
-        {
-            use std::iter::Iterator;
-            self.destinations = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4295,17 +4295,6 @@ pub mod grpc_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [action][crate::model::grpc_route::RouteRule::action].
-        pub fn set_action<
-            T: std::convert::Into<std::option::Option<crate::model::grpc_route::RouteAction>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.action = v.into();
-            self
-        }
-
         /// Sets the value of [matches][crate::model::grpc_route::RouteRule::matches].
         pub fn set_matches<T, V>(mut self, v: T) -> Self
         where
@@ -4314,6 +4303,17 @@ pub mod grpc_route {
         {
             use std::iter::Iterator;
             self.matches = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [action][crate::model::grpc_route::RouteRule::action].
+        pub fn set_action<
+            T: std::convert::Into<std::option::Option<crate::model::grpc_route::RouteAction>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.action = v.into();
             self
         }
     }
@@ -4405,12 +4405,6 @@ impl ListGrpcRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGrpcRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [grpc_routes][crate::model::ListGrpcRoutesResponse::grpc_routes].
     pub fn set_grpc_routes<T, V>(mut self, v: T) -> Self
     where
@@ -4419,6 +4413,12 @@ impl ListGrpcRoutesResponse {
     {
         use std::iter::Iterator;
         self.grpc_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGrpcRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4781,17 +4781,6 @@ impl HttpRoute {
         self
     }
 
-    /// Sets the value of [rules][crate::model::HttpRoute::rules].
-    pub fn set_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::http_route::RouteRule>,
-    {
-        use std::iter::Iterator;
-        self.rules = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::HttpRoute::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -4801,6 +4790,17 @@ impl HttpRoute {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [rules][crate::model::HttpRoute::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::http_route::RouteRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4884,6 +4884,18 @@ pub mod http_route {
             })
         }
 
+        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
+        /// to hold a `ExactMatch`.
+        ///
+        /// Note that all the setters affecting `match_type` are
+        /// mutually exclusive.
+        pub fn set_exact_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.match_type = std::option::Option::Some(
+                crate::model::http_route::header_match::MatchType::ExactMatch(v.into()),
+            );
+            self
+        }
+
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
         /// if it holds a `RegexMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -4897,6 +4909,18 @@ pub mod http_route {
             })
         }
 
+        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
+        /// to hold a `RegexMatch`.
+        ///
+        /// Note that all the setters affecting `match_type` are
+        /// mutually exclusive.
+        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.match_type = std::option::Option::Some(
+                crate::model::http_route::header_match::MatchType::RegexMatch(v.into()),
+            );
+            self
+        }
+
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
         /// if it holds a `PrefixMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -4908,73 +4932,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// if it holds a `PresentMatch`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn present_match(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.match_type.as_ref().and_then(|v| match v {
-                crate::model::http_route::header_match::MatchType::PresentMatch(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// if it holds a `SuffixMatch`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn suffix_match(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.match_type.as_ref().and_then(|v| match v {
-                crate::model::http_route::header_match::MatchType::SuffixMatch(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// if it holds a `RangeMatch`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn range_match(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::http_route::header_match::IntegerRange>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.match_type.as_ref().and_then(|v| match v {
-                crate::model::http_route::header_match::MatchType::RangeMatch(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `ExactMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_exact_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::ExactMatch(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `RegexMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::RegexMatch(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
@@ -4992,6 +4949,19 @@ pub mod http_route {
             self
         }
 
+        /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
+        /// if it holds a `PresentMatch`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn present_match(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.match_type.as_ref().and_then(|v| match v {
+                crate::model::http_route::header_match::MatchType::PresentMatch(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
         /// to hold a `PresentMatch`.
         ///
@@ -5002,6 +4972,19 @@ pub mod http_route {
                 crate::model::http_route::header_match::MatchType::PresentMatch(v.into()),
             );
             self
+        }
+
+        /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
+        /// if it holds a `SuffixMatch`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn suffix_match(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.match_type.as_ref().and_then(|v| match v {
+                crate::model::http_route::header_match::MatchType::SuffixMatch(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
@@ -5017,6 +5000,23 @@ pub mod http_route {
                 crate::model::http_route::header_match::MatchType::SuffixMatch(v.into()),
             );
             self
+        }
+
+        /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
+        /// if it holds a `RangeMatch`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn range_match(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::http_route::header_match::IntegerRange>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.match_type.as_ref().and_then(|v| match v {
+                crate::model::http_route::header_match::MatchType::RangeMatch(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
@@ -5177,6 +5177,18 @@ pub mod http_route {
             })
         }
 
+        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
+        /// to hold a `ExactMatch`.
+        ///
+        /// Note that all the setters affecting `match_type` are
+        /// mutually exclusive.
+        pub fn set_exact_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.match_type = std::option::Option::Some(
+                crate::model::http_route::query_parameter_match::MatchType::ExactMatch(v.into()),
+            );
+            self
+        }
+
         /// The value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
         /// if it holds a `RegexMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -5190,6 +5202,18 @@ pub mod http_route {
             })
         }
 
+        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
+        /// to hold a `RegexMatch`.
+        ///
+        /// Note that all the setters affecting `match_type` are
+        /// mutually exclusive.
+        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.match_type = std::option::Option::Some(
+                crate::model::http_route::query_parameter_match::MatchType::RegexMatch(v.into()),
+            );
+            self
+        }
+
         /// The value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
         /// if it holds a `PresentMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -5201,30 +5225,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
-        /// to hold a `ExactMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_exact_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::query_parameter_match::MatchType::ExactMatch(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
-        /// to hold a `RegexMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::query_parameter_match::MatchType::RegexMatch(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
@@ -5367,32 +5367,6 @@ pub mod http_route {
             })
         }
 
-        /// The value of [path_match][crate::model::http_route::RouteMatch::path_match]
-        /// if it holds a `PrefixMatch`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn prefix_match(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.path_match.as_ref().and_then(|v| match v {
-                crate::model::http_route::route_match::PathMatch::PrefixMatch(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [path_match][crate::model::http_route::RouteMatch::path_match]
-        /// if it holds a `RegexMatch`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn regex_match(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.path_match.as_ref().and_then(|v| match v {
-                crate::model::http_route::route_match::PathMatch::RegexMatch(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [path_match][crate::model::http_route::RouteMatch::path_match]
         /// to hold a `FullPathMatch`.
         ///
@@ -5408,6 +5382,19 @@ pub mod http_route {
             self
         }
 
+        /// The value of [path_match][crate::model::http_route::RouteMatch::path_match]
+        /// if it holds a `PrefixMatch`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn prefix_match(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.path_match.as_ref().and_then(|v| match v {
+                crate::model::http_route::route_match::PathMatch::PrefixMatch(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [path_match][crate::model::http_route::RouteMatch::path_match]
         /// to hold a `PrefixMatch`.
         ///
@@ -5421,6 +5408,19 @@ pub mod http_route {
                 crate::model::http_route::route_match::PathMatch::PrefixMatch(v.into()),
             );
             self
+        }
+
+        /// The value of [path_match][crate::model::http_route::RouteMatch::path_match]
+        /// if it holds a `RegexMatch`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn regex_match(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.path_match.as_ref().and_then(|v| match v {
+                crate::model::http_route::route_match::PathMatch::RegexMatch(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [path_match][crate::model::http_route::RouteMatch::path_match]
@@ -6009,17 +6009,6 @@ pub mod http_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [remove][crate::model::http_route::HeaderModifier::remove].
-        pub fn set_remove<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.remove = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
         /// Sets the value of [set][crate::model::http_route::HeaderModifier::set].
         pub fn set_set<T, K, V>(mut self, v: T) -> Self
         where
@@ -6041,6 +6030,17 @@ pub mod http_route {
         {
             use std::iter::Iterator;
             self.add = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [remove][crate::model::http_route::HeaderModifier::remove].
+        pub fn set_remove<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.remove = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6151,6 +6151,17 @@ pub mod http_route {
             std::default::Default::default()
         }
 
+        /// Sets the value of [retry_conditions][crate::model::http_route::RetryPolicy::retry_conditions].
+        pub fn set_retry_conditions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.retry_conditions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [num_retries][crate::model::http_route::RetryPolicy::num_retries].
         pub fn set_num_retries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.num_retries = v.into();
@@ -6163,17 +6174,6 @@ pub mod http_route {
             v: T,
         ) -> Self {
             self.per_try_timeout = v.into();
-            self
-        }
-
-        /// Sets the value of [retry_conditions][crate::model::http_route::RetryPolicy::retry_conditions].
-        pub fn set_retry_conditions<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.retry_conditions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -6282,24 +6282,6 @@ pub mod http_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [max_age][crate::model::http_route::CorsPolicy::max_age].
-        pub fn set_max_age<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.max_age = v.into();
-            self
-        }
-
-        /// Sets the value of [allow_credentials][crate::model::http_route::CorsPolicy::allow_credentials].
-        pub fn set_allow_credentials<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.allow_credentials = v.into();
-            self
-        }
-
-        /// Sets the value of [disabled][crate::model::http_route::CorsPolicy::disabled].
-        pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.disabled = v.into();
-            self
-        }
-
         /// Sets the value of [allow_origins][crate::model::http_route::CorsPolicy::allow_origins].
         pub fn set_allow_origins<T, V>(mut self, v: T) -> Self
         where
@@ -6352,6 +6334,24 @@ pub mod http_route {
         {
             use std::iter::Iterator;
             self.expose_headers = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [max_age][crate::model::http_route::CorsPolicy::max_age].
+        pub fn set_max_age<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.max_age = v.into();
+            self
+        }
+
+        /// Sets the value of [allow_credentials][crate::model::http_route::CorsPolicy::allow_credentials].
+        pub fn set_allow_credentials<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.allow_credentials = v.into();
+            self
+        }
+
+        /// Sets the value of [disabled][crate::model::http_route::CorsPolicy::disabled].
+        pub fn set_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.disabled = v.into();
             self
         }
     }
@@ -6438,6 +6438,17 @@ pub mod http_route {
     impl RouteAction {
         pub fn new() -> Self {
             std::default::Default::default()
+        }
+
+        /// Sets the value of [destinations][crate::model::http_route::RouteAction::destinations].
+        pub fn set_destinations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::http_route::Destination>,
+        {
+            use std::iter::Iterator;
+            self.destinations = v.into_iter().map(|i| i.into()).collect();
+            self
         }
 
         /// Sets the value of [redirect][crate::model::http_route::RouteAction::redirect].
@@ -6536,17 +6547,6 @@ pub mod http_route {
             self.cors_policy = v.into();
             self
         }
-
-        /// Sets the value of [destinations][crate::model::http_route::RouteAction::destinations].
-        pub fn set_destinations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::http_route::Destination>,
-        {
-            use std::iter::Iterator;
-            self.destinations = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
     }
 
     impl wkt::message::Message for RouteAction {
@@ -6587,17 +6587,6 @@ pub mod http_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [action][crate::model::http_route::RouteRule::action].
-        pub fn set_action<
-            T: std::convert::Into<std::option::Option<crate::model::http_route::RouteAction>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.action = v.into();
-            self
-        }
-
         /// Sets the value of [matches][crate::model::http_route::RouteRule::matches].
         pub fn set_matches<T, V>(mut self, v: T) -> Self
         where
@@ -6606,6 +6595,17 @@ pub mod http_route {
         {
             use std::iter::Iterator;
             self.matches = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [action][crate::model::http_route::RouteRule::action].
+        pub fn set_action<
+            T: std::convert::Into<std::option::Option<crate::model::http_route::RouteAction>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.action = v.into();
             self
         }
     }
@@ -6697,12 +6697,6 @@ impl ListHttpRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHttpRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [http_routes][crate::model::ListHttpRoutesResponse::http_routes].
     pub fn set_http_routes<T, V>(mut self, v: T) -> Self
     where
@@ -6711,6 +6705,12 @@ impl ListHttpRoutesResponse {
     {
         use std::iter::Iterator;
         self.http_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHttpRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6991,18 +6991,6 @@ impl Mesh {
         self
     }
 
-    /// Sets the value of [description][crate::model::Mesh::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [interception_port][crate::model::Mesh::interception_port].
-    pub fn set_interception_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.interception_port = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Mesh::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -7012,6 +7000,18 @@ impl Mesh {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::Mesh::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
+        self
+    }
+
+    /// Sets the value of [interception_port][crate::model::Mesh::interception_port].
+    pub fn set_interception_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.interception_port = v.into();
         self
     }
 }
@@ -7102,12 +7102,6 @@ impl ListMeshesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMeshesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [meshes][crate::model::ListMeshesResponse::meshes].
     pub fn set_meshes<T, V>(mut self, v: T) -> Self
     where
@@ -7116,6 +7110,12 @@ impl ListMeshesResponse {
     {
         use std::iter::Iterator;
         self.meshes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMeshesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7492,12 +7492,6 @@ impl ListServiceBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_bindings][crate::model::ListServiceBindingsResponse::service_bindings].
     pub fn set_service_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -7506,6 +7500,12 @@ impl ListServiceBindingsResponse {
     {
         use std::iter::Iterator;
         self.service_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7843,17 +7843,6 @@ pub mod tcp_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [action][crate::model::tcp_route::RouteRule::action].
-        pub fn set_action<
-            T: std::convert::Into<std::option::Option<crate::model::tcp_route::RouteAction>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.action = v.into();
-            self
-        }
-
         /// Sets the value of [matches][crate::model::tcp_route::RouteRule::matches].
         pub fn set_matches<T, V>(mut self, v: T) -> Self
         where
@@ -7862,6 +7851,17 @@ pub mod tcp_route {
         {
             use std::iter::Iterator;
             self.matches = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [action][crate::model::tcp_route::RouteRule::action].
+        pub fn set_action<
+            T: std::convert::Into<std::option::Option<crate::model::tcp_route::RouteAction>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.action = v.into();
             self
         }
     }
@@ -7952,12 +7952,6 @@ pub mod tcp_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [original_destination][crate::model::tcp_route::RouteAction::original_destination].
-        pub fn set_original_destination<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.original_destination = v.into();
-            self
-        }
-
         /// Sets the value of [destinations][crate::model::tcp_route::RouteAction::destinations].
         pub fn set_destinations<T, V>(mut self, v: T) -> Self
         where
@@ -7966,6 +7960,12 @@ pub mod tcp_route {
         {
             use std::iter::Iterator;
             self.destinations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [original_destination][crate::model::tcp_route::RouteAction::original_destination].
+        pub fn set_original_destination<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.original_destination = v.into();
             self
         }
     }
@@ -8116,12 +8116,6 @@ impl ListTcpRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTcpRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tcp_routes][crate::model::ListTcpRoutesResponse::tcp_routes].
     pub fn set_tcp_routes<T, V>(mut self, v: T) -> Self
     where
@@ -8130,6 +8124,12 @@ impl ListTcpRoutesResponse {
     {
         use std::iter::Iterator;
         self.tcp_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTcpRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8496,17 +8496,6 @@ pub mod tls_route {
             std::default::Default::default()
         }
 
-        /// Sets the value of [action][crate::model::tls_route::RouteRule::action].
-        pub fn set_action<
-            T: std::convert::Into<std::option::Option<crate::model::tls_route::RouteAction>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.action = v.into();
-            self
-        }
-
         /// Sets the value of [matches][crate::model::tls_route::RouteRule::matches].
         pub fn set_matches<T, V>(mut self, v: T) -> Self
         where
@@ -8515,6 +8504,17 @@ pub mod tls_route {
         {
             use std::iter::Iterator;
             self.matches = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [action][crate::model::tls_route::RouteRule::action].
+        pub fn set_action<
+            T: std::convert::Into<std::option::Option<crate::model::tls_route::RouteAction>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.action = v.into();
             self
         }
     }
@@ -8758,12 +8758,6 @@ impl ListTlsRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTlsRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tls_routes][crate::model::ListTlsRoutesResponse::tls_routes].
     pub fn set_tls_routes<T, V>(mut self, v: T) -> Self
     where
@@ -8772,6 +8766,12 @@ impl ListTlsRoutesResponse {
     {
         use std::iter::Iterator;
         self.tls_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTlsRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -603,6 +603,16 @@ impl VmImage {
         })
     }
 
+    /// Sets the value of [image][crate::model::VmImage::image]
+    /// to hold a `Name`.
+    ///
+    /// Note that all the setters affecting `image` are
+    /// mutually exclusive.
+    pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.image = std::option::Option::Some(crate::model::vm_image::Image::Name(v.into()));
+        self
+    }
+
     /// The value of [image][crate::model::VmImage::image]
     /// if it holds a `Family`, `None` if the field is not set or
     /// holds a different branch.
@@ -612,16 +622,6 @@ impl VmImage {
             crate::model::vm_image::Image::Family(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [image][crate::model::VmImage::image]
-    /// to hold a `Name`.
-    ///
-    /// Note that all the setters affecting `image` are
-    /// mutually exclusive.
-    pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.image = std::option::Option::Some(crate::model::vm_image::Image::Name(v.into()));
-        self
     }
 
     /// Sets the value of [image][crate::model::VmImage::image]
@@ -1339,49 +1339,6 @@ impl GceSetup {
         self
     }
 
-    /// Sets the value of [boot_disk][crate::model::GceSetup::boot_disk].
-    pub fn set_boot_disk<T: std::convert::Into<std::option::Option<crate::model::BootDisk>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.boot_disk = v.into();
-        self
-    }
-
-    /// Sets the value of [shielded_instance_config][crate::model::GceSetup::shielded_instance_config].
-    pub fn set_shielded_instance_config<
-        T: std::convert::Into<std::option::Option<crate::model::ShieldedInstanceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.shielded_instance_config = v.into();
-        self
-    }
-
-    /// Sets the value of [disable_public_ip][crate::model::GceSetup::disable_public_ip].
-    pub fn set_disable_public_ip<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.disable_public_ip = v.into();
-        self
-    }
-
-    /// Sets the value of [enable_ip_forwarding][crate::model::GceSetup::enable_ip_forwarding].
-    pub fn set_enable_ip_forwarding<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_ip_forwarding = v.into();
-        self
-    }
-
-    /// Sets the value of [gpu_driver_config][crate::model::GceSetup::gpu_driver_config].
-    pub fn set_gpu_driver_config<
-        T: std::convert::Into<std::option::Option<crate::model::GPUDriverConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.gpu_driver_config = v.into();
-        self
-    }
-
     /// Sets the value of [accelerator_configs][crate::model::GceSetup::accelerator_configs].
     pub fn set_accelerator_configs<T, V>(mut self, v: T) -> Self
     where
@@ -1404,6 +1361,15 @@ impl GceSetup {
         self
     }
 
+    /// Sets the value of [boot_disk][crate::model::GceSetup::boot_disk].
+    pub fn set_boot_disk<T: std::convert::Into<std::option::Option<crate::model::BootDisk>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.boot_disk = v.into();
+        self
+    }
+
     /// Sets the value of [data_disks][crate::model::GceSetup::data_disks].
     pub fn set_data_disks<T, V>(mut self, v: T) -> Self
     where
@@ -1415,6 +1381,17 @@ impl GceSetup {
         self
     }
 
+    /// Sets the value of [shielded_instance_config][crate::model::GceSetup::shielded_instance_config].
+    pub fn set_shielded_instance_config<
+        T: std::convert::Into<std::option::Option<crate::model::ShieldedInstanceConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.shielded_instance_config = v.into();
+        self
+    }
+
     /// Sets the value of [network_interfaces][crate::model::GceSetup::network_interfaces].
     pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
     where
@@ -1423,6 +1400,12 @@ impl GceSetup {
     {
         use std::iter::Iterator;
         self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [disable_public_ip][crate::model::GceSetup::disable_public_ip].
+    pub fn set_disable_public_ip<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.disable_public_ip = v.into();
         self
     }
 
@@ -1449,6 +1432,23 @@ impl GceSetup {
         self
     }
 
+    /// Sets the value of [enable_ip_forwarding][crate::model::GceSetup::enable_ip_forwarding].
+    pub fn set_enable_ip_forwarding<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_ip_forwarding = v.into();
+        self
+    }
+
+    /// Sets the value of [gpu_driver_config][crate::model::GceSetup::gpu_driver_config].
+    pub fn set_gpu_driver_config<
+        T: std::convert::Into<std::option::Option<crate::model::GPUDriverConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.gpu_driver_config = v.into();
+        self
+    }
+
     /// Sets the value of [image][crate::model::GceSetup::image].
     ///
     /// Note that all the setters affecting `image` are mutually
@@ -1472,19 +1472,6 @@ impl GceSetup {
         })
     }
 
-    /// The value of [image][crate::model::GceSetup::image]
-    /// if it holds a `ContainerImage`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn container_image(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ContainerImage>> {
-        #[allow(unreachable_patterns)]
-        self.image.as_ref().and_then(|v| match v {
-            crate::model::gce_setup::Image::ContainerImage(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [image][crate::model::GceSetup::image]
     /// to hold a `VmImage`.
     ///
@@ -1496,6 +1483,19 @@ impl GceSetup {
     ) -> Self {
         self.image = std::option::Option::Some(crate::model::gce_setup::Image::VmImage(v.into()));
         self
+    }
+
+    /// The value of [image][crate::model::GceSetup::image]
+    /// if it holds a `ContainerImage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn container_image(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ContainerImage>> {
+        #[allow(unreachable_patterns)]
+        self.image.as_ref().and_then(|v| match v {
+            crate::model::gce_setup::Image::ContainerImage(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [image][crate::model::GceSetup::image]
@@ -2036,6 +2036,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [instance_owners][crate::model::Instance::instance_owners].
+    pub fn set_instance_owners<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.instance_owners = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [creator][crate::model::Instance::creator].
     pub fn set_creator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.creator = v.into();
@@ -2045,6 +2056,17 @@ impl Instance {
     /// Sets the value of [state][crate::model::Instance::state].
     pub fn set_state<T: std::convert::Into<crate::model::State>>(mut self, v: T) -> Self {
         self.state = v.into();
+        self
+    }
+
+    /// Sets the value of [upgrade_history][crate::model::Instance::upgrade_history].
+    pub fn set_upgrade_history<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::UpgradeHistoryEntry>,
+    {
+        use std::iter::Iterator;
+        self.upgrade_history = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2060,6 +2082,18 @@ impl Instance {
         v: T,
     ) -> Self {
         self.health_state = v.into();
+        self
+    }
+
+    /// Sets the value of [health_info][crate::model::Instance::health_info].
+    pub fn set_health_info<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.health_info = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2084,40 +2118,6 @@ impl Instance {
     /// Sets the value of [disable_proxy_access][crate::model::Instance::disable_proxy_access].
     pub fn set_disable_proxy_access<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.disable_proxy_access = v.into();
-        self
-    }
-
-    /// Sets the value of [instance_owners][crate::model::Instance::instance_owners].
-    pub fn set_instance_owners<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.instance_owners = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [upgrade_history][crate::model::Instance::upgrade_history].
-    pub fn set_upgrade_history<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::UpgradeHistoryEntry>,
-    {
-        use std::iter::Iterator;
-        self.upgrade_history = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [health_info][crate::model::Instance::health_info].
-    pub fn set_health_info<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.health_info = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -2414,12 +2414,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -2428,6 +2422,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/optimization/v1/src/builder.rs
+++ b/src/generated/cloud/optimization/v1/src/builder.rs
@@ -140,6 +140,18 @@ pub mod fleet_routing {
             self
         }
 
+        /// Sets the value of [injected_first_solution_routes][crate::model::OptimizeToursRequest::injected_first_solution_routes].
+        pub fn set_injected_first_solution_routes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ShipmentRoute>,
+        {
+            use std::iter::Iterator;
+            self.0.request.injected_first_solution_routes =
+                v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [injected_solution_constraint][crate::model::OptimizeToursRequest::injected_solution_constraint].
         pub fn set_injected_solution_constraint<
             T: Into<std::option::Option<crate::model::InjectedSolutionConstraint>>,
@@ -148,6 +160,17 @@ pub mod fleet_routing {
             v: T,
         ) -> Self {
             self.0.request.injected_solution_constraint = v.into();
+            self
+        }
+
+        /// Sets the value of [refresh_details_routes][crate::model::OptimizeToursRequest::refresh_details_routes].
+        pub fn set_refresh_details_routes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ShipmentRoute>,
+        {
+            use std::iter::Iterator;
+            self.0.request.refresh_details_routes = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -223,29 +246,6 @@ pub mod fleet_routing {
         #[deprecated]
         pub fn set_populate_travel_step_polylines<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.populate_travel_step_polylines = v.into();
-            self
-        }
-
-        /// Sets the value of [injected_first_solution_routes][crate::model::OptimizeToursRequest::injected_first_solution_routes].
-        pub fn set_injected_first_solution_routes<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::ShipmentRoute>,
-        {
-            use std::iter::Iterator;
-            self.0.request.injected_first_solution_routes =
-                v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [refresh_details_routes][crate::model::OptimizeToursRequest::refresh_details_routes].
-        pub fn set_refresh_details_routes<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::ShipmentRoute>,
-        {
-            use std::iter::Iterator;
-            self.0.request.refresh_details_routes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -827,6 +827,17 @@ impl OptimizeToursRequest {
         self
     }
 
+    /// Sets the value of [injected_first_solution_routes][crate::model::OptimizeToursRequest::injected_first_solution_routes].
+    pub fn set_injected_first_solution_routes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ShipmentRoute>,
+    {
+        use std::iter::Iterator;
+        self.injected_first_solution_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [injected_solution_constraint][crate::model::OptimizeToursRequest::injected_solution_constraint].
     pub fn set_injected_solution_constraint<
         T: std::convert::Into<std::option::Option<crate::model::InjectedSolutionConstraint>>,
@@ -835,6 +846,17 @@ impl OptimizeToursRequest {
         v: T,
     ) -> Self {
         self.injected_solution_constraint = v.into();
+        self
+    }
+
+    /// Sets the value of [refresh_details_routes][crate::model::OptimizeToursRequest::refresh_details_routes].
+    pub fn set_refresh_details_routes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ShipmentRoute>,
+    {
+        use std::iter::Iterator;
+        self.refresh_details_routes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -908,28 +930,6 @@ impl OptimizeToursRequest {
     #[deprecated]
     pub fn set_populate_travel_step_polylines<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.populate_travel_step_polylines = v.into();
-        self
-    }
-
-    /// Sets the value of [injected_first_solution_routes][crate::model::OptimizeToursRequest::injected_first_solution_routes].
-    pub fn set_injected_first_solution_routes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ShipmentRoute>,
-    {
-        use std::iter::Iterator;
-        self.injected_first_solution_routes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [refresh_details_routes][crate::model::OptimizeToursRequest::refresh_details_routes].
-    pub fn set_refresh_details_routes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ShipmentRoute>,
-    {
-        use std::iter::Iterator;
-        self.refresh_details_routes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1300,30 +1300,6 @@ impl OptimizeToursResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [request_label][crate::model::OptimizeToursResponse::request_label].
-    pub fn set_request_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.request_label = v.into();
-        self
-    }
-
-    /// Sets the value of [metrics][crate::model::OptimizeToursResponse::metrics].
-    pub fn set_metrics<
-        T: std::convert::Into<std::option::Option<crate::model::optimize_tours_response::Metrics>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metrics = v.into();
-        self
-    }
-
-    /// Sets the value of [total_cost][crate::model::OptimizeToursResponse::total_cost].
-    #[deprecated]
-    pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.total_cost = v.into();
-        self
-    }
-
     /// Sets the value of [routes][crate::model::OptimizeToursResponse::routes].
     pub fn set_routes<T, V>(mut self, v: T) -> Self
     where
@@ -1332,6 +1308,12 @@ impl OptimizeToursResponse {
     {
         use std::iter::Iterator;
         self.routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [request_label][crate::model::OptimizeToursResponse::request_label].
+    pub fn set_request_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.request_label = v.into();
         self
     }
 
@@ -1354,6 +1336,24 @@ impl OptimizeToursResponse {
     {
         use std::iter::Iterator;
         self.validation_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metrics][crate::model::OptimizeToursResponse::metrics].
+    pub fn set_metrics<
+        T: std::convert::Into<std::option::Option<crate::model::optimize_tours_response::Metrics>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metrics = v.into();
+        self
+    }
+
+    /// Sets the value of [total_cost][crate::model::OptimizeToursResponse::total_cost].
+    #[deprecated]
+    pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.total_cost = v.into();
         self
     }
 }
@@ -1485,12 +1485,6 @@ pub mod optimize_tours_response {
             self
         }
 
-        /// Sets the value of [total_cost][crate::model::optimize_tours_response::Metrics::total_cost].
-        pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.total_cost = v.into();
-            self
-        }
-
         /// Sets the value of [costs][crate::model::optimize_tours_response::Metrics::costs].
         pub fn set_costs<T, K, V>(mut self, v: T) -> Self
         where
@@ -1500,6 +1494,12 @@ pub mod optimize_tours_response {
         {
             use std::iter::Iterator;
             self.costs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [total_cost][crate::model::optimize_tours_response::Metrics::total_cost].
+        pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+            self.total_cost = v.into();
             self
         }
     }
@@ -1904,6 +1904,28 @@ impl ShipmentModel {
         std::default::Default::default()
     }
 
+    /// Sets the value of [shipments][crate::model::ShipmentModel::shipments].
+    pub fn set_shipments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Shipment>,
+    {
+        use std::iter::Iterator;
+        self.shipments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [vehicles][crate::model::ShipmentModel::vehicles].
+    pub fn set_vehicles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Vehicle>,
+    {
+        use std::iter::Iterator;
+        self.vehicles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [max_active_vehicles][crate::model::ShipmentModel::max_active_vehicles].
     pub fn set_max_active_vehicles<T: std::convert::Into<std::option::Option<i32>>>(
         mut self,
@@ -1934,28 +1956,6 @@ impl ShipmentModel {
     /// Sets the value of [global_duration_cost_per_hour][crate::model::ShipmentModel::global_duration_cost_per_hour].
     pub fn set_global_duration_cost_per_hour<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
         self.global_duration_cost_per_hour = v.into();
-        self
-    }
-
-    /// Sets the value of [shipments][crate::model::ShipmentModel::shipments].
-    pub fn set_shipments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Shipment>,
-    {
-        use std::iter::Iterator;
-        self.shipments = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [vehicles][crate::model::ShipmentModel::vehicles].
-    pub fn set_vehicles<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Vehicle>,
-    {
-        use std::iter::Iterator;
-        self.vehicles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2096,15 +2096,6 @@ pub mod shipment_model {
             std::default::Default::default()
         }
 
-        /// Sets the value of [vehicle_start_tag][crate::model::shipment_model::DurationDistanceMatrix::vehicle_start_tag].
-        pub fn set_vehicle_start_tag<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.vehicle_start_tag = v.into();
-            self
-        }
-
         /// Sets the value of [rows][crate::model::shipment_model::DurationDistanceMatrix::rows].
         pub fn set_rows<T, V>(mut self, v: T) -> Self
         where
@@ -2113,6 +2104,15 @@ pub mod shipment_model {
         {
             use std::iter::Iterator;
             self.rows = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [vehicle_start_tag][crate::model::shipment_model::DurationDistanceMatrix::vehicle_start_tag].
+        pub fn set_vehicle_start_tag<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.vehicle_start_tag = v.into();
             self
         }
     }
@@ -2675,12 +2675,79 @@ impl Shipment {
         std::default::Default::default()
     }
 
+    /// Sets the value of [pickups][crate::model::Shipment::pickups].
+    pub fn set_pickups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::shipment::VisitRequest>,
+    {
+        use std::iter::Iterator;
+        self.pickups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [deliveries][crate::model::Shipment::deliveries].
+    pub fn set_deliveries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::shipment::VisitRequest>,
+    {
+        use std::iter::Iterator;
+        self.deliveries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [load_demands][crate::model::Shipment::load_demands].
+    pub fn set_load_demands<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::shipment::Load>,
+    {
+        use std::iter::Iterator;
+        self.load_demands = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [penalty_cost][crate::model::Shipment::penalty_cost].
     pub fn set_penalty_cost<T: std::convert::Into<std::option::Option<f64>>>(
         mut self,
         v: T,
     ) -> Self {
         self.penalty_cost = v.into();
+        self
+    }
+
+    /// Sets the value of [allowed_vehicle_indices][crate::model::Shipment::allowed_vehicle_indices].
+    pub fn set_allowed_vehicle_indices<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.allowed_vehicle_indices = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [costs_per_vehicle][crate::model::Shipment::costs_per_vehicle].
+    pub fn set_costs_per_vehicle<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<f64>,
+    {
+        use std::iter::Iterator;
+        self.costs_per_vehicle = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [costs_per_vehicle_indices][crate::model::Shipment::costs_per_vehicle_indices].
+    pub fn set_costs_per_vehicle_indices<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.costs_per_vehicle_indices = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2735,61 +2802,6 @@ impl Shipment {
         self
     }
 
-    /// Sets the value of [pickups][crate::model::Shipment::pickups].
-    pub fn set_pickups<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::shipment::VisitRequest>,
-    {
-        use std::iter::Iterator;
-        self.pickups = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [deliveries][crate::model::Shipment::deliveries].
-    pub fn set_deliveries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::shipment::VisitRequest>,
-    {
-        use std::iter::Iterator;
-        self.deliveries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [allowed_vehicle_indices][crate::model::Shipment::allowed_vehicle_indices].
-    pub fn set_allowed_vehicle_indices<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.allowed_vehicle_indices = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [costs_per_vehicle][crate::model::Shipment::costs_per_vehicle].
-    pub fn set_costs_per_vehicle<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<f64>,
-    {
-        use std::iter::Iterator;
-        self.costs_per_vehicle = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [costs_per_vehicle_indices][crate::model::Shipment::costs_per_vehicle_indices].
-    pub fn set_costs_per_vehicle_indices<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.costs_per_vehicle_indices = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [demands][crate::model::Shipment::demands].
     #[deprecated]
     pub fn set_demands<T, V>(mut self, v: T) -> Self
@@ -2799,18 +2811,6 @@ impl Shipment {
     {
         use std::iter::Iterator;
         self.demands = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [load_demands][crate::model::Shipment::load_demands].
-    pub fn set_load_demands<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::shipment::Load>,
-    {
-        use std::iter::Iterator;
-        self.load_demands = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2993,27 +2993,6 @@ pub mod shipment {
             self
         }
 
-        /// Sets the value of [duration][crate::model::shipment::VisitRequest::duration].
-        pub fn set_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.duration = v.into();
-            self
-        }
-
-        /// Sets the value of [cost][crate::model::shipment::VisitRequest::cost].
-        pub fn set_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.cost = v.into();
-            self
-        }
-
-        /// Sets the value of [label][crate::model::shipment::VisitRequest::label].
-        pub fn set_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.label = v.into();
-            self
-        }
-
         /// Sets the value of [tags][crate::model::shipment::VisitRequest::tags].
         pub fn set_tags<T, V>(mut self, v: T) -> Self
         where
@@ -3036,26 +3015,18 @@ pub mod shipment {
             self
         }
 
-        /// Sets the value of [visit_types][crate::model::shipment::VisitRequest::visit_types].
-        pub fn set_visit_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.visit_types = v.into_iter().map(|i| i.into()).collect();
+        /// Sets the value of [duration][crate::model::shipment::VisitRequest::duration].
+        pub fn set_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.duration = v.into();
             self
         }
 
-        /// Sets the value of [demands][crate::model::shipment::VisitRequest::demands].
-        #[deprecated]
-        pub fn set_demands<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::CapacityQuantity>,
-        {
-            use std::iter::Iterator;
-            self.demands = v.into_iter().map(|i| i.into()).collect();
+        /// Sets the value of [cost][crate::model::shipment::VisitRequest::cost].
+        pub fn set_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+            self.cost = v.into();
             self
         }
 
@@ -3068,6 +3039,35 @@ pub mod shipment {
         {
             use std::iter::Iterator;
             self.load_demands = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [visit_types][crate::model::shipment::VisitRequest::visit_types].
+        pub fn set_visit_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.visit_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [label][crate::model::shipment::VisitRequest::label].
+        pub fn set_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.label = v.into();
+            self
+        }
+
+        /// Sets the value of [demands][crate::model::shipment::VisitRequest::demands].
+        #[deprecated]
+        pub fn set_demands<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::CapacityQuantity>,
+        {
+            use std::iter::Iterator;
+            self.demands = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3144,17 +3144,6 @@ impl ShipmentTypeIncompatibility {
         std::default::Default::default()
     }
 
-    /// Sets the value of [incompatibility_mode][crate::model::ShipmentTypeIncompatibility::incompatibility_mode].
-    pub fn set_incompatibility_mode<
-        T: std::convert::Into<crate::model::shipment_type_incompatibility::IncompatibilityMode>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.incompatibility_mode = v.into();
-        self
-    }
-
     /// Sets the value of [types][crate::model::ShipmentTypeIncompatibility::types].
     pub fn set_types<T, V>(mut self, v: T) -> Self
     where
@@ -3163,6 +3152,17 @@ impl ShipmentTypeIncompatibility {
     {
         use std::iter::Iterator;
         self.types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [incompatibility_mode][crate::model::ShipmentTypeIncompatibility::incompatibility_mode].
+    pub fn set_incompatibility_mode<
+        T: std::convert::Into<crate::model::shipment_type_incompatibility::IncompatibilityMode>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.incompatibility_mode = v.into();
         self
     }
 }
@@ -3357,17 +3357,6 @@ impl ShipmentTypeRequirement {
         std::default::Default::default()
     }
 
-    /// Sets the value of [requirement_mode][crate::model::ShipmentTypeRequirement::requirement_mode].
-    pub fn set_requirement_mode<
-        T: std::convert::Into<crate::model::shipment_type_requirement::RequirementMode>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.requirement_mode = v.into();
-        self
-    }
-
     /// Sets the value of [required_shipment_type_alternatives][crate::model::ShipmentTypeRequirement::required_shipment_type_alternatives].
     pub fn set_required_shipment_type_alternatives<T, V>(mut self, v: T) -> Self
     where
@@ -3387,6 +3376,17 @@ impl ShipmentTypeRequirement {
     {
         use std::iter::Iterator;
         self.dependent_shipment_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [requirement_mode][crate::model::ShipmentTypeRequirement::requirement_mode].
+    pub fn set_requirement_mode<
+        T: std::convert::Into<crate::model::shipment_type_requirement::RequirementMode>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.requirement_mode = v.into();
         self
     }
 }
@@ -3980,6 +3980,50 @@ impl Vehicle {
         self
     }
 
+    /// Sets the value of [start_tags][crate::model::Vehicle::start_tags].
+    pub fn set_start_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.start_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [end_tags][crate::model::Vehicle::end_tags].
+    pub fn set_end_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.end_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [start_time_windows][crate::model::Vehicle::start_time_windows].
+    pub fn set_start_time_windows<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TimeWindow>,
+    {
+        use std::iter::Iterator;
+        self.start_time_windows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [end_time_windows][crate::model::Vehicle::end_time_windows].
+    pub fn set_end_time_windows<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TimeWindow>,
+    {
+        use std::iter::Iterator;
+        self.end_time_windows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [travel_duration_multiple][crate::model::Vehicle::travel_duration_multiple].
     pub fn set_travel_duration_multiple<T: std::convert::Into<std::option::Option<f64>>>(
         mut self,
@@ -3995,6 +4039,18 @@ impl Vehicle {
         v: T,
     ) -> Self {
         self.unloading_policy = v.into();
+        self
+    }
+
+    /// Sets the value of [load_limits][crate::model::Vehicle::load_limits].
+    pub fn set_load_limits<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::vehicle::LoadLimit>,
+    {
+        use std::iter::Iterator;
+        self.load_limits = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -4061,6 +4117,19 @@ impl Vehicle {
         self
     }
 
+    /// Sets the value of [extra_visit_duration_for_visit_type][crate::model::Vehicle::extra_visit_duration_for_visit_type].
+    pub fn set_extra_visit_duration_for_visit_type<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::Duration>,
+    {
+        use std::iter::Iterator;
+        self.extra_visit_duration_for_visit_type =
+            v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [break_rule][crate::model::Vehicle::break_rule].
     pub fn set_break_rule<T: std::convert::Into<std::option::Option<crate::model::BreakRule>>>(
         mut self,
@@ -4079,50 +4148,6 @@ impl Vehicle {
     /// Sets the value of [ignore][crate::model::Vehicle::ignore].
     pub fn set_ignore<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore = v.into();
-        self
-    }
-
-    /// Sets the value of [start_tags][crate::model::Vehicle::start_tags].
-    pub fn set_start_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.start_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [end_tags][crate::model::Vehicle::end_tags].
-    pub fn set_end_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.end_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [start_time_windows][crate::model::Vehicle::start_time_windows].
-    pub fn set_start_time_windows<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TimeWindow>,
-    {
-        use std::iter::Iterator;
-        self.start_time_windows = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [end_time_windows][crate::model::Vehicle::end_time_windows].
-    pub fn set_end_time_windows<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TimeWindow>,
-    {
-        use std::iter::Iterator;
-        self.end_time_windows = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4171,31 +4196,6 @@ impl Vehicle {
     {
         use std::iter::Iterator;
         self.end_load_intervals = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [load_limits][crate::model::Vehicle::load_limits].
-    pub fn set_load_limits<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::vehicle::LoadLimit>,
-    {
-        use std::iter::Iterator;
-        self.load_limits = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [extra_visit_duration_for_visit_type][crate::model::Vehicle::extra_visit_duration_for_visit_type].
-    pub fn set_extra_visit_duration_for_visit_type<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<wkt::Duration>,
-    {
-        use std::iter::Iterator;
-        self.extra_visit_duration_for_visit_type =
-            v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5358,17 +5358,6 @@ impl Waypoint {
         })
     }
 
-    /// The value of [location_type][crate::model::Waypoint::location_type]
-    /// if it holds a `PlaceId`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn place_id(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.location_type.as_ref().and_then(|v| match v {
-            crate::model::waypoint::LocationType::PlaceId(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [location_type][crate::model::Waypoint::location_type]
     /// to hold a `Location`.
     ///
@@ -5381,6 +5370,17 @@ impl Waypoint {
         self.location_type =
             std::option::Option::Some(crate::model::waypoint::LocationType::Location(v.into()));
         self
+    }
+
+    /// The value of [location_type][crate::model::Waypoint::location_type]
+    /// if it holds a `PlaceId`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn place_id(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.location_type.as_ref().and_then(|v| match v {
+            crate::model::waypoint::LocationType::PlaceId(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [location_type][crate::model::Waypoint::location_type]
@@ -5965,62 +5965,6 @@ impl ShipmentRoute {
         self
     }
 
-    /// Sets the value of [has_traffic_infeasibilities][crate::model::ShipmentRoute::has_traffic_infeasibilities].
-    pub fn set_has_traffic_infeasibilities<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.has_traffic_infeasibilities = v.into();
-        self
-    }
-
-    /// Sets the value of [route_polyline][crate::model::ShipmentRoute::route_polyline].
-    pub fn set_route_polyline<
-        T: std::convert::Into<std::option::Option<crate::model::shipment_route::EncodedPolyline>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.route_polyline = v.into();
-        self
-    }
-
-    /// Sets the value of [metrics][crate::model::ShipmentRoute::metrics].
-    pub fn set_metrics<
-        T: std::convert::Into<std::option::Option<crate::model::AggregatedMetrics>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metrics = v.into();
-        self
-    }
-
-    /// Sets the value of [route_total_cost][crate::model::ShipmentRoute::route_total_cost].
-    pub fn set_route_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.route_total_cost = v.into();
-        self
-    }
-
-    /// Sets the value of [vehicle_detour][crate::model::ShipmentRoute::vehicle_detour].
-    #[deprecated]
-    pub fn set_vehicle_detour<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vehicle_detour = v.into();
-        self
-    }
-
-    /// Sets the value of [delay_before_vehicle_end][crate::model::ShipmentRoute::delay_before_vehicle_end].
-    #[deprecated]
-    pub fn set_delay_before_vehicle_end<
-        T: std::convert::Into<std::option::Option<crate::model::shipment_route::Delay>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.delay_before_vehicle_end = v.into();
-        self
-    }
-
     /// Sets the value of [visits][crate::model::ShipmentRoute::visits].
     pub fn set_visits<T, V>(mut self, v: T) -> Self
     where
@@ -6043,6 +5987,23 @@ impl ShipmentRoute {
         self
     }
 
+    /// Sets the value of [has_traffic_infeasibilities][crate::model::ShipmentRoute::has_traffic_infeasibilities].
+    pub fn set_has_traffic_infeasibilities<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.has_traffic_infeasibilities = v.into();
+        self
+    }
+
+    /// Sets the value of [route_polyline][crate::model::ShipmentRoute::route_polyline].
+    pub fn set_route_polyline<
+        T: std::convert::Into<std::option::Option<crate::model::shipment_route::EncodedPolyline>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.route_polyline = v.into();
+        self
+    }
+
     /// Sets the value of [breaks][crate::model::ShipmentRoute::breaks].
     pub fn set_breaks<T, V>(mut self, v: T) -> Self
     where
@@ -6051,6 +6012,35 @@ impl ShipmentRoute {
     {
         use std::iter::Iterator;
         self.breaks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metrics][crate::model::ShipmentRoute::metrics].
+    pub fn set_metrics<
+        T: std::convert::Into<std::option::Option<crate::model::AggregatedMetrics>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metrics = v.into();
+        self
+    }
+
+    /// Sets the value of [route_costs][crate::model::ShipmentRoute::route_costs].
+    pub fn set_route_costs<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<f64>,
+    {
+        use std::iter::Iterator;
+        self.route_costs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [route_total_cost][crate::model::ShipmentRoute::route_total_cost].
+    pub fn set_route_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.route_total_cost = v.into();
         self
     }
 
@@ -6078,15 +6068,25 @@ impl ShipmentRoute {
         self
     }
 
-    /// Sets the value of [route_costs][crate::model::ShipmentRoute::route_costs].
-    pub fn set_route_costs<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<f64>,
-    {
-        use std::iter::Iterator;
-        self.route_costs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [vehicle_detour][crate::model::ShipmentRoute::vehicle_detour].
+    #[deprecated]
+    pub fn set_vehicle_detour<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.vehicle_detour = v.into();
+        self
+    }
+
+    /// Sets the value of [delay_before_vehicle_end][crate::model::ShipmentRoute::delay_before_vehicle_end].
+    #[deprecated]
+    pub fn set_delay_before_vehicle_end<
+        T: std::convert::Into<std::option::Option<crate::model::shipment_route::Delay>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.delay_before_vehicle_end = v.into();
         self
     }
 }
@@ -6302,6 +6302,18 @@ pub mod shipment_route {
             self
         }
 
+        /// Sets the value of [load_demands][crate::model::shipment_route::Visit::load_demands].
+        pub fn set_load_demands<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<crate::model::shipment::Load>,
+        {
+            use std::iter::Iterator;
+            self.load_demands = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [detour][crate::model::shipment_route::Visit::detour].
         pub fn set_detour<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
@@ -6326,18 +6338,6 @@ pub mod shipment_route {
             self
         }
 
-        /// Sets the value of [delay_before_start][crate::model::shipment_route::Visit::delay_before_start].
-        #[deprecated]
-        pub fn set_delay_before_start<
-            T: std::convert::Into<std::option::Option<crate::model::shipment_route::Delay>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.delay_before_start = v.into();
-            self
-        }
-
         /// Sets the value of [arrival_loads][crate::model::shipment_route::Visit::arrival_loads].
         #[deprecated]
         pub fn set_arrival_loads<T, V>(mut self, v: T) -> Self
@@ -6350,6 +6350,18 @@ pub mod shipment_route {
             self
         }
 
+        /// Sets the value of [delay_before_start][crate::model::shipment_route::Visit::delay_before_start].
+        #[deprecated]
+        pub fn set_delay_before_start<
+            T: std::convert::Into<std::option::Option<crate::model::shipment_route::Delay>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.delay_before_start = v.into();
+            self
+        }
+
         /// Sets the value of [demands][crate::model::shipment_route::Visit::demands].
         #[deprecated]
         pub fn set_demands<T, V>(mut self, v: T) -> Self
@@ -6359,18 +6371,6 @@ pub mod shipment_route {
         {
             use std::iter::Iterator;
             self.demands = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [load_demands][crate::model::shipment_route::Visit::load_demands].
-        pub fn set_load_demands<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<crate::model::shipment::Load>,
-        {
-            use std::iter::Iterator;
-            self.load_demands = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -6572,18 +6572,6 @@ pub mod shipment_route {
             self
         }
 
-        /// Sets the value of [loads][crate::model::shipment_route::Transition::loads].
-        #[deprecated]
-        pub fn set_loads<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::CapacityQuantity>,
-        {
-            use std::iter::Iterator;
-            self.loads = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
         /// Sets the value of [vehicle_loads][crate::model::shipment_route::Transition::vehicle_loads].
         pub fn set_vehicle_loads<T, K, V>(mut self, v: T) -> Self
         where
@@ -6593,6 +6581,18 @@ pub mod shipment_route {
         {
             use std::iter::Iterator;
             self.vehicle_loads = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [loads][crate::model::shipment_route::Transition::loads].
+        #[deprecated]
+        pub fn set_loads<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::CapacityQuantity>,
+        {
+            use std::iter::Iterator;
+            self.loads = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -7382,13 +7382,6 @@ impl AggregatedMetrics {
         self
     }
 
-    /// Sets the value of [total_cost][crate::model::AggregatedMetrics::total_cost].
-    #[deprecated]
-    pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.total_cost = v.into();
-        self
-    }
-
     /// Sets the value of [max_loads][crate::model::AggregatedMetrics::max_loads].
     pub fn set_max_loads<T, K, V>(mut self, v: T) -> Self
     where
@@ -7411,6 +7404,13 @@ impl AggregatedMetrics {
     {
         use std::iter::Iterator;
         self.costs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [total_cost][crate::model::AggregatedMetrics::total_cost].
+    #[deprecated]
+    pub fn set_total_cost<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.total_cost = v.into();
         self
     }
 }
@@ -8182,6 +8182,17 @@ impl OptimizeToursValidationError {
         self
     }
 
+    /// Sets the value of [fields][crate::model::OptimizeToursValidationError::fields].
+    pub fn set_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::optimize_tours_validation_error::FieldReference>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [error_message][crate::model::OptimizeToursValidationError::error_message].
     pub fn set_error_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.error_message = v.into();
@@ -8194,17 +8205,6 @@ impl OptimizeToursValidationError {
         v: T,
     ) -> Self {
         self.offending_values = v.into();
-        self
-    }
-
-    /// Sets the value of [fields][crate::model::OptimizeToursValidationError::fields].
-    pub fn set_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::optimize_tours_validation_error::FieldReference>,
-    {
-        use std::iter::Iterator;
-        self.fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8312,19 +8312,6 @@ pub mod optimize_tours_validation_error {
             })
         }
 
-        /// The value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]
-        /// if it holds a `Key`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn key(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.index_or_key.as_ref().and_then(|v| match v {
-                crate::model::optimize_tours_validation_error::field_reference::IndexOrKey::Key(
-                    v,
-                ) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]
         /// to hold a `Index`.
         ///
@@ -8337,6 +8324,19 @@ pub mod optimize_tours_validation_error {
                 ),
             );
             self
+        }
+
+        /// The value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]
+        /// if it holds a `Key`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn key(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.index_or_key.as_ref().and_then(|v| match v {
+                crate::model::optimize_tours_validation_error::field_reference::IndexOrKey::Key(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]

--- a/src/generated/cloud/oracledatabase/v1/src/model.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/model.rs
@@ -138,6 +138,18 @@ impl AutonomousDatabase {
         self
     }
 
+    /// Sets the value of [labels][crate::model::AutonomousDatabase::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [network][crate::model::AutonomousDatabase::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
@@ -156,18 +168,6 @@ impl AutonomousDatabase {
         v: T,
     ) -> Self {
         self.create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::AutonomousDatabase::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -556,6 +556,17 @@ impl AutonomousDatabaseProperties {
         self
     }
 
+    /// Sets the value of [customer_contacts][crate::model::AutonomousDatabaseProperties::customer_contacts].
+    pub fn set_customer_contacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CustomerContact>,
+    {
+        use std::iter::Iterator;
+        self.customer_contacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [secret_id][crate::model::AutonomousDatabaseProperties::secret_id].
     pub fn set_secret_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.secret_id = v.into();
@@ -649,6 +660,17 @@ impl AutonomousDatabaseProperties {
         v: T,
     ) -> Self {
         self.autonomous_container_database_id = v.into();
+        self
+    }
+
+    /// Sets the value of [available_upgrade_versions][crate::model::AutonomousDatabaseProperties::available_upgrade_versions].
+    pub fn set_available_upgrade_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.available_upgrade_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -781,6 +803,17 @@ impl AutonomousDatabaseProperties {
         self
     }
 
+    /// Sets the value of [peer_db_ids][crate::model::AutonomousDatabaseProperties::peer_db_ids].
+    pub fn set_peer_db_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.peer_db_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [permission_level][crate::model::AutonomousDatabaseProperties::permission_level].
     pub fn set_permission_level<
         T: std::convert::Into<crate::model::autonomous_database_properties::PermissionLevel>,
@@ -832,12 +865,34 @@ impl AutonomousDatabaseProperties {
         self
     }
 
+    /// Sets the value of [scheduled_operation_details][crate::model::AutonomousDatabaseProperties::scheduled_operation_details].
+    pub fn set_scheduled_operation_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ScheduledOperationDetails>,
+    {
+        use std::iter::Iterator;
+        self.scheduled_operation_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [sql_web_developer_url][crate::model::AutonomousDatabaseProperties::sql_web_developer_url].
     pub fn set_sql_web_developer_url<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.sql_web_developer_url = v.into();
+        self
+    }
+
+    /// Sets the value of [supported_clone_regions][crate::model::AutonomousDatabaseProperties::supported_clone_regions].
+    pub fn set_supported_clone_regions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.supported_clone_regions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -890,61 +945,6 @@ impl AutonomousDatabaseProperties {
         v: T,
     ) -> Self {
         self.maintenance_end_time = v.into();
-        self
-    }
-
-    /// Sets the value of [customer_contacts][crate::model::AutonomousDatabaseProperties::customer_contacts].
-    pub fn set_customer_contacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CustomerContact>,
-    {
-        use std::iter::Iterator;
-        self.customer_contacts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [available_upgrade_versions][crate::model::AutonomousDatabaseProperties::available_upgrade_versions].
-    pub fn set_available_upgrade_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.available_upgrade_versions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [peer_db_ids][crate::model::AutonomousDatabaseProperties::peer_db_ids].
-    pub fn set_peer_db_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.peer_db_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [scheduled_operation_details][crate::model::AutonomousDatabaseProperties::scheduled_operation_details].
-    pub fn set_scheduled_operation_details<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ScheduledOperationDetails>,
-    {
-        use std::iter::Iterator;
-        self.scheduled_operation_details = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [supported_clone_regions][crate::model::AutonomousDatabaseProperties::supported_clone_regions].
-    pub fn set_supported_clone_regions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.supported_clone_regions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6098,15 +6098,6 @@ impl CloudExadataInfrastructure {
         self
     }
 
-    /// Sets the value of [create_time][crate::model::CloudExadataInfrastructure::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::CloudExadataInfrastructure::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6116,6 +6107,15 @@ impl CloudExadataInfrastructure {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::CloudExadataInfrastructure::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
         self
     }
 }
@@ -6432,6 +6432,17 @@ impl CloudExadataInfrastructureProperties {
         self
     }
 
+    /// Sets the value of [customer_contacts][crate::model::CloudExadataInfrastructureProperties::customer_contacts].
+    pub fn set_customer_contacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CustomerContact>,
+    {
+        use std::iter::Iterator;
+        self.customer_contacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [monthly_storage_server_version][crate::model::CloudExadataInfrastructureProperties::monthly_storage_server_version].
     pub fn set_monthly_storage_server_version<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -6447,17 +6458,6 @@ impl CloudExadataInfrastructureProperties {
         v: T,
     ) -> Self {
         self.monthly_db_server_version = v.into();
-        self
-    }
-
-    /// Sets the value of [customer_contacts][crate::model::CloudExadataInfrastructureProperties::customer_contacts].
-    pub fn set_customer_contacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CustomerContact>,
-    {
-        use std::iter::Iterator;
-        self.customer_contacts = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6717,38 +6717,6 @@ impl MaintenanceWindow {
         self
     }
 
-    /// Sets the value of [lead_time_week][crate::model::MaintenanceWindow::lead_time_week].
-    pub fn set_lead_time_week<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.lead_time_week = v.into();
-        self
-    }
-
-    /// Sets the value of [patching_mode][crate::model::MaintenanceWindow::patching_mode].
-    pub fn set_patching_mode<
-        T: std::convert::Into<crate::model::maintenance_window::PatchingMode>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.patching_mode = v.into();
-        self
-    }
-
-    /// Sets the value of [custom_action_timeout_mins][crate::model::MaintenanceWindow::custom_action_timeout_mins].
-    pub fn set_custom_action_timeout_mins<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.custom_action_timeout_mins = v.into();
-        self
-    }
-
-    /// Sets the value of [is_custom_action_timeout_enabled][crate::model::MaintenanceWindow::is_custom_action_timeout_enabled].
-    pub fn set_is_custom_action_timeout_enabled<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.is_custom_action_timeout_enabled = v.into();
-        self
-    }
-
     /// Sets the value of [months][crate::model::MaintenanceWindow::months].
     pub fn set_months<T, V>(mut self, v: T) -> Self
     where
@@ -6790,6 +6758,38 @@ impl MaintenanceWindow {
     {
         use std::iter::Iterator;
         self.hours_of_day = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [lead_time_week][crate::model::MaintenanceWindow::lead_time_week].
+    pub fn set_lead_time_week<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.lead_time_week = v.into();
+        self
+    }
+
+    /// Sets the value of [patching_mode][crate::model::MaintenanceWindow::patching_mode].
+    pub fn set_patching_mode<
+        T: std::convert::Into<crate::model::maintenance_window::PatchingMode>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.patching_mode = v.into();
+        self
+    }
+
+    /// Sets the value of [custom_action_timeout_mins][crate::model::MaintenanceWindow::custom_action_timeout_mins].
+    pub fn set_custom_action_timeout_mins<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.custom_action_timeout_mins = v.into();
+        self
+    }
+
+    /// Sets the value of [is_custom_action_timeout_enabled][crate::model::MaintenanceWindow::is_custom_action_timeout_enabled].
+    pub fn set_is_custom_action_timeout_enabled<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.is_custom_action_timeout_enabled = v.into();
         self
     }
 }
@@ -7237,12 +7237,6 @@ impl ListCloudExadataInfrastructuresResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCloudExadataInfrastructuresResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cloud_exadata_infrastructures][crate::model::ListCloudExadataInfrastructuresResponse::cloud_exadata_infrastructures].
     pub fn set_cloud_exadata_infrastructures<T, V>(mut self, v: T) -> Self
     where
@@ -7251,6 +7245,12 @@ impl ListCloudExadataInfrastructuresResponse {
     {
         use std::iter::Iterator;
         self.cloud_exadata_infrastructures = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCloudExadataInfrastructuresResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7541,12 +7541,6 @@ impl ListCloudVmClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCloudVmClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cloud_vm_clusters][crate::model::ListCloudVmClustersResponse::cloud_vm_clusters].
     pub fn set_cloud_vm_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -7555,6 +7549,12 @@ impl ListCloudVmClustersResponse {
     {
         use std::iter::Iterator;
         self.cloud_vm_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCloudVmClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7833,12 +7833,6 @@ impl ListEntitlementsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntitlementsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entitlements][crate::model::ListEntitlementsResponse::entitlements].
     pub fn set_entitlements<T, V>(mut self, v: T) -> Self
     where
@@ -7847,6 +7841,12 @@ impl ListEntitlementsResponse {
     {
         use std::iter::Iterator;
         self.entitlements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntitlementsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7949,12 +7949,6 @@ impl ListDbServersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDbServersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [db_servers][crate::model::ListDbServersResponse::db_servers].
     pub fn set_db_servers<T, V>(mut self, v: T) -> Self
     where
@@ -7963,6 +7957,12 @@ impl ListDbServersResponse {
     {
         use std::iter::Iterator;
         self.db_servers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDbServersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8065,12 +8065,6 @@ impl ListDbNodesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDbNodesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [db_nodes][crate::model::ListDbNodesResponse::db_nodes].
     pub fn set_db_nodes<T, V>(mut self, v: T) -> Self
     where
@@ -8079,6 +8073,12 @@ impl ListDbNodesResponse {
     {
         use std::iter::Iterator;
         self.db_nodes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDbNodesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8182,12 +8182,6 @@ impl ListGiVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGiVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [gi_versions][crate::model::ListGiVersionsResponse::gi_versions].
     pub fn set_gi_versions<T, V>(mut self, v: T) -> Self
     where
@@ -8196,6 +8190,12 @@ impl ListGiVersionsResponse {
     {
         use std::iter::Iterator;
         self.gi_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGiVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8298,12 +8298,6 @@ impl ListDbSystemShapesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDbSystemShapesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [db_system_shapes][crate::model::ListDbSystemShapesResponse::db_system_shapes].
     pub fn set_db_system_shapes<T, V>(mut self, v: T) -> Self
     where
@@ -8312,6 +8306,12 @@ impl ListDbSystemShapesResponse {
     {
         use std::iter::Iterator;
         self.db_system_shapes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDbSystemShapesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8549,12 +8549,6 @@ impl ListAutonomousDatabasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutonomousDatabasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [autonomous_databases][crate::model::ListAutonomousDatabasesResponse::autonomous_databases].
     pub fn set_autonomous_databases<T, V>(mut self, v: T) -> Self
     where
@@ -8563,6 +8557,12 @@ impl ListAutonomousDatabasesResponse {
     {
         use std::iter::Iterator;
         self.autonomous_databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutonomousDatabasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9073,12 +9073,6 @@ impl ListAutonomousDbVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutonomousDbVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [autonomous_db_versions][crate::model::ListAutonomousDbVersionsResponse::autonomous_db_versions].
     pub fn set_autonomous_db_versions<T, V>(mut self, v: T) -> Self
     where
@@ -9087,6 +9081,12 @@ impl ListAutonomousDbVersionsResponse {
     {
         use std::iter::Iterator;
         self.autonomous_db_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutonomousDbVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9203,12 +9203,6 @@ impl ListAutonomousDatabaseCharacterSetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutonomousDatabaseCharacterSetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [autonomous_database_character_sets][crate::model::ListAutonomousDatabaseCharacterSetsResponse::autonomous_database_character_sets].
     pub fn set_autonomous_database_character_sets<T, V>(mut self, v: T) -> Self
     where
@@ -9217,6 +9211,12 @@ impl ListAutonomousDatabaseCharacterSetsResponse {
     {
         use std::iter::Iterator;
         self.autonomous_database_character_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutonomousDatabaseCharacterSetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9335,12 +9335,6 @@ impl ListAutonomousDatabaseBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAutonomousDatabaseBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [autonomous_database_backups][crate::model::ListAutonomousDatabaseBackupsResponse::autonomous_database_backups].
     pub fn set_autonomous_database_backups<T, V>(mut self, v: T) -> Self
     where
@@ -9349,6 +9343,12 @@ impl ListAutonomousDatabaseBackupsResponse {
     {
         use std::iter::Iterator;
         self.autonomous_database_backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAutonomousDatabaseBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9472,6 +9472,18 @@ impl CloudVmCluster {
         self
     }
 
+    /// Sets the value of [labels][crate::model::CloudVmCluster::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::CloudVmCluster::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -9499,18 +9511,6 @@ impl CloudVmCluster {
     /// Sets the value of [network][crate::model::CloudVmCluster::network].
     pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.network = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::CloudVmCluster::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -9698,6 +9698,17 @@ impl CloudVmClusterProperties {
         self
     }
 
+    /// Sets the value of [ssh_public_keys][crate::model::CloudVmClusterProperties::ssh_public_keys].
+    pub fn set_ssh_public_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ssh_public_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [node_count][crate::model::CloudVmClusterProperties::node_count].
     pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.node_count = v.into();
@@ -9831,6 +9842,17 @@ impl CloudVmClusterProperties {
         self
     }
 
+    /// Sets the value of [scan_ip_ids][crate::model::CloudVmClusterProperties::scan_ip_ids].
+    pub fn set_scan_ip_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.scan_ip_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [scan_dns_record_id][crate::model::CloudVmClusterProperties::scan_dns_record_id].
     pub fn set_scan_dns_record_id<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -9843,6 +9865,17 @@ impl CloudVmClusterProperties {
     /// Sets the value of [oci_url][crate::model::CloudVmClusterProperties::oci_url].
     pub fn set_oci_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.oci_url = v.into();
+        self
+    }
+
+    /// Sets the value of [db_server_ocids][crate::model::CloudVmClusterProperties::db_server_ocids].
+    pub fn set_db_server_ocids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.db_server_ocids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -9861,39 +9894,6 @@ impl CloudVmClusterProperties {
     /// Sets the value of [cluster_name][crate::model::CloudVmClusterProperties::cluster_name].
     pub fn set_cluster_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cluster_name = v.into();
-        self
-    }
-
-    /// Sets the value of [ssh_public_keys][crate::model::CloudVmClusterProperties::ssh_public_keys].
-    pub fn set_ssh_public_keys<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.ssh_public_keys = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [scan_ip_ids][crate::model::CloudVmClusterProperties::scan_ip_ids].
-    pub fn set_scan_ip_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.scan_ip_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [db_server_ocids][crate::model::CloudVmClusterProperties::db_server_ocids].
-    pub fn set_db_server_ocids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.db_server_ocids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -190,12 +190,6 @@ impl ListEnvironmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [environments][crate::model::ListEnvironmentsResponse::environments].
     pub fn set_environments<T, V>(mut self, v: T) -> Self
     where
@@ -204,6 +198,12 @@ impl ListEnvironmentsResponse {
     {
         use std::iter::Iterator;
         self.environments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEnvironmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -806,6 +806,17 @@ impl PollAirflowCommandResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [output][crate::model::PollAirflowCommandResponse::output].
+    pub fn set_output<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::poll_airflow_command_response::Line>,
+    {
+        use std::iter::Iterator;
+        self.output = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [output_end][crate::model::PollAirflowCommandResponse::output_end].
     pub fn set_output_end<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.output_end = v.into();
@@ -822,17 +833,6 @@ impl PollAirflowCommandResponse {
         v: T,
     ) -> Self {
         self.exit_info = v.into();
-        self
-    }
-
-    /// Sets the value of [output][crate::model::PollAirflowCommandResponse::output].
-    pub fn set_output<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::poll_airflow_command_response::Line>,
-    {
-        use std::iter::Iterator;
-        self.output = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1426,12 +1426,6 @@ impl ListUserWorkloadsSecretsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUserWorkloadsSecretsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [user_workloads_secrets][crate::model::ListUserWorkloadsSecretsResponse::user_workloads_secrets].
     pub fn set_user_workloads_secrets<T, V>(mut self, v: T) -> Self
     where
@@ -1440,6 +1434,12 @@ impl ListUserWorkloadsSecretsResponse {
     {
         use std::iter::Iterator;
         self.user_workloads_secrets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUserWorkloadsSecretsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1546,12 +1546,6 @@ impl ListUserWorkloadsConfigMapsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUserWorkloadsConfigMapsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [user_workloads_config_maps][crate::model::ListUserWorkloadsConfigMapsResponse::user_workloads_config_maps].
     pub fn set_user_workloads_config_maps<T, V>(mut self, v: T) -> Self
     where
@@ -1560,6 +1554,12 @@ impl ListUserWorkloadsConfigMapsResponse {
     {
         use std::iter::Iterator;
         self.user_workloads_config_maps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUserWorkloadsConfigMapsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1676,12 +1676,6 @@ impl ListWorkloadsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workloads][crate::model::ListWorkloadsResponse::workloads].
     pub fn set_workloads<T, V>(mut self, v: T) -> Self
     where
@@ -1690,6 +1684,12 @@ impl ListWorkloadsResponse {
     {
         use std::iter::Iterator;
         self.workloads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkloadsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3602,40 +3602,6 @@ impl SoftwareConfig {
         self
     }
 
-    /// Sets the value of [python_version][crate::model::SoftwareConfig::python_version].
-    pub fn set_python_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.python_version = v.into();
-        self
-    }
-
-    /// Sets the value of [scheduler_count][crate::model::SoftwareConfig::scheduler_count].
-    pub fn set_scheduler_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.scheduler_count = v.into();
-        self
-    }
-
-    /// Sets the value of [cloud_data_lineage_integration][crate::model::SoftwareConfig::cloud_data_lineage_integration].
-    pub fn set_cloud_data_lineage_integration<
-        T: std::convert::Into<std::option::Option<crate::model::CloudDataLineageIntegration>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cloud_data_lineage_integration = v.into();
-        self
-    }
-
-    /// Sets the value of [web_server_plugins_mode][crate::model::SoftwareConfig::web_server_plugins_mode].
-    pub fn set_web_server_plugins_mode<
-        T: std::convert::Into<crate::model::software_config::WebServerPluginsMode>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.web_server_plugins_mode = v.into();
-        self
-    }
-
     /// Sets the value of [airflow_config_overrides][crate::model::SoftwareConfig::airflow_config_overrides].
     pub fn set_airflow_config_overrides<T, K, V>(mut self, v: T) -> Self
     where
@@ -3669,6 +3635,40 @@ impl SoftwareConfig {
     {
         use std::iter::Iterator;
         self.env_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [python_version][crate::model::SoftwareConfig::python_version].
+    pub fn set_python_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.python_version = v.into();
+        self
+    }
+
+    /// Sets the value of [scheduler_count][crate::model::SoftwareConfig::scheduler_count].
+    pub fn set_scheduler_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.scheduler_count = v.into();
+        self
+    }
+
+    /// Sets the value of [cloud_data_lineage_integration][crate::model::SoftwareConfig::cloud_data_lineage_integration].
+    pub fn set_cloud_data_lineage_integration<
+        T: std::convert::Into<std::option::Option<crate::model::CloudDataLineageIntegration>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.cloud_data_lineage_integration = v.into();
+        self
+    }
+
+    /// Sets the value of [web_server_plugins_mode][crate::model::SoftwareConfig::web_server_plugins_mode].
+    pub fn set_web_server_plugins_mode<
+        T: std::convert::Into<crate::model::software_config::WebServerPluginsMode>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.web_server_plugins_mode = v.into();
         self
     }
 }
@@ -3888,19 +3888,6 @@ impl IPAllocationPolicy {
         })
     }
 
-    /// The value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
-    /// if it holds a `ClusterIpv4CidrBlock`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cluster_ipv4_cidr_block(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.cluster_ip_allocation.as_ref().and_then(|v| match v {
-            crate::model::ip_allocation_policy::ClusterIpAllocation::ClusterIpv4CidrBlock(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
     /// to hold a `ClusterSecondaryRangeName`.
     ///
@@ -3916,6 +3903,19 @@ impl IPAllocationPolicy {
             ),
         );
         self
+    }
+
+    /// The value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
+    /// if it holds a `ClusterIpv4CidrBlock`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cluster_ipv4_cidr_block(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.cluster_ip_allocation.as_ref().and_then(|v| match v {
+            crate::model::ip_allocation_policy::ClusterIpAllocation::ClusterIpv4CidrBlock(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
@@ -3960,19 +3960,6 @@ impl IPAllocationPolicy {
         })
     }
 
-    /// The value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
-    /// if it holds a `ServicesIpv4CidrBlock`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn services_ipv4_cidr_block(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.services_ip_allocation.as_ref().and_then(|v| match v {
-            crate::model::ip_allocation_policy::ServicesIpAllocation::ServicesIpv4CidrBlock(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
     /// to hold a `ServicesSecondaryRangeName`.
     ///
@@ -3988,6 +3975,19 @@ impl IPAllocationPolicy {
             ),
         );
         self
+    }
+
+    /// The value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
+    /// if it holds a `ServicesIpv4CidrBlock`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn services_ipv4_cidr_block(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.services_ip_allocation.as_ref().and_then(|v| match v {
+            crate::model::ip_allocation_policy::ServicesIpAllocation::ServicesIpv4CidrBlock(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
@@ -4268,9 +4268,31 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the value of [oauth_scopes][crate::model::NodeConfig::oauth_scopes].
+    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::NodeConfig::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::NodeConfig::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4306,28 +4328,6 @@ impl NodeConfig {
         v: T,
     ) -> Self {
         self.composer_internal_ipv4_cidr_block = v.into();
-        self
-    }
-
-    /// Sets the value of [oauth_scopes][crate::model::NodeConfig::oauth_scopes].
-    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::NodeConfig::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5573,6 +5573,18 @@ impl Environment {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Environment::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [satisfies_pzs][crate::model::Environment::satisfies_pzs].
     pub fn set_satisfies_pzs<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.satisfies_pzs = v.into();
@@ -5593,18 +5605,6 @@ impl Environment {
         v: T,
     ) -> Self {
         self.storage_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Environment::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6567,12 +6567,6 @@ impl ListImageVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListImageVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [image_versions][crate::model::ListImageVersionsResponse::image_versions].
     pub fn set_image_versions<T, V>(mut self, v: T) -> Self
     where
@@ -6581,6 +6575,12 @@ impl ListImageVersionsResponse {
     {
         use std::iter::Iterator;
         self.image_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListImageVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6662,6 +6662,17 @@ impl ImageVersion {
         self
     }
 
+    /// Sets the value of [supported_python_versions][crate::model::ImageVersion::supported_python_versions].
+    pub fn set_supported_python_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.supported_python_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [release_date][crate::model::ImageVersion::release_date].
     pub fn set_release_date<T: std::convert::Into<std::option::Option<gtype::model::Date>>>(
         mut self,
@@ -6680,17 +6691,6 @@ impl ImageVersion {
     /// Sets the value of [upgrade_disabled][crate::model::ImageVersion::upgrade_disabled].
     pub fn set_upgrade_disabled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.upgrade_disabled = v.into();
-        self
-    }
-
-    /// Sets the value of [supported_python_versions][crate::model::ImageVersion::supported_python_versions].
-    pub fn set_supported_python_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.supported_python_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -146,32 +146,6 @@ impl Policy {
         })
     }
 
-    /// The value of [policy_type][crate::model::Policy::policy_type]
-    /// if it holds a `BooleanPolicy`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn boolean_policy(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::policy::BooleanPolicy>> {
-        #[allow(unreachable_patterns)]
-        self.policy_type.as_ref().and_then(|v| match v {
-            crate::model::policy::PolicyType::BooleanPolicy(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [policy_type][crate::model::Policy::policy_type]
-    /// if it holds a `RestoreDefault`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn restore_default(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::policy::RestoreDefault>> {
-        #[allow(unreachable_patterns)]
-        self.policy_type.as_ref().and_then(|v| match v {
-            crate::model::policy::PolicyType::RestoreDefault(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [policy_type][crate::model::Policy::policy_type]
     /// to hold a `ListPolicy`.
     ///
@@ -188,6 +162,19 @@ impl Policy {
         self
     }
 
+    /// The value of [policy_type][crate::model::Policy::policy_type]
+    /// if it holds a `BooleanPolicy`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn boolean_policy(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::policy::BooleanPolicy>> {
+        #[allow(unreachable_patterns)]
+        self.policy_type.as_ref().and_then(|v| match v {
+            crate::model::policy::PolicyType::BooleanPolicy(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [policy_type][crate::model::Policy::policy_type]
     /// to hold a `BooleanPolicy`.
     ///
@@ -202,6 +189,19 @@ impl Policy {
         self.policy_type =
             std::option::Option::Some(crate::model::policy::PolicyType::BooleanPolicy(v.into()));
         self
+    }
+
+    /// The value of [policy_type][crate::model::Policy::policy_type]
+    /// if it holds a `RestoreDefault`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn restore_default(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::policy::RestoreDefault>> {
+        #[allow(unreachable_patterns)]
+        self.policy_type.as_ref().and_then(|v| match v {
+            crate::model::policy::PolicyType::RestoreDefault(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [policy_type][crate::model::Policy::policy_type]
@@ -387,6 +387,28 @@ pub mod policy {
             std::default::Default::default()
         }
 
+        /// Sets the value of [allowed_values][crate::model::policy::ListPolicy::allowed_values].
+        pub fn set_allowed_values<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.allowed_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [denied_values][crate::model::policy::ListPolicy::denied_values].
+        pub fn set_denied_values<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.denied_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [all_values][crate::model::policy::ListPolicy::all_values].
         pub fn set_all_values<
             T: std::convert::Into<crate::model::policy::list_policy::AllValues>,
@@ -410,28 +432,6 @@ pub mod policy {
         /// Sets the value of [inherit_from_parent][crate::model::policy::ListPolicy::inherit_from_parent].
         pub fn set_inherit_from_parent<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.inherit_from_parent = v.into();
-            self
-        }
-
-        /// Sets the value of [allowed_values][crate::model::policy::ListPolicy::allowed_values].
-        pub fn set_allowed_values<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.allowed_values = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [denied_values][crate::model::policy::ListPolicy::denied_values].
-        pub fn set_denied_values<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.denied_values = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -186,21 +186,6 @@ impl Constraint {
         })
     }
 
-    /// The value of [constraint_type][crate::model::Constraint::constraint_type]
-    /// if it holds a `BooleanConstraint`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn boolean_constraint(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::constraint::BooleanConstraint>> {
-        #[allow(unreachable_patterns)]
-        self.constraint_type.as_ref().and_then(|v| match v {
-            crate::model::constraint::ConstraintType::BooleanConstraint(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [constraint_type][crate::model::Constraint::constraint_type]
     /// to hold a `ListConstraint`.
     ///
@@ -216,6 +201,21 @@ impl Constraint {
             crate::model::constraint::ConstraintType::ListConstraint(v.into()),
         );
         self
+    }
+
+    /// The value of [constraint_type][crate::model::Constraint::constraint_type]
+    /// if it holds a `BooleanConstraint`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn boolean_constraint(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::constraint::BooleanConstraint>> {
+        #[allow(unreachable_patterns)]
+        self.constraint_type.as_ref().and_then(|v| match v {
+            crate::model::constraint::ConstraintType::BooleanConstraint(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [constraint_type][crate::model::Constraint::constraint_type]
@@ -348,23 +348,6 @@ pub mod constraint {
             std::default::Default::default()
         }
 
-        /// Sets the value of [condition][crate::model::constraint::CustomConstraintDefinition::condition].
-        pub fn set_condition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.condition = v.into();
-            self
-        }
-
-        /// Sets the value of [action_type][crate::model::constraint::CustomConstraintDefinition::action_type].
-        pub fn set_action_type<
-            T: std::convert::Into<crate::model::constraint::custom_constraint_definition::ActionType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.action_type = v.into();
-            self
-        }
-
         /// Sets the value of [resource_types][crate::model::constraint::CustomConstraintDefinition::resource_types].
         pub fn set_resource_types<T, V>(mut self, v: T) -> Self
         where
@@ -386,6 +369,23 @@ pub mod constraint {
         {
             use std::iter::Iterator;
             self.method_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [condition][crate::model::constraint::CustomConstraintDefinition::condition].
+        pub fn set_condition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.condition = v.into();
+            self
+        }
+
+        /// Sets the value of [action_type][crate::model::constraint::CustomConstraintDefinition::action_type].
+        pub fn set_action_type<
+            T: std::convert::Into<crate::model::constraint::custom_constraint_definition::ActionType>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.action_type = v.into();
             self
         }
 
@@ -1273,6 +1273,28 @@ impl CustomConstraint {
         self
     }
 
+    /// Sets the value of [resource_types][crate::model::CustomConstraint::resource_types].
+    pub fn set_resource_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [method_types][crate::model::CustomConstraint::method_types].
+    pub fn set_method_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::custom_constraint::MethodType>,
+    {
+        use std::iter::Iterator;
+        self.method_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [condition][crate::model::CustomConstraint::condition].
     pub fn set_condition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.condition = v.into();
@@ -1306,28 +1328,6 @@ impl CustomConstraint {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_types][crate::model::CustomConstraint::resource_types].
-    pub fn set_resource_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [method_types][crate::model::CustomConstraint::method_types].
-    pub fn set_method_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::custom_constraint::MethodType>,
-    {
-        use std::iter::Iterator;
-        self.method_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1871,6 +1871,17 @@ impl PolicySpec {
         self
     }
 
+    /// Sets the value of [rules][crate::model::PolicySpec::rules].
+    pub fn set_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::policy_spec::PolicyRule>,
+    {
+        use std::iter::Iterator;
+        self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [inherit_from_parent][crate::model::PolicySpec::inherit_from_parent].
     pub fn set_inherit_from_parent<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.inherit_from_parent = v.into();
@@ -1880,17 +1891,6 @@ impl PolicySpec {
     /// Sets the value of [reset][crate::model::PolicySpec::reset].
     pub fn set_reset<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reset = v.into();
-        self
-    }
-
-    /// Sets the value of [rules][crate::model::PolicySpec::rules].
-    pub fn set_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::policy_spec::PolicyRule>,
-    {
-        use std::iter::Iterator;
-        self.rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1999,45 +1999,6 @@ pub mod policy_spec {
             })
         }
 
-        /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// if it holds a `AllowAll`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn allow_all(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::policy_spec::policy_rule::Kind::AllowAll(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// if it holds a `DenyAll`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn deny_all(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::policy_spec::policy_rule::Kind::DenyAll(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// if it holds a `Enforce`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn enforce(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.kind.as_ref().and_then(|v| match v {
-                crate::model::policy_spec::policy_rule::Kind::Enforce(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
         /// to hold a `Values`.
         ///
@@ -2057,6 +2018,19 @@ pub mod policy_spec {
             self
         }
 
+        /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
+        /// if it holds a `AllowAll`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn allow_all(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::policy_spec::policy_rule::Kind::AllowAll(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
         /// to hold a `AllowAll`.
         ///
@@ -2069,6 +2043,19 @@ pub mod policy_spec {
             self
         }
 
+        /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
+        /// if it holds a `DenyAll`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn deny_all(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::policy_spec::policy_rule::Kind::DenyAll(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
         /// to hold a `DenyAll`.
         ///
@@ -2079,6 +2066,19 @@ pub mod policy_spec {
                 crate::model::policy_spec::policy_rule::Kind::DenyAll(v.into()),
             );
             self
+        }
+
+        /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
+        /// if it holds a `Enforce`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn enforce(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.kind.as_ref().and_then(|v| match v {
+                crate::model::policy_spec::policy_rule::Kind::Enforce(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
@@ -2280,12 +2280,6 @@ impl ListConstraintsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConstraintsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [constraints][crate::model::ListConstraintsResponse::constraints].
     pub fn set_constraints<T, V>(mut self, v: T) -> Self
     where
@@ -2294,6 +2288,12 @@ impl ListConstraintsResponse {
     {
         use std::iter::Iterator;
         self.constraints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConstraintsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2408,12 +2408,6 @@ impl ListPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policies][crate::model::ListPoliciesResponse::policies].
     pub fn set_policies<T, V>(mut self, v: T) -> Self
     where
@@ -2422,6 +2416,12 @@ impl ListPoliciesResponse {
     {
         use std::iter::Iterator;
         self.policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2839,12 +2839,6 @@ impl ListCustomConstraintsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCustomConstraintsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [custom_constraints][crate::model::ListCustomConstraintsResponse::custom_constraints].
     pub fn set_custom_constraints<T, V>(mut self, v: T) -> Self
     where
@@ -2853,6 +2847,12 @@ impl ListCustomConstraintsResponse {
     {
         use std::iter::Iterator;
         self.custom_constraints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCustomConstraintsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -95,15 +95,6 @@ impl Inventory {
         self
     }
 
-    /// Sets the value of [update_time][crate::model::Inventory::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [items][crate::model::Inventory::items].
     pub fn set_items<T, K, V>(mut self, v: T) -> Self
     where
@@ -113,6 +104,15 @@ impl Inventory {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::Inventory::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -355,22 +355,6 @@ pub mod inventory {
             })
         }
 
-        /// The value of [details][crate::model::inventory::Item::details]
-        /// if it holds a `AvailablePackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn available_package(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::SoftwarePackage>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::item::Details::AvailablePackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [details][crate::model::inventory::Item::details]
         /// to hold a `InstalledPackage`.
         ///
@@ -386,6 +370,22 @@ pub mod inventory {
                 crate::model::inventory::item::Details::InstalledPackage(v.into()),
             );
             self
+        }
+
+        /// The value of [details][crate::model::inventory::Item::details]
+        /// if it holds a `AvailablePackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn available_package(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::SoftwarePackage>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::item::Details::AvailablePackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [details][crate::model::inventory::Item::details]
@@ -744,134 +744,6 @@ pub mod inventory {
             })
         }
 
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `AptPackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn apt_package(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::AptPackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `ZypperPackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn zypper_package(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::ZypperPackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `GoogetPackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn googet_package(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::GoogetPackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `ZypperPatch`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn zypper_patch(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::ZypperPatch>> {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::ZypperPatch(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `WuaPackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn wua_package(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::WindowsUpdatePackage>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::WuaPackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `QfePackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn qfe_package(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::inventory::WindowsQuickFixEngineeringPackage>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::QfePackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `CosPackage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn cos_package(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::CosPackage(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// if it holds a `WindowsApplication`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn windows_application(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::WindowsApplication>>
-        {
-            #[allow(unreachable_patterns)]
-            self.details.as_ref().and_then(|v| match v {
-                crate::model::inventory::software_package::Details::WindowsApplication(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
         /// to hold a `YumPackage`.
         ///
@@ -887,6 +759,22 @@ pub mod inventory {
                 crate::model::inventory::software_package::Details::YumPackage(v.into()),
             );
             self
+        }
+
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `AptPackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn apt_package(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::AptPackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -906,6 +794,22 @@ pub mod inventory {
             self
         }
 
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `ZypperPackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn zypper_package(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::ZypperPackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
         /// to hold a `ZypperPackage`.
         ///
@@ -921,6 +825,22 @@ pub mod inventory {
                 crate::model::inventory::software_package::Details::ZypperPackage(v.into()),
             );
             self
+        }
+
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `GoogetPackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn googet_package(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::GoogetPackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -940,6 +860,21 @@ pub mod inventory {
             self
         }
 
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `ZypperPatch`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn zypper_patch(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::ZypperPatch>> {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::ZypperPatch(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
         /// to hold a `ZypperPatch`.
         ///
@@ -957,6 +892,22 @@ pub mod inventory {
             self
         }
 
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `WuaPackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn wua_package(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::WindowsUpdatePackage>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::WuaPackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
         /// to hold a `WuaPackage`.
         ///
@@ -972,6 +923,23 @@ pub mod inventory {
                 crate::model::inventory::software_package::Details::WuaPackage(v.into()),
             );
             self
+        }
+
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `QfePackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn qfe_package(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::inventory::WindowsQuickFixEngineeringPackage>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::QfePackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -993,6 +961,22 @@ pub mod inventory {
             self
         }
 
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `CosPackage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn cos_package(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::VersionedPackage>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::CosPackage(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
         /// to hold a `CosPackage`.
         ///
@@ -1008,6 +992,22 @@ pub mod inventory {
                 crate::model::inventory::software_package::Details::CosPackage(v.into()),
             );
             self
+        }
+
+        /// The value of [details][crate::model::inventory::SoftwarePackage::details]
+        /// if it holds a `WindowsApplication`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn windows_application(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::inventory::WindowsApplication>>
+        {
+            #[allow(unreachable_patterns)]
+            self.details.as_ref().and_then(|v| match v {
+                crate::model::inventory::software_package::Details::WindowsApplication(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -1272,35 +1272,6 @@ pub mod inventory {
             self
         }
 
-        /// Sets the value of [support_url][crate::model::inventory::WindowsUpdatePackage::support_url].
-        pub fn set_support_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.support_url = v.into();
-            self
-        }
-
-        /// Sets the value of [update_id][crate::model::inventory::WindowsUpdatePackage::update_id].
-        pub fn set_update_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.update_id = v.into();
-            self
-        }
-
-        /// Sets the value of [revision_number][crate::model::inventory::WindowsUpdatePackage::revision_number].
-        pub fn set_revision_number<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.revision_number = v.into();
-            self
-        }
-
-        /// Sets the value of [last_deployment_change_time][crate::model::inventory::WindowsUpdatePackage::last_deployment_change_time].
-        pub fn set_last_deployment_change_time<
-            T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.last_deployment_change_time = v.into();
-            self
-        }
-
         /// Sets the value of [categories][crate::model::inventory::WindowsUpdatePackage::categories].
         pub fn set_categories<T, V>(mut self, v: T) -> Self
         where
@@ -1325,6 +1296,12 @@ pub mod inventory {
             self
         }
 
+        /// Sets the value of [support_url][crate::model::inventory::WindowsUpdatePackage::support_url].
+        pub fn set_support_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.support_url = v.into();
+            self
+        }
+
         /// Sets the value of [more_info_urls][crate::model::inventory::WindowsUpdatePackage::more_info_urls].
         pub fn set_more_info_urls<T, V>(mut self, v: T) -> Self
         where
@@ -1333,6 +1310,29 @@ pub mod inventory {
         {
             use std::iter::Iterator;
             self.more_info_urls = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [update_id][crate::model::inventory::WindowsUpdatePackage::update_id].
+        pub fn set_update_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.update_id = v.into();
+            self
+        }
+
+        /// Sets the value of [revision_number][crate::model::inventory::WindowsUpdatePackage::revision_number].
+        pub fn set_revision_number<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.revision_number = v.into();
+            self
+        }
+
+        /// Sets the value of [last_deployment_change_time][crate::model::inventory::WindowsUpdatePackage::last_deployment_change_time].
+        pub fn set_last_deployment_change_time<
+            T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.last_deployment_change_time = v.into();
             self
         }
     }
@@ -1698,12 +1698,6 @@ impl ListInventoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInventoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [inventories][crate::model::ListInventoriesResponse::inventories].
     pub fn set_inventories<T, V>(mut self, v: T) -> Self
     where
@@ -1712,6 +1706,12 @@ impl ListInventoriesResponse {
     {
         use std::iter::Iterator;
         self.inventories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInventoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1805,12 +1805,6 @@ impl OSPolicy {
         self
     }
 
-    /// Sets the value of [allow_no_resource_group_match][crate::model::OSPolicy::allow_no_resource_group_match].
-    pub fn set_allow_no_resource_group_match<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.allow_no_resource_group_match = v.into();
-        self
-    }
-
     /// Sets the value of [resource_groups][crate::model::OSPolicy::resource_groups].
     pub fn set_resource_groups<T, V>(mut self, v: T) -> Self
     where
@@ -1819,6 +1813,12 @@ impl OSPolicy {
     {
         use std::iter::Iterator;
         self.resource_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [allow_no_resource_group_match][crate::model::OSPolicy::allow_no_resource_group_match].
+    pub fn set_allow_no_resource_group_match<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.allow_no_resource_group_match = v.into();
         self
     }
 }
@@ -1957,55 +1957,6 @@ pub mod os_policy {
             })
         }
 
-        /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// if it holds a `Repository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::os_policy::resource::RepositoryResource>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.resource_type.as_ref().and_then(|v| match v {
-                crate::model::os_policy::resource::ResourceType::Repository(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// if it holds a `Exec`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn exec(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::os_policy::resource::ExecResource>>
-        {
-            #[allow(unreachable_patterns)]
-            self.resource_type.as_ref().and_then(|v| match v {
-                crate::model::os_policy::resource::ResourceType::Exec(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// if it holds a `File`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn file(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::os_policy::resource::FileResource>>
-        {
-            #[allow(unreachable_patterns)]
-            self.resource_type.as_ref().and_then(|v| match v {
-                crate::model::os_policy::resource::ResourceType::File(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
         /// to hold a `Pkg`.
         ///
@@ -2021,6 +1972,23 @@ pub mod os_policy {
                 crate::model::os_policy::resource::ResourceType::Pkg(v.into()),
             );
             self
+        }
+
+        /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
+        /// if it holds a `Repository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::os_policy::resource::RepositoryResource>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.resource_type.as_ref().and_then(|v| match v {
+                crate::model::os_policy::resource::ResourceType::Repository(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
@@ -2042,6 +2010,22 @@ pub mod os_policy {
             self
         }
 
+        /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
+        /// if it holds a `Exec`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn exec(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::os_policy::resource::ExecResource>>
+        {
+            #[allow(unreachable_patterns)]
+            self.resource_type.as_ref().and_then(|v| match v {
+                crate::model::os_policy::resource::ResourceType::Exec(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
         /// to hold a `Exec`.
         ///
@@ -2057,6 +2041,22 @@ pub mod os_policy {
                 crate::model::os_policy::resource::ResourceType::Exec(v.into()),
             );
             self
+        }
+
+        /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
+        /// if it holds a `File`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn file(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::os_policy::resource::FileResource>>
+        {
+            #[allow(unreachable_patterns)]
+            self.resource_type.as_ref().and_then(|v| match v {
+                crate::model::os_policy::resource::ResourceType::File(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
@@ -2154,35 +2154,6 @@ pub mod os_policy {
                 })
             }
 
-            /// The value of [r#type][crate::model::os_policy::resource::File::r#type]
-            /// if it holds a `Gcs`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn gcs(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::os_policy::resource::file::Gcs>>
-            {
-                #[allow(unreachable_patterns)]
-                self.r#type.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::file::Type::Gcs(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [r#type][crate::model::os_policy::resource::File::r#type]
-            /// if it holds a `LocalPath`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn local_path(&self) -> std::option::Option<&std::string::String> {
-                #[allow(unreachable_patterns)]
-                self.r#type.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::file::Type::LocalPath(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [r#type][crate::model::os_policy::resource::File::r#type]
             /// to hold a `Remote`.
             ///
@@ -2202,6 +2173,22 @@ pub mod os_policy {
                 self
             }
 
+            /// The value of [r#type][crate::model::os_policy::resource::File::r#type]
+            /// if it holds a `Gcs`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn gcs(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::os_policy::resource::file::Gcs>>
+            {
+                #[allow(unreachable_patterns)]
+                self.r#type.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::file::Type::Gcs(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [r#type][crate::model::os_policy::resource::File::r#type]
             /// to hold a `Gcs`.
             ///
@@ -2217,6 +2204,19 @@ pub mod os_policy {
                     crate::model::os_policy::resource::file::Type::Gcs(v.into()),
                 );
                 self
+            }
+
+            /// The value of [r#type][crate::model::os_policy::resource::File::r#type]
+            /// if it holds a `LocalPath`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn local_path(&self) -> std::option::Option<&std::string::String> {
+                #[allow(unreachable_patterns)]
+                self.r#type.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::file::Type::LocalPath(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [r#type][crate::model::os_policy::resource::File::r#type]
@@ -2437,108 +2437,6 @@ pub mod os_policy {
                 })
             }
 
-            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// if it holds a `Deb`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn deb(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Deb>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.system_package.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Deb(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// if it holds a `Yum`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn yum(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Yum>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.system_package.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Yum(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// if it holds a `Zypper`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn zypper(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Zypper>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.system_package.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Zypper(
-                        v,
-                    ) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// if it holds a `Rpm`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn rpm(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Rpm>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.system_package.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Rpm(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// if it holds a `Googet`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn googet(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::os_policy::resource::package_resource::GooGet>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.system_package.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Googet(
-                        v,
-                    ) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// if it holds a `Msi`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn msi(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Msi>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.system_package.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Msi(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// to hold a `Apt`.
             ///
@@ -2558,6 +2456,23 @@ pub mod os_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
+            /// if it holds a `Deb`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn deb(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Deb>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.system_package.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::package_resource::SystemPackage::Deb(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
@@ -2581,6 +2496,23 @@ pub mod os_policy {
                 self
             }
 
+            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
+            /// if it holds a `Yum`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn yum(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Yum>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.system_package.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::package_resource::SystemPackage::Yum(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// to hold a `Yum`.
             ///
@@ -2600,6 +2532,23 @@ pub mod os_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
+            /// if it holds a `Zypper`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn zypper(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Zypper>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.system_package.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::package_resource::SystemPackage::Zypper(
+                        v,
+                    ) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
@@ -2625,6 +2574,23 @@ pub mod os_policy {
                 self
             }
 
+            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
+            /// if it holds a `Rpm`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn rpm(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Rpm>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.system_package.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::package_resource::SystemPackage::Rpm(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// to hold a `Rpm`.
             ///
@@ -2644,6 +2610,23 @@ pub mod os_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
+            /// if it holds a `Googet`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn googet(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::os_policy::resource::package_resource::GooGet>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.system_package.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::package_resource::SystemPackage::Googet(
+                        v,
+                    ) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
@@ -2667,6 +2650,23 @@ pub mod os_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
+            /// if it holds a `Msi`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn msi(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::os_policy::resource::package_resource::Msi>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.system_package.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::package_resource::SystemPackage::Msi(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
@@ -3237,63 +3237,6 @@ pub mod os_policy {
                 })
             }
 
-            /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// if it holds a `Yum`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn yum(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<
-                    crate::model::os_policy::resource::repository_resource::YumRepository,
-                >,
-            > {
-                #[allow(unreachable_patterns)]
-                self.repository.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::repository_resource::Repository::Yum(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// if it holds a `Zypper`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn zypper(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<
-                    crate::model::os_policy::resource::repository_resource::ZypperRepository,
-                >,
-            > {
-                #[allow(unreachable_patterns)]
-                self.repository.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::repository_resource::Repository::Zypper(
-                        v,
-                    ) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// if it holds a `Goo`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn goo(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<
-                    crate::model::os_policy::resource::repository_resource::GooRepository,
-                >,
-            > {
-                #[allow(unreachable_patterns)]
-                self.repository.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::repository_resource::Repository::Goo(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
             /// to hold a `Apt`.
             ///
@@ -3315,6 +3258,25 @@ pub mod os_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
+            /// if it holds a `Yum`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn yum(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<
+                    crate::model::os_policy::resource::repository_resource::YumRepository,
+                >,
+            > {
+                #[allow(unreachable_patterns)]
+                self.repository.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::repository_resource::Repository::Yum(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
@@ -3340,6 +3302,25 @@ pub mod os_policy {
                 self
             }
 
+            /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
+            /// if it holds a `Zypper`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn zypper(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<
+                    crate::model::os_policy::resource::repository_resource::ZypperRepository,
+                >,
+            > {
+                #[allow(unreachable_patterns)]
+                self.repository.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::repository_resource::Repository::Zypper(
+                        v,
+                    ) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
             /// to hold a `Zypper`.
             ///
@@ -3352,6 +3333,25 @@ pub mod os_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
+            /// if it holds a `Goo`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn goo(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<
+                    crate::model::os_policy::resource::repository_resource::GooRepository,
+                >,
+            > {
+                #[allow(unreachable_patterns)]
+                self.repository.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::repository_resource::Repository::Goo(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
@@ -3449,15 +3449,6 @@ pub mod os_policy {
                     self
                 }
 
-                /// Sets the value of [gpg_key][crate::model::os_policy::resource::repository_resource::AptRepository::gpg_key].
-                pub fn set_gpg_key<T: std::convert::Into<std::string::String>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.gpg_key = v.into();
-                    self
-                }
-
                 /// Sets the value of [components][crate::model::os_policy::resource::repository_resource::AptRepository::components].
                 pub fn set_components<T, V>(mut self, v: T) -> Self
                 where
@@ -3466,6 +3457,15 @@ pub mod os_policy {
                 {
                     use std::iter::Iterator;
                     self.components = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [gpg_key][crate::model::os_policy::resource::repository_resource::AptRepository::gpg_key].
+                pub fn set_gpg_key<T: std::convert::Into<std::string::String>>(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.gpg_key = v.into();
                     self
                 }
             }
@@ -3984,6 +3984,17 @@ pub mod os_policy {
                     std::default::Default::default()
                 }
 
+                /// Sets the value of [args][crate::model::os_policy::resource::exec_resource::Exec::args].
+                pub fn set_args<T, V>(mut self, v: T) -> Self
+                where
+                    T: std::iter::IntoIterator<Item = V>,
+                    V: std::convert::Into<std::string::String>,
+                {
+                    use std::iter::Iterator;
+                    self.args = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
                 /// Sets the value of [interpreter][crate::model::os_policy::resource::exec_resource::Exec::interpreter].
                 pub fn set_interpreter<
                     T: std::convert::Into<
@@ -4003,17 +4014,6 @@ pub mod os_policy {
                     v: T,
                 ) -> Self {
                     self.output_file_path = v.into();
-                    self
-                }
-
-                /// Sets the value of [args][crate::model::os_policy::resource::exec_resource::Exec::args].
-                pub fn set_args<T, V>(mut self, v: T) -> Self
-                where
-                    T: std::iter::IntoIterator<Item = V>,
-                    V: std::convert::Into<std::string::String>,
-                {
-                    use std::iter::Iterator;
-                    self.args = v.into_iter().map(|i| i.into()).collect();
                     self
                 }
 
@@ -4051,19 +4051,6 @@ pub mod os_policy {
                     })
                 }
 
-                /// The value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
-                /// if it holds a `Script`, `None` if the field is not set or
-                /// holds a different branch.
-                pub fn script(&self) -> std::option::Option<&std::string::String> {
-                    #[allow(unreachable_patterns)]
-                    self.source.as_ref().and_then(|v| match v {
-                        crate::model::os_policy::resource::exec_resource::exec::Source::Script(
-                            v,
-                        ) => std::option::Option::Some(v),
-                        _ => std::option::Option::None,
-                    })
-                }
-
                 /// Sets the value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
                 /// to hold a `File`.
                 ///
@@ -4081,6 +4068,19 @@ pub mod os_policy {
                         ),
                     );
                     self
+                }
+
+                /// The value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
+                /// if it holds a `Script`, `None` if the field is not set or
+                /// holds a different branch.
+                pub fn script(&self) -> std::option::Option<&std::string::String> {
+                    #[allow(unreachable_patterns)]
+                    self.source.as_ref().and_then(|v| match v {
+                        crate::model::os_policy::resource::exec_resource::exec::Source::Script(
+                            v,
+                        ) => std::option::Option::Some(v),
+                        _ => std::option::Option::None,
+                    })
                 }
 
                 /// Sets the value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
@@ -4377,19 +4377,6 @@ pub mod os_policy {
                 })
             }
 
-            /// The value of [source][crate::model::os_policy::resource::FileResource::source]
-            /// if it holds a `Content`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn content(&self) -> std::option::Option<&std::string::String> {
-                #[allow(unreachable_patterns)]
-                self.source.as_ref().and_then(|v| match v {
-                    crate::model::os_policy::resource::file_resource::Source::Content(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [source][crate::model::os_policy::resource::FileResource::source]
             /// to hold a `File`.
             ///
@@ -4405,6 +4392,19 @@ pub mod os_policy {
                     crate::model::os_policy::resource::file_resource::Source::File(v.into()),
                 );
                 self
+            }
+
+            /// The value of [source][crate::model::os_policy::resource::FileResource::source]
+            /// if it holds a `Content`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn content(&self) -> std::option::Option<&std::string::String> {
+                #[allow(unreachable_patterns)]
+                self.source.as_ref().and_then(|v| match v {
+                    crate::model::os_policy::resource::file_resource::Source::Content(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [source][crate::model::os_policy::resource::FileResource::source]
@@ -4961,12 +4961,6 @@ impl ListOSPolicyAssignmentReportsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOSPolicyAssignmentReportsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [os_policy_assignment_reports][crate::model::ListOSPolicyAssignmentReportsResponse::os_policy_assignment_reports].
     pub fn set_os_policy_assignment_reports<T, V>(mut self, v: T) -> Self
     where
@@ -4975,6 +4969,12 @@ impl ListOSPolicyAssignmentReportsResponse {
     {
         use std::iter::Iterator;
         self.os_policy_assignment_reports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOSPolicyAssignmentReportsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5073,6 +5073,17 @@ impl OSPolicyAssignmentReport {
         self
     }
 
+    /// Sets the value of [os_policy_compliances][crate::model::OSPolicyAssignmentReport::os_policy_compliances].
+    pub fn set_os_policy_compliances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::os_policy_assignment_report::OSPolicyCompliance>,
+    {
+        use std::iter::Iterator;
+        self.os_policy_compliances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [update_time][crate::model::OSPolicyAssignmentReport::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5085,17 +5096,6 @@ impl OSPolicyAssignmentReport {
     /// Sets the value of [last_run_id][crate::model::OSPolicyAssignmentReport::last_run_id].
     pub fn set_last_run_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.last_run_id = v.into();
-        self
-    }
-
-    /// Sets the value of [os_policy_compliances][crate::model::OSPolicyAssignmentReport::os_policy_compliances].
-    pub fn set_os_policy_compliances<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::os_policy_assignment_report::OSPolicyCompliance>,
-    {
-        use std::iter::Iterator;
-        self.os_policy_compliances = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5267,6 +5267,17 @@ pub mod os_policy_assignment_report {
                 self
             }
 
+            /// Sets the value of [config_steps][crate::model::os_policy_assignment_report::os_policy_compliance::OSPolicyResourceCompliance::config_steps].
+            pub fn set_config_steps<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::os_policy_assignment_report::os_policy_compliance::os_policy_resource_compliance::OSPolicyResourceConfigStep>
+            {
+                use std::iter::Iterator;
+                self.config_steps = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [compliance_state][crate::model::os_policy_assignment_report::os_policy_compliance::OSPolicyResourceCompliance::compliance_state].
             pub fn set_compliance_state<T: std::convert::Into<crate::model::os_policy_assignment_report::os_policy_compliance::os_policy_resource_compliance::ComplianceState>>(mut self, v: T) -> Self{
                 self.compliance_state = v.into();
@@ -5279,17 +5290,6 @@ pub mod os_policy_assignment_report {
                 v: T,
             ) -> Self {
                 self.compliance_state_reason = v.into();
-                self
-            }
-
-            /// Sets the value of [config_steps][crate::model::os_policy_assignment_report::os_policy_compliance::OSPolicyResourceCompliance::config_steps].
-            pub fn set_config_steps<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::os_policy_assignment_report::os_policy_compliance::os_policy_resource_compliance::OSPolicyResourceConfigStep>
-            {
-                use std::iter::Iterator;
-                self.config_steps = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -6000,6 +6000,17 @@ impl OSPolicyAssignment {
         self
     }
 
+    /// Sets the value of [os_policies][crate::model::OSPolicyAssignment::os_policies].
+    pub fn set_os_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::OSPolicy>,
+    {
+        use std::iter::Iterator;
+        self.os_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [instance_filter][crate::model::OSPolicyAssignment::instance_filter].
     pub fn set_instance_filter<
         T: std::convert::Into<std::option::Option<crate::model::os_policy_assignment::InstanceFilter>>,
@@ -6075,17 +6086,6 @@ impl OSPolicyAssignment {
     /// Sets the value of [uid][crate::model::OSPolicyAssignment::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
-        self
-    }
-
-    /// Sets the value of [os_policies][crate::model::OSPolicyAssignment::os_policies].
-    pub fn set_os_policies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::OSPolicy>,
-    {
-        use std::iter::Iterator;
-        self.os_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7119,12 +7119,6 @@ impl ListOSPolicyAssignmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOSPolicyAssignmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [os_policy_assignments][crate::model::ListOSPolicyAssignmentsResponse::os_policy_assignments].
     pub fn set_os_policy_assignments<T, V>(mut self, v: T) -> Self
     where
@@ -7133,6 +7127,12 @@ impl ListOSPolicyAssignmentsResponse {
     {
         use std::iter::Iterator;
         self.os_policy_assignments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOSPolicyAssignmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7235,12 +7235,6 @@ impl ListOSPolicyAssignmentRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOSPolicyAssignmentRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [os_policy_assignments][crate::model::ListOSPolicyAssignmentRevisionsResponse::os_policy_assignments].
     pub fn set_os_policy_assignments<T, V>(mut self, v: T) -> Self
     where
@@ -7249,6 +7243,12 @@ impl ListOSPolicyAssignmentRevisionsResponse {
     {
         use std::iter::Iterator;
         self.os_policy_assignments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOSPolicyAssignmentRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7350,17 +7350,6 @@ impl FixedOrPercent {
         })
     }
 
-    /// The value of [mode][crate::model::FixedOrPercent::mode]
-    /// if it holds a `Percent`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn percent(&self) -> std::option::Option<&i32> {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::fixed_or_percent::Mode::Percent(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::FixedOrPercent::mode]
     /// to hold a `Fixed`.
     ///
@@ -7370,6 +7359,17 @@ impl FixedOrPercent {
         self.mode =
             std::option::Option::Some(crate::model::fixed_or_percent::Mode::Fixed(v.into()));
         self
+    }
+
+    /// The value of [mode][crate::model::FixedOrPercent::mode]
+    /// if it holds a `Percent`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn percent(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::fixed_or_percent::Mode::Percent(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::FixedOrPercent::mode]
@@ -7596,21 +7596,6 @@ impl PatchDeployment {
         })
     }
 
-    /// The value of [schedule][crate::model::PatchDeployment::schedule]
-    /// if it holds a `RecurringSchedule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn recurring_schedule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RecurringSchedule>> {
-        #[allow(unreachable_patterns)]
-        self.schedule.as_ref().and_then(|v| match v {
-            crate::model::patch_deployment::Schedule::RecurringSchedule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [schedule][crate::model::PatchDeployment::schedule]
     /// to hold a `OneTimeSchedule`.
     ///
@@ -7626,6 +7611,21 @@ impl PatchDeployment {
             crate::model::patch_deployment::Schedule::OneTimeSchedule(v.into()),
         );
         self
+    }
+
+    /// The value of [schedule][crate::model::PatchDeployment::schedule]
+    /// if it holds a `RecurringSchedule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn recurring_schedule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RecurringSchedule>> {
+        #[allow(unreachable_patterns)]
+        self.schedule.as_ref().and_then(|v| match v {
+            crate::model::patch_deployment::Schedule::RecurringSchedule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schedule][crate::model::PatchDeployment::schedule]
@@ -7978,19 +7978,6 @@ impl RecurringSchedule {
         })
     }
 
-    /// The value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
-    /// if it holds a `Monthly`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn monthly(&self) -> std::option::Option<&std::boxed::Box<crate::model::MonthlySchedule>> {
-        #[allow(unreachable_patterns)]
-        self.schedule_config.as_ref().and_then(|v| match v {
-            crate::model::recurring_schedule::ScheduleConfig::Monthly(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
     /// to hold a `Weekly`.
     ///
@@ -8004,6 +7991,19 @@ impl RecurringSchedule {
             crate::model::recurring_schedule::ScheduleConfig::Weekly(v.into()),
         );
         self
+    }
+
+    /// The value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
+    /// if it holds a `Monthly`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn monthly(&self) -> std::option::Option<&std::boxed::Box<crate::model::MonthlySchedule>> {
+        #[allow(unreachable_patterns)]
+        self.schedule_config.as_ref().and_then(|v| match v {
+            crate::model::recurring_schedule::ScheduleConfig::Monthly(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
@@ -8268,17 +8268,6 @@ impl MonthlySchedule {
         })
     }
 
-    /// The value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
-    /// if it holds a `MonthDay`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn month_day(&self) -> std::option::Option<&i32> {
-        #[allow(unreachable_patterns)]
-        self.day_of_month.as_ref().and_then(|v| match v {
-            crate::model::monthly_schedule::DayOfMonth::MonthDay(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
     /// to hold a `WeekDayOfMonth`.
     ///
@@ -8294,6 +8283,17 @@ impl MonthlySchedule {
             crate::model::monthly_schedule::DayOfMonth::WeekDayOfMonth(v.into()),
         );
         self
+    }
+
+    /// The value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
+    /// if it holds a `MonthDay`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn month_day(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.day_of_month.as_ref().and_then(|v| match v {
+            crate::model::monthly_schedule::DayOfMonth::MonthDay(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
@@ -8573,12 +8573,6 @@ impl ListPatchDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPatchDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [patch_deployments][crate::model::ListPatchDeploymentsResponse::patch_deployments].
     pub fn set_patch_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -8587,6 +8581,12 @@ impl ListPatchDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.patch_deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPatchDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9006,12 +9006,6 @@ impl ListPatchJobInstanceDetailsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPatchJobInstanceDetailsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [patch_job_instance_details][crate::model::ListPatchJobInstanceDetailsResponse::patch_job_instance_details].
     pub fn set_patch_job_instance_details<T, V>(mut self, v: T) -> Self
     where
@@ -9020,6 +9014,12 @@ impl ListPatchJobInstanceDetailsResponse {
     {
         use std::iter::Iterator;
         self.patch_job_instance_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPatchJobInstanceDetailsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9214,12 +9214,6 @@ impl ListPatchJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPatchJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [patch_jobs][crate::model::ListPatchJobsResponse::patch_jobs].
     pub fn set_patch_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -9228,6 +9222,12 @@ impl ListPatchJobsResponse {
     {
         use std::iter::Iterator;
         self.patch_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPatchJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11207,15 +11207,6 @@ impl ExecStepConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [interpreter][crate::model::ExecStepConfig::interpreter].
-    pub fn set_interpreter<T: std::convert::Into<crate::model::exec_step_config::Interpreter>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.interpreter = v.into();
-        self
-    }
-
     /// Sets the value of [allowed_success_codes][crate::model::ExecStepConfig::allowed_success_codes].
     pub fn set_allowed_success_codes<T, V>(mut self, v: T) -> Self
     where
@@ -11224,6 +11215,15 @@ impl ExecStepConfig {
     {
         use std::iter::Iterator;
         self.allowed_success_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [interpreter][crate::model::ExecStepConfig::interpreter].
+    pub fn set_interpreter<T: std::convert::Into<crate::model::exec_step_config::Interpreter>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.interpreter = v.into();
         self
     }
 
@@ -11254,6 +11254,18 @@ impl ExecStepConfig {
         })
     }
 
+    /// Sets the value of [executable][crate::model::ExecStepConfig::executable]
+    /// to hold a `LocalPath`.
+    ///
+    /// Note that all the setters affecting `executable` are
+    /// mutually exclusive.
+    pub fn set_local_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.executable = std::option::Option::Some(
+            crate::model::exec_step_config::Executable::LocalPath(v.into()),
+        );
+        self
+    }
+
     /// The value of [executable][crate::model::ExecStepConfig::executable]
     /// if it holds a `GcsObject`, `None` if the field is not set or
     /// holds a different branch.
@@ -11265,18 +11277,6 @@ impl ExecStepConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [executable][crate::model::ExecStepConfig::executable]
-    /// to hold a `LocalPath`.
-    ///
-    /// Note that all the setters affecting `executable` are
-    /// mutually exclusive.
-    pub fn set_local_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.executable = std::option::Option::Some(
-            crate::model::exec_step_config::Executable::LocalPath(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [executable][crate::model::ExecStepConfig::executable]
@@ -11919,15 +11919,6 @@ impl VulnerabilityReport {
         self
     }
 
-    /// Sets the value of [update_time][crate::model::VulnerabilityReport::update_time].
-    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_time = v.into();
-        self
-    }
-
     /// Sets the value of [vulnerabilities][crate::model::VulnerabilityReport::vulnerabilities].
     pub fn set_vulnerabilities<T, V>(mut self, v: T) -> Self
     where
@@ -11936,6 +11927,15 @@ impl VulnerabilityReport {
     {
         use std::iter::Iterator;
         self.vulnerabilities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_time][crate::model::VulnerabilityReport::update_time].
+    pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_time = v.into();
         self
     }
 }
@@ -12016,24 +12016,6 @@ pub mod vulnerability_report {
             self
         }
 
-        /// Sets the value of [create_time][crate::model::vulnerability_report::Vulnerability::create_time].
-        pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.create_time = v.into();
-            self
-        }
-
-        /// Sets the value of [update_time][crate::model::vulnerability_report::Vulnerability::update_time].
-        pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.update_time = v.into();
-            self
-        }
-
         /// Sets the value of [installed_inventory_item_ids][crate::model::vulnerability_report::Vulnerability::installed_inventory_item_ids].
         #[deprecated]
         pub fn set_installed_inventory_item_ids<T, V>(mut self, v: T) -> Self
@@ -12055,6 +12037,24 @@ pub mod vulnerability_report {
         {
             use std::iter::Iterator;
             self.available_inventory_item_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [create_time][crate::model::vulnerability_report::Vulnerability::create_time].
+        pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.create_time = v.into();
+            self
+        }
+
+        /// Sets the value of [update_time][crate::model::vulnerability_report::Vulnerability::update_time].
+        pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.update_time = v.into();
             self
         }
 
@@ -12457,12 +12457,6 @@ impl ListVulnerabilityReportsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVulnerabilityReportsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vulnerability_reports][crate::model::ListVulnerabilityReportsResponse::vulnerability_reports].
     pub fn set_vulnerability_reports<T, V>(mut self, v: T) -> Self
     where
@@ -12471,6 +12465,12 @@ impl ListVulnerabilityReportsResponse {
     {
         use std::iter::Iterator;
         self.vulnerability_reports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVulnerabilityReportsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -174,6 +174,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [capacity_gib][crate::model::Instance::capacity_gib].
     pub fn set_capacity_gib<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.capacity_gib = v.into();
@@ -184,6 +196,17 @@ impl Instance {
     #[deprecated]
     pub fn set_daos_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.daos_version = v.into();
+        self
+    }
+
+    /// Sets the value of [access_points][crate::model::Instance::access_points].
+    pub fn set_access_points<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.access_points = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -235,29 +258,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.deployment_type = v.into();
-        self
-    }
-
-    /// Sets the value of [access_points][crate::model::Instance::access_points].
-    pub fn set_access_points<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.access_points = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -542,12 +542,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -556,6 +550,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1955,21 +1955,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// The value of [source][crate::model::TransferOperationMetadata::source]
-    /// if it holds a `SourceGcsBucket`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn source_gcs_bucket(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceGcsBucket>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::transfer_operation_metadata::Source::SourceGcsBucket(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
     /// to hold a `SourceParallelstore`.
     ///
@@ -1985,6 +1970,21 @@ impl TransferOperationMetadata {
             crate::model::transfer_operation_metadata::Source::SourceParallelstore(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::TransferOperationMetadata::source]
+    /// if it holds a `SourceGcsBucket`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn source_gcs_bucket(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SourceGcsBucket>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::transfer_operation_metadata::Source::SourceGcsBucket(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
@@ -2035,21 +2035,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// The value of [destination][crate::model::TransferOperationMetadata::destination]
-    /// if it holds a `DestinationParallelstore`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn destination_parallelstore(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DestinationParallelstore>> {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::transfer_operation_metadata::Destination::DestinationParallelstore(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]
     /// to hold a `DestinationGcsBucket`.
     ///
@@ -2065,6 +2050,21 @@ impl TransferOperationMetadata {
             crate::model::transfer_operation_metadata::Destination::DestinationGcsBucket(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::TransferOperationMetadata::destination]
+    /// if it holds a `DestinationParallelstore`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn destination_parallelstore(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DestinationParallelstore>> {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::transfer_operation_metadata::Destination::DestinationParallelstore(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]

--- a/src/generated/cloud/parametermanager/v1/src/model.rs
+++ b/src/generated/cloud/parametermanager/v1/src/model.rs
@@ -104,6 +104,18 @@ impl Parameter {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Parameter::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [format][crate::model::Parameter::format].
     pub fn set_format<T: std::convert::Into<crate::model::ParameterFormat>>(
         mut self,
@@ -130,18 +142,6 @@ impl Parameter {
         v: T,
     ) -> Self {
         self.kms_key = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Parameter::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -253,12 +253,6 @@ impl ListParametersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListParametersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [parameters][crate::model::ListParametersResponse::parameters].
     pub fn set_parameters<T, V>(mut self, v: T) -> Self
     where
@@ -267,6 +261,12 @@ impl ListParametersResponse {
     {
         use std::iter::Iterator;
         self.parameters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListParametersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -783,12 +783,6 @@ impl ListParameterVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListParameterVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [parameter_versions][crate::model::ListParameterVersionsResponse::parameter_versions].
     pub fn set_parameter_versions<T, V>(mut self, v: T) -> Self
     where
@@ -797,6 +791,12 @@ impl ListParameterVersionsResponse {
     {
         use std::iter::Iterator;
         self.parameter_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListParameterVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -204,15 +204,6 @@ impl ExplainedPolicy {
         self
     }
 
-    /// Sets the value of [relevance][crate::model::ExplainedPolicy::relevance].
-    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relevance = v.into();
-        self
-    }
-
     /// Sets the value of [binding_explanations][crate::model::ExplainedPolicy::binding_explanations].
     pub fn set_binding_explanations<T, V>(mut self, v: T) -> Self
     where
@@ -221,6 +212,15 @@ impl ExplainedPolicy {
     {
         use std::iter::Iterator;
         self.binding_explanations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relevance][crate::model::ExplainedPolicy::relevance].
+    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relevance = v.into();
         self
     }
 }
@@ -345,6 +345,18 @@ impl BindingExplanation {
         self
     }
 
+    /// Sets the value of [memberships][crate::model::BindingExplanation::memberships].
+    pub fn set_memberships<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::binding_explanation::AnnotatedMembership>,
+    {
+        use std::iter::Iterator;
+        self.memberships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [relevance][crate::model::BindingExplanation::relevance].
     pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
         mut self,
@@ -360,18 +372,6 @@ impl BindingExplanation {
         v: T,
     ) -> Self {
         self.condition = v.into();
-        self
-    }
-
-    /// Sets the value of [memberships][crate::model::BindingExplanation::memberships].
-    pub fn set_memberships<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::binding_explanation::AnnotatedMembership>,
-    {
-        use std::iter::Iterator;
-        self.memberships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1170,17 +1170,6 @@ impl ReplayResult {
         })
     }
 
-    /// The value of [result][crate::model::ReplayResult::result]
-    /// if it holds a `Error`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::replay_result::Result::Error(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::ReplayResult::result]
     /// to hold a `Diff`.
     ///
@@ -1193,6 +1182,17 @@ impl ReplayResult {
         self.result =
             std::option::Option::Some(crate::model::replay_result::Result::Diff(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::ReplayResult::result]
+    /// if it holds a `Error`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::replay_result::Result::Error(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::ReplayResult::result]
@@ -1488,12 +1488,6 @@ impl ListReplayResultsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReplayResultsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [replay_results][crate::model::ListReplayResultsResponse::replay_results].
     pub fn set_replay_results<T, V>(mut self, v: T) -> Self
     where
@@ -1502,6 +1496,12 @@ impl ListReplayResultsResponse {
     {
         use std::iter::Iterator;
         self.replay_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReplayResultsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1569,15 +1569,6 @@ impl ReplayConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [log_source][crate::model::ReplayConfig::log_source].
-    pub fn set_log_source<T: std::convert::Into<crate::model::replay_config::LogSource>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.log_source = v.into();
-        self
-    }
-
     /// Sets the value of [policy_overlay][crate::model::ReplayConfig::policy_overlay].
     pub fn set_policy_overlay<T, K, V>(mut self, v: T) -> Self
     where
@@ -1587,6 +1578,15 @@ impl ReplayConfig {
     {
         use std::iter::Iterator;
         self.policy_overlay = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [log_source][crate::model::ReplayConfig::log_source].
+    pub fn set_log_source<T: std::convert::Into<crate::model::replay_config::LogSource>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.log_source = v.into();
         self
     }
 }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/model.rs
@@ -819,15 +819,6 @@ impl AllowPolicyExplanation {
         self
     }
 
-    /// Sets the value of [relevance][crate::model::AllowPolicyExplanation::relevance].
-    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relevance = v.into();
-        self
-    }
-
     /// Sets the value of [explained_policies][crate::model::AllowPolicyExplanation::explained_policies].
     pub fn set_explained_policies<T, V>(mut self, v: T) -> Self
     where
@@ -836,6 +827,15 @@ impl AllowPolicyExplanation {
     {
         use std::iter::Iterator;
         self.explained_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relevance][crate::model::AllowPolicyExplanation::relevance].
+    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relevance = v.into();
         self
     }
 }
@@ -928,6 +928,17 @@ impl ExplainedAllowPolicy {
         self
     }
 
+    /// Sets the value of [binding_explanations][crate::model::ExplainedAllowPolicy::binding_explanations].
+    pub fn set_binding_explanations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AllowBindingExplanation>,
+    {
+        use std::iter::Iterator;
+        self.binding_explanations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [relevance][crate::model::ExplainedAllowPolicy::relevance].
     pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
         mut self,
@@ -943,17 +954,6 @@ impl ExplainedAllowPolicy {
         v: T,
     ) -> Self {
         self.policy = v.into();
-        self
-    }
-
-    /// Sets the value of [binding_explanations][crate::model::ExplainedAllowPolicy::binding_explanations].
-    pub fn set_binding_explanations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AllowBindingExplanation>,
-    {
-        use std::iter::Iterator;
-        self.binding_explanations = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1107,6 +1107,18 @@ impl AllowBindingExplanation {
         self
     }
 
+    /// Sets the value of [memberships][crate::model::AllowBindingExplanation::memberships].
+    pub fn set_memberships<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::allow_binding_explanation::AnnotatedAllowMembership>,
+    {
+        use std::iter::Iterator;
+        self.memberships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [relevance][crate::model::AllowBindingExplanation::relevance].
     pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
         mut self,
@@ -1133,18 +1145,6 @@ impl AllowBindingExplanation {
         v: T,
     ) -> Self {
         self.condition_explanation = v.into();
-        self
-    }
-
-    /// Sets the value of [memberships][crate::model::AllowBindingExplanation::memberships].
-    pub fn set_memberships<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::allow_binding_explanation::AnnotatedAllowMembership>,
-    {
-        use std::iter::Iterator;
-        self.memberships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1261,6 +1261,17 @@ impl DenyPolicyExplanation {
         self
     }
 
+    /// Sets the value of [explained_resources][crate::model::DenyPolicyExplanation::explained_resources].
+    pub fn set_explained_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ExplainedDenyResource>,
+    {
+        use std::iter::Iterator;
+        self.explained_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [relevance][crate::model::DenyPolicyExplanation::relevance].
     pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
         mut self,
@@ -1273,17 +1284,6 @@ impl DenyPolicyExplanation {
     /// Sets the value of [permission_deniable][crate::model::DenyPolicyExplanation::permission_deniable].
     pub fn set_permission_deniable<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.permission_deniable = v.into();
-        self
-    }
-
-    /// Sets the value of [explained_resources][crate::model::DenyPolicyExplanation::explained_resources].
-    pub fn set_explained_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ExplainedDenyResource>,
-    {
-        use std::iter::Iterator;
-        self.explained_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1367,15 +1367,6 @@ impl ExplainedDenyResource {
         self
     }
 
-    /// Sets the value of [relevance][crate::model::ExplainedDenyResource::relevance].
-    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relevance = v.into();
-        self
-    }
-
     /// Sets the value of [explained_policies][crate::model::ExplainedDenyResource::explained_policies].
     pub fn set_explained_policies<T, V>(mut self, v: T) -> Self
     where
@@ -1384,6 +1375,15 @@ impl ExplainedDenyResource {
     {
         use std::iter::Iterator;
         self.explained_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relevance][crate::model::ExplainedDenyResource::relevance].
+    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relevance = v.into();
         self
     }
 }
@@ -1467,15 +1467,6 @@ impl ExplainedDenyPolicy {
         self
     }
 
-    /// Sets the value of [relevance][crate::model::ExplainedDenyPolicy::relevance].
-    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relevance = v.into();
-        self
-    }
-
     /// Sets the value of [rule_explanations][crate::model::ExplainedDenyPolicy::rule_explanations].
     pub fn set_rule_explanations<T, V>(mut self, v: T) -> Self
     where
@@ -1484,6 +1475,15 @@ impl ExplainedDenyPolicy {
     {
         use std::iter::Iterator;
         self.rule_explanations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relevance][crate::model::ExplainedDenyPolicy::relevance].
+    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relevance = v.into();
         self
     }
 }
@@ -1636,6 +1636,18 @@ impl DenyRuleExplanation {
         self
     }
 
+    /// Sets the value of [denied_permissions][crate::model::DenyRuleExplanation::denied_permissions].
+    pub fn set_denied_permissions<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedPermissionMatching>,
+    {
+        use std::iter::Iterator;
+        self.denied_permissions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [combined_exception_permission][crate::model::DenyRuleExplanation::combined_exception_permission].
     pub fn set_combined_exception_permission<
         T: std::convert::Into<
@@ -1648,6 +1660,18 @@ impl DenyRuleExplanation {
         v: T,
     ) -> Self {
         self.combined_exception_permission = v.into();
+        self
+    }
+
+    /// Sets the value of [exception_permissions][crate::model::DenyRuleExplanation::exception_permissions].
+    pub fn set_exception_permissions<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedPermissionMatching>,
+    {
+        use std::iter::Iterator;
+        self.exception_permissions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1666,6 +1690,18 @@ impl DenyRuleExplanation {
         self
     }
 
+    /// Sets the value of [denied_principals][crate::model::DenyRuleExplanation::denied_principals].
+    pub fn set_denied_principals<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedDenyPrincipalMatching>,
+    {
+        use std::iter::Iterator;
+        self.denied_principals = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [combined_exception_principal][crate::model::DenyRuleExplanation::combined_exception_principal].
     pub fn set_combined_exception_principal<
         T: std::convert::Into<
@@ -1678,6 +1714,18 @@ impl DenyRuleExplanation {
         v: T,
     ) -> Self {
         self.combined_exception_principal = v.into();
+        self
+    }
+
+    /// Sets the value of [exception_principals][crate::model::DenyRuleExplanation::exception_principals].
+    pub fn set_exception_principals<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedDenyPrincipalMatching>,
+    {
+        use std::iter::Iterator;
+        self.exception_principals = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1707,54 +1755,6 @@ impl DenyRuleExplanation {
         v: T,
     ) -> Self {
         self.condition_explanation = v.into();
-        self
-    }
-
-    /// Sets the value of [denied_permissions][crate::model::DenyRuleExplanation::denied_permissions].
-    pub fn set_denied_permissions<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedPermissionMatching>,
-    {
-        use std::iter::Iterator;
-        self.denied_permissions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [exception_permissions][crate::model::DenyRuleExplanation::exception_permissions].
-    pub fn set_exception_permissions<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedPermissionMatching>,
-    {
-        use std::iter::Iterator;
-        self.exception_permissions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [denied_principals][crate::model::DenyRuleExplanation::denied_principals].
-    pub fn set_denied_principals<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedDenyPrincipalMatching>,
-    {
-        use std::iter::Iterator;
-        self.denied_principals = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [exception_principals][crate::model::DenyRuleExplanation::exception_principals].
-    pub fn set_exception_principals<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::deny_rule_explanation::AnnotatedDenyPrincipalMatching>,
-    {
-        use std::iter::Iterator;
-        self.exception_principals = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/policytroubleshooter/v1/src/model.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/model.rs
@@ -305,15 +305,6 @@ impl ExplainedPolicy {
         self
     }
 
-    /// Sets the value of [relevance][crate::model::ExplainedPolicy::relevance].
-    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relevance = v.into();
-        self
-    }
-
     /// Sets the value of [binding_explanations][crate::model::ExplainedPolicy::binding_explanations].
     pub fn set_binding_explanations<T, V>(mut self, v: T) -> Self
     where
@@ -322,6 +313,15 @@ impl ExplainedPolicy {
     {
         use std::iter::Iterator;
         self.binding_explanations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relevance][crate::model::ExplainedPolicy::relevance].
+    pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relevance = v.into();
         self
     }
 }
@@ -446,6 +446,18 @@ impl BindingExplanation {
         self
     }
 
+    /// Sets the value of [memberships][crate::model::BindingExplanation::memberships].
+    pub fn set_memberships<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::binding_explanation::AnnotatedMembership>,
+    {
+        use std::iter::Iterator;
+        self.memberships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [relevance][crate::model::BindingExplanation::relevance].
     pub fn set_relevance<T: std::convert::Into<crate::model::HeuristicRelevance>>(
         mut self,
@@ -461,18 +473,6 @@ impl BindingExplanation {
         v: T,
     ) -> Self {
         self.condition = v.into();
-        self
-    }
-
-    /// Sets the value of [memberships][crate::model::BindingExplanation::memberships].
-    pub fn set_memberships<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::binding_explanation::AnnotatedMembership>,
-    {
-        use std::iter::Iterator;
-        self.memberships = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -370,6 +370,17 @@ impl Entitlement {
         self
     }
 
+    /// Sets the value of [eligible_users][crate::model::Entitlement::eligible_users].
+    pub fn set_eligible_users<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AccessControlEntry>,
+    {
+        use std::iter::Iterator;
+        self.eligible_users = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [approval_workflow][crate::model::Entitlement::approval_workflow].
     pub fn set_approval_workflow<
         T: std::convert::Into<std::option::Option<crate::model::ApprovalWorkflow>>,
@@ -441,17 +452,6 @@ impl Entitlement {
         self.etag = v.into();
         self
     }
-
-    /// Sets the value of [eligible_users][crate::model::Entitlement::eligible_users].
-    pub fn set_eligible_users<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AccessControlEntry>,
-    {
-        use std::iter::Iterator;
-        self.eligible_users = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
 }
 
 impl wkt::message::Message for Entitlement {
@@ -515,23 +515,6 @@ pub mod entitlement {
             })
         }
 
-        /// The value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
-        /// if it holds a `Unstructured`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn unstructured(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::entitlement::requester_justification_config::Unstructured,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.justification_type.as_ref().and_then(|v| match v {
-                crate::model::entitlement::requester_justification_config::JustificationType::Unstructured(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
         /// to hold a `NotMandatory`.
         ///
@@ -553,6 +536,23 @@ pub mod entitlement {
                 )
             );
             self
+        }
+
+        /// The value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
+        /// if it holds a `Unstructured`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn unstructured(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::entitlement::requester_justification_config::Unstructured,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.justification_type.as_ref().and_then(|v| match v {
+                crate::model::entitlement::requester_justification_config::JustificationType::Unstructured(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
@@ -1092,12 +1092,6 @@ pub mod manual_approvals {
             std::default::Default::default()
         }
 
-        /// Sets the value of [approvals_needed][crate::model::manual_approvals::Step::approvals_needed].
-        pub fn set_approvals_needed<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.approvals_needed = v.into();
-            self
-        }
-
         /// Sets the value of [approvers][crate::model::manual_approvals::Step::approvers].
         pub fn set_approvers<T, V>(mut self, v: T) -> Self
         where
@@ -1106,6 +1100,12 @@ pub mod manual_approvals {
         {
             use std::iter::Iterator;
             self.approvers = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [approvals_needed][crate::model::manual_approvals::Step::approvals_needed].
+        pub fn set_approvals_needed<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.approvals_needed = v.into();
             self
         }
 
@@ -1435,12 +1435,6 @@ impl ListEntitlementsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEntitlementsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entitlements][crate::model::ListEntitlementsResponse::entitlements].
     pub fn set_entitlements<T, V>(mut self, v: T) -> Self
     where
@@ -1449,6 +1443,12 @@ impl ListEntitlementsResponse {
     {
         use std::iter::Iterator;
         self.entitlements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEntitlementsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1724,12 +1724,6 @@ impl SearchEntitlementsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchEntitlementsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entitlements][crate::model::SearchEntitlementsResponse::entitlements].
     pub fn set_entitlements<T, V>(mut self, v: T) -> Self
     where
@@ -1738,6 +1732,12 @@ impl SearchEntitlementsResponse {
     {
         use std::iter::Iterator;
         self.entitlements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchEntitlementsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2176,12 +2176,6 @@ impl Grant {
         self
     }
 
-    /// Sets the value of [externally_modified][crate::model::Grant::externally_modified].
-    pub fn set_externally_modified<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.externally_modified = v.into();
-        self
-    }
-
     /// Sets the value of [additional_email_recipients][crate::model::Grant::additional_email_recipients].
     pub fn set_additional_email_recipients<T, V>(mut self, v: T) -> Self
     where
@@ -2190,6 +2184,12 @@ impl Grant {
     {
         use std::iter::Iterator;
         self.additional_email_recipients = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [externally_modified][crate::model::Grant::externally_modified].
+    pub fn set_externally_modified<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.externally_modified = v.into();
         self
     }
 }
@@ -2314,154 +2314,6 @@ pub mod grant {
                 })
             }
 
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Approved`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn approved(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Approved>>
-            {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Approved(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Denied`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn denied(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Denied>>
-            {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Denied(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Revoked`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn revoked(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Revoked>>
-            {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Revoked(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Scheduled`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn scheduled(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::grant::timeline::event::Scheduled>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Scheduled(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Activated`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn activated(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::grant::timeline::event::Activated>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Activated(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `ActivationFailed`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn activation_failed(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::grant::timeline::event::ActivationFailed>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::ActivationFailed(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Expired`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn expired(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Expired>>
-            {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Expired(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `Ended`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn ended(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Ended>>
-            {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::Ended(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [event][crate::model::grant::timeline::Event::event]
-            /// if it holds a `ExternallyModified`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn externally_modified(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::grant::timeline::event::ExternallyModified>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.event.as_ref().and_then(|v| match v {
-                    crate::model::grant::timeline::event::Event::ExternallyModified(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
             /// to hold a `Requested`.
             ///
@@ -2481,6 +2333,22 @@ pub mod grant {
                 self
             }
 
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Approved`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn approved(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Approved>>
+            {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Approved(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
             /// to hold a `Approved`.
             ///
@@ -2496,6 +2364,22 @@ pub mod grant {
                     crate::model::grant::timeline::event::Event::Approved(v.into()),
                 );
                 self
+            }
+
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Denied`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn denied(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Denied>>
+            {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Denied(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
@@ -2515,6 +2399,22 @@ pub mod grant {
                 self
             }
 
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Revoked`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn revoked(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Revoked>>
+            {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Revoked(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
             /// to hold a `Revoked`.
             ///
@@ -2530,6 +2430,23 @@ pub mod grant {
                     crate::model::grant::timeline::event::Event::Revoked(v.into()),
                 );
                 self
+            }
+
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Scheduled`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn scheduled(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::grant::timeline::event::Scheduled>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Scheduled(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
@@ -2551,6 +2468,23 @@ pub mod grant {
                 self
             }
 
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Activated`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn activated(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::grant::timeline::event::Activated>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Activated(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
             /// to hold a `Activated`.
             ///
@@ -2568,6 +2502,23 @@ pub mod grant {
                     crate::model::grant::timeline::event::Event::Activated(v.into()),
                 );
                 self
+            }
+
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `ActivationFailed`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn activation_failed(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::grant::timeline::event::ActivationFailed>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::ActivationFailed(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
@@ -2589,6 +2540,22 @@ pub mod grant {
                 self
             }
 
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Expired`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn expired(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Expired>>
+            {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Expired(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
             /// to hold a `Expired`.
             ///
@@ -2606,6 +2573,22 @@ pub mod grant {
                 self
             }
 
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `Ended`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn ended(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::grant::timeline::event::Ended>>
+            {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::Ended(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
             /// to hold a `Ended`.
             ///
@@ -2621,6 +2604,23 @@ pub mod grant {
                     crate::model::grant::timeline::event::Event::Ended(v.into()),
                 );
                 self
+            }
+
+            /// The value of [event][crate::model::grant::timeline::Event::event]
+            /// if it holds a `ExternallyModified`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn externally_modified(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::grant::timeline::event::ExternallyModified>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.event.as_ref().and_then(|v| match v {
+                    crate::model::grant::timeline::event::Event::ExternallyModified(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [event][crate::model::grant::timeline::Event::event]
@@ -3465,12 +3465,6 @@ impl ListGrantsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGrantsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [grants][crate::model::ListGrantsResponse::grants].
     pub fn set_grants<T, V>(mut self, v: T) -> Self
     where
@@ -3479,6 +3473,12 @@ impl ListGrantsResponse {
     {
         use std::iter::Iterator;
         self.grants = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGrantsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3762,12 +3762,6 @@ impl SearchGrantsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchGrantsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [grants][crate::model::SearchGrantsResponse::grants].
     pub fn set_grants<T, V>(mut self, v: T) -> Self
     where
@@ -3776,6 +3770,12 @@ impl SearchGrantsResponse {
     {
         use std::iter::Iterator;
         self.grants = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchGrantsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/model.rs
@@ -197,6 +197,18 @@ impl Collector {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Collector::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [display_name][crate::model::Collector::display_name].
     pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.display_name = v.into();
@@ -273,18 +285,6 @@ impl Collector {
     /// Sets the value of [eula_uri][crate::model::Collector::eula_uri].
     pub fn set_eula_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.eula_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Collector::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -541,12 +541,6 @@ impl Annotation {
         self
     }
 
-    /// Sets the value of [r#type][crate::model::Annotation::type].
-    pub fn set_type<T: std::convert::Into<crate::model::annotation::Type>>(mut self, v: T) -> Self {
-        self.r#type = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Annotation::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -556,6 +550,12 @@ impl Annotation {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [r#type][crate::model::Annotation::type].
+    pub fn set_type<T: std::convert::Into<crate::model::annotation::Type>>(mut self, v: T) -> Self {
+        self.r#type = v.into();
         self
     }
 }
@@ -958,12 +958,6 @@ impl ListCollectorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCollectorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [collectors][crate::model::ListCollectorsResponse::collectors].
     pub fn set_collectors<T, V>(mut self, v: T) -> Self
     where
@@ -972,6 +966,12 @@ impl ListCollectorsResponse {
     {
         use std::iter::Iterator;
         self.collectors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCollectorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
@@ -180,6 +180,17 @@ pub mod recaptcha_enterprise_service {
             self
         }
 
+        /// Sets the value of [reasons][crate::model::AnnotateAssessmentRequest::reasons].
+        pub fn set_reasons<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::annotate_assessment_request::Reason>,
+        {
+            use std::iter::Iterator;
+            self.0.request.reasons = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [account_id][crate::model::AnnotateAssessmentRequest::account_id].
         pub fn set_account_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.account_id = v.into();
@@ -200,17 +211,6 @@ pub mod recaptcha_enterprise_service {
             v: T,
         ) -> Self {
             self.0.request.transaction_event = v.into();
-            self
-        }
-
-        /// Sets the value of [reasons][crate::model::AnnotateAssessmentRequest::reasons].
-        pub fn set_reasons<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::annotate_assessment_request::Reason>,
-        {
-            use std::iter::Iterator;
-            self.0.request.reasons = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -508,6 +508,17 @@ impl AnnotateAssessmentRequest {
         self
     }
 
+    /// Sets the value of [reasons][crate::model::AnnotateAssessmentRequest::reasons].
+    pub fn set_reasons<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::annotate_assessment_request::Reason>,
+    {
+        use std::iter::Iterator;
+        self.reasons = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [account_id][crate::model::AnnotateAssessmentRequest::account_id].
     pub fn set_account_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.account_id = v.into();
@@ -528,17 +539,6 @@ impl AnnotateAssessmentRequest {
         v: T,
     ) -> Self {
         self.transaction_event = v.into();
-        self
-    }
-
-    /// Sets the value of [reasons][crate::model::AnnotateAssessmentRequest::reasons].
-    pub fn set_reasons<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::annotate_assessment_request::Reason>,
-    {
-        use std::iter::Iterator;
-        self.reasons = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1034,6 +1034,18 @@ impl EndpointVerificationInfo {
         })
     }
 
+    /// Sets the value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
+    /// to hold a `EmailAddress`.
+    ///
+    /// Note that all the setters affecting `endpoint` are
+    /// mutually exclusive.
+    pub fn set_email_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.endpoint = std::option::Option::Some(
+            crate::model::endpoint_verification_info::Endpoint::EmailAddress(v.into()),
+        );
+        self
+    }
+
     /// The value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
     /// if it holds a `PhoneNumber`, `None` if the field is not set or
     /// holds a different branch.
@@ -1045,18 +1057,6 @@ impl EndpointVerificationInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
-    /// to hold a `EmailAddress`.
-    ///
-    /// Note that all the setters affecting `endpoint` are
-    /// mutually exclusive.
-    pub fn set_email_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.endpoint = std::option::Option::Some(
-            crate::model::endpoint_verification_info::Endpoint::EmailAddress(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
@@ -1128,6 +1128,17 @@ impl AccountVerificationInfo {
         std::default::Default::default()
     }
 
+    /// Sets the value of [endpoints][crate::model::AccountVerificationInfo::endpoints].
+    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EndpointVerificationInfo>,
+    {
+        use std::iter::Iterator;
+        self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [language_code][crate::model::AccountVerificationInfo::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
@@ -1149,17 +1160,6 @@ impl AccountVerificationInfo {
     #[deprecated]
     pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.username = v.into();
-        self
-    }
-
-    /// Sets the value of [endpoints][crate::model::AccountVerificationInfo::endpoints].
-    pub fn set_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EndpointVerificationInfo>,
-    {
-        use std::iter::Iterator;
-        self.endpoints = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1435,15 +1435,6 @@ impl PrivatePasswordLeakVerification {
         self
     }
 
-    /// Sets the value of [reencrypted_user_credentials_hash][crate::model::PrivatePasswordLeakVerification::reencrypted_user_credentials_hash].
-    pub fn set_reencrypted_user_credentials_hash<T: std::convert::Into<::bytes::Bytes>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.reencrypted_user_credentials_hash = v.into();
-        self
-    }
-
     /// Sets the value of [encrypted_leak_match_prefixes][crate::model::PrivatePasswordLeakVerification::encrypted_leak_match_prefixes].
     pub fn set_encrypted_leak_match_prefixes<T, V>(mut self, v: T) -> Self
     where
@@ -1452,6 +1443,15 @@ impl PrivatePasswordLeakVerification {
     {
         use std::iter::Iterator;
         self.encrypted_leak_match_prefixes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [reencrypted_user_credentials_hash][crate::model::PrivatePasswordLeakVerification::reencrypted_user_credentials_hash].
+    pub fn set_reencrypted_user_credentials_hash<T: std::convert::Into<::bytes::Bytes>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.reencrypted_user_credentials_hash = v.into();
         self
     }
 }
@@ -1837,6 +1837,17 @@ impl Event {
         self
     }
 
+    /// Sets the value of [headers][crate::model::Event::headers].
+    pub fn set_headers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.headers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [firewall_policy_evaluation][crate::model::Event::firewall_policy_evaluation].
     pub fn set_firewall_policy_evaluation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.firewall_policy_evaluation = v.into();
@@ -1869,17 +1880,6 @@ impl Event {
         v: T,
     ) -> Self {
         self.fraud_prevention = v.into();
-        self
-    }
-
-    /// Sets the value of [headers][crate::model::Event::headers].
-    pub fn set_headers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.headers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2192,17 +2192,6 @@ impl TransactionData {
         self
     }
 
-    /// Sets the value of [gateway_info][crate::model::TransactionData::gateway_info].
-    pub fn set_gateway_info<
-        T: std::convert::Into<std::option::Option<crate::model::transaction_data::GatewayInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.gateway_info = v.into();
-        self
-    }
-
     /// Sets the value of [merchants][crate::model::TransactionData::merchants].
     pub fn set_merchants<T, V>(mut self, v: T) -> Self
     where
@@ -2222,6 +2211,17 @@ impl TransactionData {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [gateway_info][crate::model::TransactionData::gateway_info].
+    pub fn set_gateway_info<
+        T: std::convert::Into<std::option::Option<crate::model::transaction_data::GatewayInfo>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.gateway_info = v.into();
         self
     }
 }
@@ -2286,6 +2286,17 @@ pub mod transaction_data {
             self
         }
 
+        /// Sets the value of [address][crate::model::transaction_data::Address::address].
+        pub fn set_address<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.address = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [locality][crate::model::transaction_data::Address::locality].
         pub fn set_locality<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.locality = v.into();
@@ -2310,17 +2321,6 @@ pub mod transaction_data {
         /// Sets the value of [postal_code][crate::model::transaction_data::Address::postal_code].
         pub fn set_postal_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.postal_code = v.into();
-            self
-        }
-
-        /// Sets the value of [address][crate::model::transaction_data::Address::address].
-        pub fn set_address<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.address = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2673,6 +2673,16 @@ impl UserId {
         })
     }
 
+    /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
+    /// to hold a `Email`.
+    ///
+    /// Note that all the setters affecting `id_oneof` are
+    /// mutually exclusive.
+    pub fn set_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.id_oneof = std::option::Option::Some(crate::model::user_id::IdOneof::Email(v.into()));
+        self
+    }
+
     /// The value of [id_oneof][crate::model::UserId::id_oneof]
     /// if it holds a `PhoneNumber`, `None` if the field is not set or
     /// holds a different branch.
@@ -2684,27 +2694,6 @@ impl UserId {
         })
     }
 
-    /// The value of [id_oneof][crate::model::UserId::id_oneof]
-    /// if it holds a `Username`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn username(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.id_oneof.as_ref().and_then(|v| match v {
-            crate::model::user_id::IdOneof::Username(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
-    /// to hold a `Email`.
-    ///
-    /// Note that all the setters affecting `id_oneof` are
-    /// mutually exclusive.
-    pub fn set_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id_oneof = std::option::Option::Some(crate::model::user_id::IdOneof::Email(v.into()));
-        self
-    }
-
     /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
     /// to hold a `PhoneNumber`.
     ///
@@ -2714,6 +2703,17 @@ impl UserId {
         self.id_oneof =
             std::option::Option::Some(crate::model::user_id::IdOneof::PhoneNumber(v.into()));
         self
+    }
+
+    /// The value of [id_oneof][crate::model::UserId::id_oneof]
+    /// if it holds a `Username`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn username(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.id_oneof.as_ref().and_then(|v| match v {
+            crate::model::user_id::IdOneof::Username(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
@@ -2794,15 +2794,6 @@ impl RiskAnalysis {
         self
     }
 
-    /// Sets the value of [challenge][crate::model::RiskAnalysis::challenge].
-    pub fn set_challenge<T: std::convert::Into<crate::model::risk_analysis::Challenge>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.challenge = v.into();
-        self
-    }
-
     /// Sets the value of [reasons][crate::model::RiskAnalysis::reasons].
     pub fn set_reasons<T, V>(mut self, v: T) -> Self
     where
@@ -2822,6 +2813,15 @@ impl RiskAnalysis {
     {
         use std::iter::Iterator;
         self.extended_verdict_reasons = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [challenge][crate::model::RiskAnalysis::challenge].
+    pub fn set_challenge<T: std::convert::Into<crate::model::risk_analysis::Challenge>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.challenge = v.into();
         self
     }
 }
@@ -4460,12 +4460,6 @@ impl ListKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [keys][crate::model::ListKeysResponse::keys].
     pub fn set_keys<T, V>(mut self, v: T) -> Self
     where
@@ -4474,6 +4468,12 @@ impl ListKeysResponse {
     {
         use std::iter::Iterator;
         self.keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4773,12 +4773,6 @@ impl ListFirewallPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFirewallPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [firewall_policies][crate::model::ListFirewallPoliciesResponse::firewall_policies].
     pub fn set_firewall_policies<T, V>(mut self, v: T) -> Self
     where
@@ -4787,6 +4781,12 @@ impl ListFirewallPoliciesResponse {
     {
         use std::iter::Iterator;
         self.firewall_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFirewallPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5260,6 +5260,18 @@ impl Key {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Key::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Key::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5291,18 +5303,6 @@ impl Key {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Key::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [platform_settings][crate::model::Key::platform_settings].
     ///
     /// Note that all the setters affecting `platform_settings` are mutually
@@ -5330,45 +5330,6 @@ impl Key {
         })
     }
 
-    /// The value of [platform_settings][crate::model::Key::platform_settings]
-    /// if it holds a `AndroidSettings`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn android_settings(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AndroidKeySettings>> {
-        #[allow(unreachable_patterns)]
-        self.platform_settings.as_ref().and_then(|v| match v {
-            crate::model::key::PlatformSettings::AndroidSettings(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [platform_settings][crate::model::Key::platform_settings]
-    /// if it holds a `IosSettings`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ios_settings(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IOSKeySettings>> {
-        #[allow(unreachable_patterns)]
-        self.platform_settings.as_ref().and_then(|v| match v {
-            crate::model::key::PlatformSettings::IosSettings(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [platform_settings][crate::model::Key::platform_settings]
-    /// if it holds a `ExpressSettings`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn express_settings(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExpressKeySettings>> {
-        #[allow(unreachable_patterns)]
-        self.platform_settings.as_ref().and_then(|v| match v {
-            crate::model::key::PlatformSettings::ExpressSettings(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
     /// to hold a `WebSettings`.
     ///
@@ -5383,6 +5344,19 @@ impl Key {
         self.platform_settings =
             std::option::Option::Some(crate::model::key::PlatformSettings::WebSettings(v.into()));
         self
+    }
+
+    /// The value of [platform_settings][crate::model::Key::platform_settings]
+    /// if it holds a `AndroidSettings`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn android_settings(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AndroidKeySettings>> {
+        #[allow(unreachable_patterns)]
+        self.platform_settings.as_ref().and_then(|v| match v {
+            crate::model::key::PlatformSettings::AndroidSettings(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
@@ -5402,6 +5376,19 @@ impl Key {
         self
     }
 
+    /// The value of [platform_settings][crate::model::Key::platform_settings]
+    /// if it holds a `IosSettings`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ios_settings(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IOSKeySettings>> {
+        #[allow(unreachable_patterns)]
+        self.platform_settings.as_ref().and_then(|v| match v {
+            crate::model::key::PlatformSettings::IosSettings(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
     /// to hold a `IosSettings`.
     ///
@@ -5416,6 +5403,19 @@ impl Key {
         self.platform_settings =
             std::option::Option::Some(crate::model::key::PlatformSettings::IosSettings(v.into()));
         self
+    }
+
+    /// The value of [platform_settings][crate::model::Key::platform_settings]
+    /// if it holds a `ExpressSettings`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn express_settings(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExpressKeySettings>> {
+        #[allow(unreachable_patterns)]
+        self.platform_settings.as_ref().and_then(|v| match v {
+            crate::model::key::PlatformSettings::ExpressSettings(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
@@ -5700,6 +5700,17 @@ impl WebKeySettings {
         self
     }
 
+    /// Sets the value of [allowed_domains][crate::model::WebKeySettings::allowed_domains].
+    pub fn set_allowed_domains<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.allowed_domains = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [allow_amp_traffic][crate::model::WebKeySettings::allow_amp_traffic].
     pub fn set_allow_amp_traffic<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_amp_traffic = v.into();
@@ -5725,17 +5736,6 @@ impl WebKeySettings {
         v: T,
     ) -> Self {
         self.challenge_security_preference = v.into();
-        self
-    }
-
-    /// Sets the value of [allowed_domains][crate::model::WebKeySettings::allowed_domains].
-    pub fn set_allowed_domains<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.allowed_domains = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6073,15 +6073,6 @@ impl AndroidKeySettings {
         self
     }
 
-    /// Sets the value of [support_non_google_app_store_distribution][crate::model::AndroidKeySettings::support_non_google_app_store_distribution].
-    pub fn set_support_non_google_app_store_distribution<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.support_non_google_app_store_distribution = v.into();
-        self
-    }
-
     /// Sets the value of [allowed_package_names][crate::model::AndroidKeySettings::allowed_package_names].
     pub fn set_allowed_package_names<T, V>(mut self, v: T) -> Self
     where
@@ -6090,6 +6081,15 @@ impl AndroidKeySettings {
     {
         use std::iter::Iterator;
         self.allowed_package_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [support_non_google_app_store_distribution][crate::model::AndroidKeySettings::support_non_google_app_store_distribution].
+    pub fn set_support_non_google_app_store_distribution<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.support_non_google_app_store_distribution = v.into();
         self
     }
 }
@@ -6138,17 +6138,6 @@ impl IOSKeySettings {
         self
     }
 
-    /// Sets the value of [apple_developer_id][crate::model::IOSKeySettings::apple_developer_id].
-    pub fn set_apple_developer_id<
-        T: std::convert::Into<std::option::Option<crate::model::AppleDeveloperId>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.apple_developer_id = v.into();
-        self
-    }
-
     /// Sets the value of [allowed_bundle_ids][crate::model::IOSKeySettings::allowed_bundle_ids].
     pub fn set_allowed_bundle_ids<T, V>(mut self, v: T) -> Self
     where
@@ -6157,6 +6146,17 @@ impl IOSKeySettings {
     {
         use std::iter::Iterator;
         self.allowed_bundle_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [apple_developer_id][crate::model::IOSKeySettings::apple_developer_id].
+    pub fn set_apple_developer_id<
+        T: std::convert::Into<std::option::Option<crate::model::AppleDeveloperId>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.apple_developer_id = v.into();
         self
     }
 }
@@ -6512,84 +6512,6 @@ impl FirewallAction {
         })
     }
 
-    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// if it holds a `Block`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn block(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::BlockAction>> {
-        #[allow(unreachable_patterns)]
-        self.firewall_action_oneof.as_ref().and_then(|v| match v {
-            crate::model::firewall_action::FirewallActionOneof::Block(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// if it holds a `IncludeRecaptchaScript`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn include_recaptcha_script(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::firewall_action::IncludeRecaptchaScriptAction>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.firewall_action_oneof.as_ref().and_then(|v| match v {
-            crate::model::firewall_action::FirewallActionOneof::IncludeRecaptchaScript(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// if it holds a `Redirect`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redirect(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::RedirectAction>> {
-        #[allow(unreachable_patterns)]
-        self.firewall_action_oneof.as_ref().and_then(|v| match v {
-            crate::model::firewall_action::FirewallActionOneof::Redirect(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// if it holds a `Substitute`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn substitute(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::SubstituteAction>>
-    {
-        #[allow(unreachable_patterns)]
-        self.firewall_action_oneof.as_ref().and_then(|v| match v {
-            crate::model::firewall_action::FirewallActionOneof::Substitute(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// if it holds a `SetHeader`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn set_header(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::SetHeaderAction>> {
-        #[allow(unreachable_patterns)]
-        self.firewall_action_oneof.as_ref().and_then(|v| match v {
-            crate::model::firewall_action::FirewallActionOneof::SetHeader(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// to hold a `Allow`.
     ///
@@ -6607,6 +6529,21 @@ impl FirewallAction {
         self
     }
 
+    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
+    /// if it holds a `Block`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn block(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::BlockAction>> {
+        #[allow(unreachable_patterns)]
+        self.firewall_action_oneof.as_ref().and_then(|v| match v {
+            crate::model::firewall_action::FirewallActionOneof::Block(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// to hold a `Block`.
     ///
@@ -6622,6 +6559,23 @@ impl FirewallAction {
             crate::model::firewall_action::FirewallActionOneof::Block(v.into()),
         );
         self
+    }
+
+    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
+    /// if it holds a `IncludeRecaptchaScript`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn include_recaptcha_script(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::firewall_action::IncludeRecaptchaScriptAction>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.firewall_action_oneof.as_ref().and_then(|v| match v {
+            crate::model::firewall_action::FirewallActionOneof::IncludeRecaptchaScript(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
@@ -6643,6 +6597,21 @@ impl FirewallAction {
         self
     }
 
+    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
+    /// if it holds a `Redirect`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redirect(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::RedirectAction>> {
+        #[allow(unreachable_patterns)]
+        self.firewall_action_oneof.as_ref().and_then(|v| match v {
+            crate::model::firewall_action::FirewallActionOneof::Redirect(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// to hold a `Redirect`.
     ///
@@ -6660,6 +6629,22 @@ impl FirewallAction {
         self
     }
 
+    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
+    /// if it holds a `Substitute`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn substitute(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::SubstituteAction>>
+    {
+        #[allow(unreachable_patterns)]
+        self.firewall_action_oneof.as_ref().and_then(|v| match v {
+            crate::model::firewall_action::FirewallActionOneof::Substitute(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// to hold a `Substitute`.
     ///
@@ -6675,6 +6660,21 @@ impl FirewallAction {
             crate::model::firewall_action::FirewallActionOneof::Substitute(v.into()),
         );
         self
+    }
+
+    /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
+    /// if it holds a `SetHeader`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn set_header(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::firewall_action::SetHeaderAction>> {
+        #[allow(unreachable_patterns)]
+        self.firewall_action_oneof.as_ref().and_then(|v| match v {
+            crate::model::firewall_action::FirewallActionOneof::SetHeader(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
@@ -7087,12 +7087,6 @@ impl ListRelatedAccountGroupMembershipsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRelatedAccountGroupMembershipsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [related_account_group_memberships][crate::model::ListRelatedAccountGroupMembershipsResponse::related_account_group_memberships].
     pub fn set_related_account_group_memberships<T, V>(mut self, v: T) -> Self
     where
@@ -7101,6 +7095,12 @@ impl ListRelatedAccountGroupMembershipsResponse {
     {
         use std::iter::Iterator;
         self.related_account_group_memberships = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRelatedAccountGroupMembershipsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7209,12 +7209,6 @@ impl ListRelatedAccountGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRelatedAccountGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [related_account_groups][crate::model::ListRelatedAccountGroupsResponse::related_account_groups].
     pub fn set_related_account_groups<T, V>(mut self, v: T) -> Self
     where
@@ -7223,6 +7217,12 @@ impl ListRelatedAccountGroupsResponse {
     {
         use std::iter::Iterator;
         self.related_account_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRelatedAccountGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7364,12 +7364,6 @@ impl SearchRelatedAccountGroupMembershipsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchRelatedAccountGroupMembershipsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [related_account_group_memberships][crate::model::SearchRelatedAccountGroupMembershipsResponse::related_account_group_memberships].
     pub fn set_related_account_group_memberships<T, V>(mut self, v: T) -> Self
     where
@@ -7378,6 +7372,12 @@ impl SearchRelatedAccountGroupMembershipsResponse {
     {
         use std::iter::Iterator;
         self.related_account_group_memberships = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchRelatedAccountGroupMembershipsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7623,12 +7623,6 @@ impl ListIpOverridesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIpOverridesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [ip_overrides][crate::model::ListIpOverridesResponse::ip_overrides].
     pub fn set_ip_overrides<T, V>(mut self, v: T) -> Self
     where
@@ -7637,6 +7631,12 @@ impl ListIpOverridesResponse {
     {
         use std::iter::Iterator;
         self.ip_overrides = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIpOverridesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/recommender/logging/v1/src/model.rs
+++ b/src/generated/cloud/recommender/logging/v1/src/model.rs
@@ -73,15 +73,6 @@ impl ActionLog {
         self
     }
 
-    /// Sets the value of [recommendation_name][crate::model::ActionLog::recommendation_name].
-    pub fn set_recommendation_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recommendation_name = v.into();
-        self
-    }
-
     /// Sets the value of [state_metadata][crate::model::ActionLog::state_metadata].
     pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -91,6 +82,15 @@ impl ActionLog {
     {
         use std::iter::Iterator;
         self.state_metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [recommendation_name][crate::model::ActionLog::recommendation_name].
+    pub fn set_recommendation_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.recommendation_name = v.into();
         self
     }
 }
@@ -147,12 +147,6 @@ impl InsightActionLog {
         self
     }
 
-    /// Sets the value of [insight][crate::model::InsightActionLog::insight].
-    pub fn set_insight<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.insight = v.into();
-        self
-    }
-
     /// Sets the value of [state_metadata][crate::model::InsightActionLog::state_metadata].
     pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -162,6 +156,12 @@ impl InsightActionLog {
     {
         use std::iter::Iterator;
         self.state_metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [insight][crate::model::InsightActionLog::insight].
+    pub fn set_insight<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.insight = v.into();
         self
     }
 }

--- a/src/generated/cloud/recommender/v1/src/builder.rs
+++ b/src/generated/cloud/recommender/v1/src/builder.rs
@@ -237,14 +237,6 @@ pub mod recommender {
             self
         }
 
-        /// Sets the value of [etag][crate::model::MarkInsightAcceptedRequest::etag].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.etag = v.into();
-            self
-        }
-
         /// Sets the value of [state_metadata][crate::model::MarkInsightAcceptedRequest::state_metadata].
         pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
         where
@@ -254,6 +246,14 @@ pub mod recommender {
         {
             self.0.request.state_metadata =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [etag][crate::model::MarkInsightAcceptedRequest::etag].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.etag = v.into();
             self
         }
     }
@@ -500,14 +500,6 @@ pub mod recommender {
             self
         }
 
-        /// Sets the value of [etag][crate::model::MarkRecommendationClaimedRequest::etag].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.etag = v.into();
-            self
-        }
-
         /// Sets the value of [state_metadata][crate::model::MarkRecommendationClaimedRequest::state_metadata].
         pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
         where
@@ -517,6 +509,14 @@ pub mod recommender {
         {
             self.0.request.state_metadata =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [etag][crate::model::MarkRecommendationClaimedRequest::etag].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.etag = v.into();
             self
         }
     }
@@ -572,14 +572,6 @@ pub mod recommender {
             self
         }
 
-        /// Sets the value of [etag][crate::model::MarkRecommendationSucceededRequest::etag].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.etag = v.into();
-            self
-        }
-
         /// Sets the value of [state_metadata][crate::model::MarkRecommendationSucceededRequest::state_metadata].
         pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
         where
@@ -589,6 +581,14 @@ pub mod recommender {
         {
             self.0.request.state_metadata =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [etag][crate::model::MarkRecommendationSucceededRequest::etag].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.etag = v.into();
             self
         }
     }
@@ -644,14 +644,6 @@ pub mod recommender {
             self
         }
 
-        /// Sets the value of [etag][crate::model::MarkRecommendationFailedRequest::etag].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.etag = v.into();
-            self
-        }
-
         /// Sets the value of [state_metadata][crate::model::MarkRecommendationFailedRequest::state_metadata].
         pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
         where
@@ -661,6 +653,14 @@ pub mod recommender {
         {
             self.0.request.state_metadata =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [etag][crate::model::MarkRecommendationFailedRequest::etag].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.etag = v.into();
             self
         }
     }

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -110,6 +110,17 @@ impl Insight {
         self
     }
 
+    /// Sets the value of [target_resources][crate::model::Insight::target_resources].
+    pub fn set_target_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.target_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [insight_subtype][crate::model::Insight::insight_subtype].
     pub fn set_insight_subtype<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.insight_subtype = v.into();
@@ -175,17 +186,6 @@ impl Insight {
     /// Sets the value of [etag][crate::model::Insight::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [target_resources][crate::model::Insight::target_resources].
-    pub fn set_target_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.target_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -852,12 +852,6 @@ impl InsightTypeConfig {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::InsightTypeConfig::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::InsightTypeConfig::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -867,6 +861,12 @@ impl InsightTypeConfig {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::InsightTypeConfig::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 }
@@ -1034,6 +1034,17 @@ impl Recommendation {
         self
     }
 
+    /// Sets the value of [additional_impact][crate::model::Recommendation::additional_impact].
+    pub fn set_additional_impact<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Impact>,
+    {
+        use std::iter::Iterator;
+        self.additional_impact = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [priority][crate::model::Recommendation::priority].
     pub fn set_priority<T: std::convert::Into<crate::model::recommendation::Priority>>(
         mut self,
@@ -1071,23 +1082,6 @@ impl Recommendation {
         self
     }
 
-    /// Sets the value of [xor_group_id][crate::model::Recommendation::xor_group_id].
-    pub fn set_xor_group_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.xor_group_id = v.into();
-        self
-    }
-
-    /// Sets the value of [additional_impact][crate::model::Recommendation::additional_impact].
-    pub fn set_additional_impact<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Impact>,
-    {
-        use std::iter::Iterator;
-        self.additional_impact = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [associated_insights][crate::model::Recommendation::associated_insights].
     pub fn set_associated_insights<T, V>(mut self, v: T) -> Self
     where
@@ -1096,6 +1090,12 @@ impl Recommendation {
     {
         use std::iter::Iterator;
         self.associated_insights = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [xor_group_id][crate::model::Recommendation::xor_group_id].
+    pub fn set_xor_group_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.xor_group_id = v.into();
         self
     }
 }
@@ -1316,15 +1316,6 @@ impl RecommendationContent {
         std::default::Default::default()
     }
 
-    /// Sets the value of [overview][crate::model::RecommendationContent::overview].
-    pub fn set_overview<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.overview = v.into();
-        self
-    }
-
     /// Sets the value of [operation_groups][crate::model::RecommendationContent::operation_groups].
     pub fn set_operation_groups<T, V>(mut self, v: T) -> Self
     where
@@ -1333,6 +1324,15 @@ impl RecommendationContent {
     {
         use std::iter::Iterator;
         self.operation_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [overview][crate::model::RecommendationContent::overview].
+    pub fn set_overview<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.overview = v.into();
         self
     }
 }
@@ -1576,6 +1576,17 @@ impl Operation {
         })
     }
 
+    /// Sets the value of [path_value][crate::model::Operation::path_value]
+    /// to hold a `Value`.
+    ///
+    /// Note that all the setters affecting `path_value` are
+    /// mutually exclusive.
+    pub fn set_value<T: std::convert::Into<std::boxed::Box<wkt::Value>>>(mut self, v: T) -> Self {
+        self.path_value =
+            std::option::Option::Some(crate::model::operation::PathValue::Value(v.into()));
+        self
+    }
+
     /// The value of [path_value][crate::model::Operation::path_value]
     /// if it holds a `ValueMatcher`, `None` if the field is not set or
     /// holds a different branch.
@@ -1587,17 +1598,6 @@ impl Operation {
             crate::model::operation::PathValue::ValueMatcher(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [path_value][crate::model::Operation::path_value]
-    /// to hold a `Value`.
-    ///
-    /// Note that all the setters affecting `path_value` are
-    /// mutually exclusive.
-    pub fn set_value<T: std::convert::Into<std::boxed::Box<wkt::Value>>>(mut self, v: T) -> Self {
-        self.path_value =
-            std::option::Option::Some(crate::model::operation::PathValue::Value(v.into()));
-        self
     }
 
     /// Sets the value of [path_value][crate::model::Operation::path_value]
@@ -1896,15 +1896,6 @@ impl ReliabilityProjection {
         std::default::Default::default()
     }
 
-    /// Sets the value of [details][crate::model::ReliabilityProjection::details].
-    pub fn set_details<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = v.into();
-        self
-    }
-
     /// Sets the value of [risks][crate::model::ReliabilityProjection::risks].
     pub fn set_risks<T, V>(mut self, v: T) -> Self
     where
@@ -1913,6 +1904,15 @@ impl ReliabilityProjection {
     {
         use std::iter::Iterator;
         self.risks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [details][crate::model::ReliabilityProjection::details].
+    pub fn set_details<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.details = v.into();
         self
     }
 }
@@ -2127,49 +2127,6 @@ impl Impact {
         })
     }
 
-    /// The value of [projection][crate::model::Impact::projection]
-    /// if it holds a `SecurityProjection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn security_projection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SecurityProjection>> {
-        #[allow(unreachable_patterns)]
-        self.projection.as_ref().and_then(|v| match v {
-            crate::model::impact::Projection::SecurityProjection(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [projection][crate::model::Impact::projection]
-    /// if it holds a `SustainabilityProjection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sustainability_projection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SustainabilityProjection>> {
-        #[allow(unreachable_patterns)]
-        self.projection.as_ref().and_then(|v| match v {
-            crate::model::impact::Projection::SustainabilityProjection(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [projection][crate::model::Impact::projection]
-    /// if it holds a `ReliabilityProjection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn reliability_projection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ReliabilityProjection>> {
-        #[allow(unreachable_patterns)]
-        self.projection.as_ref().and_then(|v| match v {
-            crate::model::impact::Projection::ReliabilityProjection(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [projection][crate::model::Impact::projection]
     /// to hold a `CostProjection`.
     ///
@@ -2184,6 +2141,19 @@ impl Impact {
         self.projection =
             std::option::Option::Some(crate::model::impact::Projection::CostProjection(v.into()));
         self
+    }
+
+    /// The value of [projection][crate::model::Impact::projection]
+    /// if it holds a `SecurityProjection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn security_projection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SecurityProjection>> {
+        #[allow(unreachable_patterns)]
+        self.projection.as_ref().and_then(|v| match v {
+            crate::model::impact::Projection::SecurityProjection(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [projection][crate::model::Impact::projection]
@@ -2203,6 +2173,21 @@ impl Impact {
         self
     }
 
+    /// The value of [projection][crate::model::Impact::projection]
+    /// if it holds a `SustainabilityProjection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sustainability_projection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SustainabilityProjection>> {
+        #[allow(unreachable_patterns)]
+        self.projection.as_ref().and_then(|v| match v {
+            crate::model::impact::Projection::SustainabilityProjection(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [projection][crate::model::Impact::projection]
     /// to hold a `SustainabilityProjection`.
     ///
@@ -2218,6 +2203,21 @@ impl Impact {
             crate::model::impact::Projection::SustainabilityProjection(v.into()),
         );
         self
+    }
+
+    /// The value of [projection][crate::model::Impact::projection]
+    /// if it holds a `ReliabilityProjection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn reliability_projection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ReliabilityProjection>> {
+        #[allow(unreachable_patterns)]
+        self.projection.as_ref().and_then(|v| match v {
+            crate::model::impact::Projection::ReliabilityProjection(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [projection][crate::model::Impact::projection]
@@ -2745,12 +2745,6 @@ impl RecommenderConfig {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::RecommenderConfig::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::RecommenderConfig::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -2760,6 +2754,12 @@ impl RecommenderConfig {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::RecommenderConfig::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 }
@@ -2945,12 +2945,6 @@ impl ListInsightsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInsightsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [insights][crate::model::ListInsightsResponse::insights].
     pub fn set_insights<T, V>(mut self, v: T) -> Self
     where
@@ -2959,6 +2953,12 @@ impl ListInsightsResponse {
     {
         use std::iter::Iterator;
         self.insights = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInsightsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3049,12 +3049,6 @@ impl MarkInsightAcceptedRequest {
         self
     }
 
-    /// Sets the value of [etag][crate::model::MarkInsightAcceptedRequest::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [state_metadata][crate::model::MarkInsightAcceptedRequest::state_metadata].
     pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -3064,6 +3058,12 @@ impl MarkInsightAcceptedRequest {
     {
         use std::iter::Iterator;
         self.state_metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::MarkInsightAcceptedRequest::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -3211,12 +3211,6 @@ impl ListRecommendationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRecommendationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [recommendations][crate::model::ListRecommendationsResponse::recommendations].
     pub fn set_recommendations<T, V>(mut self, v: T) -> Self
     where
@@ -3225,6 +3219,12 @@ impl ListRecommendationsResponse {
     {
         use std::iter::Iterator;
         self.recommendations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRecommendationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3359,12 +3359,6 @@ impl MarkRecommendationClaimedRequest {
         self
     }
 
-    /// Sets the value of [etag][crate::model::MarkRecommendationClaimedRequest::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [state_metadata][crate::model::MarkRecommendationClaimedRequest::state_metadata].
     pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -3374,6 +3368,12 @@ impl MarkRecommendationClaimedRequest {
     {
         use std::iter::Iterator;
         self.state_metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::MarkRecommendationClaimedRequest::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -3420,12 +3420,6 @@ impl MarkRecommendationSucceededRequest {
         self
     }
 
-    /// Sets the value of [etag][crate::model::MarkRecommendationSucceededRequest::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [state_metadata][crate::model::MarkRecommendationSucceededRequest::state_metadata].
     pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -3435,6 +3429,12 @@ impl MarkRecommendationSucceededRequest {
     {
         use std::iter::Iterator;
         self.state_metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::MarkRecommendationSucceededRequest::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -3481,12 +3481,6 @@ impl MarkRecommendationFailedRequest {
         self
     }
 
-    /// Sets the value of [etag][crate::model::MarkRecommendationFailedRequest::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [state_metadata][crate::model::MarkRecommendationFailedRequest::state_metadata].
     pub fn set_state_metadata<T, K, V>(mut self, v: T) -> Self
     where
@@ -3496,6 +3490,12 @@ impl MarkRecommendationFailedRequest {
     {
         use std::iter::Iterator;
         self.state_metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::MarkRecommendationFailedRequest::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -209,12 +209,6 @@ impl ListClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
     pub fn set_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -223,6 +217,12 @@ impl ListClustersResponse {
     {
         use std::iter::Iterator;
         self.clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -538,12 +538,6 @@ impl ListBackupCollectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupCollectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_collections][crate::model::ListBackupCollectionsResponse::backup_collections].
     pub fn set_backup_collections<T, V>(mut self, v: T) -> Self
     where
@@ -552,6 +546,12 @@ impl ListBackupCollectionsResponse {
     {
         use std::iter::Iterator;
         self.backup_collections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupCollectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -711,12 +711,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -725,6 +719,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1204,6 +1204,39 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [psc_configs][crate::model::Cluster::psc_configs].
+    pub fn set_psc_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PscConfig>,
+    {
+        use std::iter::Iterator;
+        self.psc_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [discovery_endpoints][crate::model::Cluster::discovery_endpoints].
+    pub fn set_discovery_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DiscoveryEndpoint>,
+    {
+        use std::iter::Iterator;
+        self.discovery_endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [psc_connections][crate::model::Cluster::psc_connections].
+    pub fn set_psc_connections<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PscConnection>,
+    {
+        use std::iter::Iterator;
+        self.psc_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state_info][crate::model::Cluster::state_info].
     pub fn set_state_info<
         T: std::convert::Into<std::option::Option<crate::model::cluster::StateInfo>>,
@@ -1229,6 +1262,18 @@ impl Cluster {
         v: T,
     ) -> Self {
         self.persistence_config = v.into();
+        self
+    }
+
+    /// Sets the value of [redis_configs][crate::model::Cluster::redis_configs].
+    pub fn set_redis_configs<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.redis_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1294,6 +1339,28 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [psc_service_attachments][crate::model::Cluster::psc_service_attachments].
+    pub fn set_psc_service_attachments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PscServiceAttachment>,
+    {
+        use std::iter::Iterator;
+        self.psc_service_attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [cluster_endpoints][crate::model::Cluster::cluster_endpoints].
+    pub fn set_cluster_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ClusterEndpoint>,
+    {
+        use std::iter::Iterator;
+        self.cluster_endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [backup_collection][crate::model::Cluster::backup_collection].
     pub fn set_backup_collection<
         T: std::convert::Into<std::option::Option<std::string::String>>,
@@ -1336,73 +1403,6 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of [psc_configs][crate::model::Cluster::psc_configs].
-    pub fn set_psc_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PscConfig>,
-    {
-        use std::iter::Iterator;
-        self.psc_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [discovery_endpoints][crate::model::Cluster::discovery_endpoints].
-    pub fn set_discovery_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DiscoveryEndpoint>,
-    {
-        use std::iter::Iterator;
-        self.discovery_endpoints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [psc_connections][crate::model::Cluster::psc_connections].
-    pub fn set_psc_connections<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PscConnection>,
-    {
-        use std::iter::Iterator;
-        self.psc_connections = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [psc_service_attachments][crate::model::Cluster::psc_service_attachments].
-    pub fn set_psc_service_attachments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PscServiceAttachment>,
-    {
-        use std::iter::Iterator;
-        self.psc_service_attachments = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [cluster_endpoints][crate::model::Cluster::cluster_endpoints].
-    pub fn set_cluster_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ClusterEndpoint>,
-    {
-        use std::iter::Iterator;
-        self.cluster_endpoints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [redis_configs][crate::model::Cluster::redis_configs].
-    pub fn set_redis_configs<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.redis_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [import_sources][crate::model::Cluster::import_sources].
     ///
     /// Note that all the setters affecting `import_sources` are mutually
@@ -1430,21 +1430,6 @@ impl Cluster {
         })
     }
 
-    /// The value of [import_sources][crate::model::Cluster::import_sources]
-    /// if it holds a `ManagedBackupSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn managed_backup_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::cluster::ManagedBackupSource>> {
-        #[allow(unreachable_patterns)]
-        self.import_sources.as_ref().and_then(|v| match v {
-            crate::model::cluster::ImportSources::ManagedBackupSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [import_sources][crate::model::Cluster::import_sources]
     /// to hold a `GcsSource`.
     ///
@@ -1459,6 +1444,21 @@ impl Cluster {
         self.import_sources =
             std::option::Option::Some(crate::model::cluster::ImportSources::GcsSource(v.into()));
         self
+    }
+
+    /// The value of [import_sources][crate::model::Cluster::import_sources]
+    /// if it holds a `ManagedBackupSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn managed_backup_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::cluster::ManagedBackupSource>> {
+        #[allow(unreachable_patterns)]
+        self.import_sources.as_ref().and_then(|v| match v {
+            crate::model::cluster::ImportSources::ManagedBackupSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [import_sources][crate::model::Cluster::import_sources]
@@ -2354,6 +2354,17 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [backup_files][crate::model::Backup::backup_files].
+    pub fn set_backup_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BackupFile>,
+    {
+        use std::iter::Iterator;
+        self.backup_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [node_type][crate::model::Backup::node_type].
     pub fn set_node_type<T: std::convert::Into<crate::model::NodeType>>(mut self, v: T) -> Self {
         self.node_type = v.into();
@@ -2401,17 +2412,6 @@ impl Backup {
     /// Sets the value of [uid][crate::model::Backup::uid].
     pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uid = v.into();
-        self
-    }
-
-    /// Sets the value of [backup_files][crate::model::Backup::backup_files].
-    pub fn set_backup_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BackupFile>,
-    {
-        use std::iter::Iterator;
-        self.backup_files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2886,6 +2886,17 @@ impl CrossClusterReplicationConfig {
         self
     }
 
+    /// Sets the value of [secondary_clusters][crate::model::CrossClusterReplicationConfig::secondary_clusters].
+    pub fn set_secondary_clusters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::cross_cluster_replication_config::RemoteCluster>,
+    {
+        use std::iter::Iterator;
+        self.secondary_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [update_time][crate::model::CrossClusterReplicationConfig::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2905,17 +2916,6 @@ impl CrossClusterReplicationConfig {
         v: T,
     ) -> Self {
         self.membership = v.into();
-        self
-    }
-
-    /// Sets the value of [secondary_clusters][crate::model::CrossClusterReplicationConfig::secondary_clusters].
-    pub fn set_secondary_clusters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::cross_cluster_replication_config::RemoteCluster>,
-    {
-        use std::iter::Iterator;
-        self.secondary_clusters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3645,21 +3645,6 @@ impl ConnectionDetail {
         })
     }
 
-    /// The value of [connection][crate::model::ConnectionDetail::connection]
-    /// if it holds a `PscConnection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn psc_connection(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PscConnection>> {
-        #[allow(unreachable_patterns)]
-        self.connection.as_ref().and_then(|v| match v {
-            crate::model::connection_detail::Connection::PscConnection(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connection][crate::model::ConnectionDetail::connection]
     /// to hold a `PscAutoConnection`.
     ///
@@ -3675,6 +3660,21 @@ impl ConnectionDetail {
             crate::model::connection_detail::Connection::PscAutoConnection(v.into()),
         );
         self
+    }
+
+    /// The value of [connection][crate::model::ConnectionDetail::connection]
+    /// if it holds a `PscConnection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn psc_connection(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PscConnection>> {
+        #[allow(unreachable_patterns)]
+        self.connection.as_ref().and_then(|v| match v {
+            crate::model::connection_detail::Connection::PscConnection(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection][crate::model::ConnectionDetail::connection]
@@ -5182,6 +5182,17 @@ impl EncryptionInfo {
         self
     }
 
+    /// Sets the value of [kms_key_versions][crate::model::EncryptionInfo::kms_key_versions].
+    pub fn set_kms_key_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.kms_key_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [kms_key_primary_state][crate::model::EncryptionInfo::kms_key_primary_state].
     pub fn set_kms_key_primary_state<
         T: std::convert::Into<crate::model::encryption_info::KmsKeyState>,
@@ -5199,17 +5210,6 @@ impl EncryptionInfo {
         v: T,
     ) -> Self {
         self.last_update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [kms_key_versions][crate::model::EncryptionInfo::kms_key_versions].
-    pub fn set_kms_key_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.kms_key_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -325,6 +325,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [location_id][crate::model::Instance::location_id].
     pub fn set_location_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location_id = v.into();
@@ -406,6 +418,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [redis_configs][crate::model::Instance::redis_configs].
+    pub fn set_redis_configs<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.redis_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [tier][crate::model::Instance::tier].
     pub fn set_tier<T: std::convert::Into<crate::model::instance::Tier>>(mut self, v: T) -> Self {
         self.tier = v.into();
@@ -451,6 +475,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [server_ca_certs][crate::model::Instance::server_ca_certs].
+    pub fn set_server_ca_certs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TlsCertificate>,
+    {
+        use std::iter::Iterator;
+        self.server_ca_certs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [transit_encryption_mode][crate::model::Instance::transit_encryption_mode].
     pub fn set_transit_encryption_mode<
         T: std::convert::Into<crate::model::instance::TransitEncryptionMode>,
@@ -487,6 +522,17 @@ impl Instance {
     /// Sets the value of [replica_count][crate::model::Instance::replica_count].
     pub fn set_replica_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.replica_count = v.into();
+        self
+    }
+
+    /// Sets the value of [nodes][crate::model::Instance::nodes].
+    pub fn set_nodes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NodeInfo>,
+    {
+        use std::iter::Iterator;
+        self.nodes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -533,37 +579,6 @@ impl Instance {
         self
     }
 
-    /// Sets the value of [maintenance_version][crate::model::Instance::maintenance_version].
-    pub fn set_maintenance_version<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.maintenance_version = v.into();
-        self
-    }
-
-    /// Sets the value of [server_ca_certs][crate::model::Instance::server_ca_certs].
-    pub fn set_server_ca_certs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TlsCertificate>,
-    {
-        use std::iter::Iterator;
-        self.server_ca_certs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [nodes][crate::model::Instance::nodes].
-    pub fn set_nodes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NodeInfo>,
-    {
-        use std::iter::Iterator;
-        self.nodes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [suspension_reasons][crate::model::Instance::suspension_reasons].
     pub fn set_suspension_reasons<T, V>(mut self, v: T) -> Self
     where
@@ -575,6 +590,15 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [maintenance_version][crate::model::Instance::maintenance_version].
+    pub fn set_maintenance_version<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.maintenance_version = v.into();
+        self
+    }
+
     /// Sets the value of [available_maintenance_versions][crate::model::Instance::available_maintenance_versions].
     pub fn set_available_maintenance_versions<T, V>(mut self, v: T) -> Self
     where
@@ -583,30 +607,6 @@ impl Instance {
     {
         use std::iter::Iterator;
         self.available_maintenance_versions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [redis_configs][crate::model::Instance::redis_configs].
-    pub fn set_redis_configs<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.redis_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2369,12 +2369,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -2383,6 +2377,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -436,12 +436,6 @@ impl ListFoldersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFoldersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [folders][crate::model::ListFoldersResponse::folders].
     pub fn set_folders<T, V>(mut self, v: T) -> Self
     where
@@ -450,6 +444,12 @@ impl ListFoldersResponse {
     {
         use std::iter::Iterator;
         self.folders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFoldersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -584,12 +584,6 @@ impl SearchFoldersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchFoldersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [folders][crate::model::SearchFoldersResponse::folders].
     pub fn set_folders<T, V>(mut self, v: T) -> Self
     where
@@ -598,6 +592,12 @@ impl SearchFoldersResponse {
     {
         use std::iter::Iterator;
         self.folders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchFoldersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1447,12 +1447,6 @@ impl SearchOrganizationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchOrganizationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [organizations][crate::model::SearchOrganizationsResponse::organizations].
     pub fn set_organizations<T, V>(mut self, v: T) -> Self
     where
@@ -1461,6 +1455,12 @@ impl SearchOrganizationsResponse {
     {
         use std::iter::Iterator;
         self.organizations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchOrganizationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2000,12 +2000,6 @@ impl ListProjectsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProjectsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [projects][crate::model::ListProjectsResponse::projects].
     pub fn set_projects<T, V>(mut self, v: T) -> Self
     where
@@ -2014,6 +2008,12 @@ impl ListProjectsResponse {
     {
         use std::iter::Iterator;
         self.projects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProjectsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2171,12 +2171,6 @@ impl SearchProjectsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchProjectsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [projects][crate::model::SearchProjectsResponse::projects].
     pub fn set_projects<T, V>(mut self, v: T) -> Self
     where
@@ -2185,6 +2179,12 @@ impl SearchProjectsResponse {
     {
         use std::iter::Iterator;
         self.projects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchProjectsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2875,12 +2875,6 @@ impl ListTagBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTagBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tag_bindings][crate::model::ListTagBindingsResponse::tag_bindings].
     pub fn set_tag_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -2889,6 +2883,12 @@ impl ListTagBindingsResponse {
     {
         use std::iter::Iterator;
         self.tag_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTagBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3003,12 +3003,6 @@ impl ListEffectiveTagsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEffectiveTagsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [effective_tags][crate::model::ListEffectiveTagsResponse::effective_tags].
     pub fn set_effective_tags<T, V>(mut self, v: T) -> Self
     where
@@ -3017,6 +3011,12 @@ impl ListEffectiveTagsResponse {
     {
         use std::iter::Iterator;
         self.effective_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEffectiveTagsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3494,12 +3494,6 @@ impl ListTagHoldsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTagHoldsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tag_holds][crate::model::ListTagHoldsResponse::tag_holds].
     pub fn set_tag_holds<T, V>(mut self, v: T) -> Self
     where
@@ -3508,6 +3502,12 @@ impl ListTagHoldsResponse {
     {
         use std::iter::Iterator;
         self.tag_holds = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTagHoldsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3771,12 +3771,6 @@ impl ListTagKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTagKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tag_keys][crate::model::ListTagKeysResponse::tag_keys].
     pub fn set_tag_keys<T, V>(mut self, v: T) -> Self
     where
@@ -3785,6 +3779,12 @@ impl ListTagKeysResponse {
     {
         use std::iter::Iterator;
         self.tag_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTagKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4316,12 +4316,6 @@ impl ListTagValuesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTagValuesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tag_values][crate::model::ListTagValuesResponse::tag_values].
     pub fn set_tag_values<T, V>(mut self, v: T) -> Self
     where
@@ -4330,6 +4324,12 @@ impl ListTagValuesResponse {
     {
         use std::iter::Iterator;
         self.tag_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTagValuesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -1267,6 +1267,17 @@ pub mod completion_service {
             self
         }
 
+        /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
+        pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.language_codes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [device_type][crate::model::CompleteQueryRequest::device_type].
         pub fn set_device_type<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.device_type = v.into();
@@ -1294,17 +1305,6 @@ pub mod completion_service {
         /// Sets the value of [entity][crate::model::CompleteQueryRequest::entity].
         pub fn set_entity<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.entity = v.into();
-            self
-        }
-
-        /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
-        pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.language_codes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4315,18 +4315,6 @@ pub mod product_service {
             self
         }
 
-        /// Sets the value of [add_time][crate::model::AddFulfillmentPlacesRequest::add_time].
-        pub fn set_add_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
-            self.0.request.add_time = v.into();
-            self
-        }
-
-        /// Sets the value of [allow_missing][crate::model::AddFulfillmentPlacesRequest::allow_missing].
-        pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.allow_missing = v.into();
-            self
-        }
-
         /// Sets the value of [place_ids][crate::model::AddFulfillmentPlacesRequest::place_ids].
         ///
         /// This is a **required** field for requests.
@@ -4337,6 +4325,18 @@ pub mod product_service {
         {
             use std::iter::Iterator;
             self.0.request.place_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [add_time][crate::model::AddFulfillmentPlacesRequest::add_time].
+        pub fn set_add_time<T: Into<std::option::Option<wkt::Timestamp>>>(mut self, v: T) -> Self {
+            self.0.request.add_time = v.into();
+            self
+        }
+
+        /// Sets the value of [allow_missing][crate::model::AddFulfillmentPlacesRequest::allow_missing].
+        pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.allow_missing = v.into();
             self
         }
     }
@@ -4443,6 +4443,19 @@ pub mod product_service {
             self
         }
 
+        /// Sets the value of [place_ids][crate::model::RemoveFulfillmentPlacesRequest::place_ids].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_place_ids<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.place_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [remove_time][crate::model::RemoveFulfillmentPlacesRequest::remove_time].
         pub fn set_remove_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
@@ -4455,19 +4468,6 @@ pub mod product_service {
         /// Sets the value of [allow_missing][crate::model::RemoveFulfillmentPlacesRequest::allow_missing].
         pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.allow_missing = v.into();
-            self
-        }
-
-        /// Sets the value of [place_ids][crate::model::RemoveFulfillmentPlacesRequest::place_ids].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_place_ids<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.place_ids = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4564,6 +4564,19 @@ pub mod product_service {
             self
         }
 
+        /// Sets the value of [local_inventories][crate::model::AddLocalInventoriesRequest::local_inventories].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_local_inventories<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::LocalInventory>,
+        {
+            use std::iter::Iterator;
+            self.0.request.local_inventories = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [add_mask][crate::model::AddLocalInventoriesRequest::add_mask].
         pub fn set_add_mask<T: Into<std::option::Option<wkt::FieldMask>>>(mut self, v: T) -> Self {
             self.0.request.add_mask = v.into();
@@ -4579,19 +4592,6 @@ pub mod product_service {
         /// Sets the value of [allow_missing][crate::model::AddLocalInventoriesRequest::allow_missing].
         pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.allow_missing = v.into();
-            self
-        }
-
-        /// Sets the value of [local_inventories][crate::model::AddLocalInventoriesRequest::local_inventories].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_local_inventories<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::LocalInventory>,
-        {
-            use std::iter::Iterator;
-            self.0.request.local_inventories = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4688,6 +4688,19 @@ pub mod product_service {
             self
         }
 
+        /// Sets the value of [place_ids][crate::model::RemoveLocalInventoriesRequest::place_ids].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_place_ids<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.place_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [remove_time][crate::model::RemoveLocalInventoriesRequest::remove_time].
         pub fn set_remove_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
@@ -4700,19 +4713,6 @@ pub mod product_service {
         /// Sets the value of [allow_missing][crate::model::RemoveLocalInventoriesRequest::allow_missing].
         pub fn set_allow_missing<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.allow_missing = v.into();
-            self
-        }
-
-        /// Sets the value of [place_ids][crate::model::RemoveLocalInventoriesRequest::place_ids].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_place_ids<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.place_ids = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5027,6 +5027,17 @@ pub mod search_service {
             self
         }
 
+        /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
+        pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::search_request::FacetSpec>,
+        {
+            use std::iter::Iterator;
+            self.0.request.facet_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [dynamic_facet_spec][crate::model::SearchRequest::dynamic_facet_spec].
         #[deprecated]
         pub fn set_dynamic_facet_spec<
@@ -5061,6 +5072,28 @@ pub mod search_service {
             self
         }
 
+        /// Sets the value of [variant_rollup_keys][crate::model::SearchRequest::variant_rollup_keys].
+        pub fn set_variant_rollup_keys<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.variant_rollup_keys = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [page_categories][crate::model::SearchRequest::page_categories].
+        pub fn set_page_categories<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.page_categories = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [search_mode][crate::model::SearchRequest::search_mode].
         pub fn set_search_mode<T: Into<crate::model::search_request::SearchMode>>(
             mut self,
@@ -5078,6 +5111,17 @@ pub mod search_service {
             v: T,
         ) -> Self {
             self.0.request.personalization_spec = v.into();
+            self
+        }
+
+        /// Sets the value of [labels][crate::model::SearchRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -5117,50 +5161,6 @@ pub mod search_service {
             v: T,
         ) -> Self {
             self.0.request.tile_navigation_spec = v.into();
-            self
-        }
-
-        /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
-        pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::search_request::FacetSpec>,
-        {
-            use std::iter::Iterator;
-            self.0.request.facet_specs = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [variant_rollup_keys][crate::model::SearchRequest::variant_rollup_keys].
-        pub fn set_variant_rollup_keys<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.variant_rollup_keys = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [page_categories][crate::model::SearchRequest::page_categories].
-        pub fn set_page_categories<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.page_categories = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [labels][crate::model::SearchRequest::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -437,34 +437,6 @@ pub mod catalog_attribute {
             std::default::Default::default()
         }
 
-        /// Sets the value of [merged_facet][crate::model::catalog_attribute::FacetConfig::merged_facet].
-        pub fn set_merged_facet<
-            T: std::convert::Into<
-                    std::option::Option<crate::model::catalog_attribute::facet_config::MergedFacet>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.merged_facet = v.into();
-            self
-        }
-
-        /// Sets the value of [rerank_config][crate::model::catalog_attribute::FacetConfig::rerank_config].
-        pub fn set_rerank_config<
-            T: std::convert::Into<
-                    std::option::Option<
-                        crate::model::catalog_attribute::facet_config::RerankConfig,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.rerank_config = v.into();
-            self
-        }
-
         /// Sets the value of [facet_intervals][crate::model::catalog_attribute::FacetConfig::facet_intervals].
         pub fn set_facet_intervals<T, V>(mut self, v: T) -> Self
         where
@@ -497,6 +469,34 @@ pub mod catalog_attribute {
         {
             use std::iter::Iterator;
             self.merged_facet_values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [merged_facet][crate::model::catalog_attribute::FacetConfig::merged_facet].
+        pub fn set_merged_facet<
+            T: std::convert::Into<
+                    std::option::Option<crate::model::catalog_attribute::facet_config::MergedFacet>,
+                >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.merged_facet = v.into();
+            self
+        }
+
+        /// Sets the value of [rerank_config][crate::model::catalog_attribute::FacetConfig::rerank_config].
+        pub fn set_rerank_config<
+            T: std::convert::Into<
+                    std::option::Option<
+                        crate::model::catalog_attribute::facet_config::RerankConfig,
+                    >,
+                >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.rerank_config = v.into();
             self
         }
     }
@@ -557,6 +557,17 @@ pub mod catalog_attribute {
                 std::default::Default::default()
             }
 
+            /// Sets the value of [values][crate::model::catalog_attribute::facet_config::IgnoredFacetValues::values].
+            pub fn set_values<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [start_time][crate::model::catalog_attribute::facet_config::IgnoredFacetValues::start_time].
             pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
                 mut self,
@@ -572,17 +583,6 @@ pub mod catalog_attribute {
                 v: T,
             ) -> Self {
                 self.end_time = v.into();
-                self
-            }
-
-            /// Sets the value of [values][crate::model::catalog_attribute::facet_config::IgnoredFacetValues::values].
-            pub fn set_values<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.values = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -627,15 +627,6 @@ pub mod catalog_attribute {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [merged_value][crate::model::catalog_attribute::facet_config::MergedFacetValue::merged_value].
-            pub fn set_merged_value<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.merged_value = v.into();
-                self
-            }
-
             /// Sets the value of [values][crate::model::catalog_attribute::facet_config::MergedFacetValue::values].
             pub fn set_values<T, V>(mut self, v: T) -> Self
             where
@@ -644,6 +635,15 @@ pub mod catalog_attribute {
             {
                 use std::iter::Iterator;
                 self.values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [merged_value][crate::model::catalog_attribute::facet_config::MergedFacetValue::merged_value].
+            pub fn set_merged_value<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.merged_value = v.into();
                 self
             }
         }
@@ -1614,15 +1614,6 @@ impl AttributesConfig {
         self
     }
 
-    /// Sets the value of [attribute_config_level][crate::model::AttributesConfig::attribute_config_level].
-    pub fn set_attribute_config_level<T: std::convert::Into<crate::model::AttributeConfigLevel>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.attribute_config_level = v.into();
-        self
-    }
-
     /// Sets the value of [catalog_attributes][crate::model::AttributesConfig::catalog_attributes].
     pub fn set_catalog_attributes<T, K, V>(mut self, v: T) -> Self
     where
@@ -1632,6 +1623,15 @@ impl AttributesConfig {
     {
         use std::iter::Iterator;
         self.catalog_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [attribute_config_level][crate::model::AttributesConfig::attribute_config_level].
+    pub fn set_attribute_config_level<T: std::convert::Into<crate::model::AttributeConfigLevel>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.attribute_config_level = v.into();
         self
     }
 }
@@ -2010,12 +2010,6 @@ impl ListCatalogsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCatalogsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [catalogs][crate::model::ListCatalogsResponse::catalogs].
     pub fn set_catalogs<T, V>(mut self, v: T) -> Self
     where
@@ -2024,6 +2018,12 @@ impl ListCatalogsResponse {
     {
         use std::iter::Iterator;
         self.catalogs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCatalogsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2952,123 +2952,6 @@ impl Rule {
         })
     }
 
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `RedirectAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redirect_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::RedirectAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::RedirectAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `OnewaySynonymsAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oneway_synonyms_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::OnewaySynonymsAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::OnewaySynonymsAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `DoNotAssociateAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn do_not_associate_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::DoNotAssociateAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::DoNotAssociateAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `ReplacementAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn replacement_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::ReplacementAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::ReplacementAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `IgnoreAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ignore_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::IgnoreAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::IgnoreAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `FilterAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filter_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::FilterAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::FilterAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `TwowaySynonymsAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn twoway_synonyms_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::TwowaySynonymsAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::TwowaySynonymsAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `ForceReturnFacetAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn force_return_facet_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::ForceReturnFacetAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::ForceReturnFacetAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Rule::action]
-    /// if it holds a `RemoveFacetAction`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn remove_facet_action(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::RemoveFacetAction>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::rule::Action::RemoveFacetAction(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [action][crate::model::Rule::action]
     /// to hold a `BoostAction`.
     ///
@@ -3082,6 +2965,19 @@ impl Rule {
     ) -> Self {
         self.action = std::option::Option::Some(crate::model::rule::Action::BoostAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `RedirectAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redirect_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::RedirectAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::RedirectAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Rule::action]
@@ -3100,6 +2996,19 @@ impl Rule {
         self
     }
 
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `OnewaySynonymsAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oneway_synonyms_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::OnewaySynonymsAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::OnewaySynonymsAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Rule::action]
     /// to hold a `OnewaySynonymsAction`.
     ///
@@ -3114,6 +3023,19 @@ impl Rule {
         self.action =
             std::option::Option::Some(crate::model::rule::Action::OnewaySynonymsAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `DoNotAssociateAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn do_not_associate_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::DoNotAssociateAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::DoNotAssociateAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Rule::action]
@@ -3132,6 +3054,19 @@ impl Rule {
         self
     }
 
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `ReplacementAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn replacement_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::ReplacementAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::ReplacementAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Rule::action]
     /// to hold a `ReplacementAction`.
     ///
@@ -3146,6 +3081,19 @@ impl Rule {
         self.action =
             std::option::Option::Some(crate::model::rule::Action::ReplacementAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `IgnoreAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ignore_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::IgnoreAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::IgnoreAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Rule::action]
@@ -3163,6 +3111,19 @@ impl Rule {
         self
     }
 
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `FilterAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filter_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::FilterAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::FilterAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Rule::action]
     /// to hold a `FilterAction`.
     ///
@@ -3176,6 +3137,19 @@ impl Rule {
     ) -> Self {
         self.action = std::option::Option::Some(crate::model::rule::Action::FilterAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `TwowaySynonymsAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn twoway_synonyms_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::TwowaySynonymsAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::TwowaySynonymsAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Rule::action]
@@ -3194,6 +3168,19 @@ impl Rule {
         self
     }
 
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `ForceReturnFacetAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn force_return_facet_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::ForceReturnFacetAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::ForceReturnFacetAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Rule::action]
     /// to hold a `ForceReturnFacetAction`.
     ///
@@ -3208,6 +3195,19 @@ impl Rule {
         self.action =
             std::option::Option::Some(crate::model::rule::Action::ForceReturnFacetAction(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Rule::action]
+    /// if it holds a `RemoveFacetAction`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn remove_facet_action(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::rule::RemoveFacetAction>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::rule::Action::RemoveFacetAction(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Rule::action]
@@ -3644,6 +3644,17 @@ pub mod rule {
             std::default::Default::default()
         }
 
+        /// Sets the value of [query_terms][crate::model::rule::ReplacementAction::query_terms].
+        pub fn set_query_terms<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.query_terms = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [replacement_term][crate::model::rule::ReplacementAction::replacement_term].
         pub fn set_replacement_term<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -3656,17 +3667,6 @@ pub mod rule {
         /// Sets the value of [term][crate::model::rule::ReplacementAction::term].
         pub fn set_term<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.term = v.into();
-            self
-        }
-
-        /// Sets the value of [query_terms][crate::model::rule::ReplacementAction::query_terms].
-        pub fn set_query_terms<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.query_terms = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4185,23 +4185,6 @@ impl CustomAttribute {
         std::default::Default::default()
     }
 
-    /// Sets the value of [searchable][crate::model::CustomAttribute::searchable].
-    #[deprecated]
-    pub fn set_searchable<T: std::convert::Into<std::option::Option<bool>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.searchable = v.into();
-        self
-    }
-
-    /// Sets the value of [indexable][crate::model::CustomAttribute::indexable].
-    #[deprecated]
-    pub fn set_indexable<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
-        self.indexable = v.into();
-        self
-    }
-
     /// Sets the value of [text][crate::model::CustomAttribute::text].
     pub fn set_text<T, V>(mut self, v: T) -> Self
     where
@@ -4221,6 +4204,23 @@ impl CustomAttribute {
     {
         use std::iter::Iterator;
         self.numbers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [searchable][crate::model::CustomAttribute::searchable].
+    #[deprecated]
+    pub fn set_searchable<T: std::convert::Into<std::option::Option<bool>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.searchable = v.into();
+        self
+    }
+
+    /// Sets the value of [indexable][crate::model::CustomAttribute::indexable].
+    #[deprecated]
+    pub fn set_indexable<T: std::convert::Into<std::option::Option<bool>>>(mut self, v: T) -> Self {
+        self.indexable = v.into();
         self
     }
 }
@@ -4432,6 +4432,16 @@ impl Interval {
         })
     }
 
+    /// Sets the value of [min][crate::model::Interval::min]
+    /// to hold a `Minimum`.
+    ///
+    /// Note that all the setters affecting `min` are
+    /// mutually exclusive.
+    pub fn set_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.min = std::option::Option::Some(crate::model::interval::Min::Minimum(v.into()));
+        self
+    }
+
     /// The value of [min][crate::model::Interval::min]
     /// if it holds a `ExclusiveMinimum`, `None` if the field is not set or
     /// holds a different branch.
@@ -4441,16 +4451,6 @@ impl Interval {
             crate::model::interval::Min::ExclusiveMinimum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [min][crate::model::Interval::min]
-    /// to hold a `Minimum`.
-    ///
-    /// Note that all the setters affecting `min` are
-    /// mutually exclusive.
-    pub fn set_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.min = std::option::Option::Some(crate::model::interval::Min::Minimum(v.into()));
-        self
     }
 
     /// Sets the value of [min][crate::model::Interval::min]
@@ -4487,6 +4487,16 @@ impl Interval {
         })
     }
 
+    /// Sets the value of [max][crate::model::Interval::max]
+    /// to hold a `Maximum`.
+    ///
+    /// Note that all the setters affecting `max` are
+    /// mutually exclusive.
+    pub fn set_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.max = std::option::Option::Some(crate::model::interval::Max::Maximum(v.into()));
+        self
+    }
+
     /// The value of [max][crate::model::Interval::max]
     /// if it holds a `ExclusiveMaximum`, `None` if the field is not set or
     /// holds a different branch.
@@ -4496,16 +4506,6 @@ impl Interval {
             crate::model::interval::Max::ExclusiveMaximum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [max][crate::model::Interval::max]
-    /// to hold a `Maximum`.
-    ///
-    /// Note that all the setters affecting `max` are
-    /// mutually exclusive.
-    pub fn set_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.max = std::option::Option::Some(crate::model::interval::Max::Maximum(v.into()));
-        self
     }
 
     /// Sets the value of [max][crate::model::Interval::max]
@@ -5114,17 +5114,6 @@ impl LocalInventory {
         self
     }
 
-    /// Sets the value of [fulfillment_types][crate::model::LocalInventory::fulfillment_types].
-    pub fn set_fulfillment_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.fulfillment_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [attributes][crate::model::LocalInventory::attributes].
     pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
     where
@@ -5134,6 +5123,17 @@ impl LocalInventory {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [fulfillment_types][crate::model::LocalInventory::fulfillment_types].
+    pub fn set_fulfillment_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.fulfillment_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5279,6 +5279,17 @@ impl CompleteQueryRequest {
         self
     }
 
+    /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
+    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [device_type][crate::model::CompleteQueryRequest::device_type].
     pub fn set_device_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.device_type = v.into();
@@ -5306,17 +5317,6 @@ impl CompleteQueryRequest {
     /// Sets the value of [entity][crate::model::CompleteQueryRequest::entity].
     pub fn set_entity<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.entity = v.into();
-        self
-    }
-
-    /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
-    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.language_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5402,15 +5402,6 @@ impl CompleteQueryResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [attribution_token][crate::model::CompleteQueryResponse::attribution_token].
-    pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.attribution_token = v.into();
-        self
-    }
-
     /// Sets the value of [completion_results][crate::model::CompleteQueryResponse::completion_results].
     pub fn set_completion_results<T, V>(mut self, v: T) -> Self
     where
@@ -5419,6 +5410,15 @@ impl CompleteQueryResponse {
     {
         use std::iter::Iterator;
         self.completion_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [attribution_token][crate::model::CompleteQueryResponse::attribution_token].
+    pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.attribution_token = v.into();
         self
     }
 
@@ -6056,12 +6056,6 @@ impl ListControlsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListControlsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [controls][crate::model::ListControlsResponse::controls].
     pub fn set_controls<T, V>(mut self, v: T) -> Self
     where
@@ -6070,6 +6064,12 @@ impl ListControlsResponse {
     {
         use std::iter::Iterator;
         self.controls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListControlsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6142,22 +6142,6 @@ impl OutputConfig {
         })
     }
 
-    /// The value of [destination][crate::model::OutputConfig::destination]
-    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bigquery_destination(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::output_config::BigQueryDestination>>
-    {
-        #[allow(unreachable_patterns)]
-        self.destination.as_ref().and_then(|v| match v {
-            crate::model::output_config::Destination::BigqueryDestination(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [destination][crate::model::OutputConfig::destination]
     /// to hold a `GcsDestination`.
     ///
@@ -6173,6 +6157,22 @@ impl OutputConfig {
             crate::model::output_config::Destination::GcsDestination(v.into()),
         );
         self
+    }
+
+    /// The value of [destination][crate::model::OutputConfig::destination]
+    /// if it holds a `BigqueryDestination`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bigquery_destination(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::output_config::BigQueryDestination>>
+    {
+        #[allow(unreachable_patterns)]
+        self.destination.as_ref().and_then(|v| match v {
+            crate::model::output_config::Destination::BigqueryDestination(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [destination][crate::model::OutputConfig::destination]
@@ -6551,6 +6551,17 @@ impl ExportAnalyticsMetricsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [error_samples][crate::model::ExportAnalyticsMetricsResponse::error_samples].
+    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [errors_config][crate::model::ExportAnalyticsMetricsResponse::errors_config].
     pub fn set_errors_config<
         T: std::convert::Into<std::option::Option<crate::model::ExportErrorsConfig>>,
@@ -6570,17 +6581,6 @@ impl ExportAnalyticsMetricsResponse {
         v: T,
     ) -> Self {
         self.output_result = v.into();
-        self
-    }
-
-    /// Sets the value of [error_samples][crate::model::ExportAnalyticsMetricsResponse::error_samples].
-    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.error_samples = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6847,6 +6847,17 @@ impl GenerativeQuestionConfig {
         self
     }
 
+    /// Sets the value of [example_values][crate::model::GenerativeQuestionConfig::example_values].
+    pub fn set_example_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.example_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [frequency][crate::model::GenerativeQuestionConfig::frequency].
     pub fn set_frequency<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.frequency = v.into();
@@ -6856,17 +6867,6 @@ impl GenerativeQuestionConfig {
     /// Sets the value of [allowed_in_conversation][crate::model::GenerativeQuestionConfig::allowed_in_conversation].
     pub fn set_allowed_in_conversation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allowed_in_conversation = v.into();
-        self
-    }
-
-    /// Sets the value of [example_values][crate::model::GenerativeQuestionConfig::example_values].
-    pub fn set_example_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.example_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7240,12 +7240,6 @@ impl GcsSource {
         std::default::Default::default()
     }
 
-    /// Sets the value of [data_schema][crate::model::GcsSource::data_schema].
-    pub fn set_data_schema<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data_schema = v.into();
-        self
-    }
-
     /// Sets the value of [input_uris][crate::model::GcsSource::input_uris].
     pub fn set_input_uris<T, V>(mut self, v: T) -> Self
     where
@@ -7254,6 +7248,12 @@ impl GcsSource {
     {
         use std::iter::Iterator;
         self.input_uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_schema][crate::model::GcsSource::data_schema].
+    pub fn set_data_schema<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.data_schema = v.into();
         self
     }
 }
@@ -8062,34 +8062,6 @@ impl ProductInputConfig {
         })
     }
 
-    /// The value of [source][crate::model::ProductInputConfig::source]
-    /// if it holds a `GcsSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::product_input_config::Source::GcsSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::ProductInputConfig::source]
-    /// if it holds a `BigQuerySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn big_query_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::product_input_config::Source::BigQuerySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ProductInputConfig::source]
     /// to hold a `ProductInlineSource`.
     ///
@@ -8107,6 +8079,19 @@ impl ProductInputConfig {
         self
     }
 
+    /// The value of [source][crate::model::ProductInputConfig::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::product_input_config::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::ProductInputConfig::source]
     /// to hold a `GcsSource`.
     ///
@@ -8120,6 +8105,21 @@ impl ProductInputConfig {
             crate::model::product_input_config::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ProductInputConfig::source]
+    /// if it holds a `BigQuerySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn big_query_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::product_input_config::Source::BigQuerySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ProductInputConfig::source]
@@ -8213,34 +8213,6 @@ impl UserEventInputConfig {
         })
     }
 
-    /// The value of [source][crate::model::UserEventInputConfig::source]
-    /// if it holds a `GcsSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::user_event_input_config::Source::GcsSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::UserEventInputConfig::source]
-    /// if it holds a `BigQuerySource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn big_query_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::user_event_input_config::Source::BigQuerySource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::UserEventInputConfig::source]
     /// to hold a `UserEventInlineSource`.
     ///
@@ -8258,6 +8230,19 @@ impl UserEventInputConfig {
         self
     }
 
+    /// The value of [source][crate::model::UserEventInputConfig::source]
+    /// if it holds a `GcsSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GcsSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::user_event_input_config::Source::GcsSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::UserEventInputConfig::source]
     /// to hold a `GcsSource`.
     ///
@@ -8271,6 +8256,21 @@ impl UserEventInputConfig {
             crate::model::user_event_input_config::Source::GcsSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::UserEventInputConfig::source]
+    /// if it holds a `BigQuerySource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn big_query_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQuerySource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::user_event_input_config::Source::BigQuerySource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::UserEventInputConfig::source]
@@ -8558,17 +8558,6 @@ impl ImportProductsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [errors_config][crate::model::ImportProductsResponse::errors_config].
-    pub fn set_errors_config<
-        T: std::convert::Into<std::option::Option<crate::model::ImportErrorsConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.errors_config = v.into();
-        self
-    }
-
     /// Sets the value of [error_samples][crate::model::ImportProductsResponse::error_samples].
     pub fn set_error_samples<T, V>(mut self, v: T) -> Self
     where
@@ -8577,6 +8566,17 @@ impl ImportProductsResponse {
     {
         use std::iter::Iterator;
         self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [errors_config][crate::model::ImportProductsResponse::errors_config].
+    pub fn set_errors_config<
+        T: std::convert::Into<std::option::Option<crate::model::ImportErrorsConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.errors_config = v.into();
         self
     }
 }
@@ -8617,6 +8617,17 @@ impl ImportUserEventsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [error_samples][crate::model::ImportUserEventsResponse::error_samples].
+    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.error_samples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [errors_config][crate::model::ImportUserEventsResponse::errors_config].
     pub fn set_errors_config<
         T: std::convert::Into<std::option::Option<crate::model::ImportErrorsConfig>>,
@@ -8636,17 +8647,6 @@ impl ImportUserEventsResponse {
         v: T,
     ) -> Self {
         self.import_summary = v.into();
-        self
-    }
-
-    /// Sets the value of [error_samples][crate::model::ImportUserEventsResponse::error_samples].
-    pub fn set_error_samples<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.error_samples = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9009,17 +9009,6 @@ impl Model {
         self
     }
 
-    /// Sets the value of [model_features_config][crate::model::Model::model_features_config].
-    pub fn set_model_features_config<
-        T: std::convert::Into<std::option::Option<crate::model::model::ModelFeaturesConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model_features_config = v.into();
-        self
-    }
-
     /// Sets the value of [serving_config_lists][crate::model::Model::serving_config_lists].
     pub fn set_serving_config_lists<T, V>(mut self, v: T) -> Self
     where
@@ -9028,6 +9017,17 @@ impl Model {
     {
         use std::iter::Iterator;
         self.serving_config_lists = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [model_features_config][crate::model::Model::model_features_config].
+    pub fn set_model_features_config<
+        T: std::convert::Into<std::option::Option<crate::model::model::ModelFeaturesConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.model_features_config = v.into();
         self
     }
 }
@@ -10248,12 +10248,6 @@ impl ListModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [models][crate::model::ListModelsResponse::models].
     pub fn set_models<T, V>(mut self, v: T) -> Self
     where
@@ -10262,6 +10256,12 @@ impl ListModelsResponse {
     {
         use std::iter::Iterator;
         self.models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -10683,21 +10683,6 @@ impl PredictResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [attribution_token][crate::model::PredictResponse::attribution_token].
-    pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.attribution_token = v.into();
-        self
-    }
-
-    /// Sets the value of [validate_only][crate::model::PredictResponse::validate_only].
-    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.validate_only = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::PredictResponse::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -10709,6 +10694,15 @@ impl PredictResponse {
         self
     }
 
+    /// Sets the value of [attribution_token][crate::model::PredictResponse::attribution_token].
+    pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.attribution_token = v.into();
+        self
+    }
+
     /// Sets the value of [missing_ids][crate::model::PredictResponse::missing_ids].
     pub fn set_missing_ids<T, V>(mut self, v: T) -> Self
     where
@@ -10717,6 +10711,12 @@ impl PredictResponse {
     {
         use std::iter::Iterator;
         self.missing_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [validate_only][crate::model::PredictResponse::validate_only].
+    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.validate_only = v.into();
         self
     }
 }
@@ -11378,15 +11378,48 @@ impl Product {
         self
     }
 
+    /// Sets the value of [collection_member_ids][crate::model::Product::collection_member_ids].
+    pub fn set_collection_member_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.collection_member_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [gtin][crate::model::Product::gtin].
     pub fn set_gtin<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.gtin = v.into();
         self
     }
 
+    /// Sets the value of [categories][crate::model::Product::categories].
+    pub fn set_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [title][crate::model::Product::title].
     pub fn set_title<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.title = v.into();
+        self
+    }
+
+    /// Sets the value of [brands][crate::model::Product::brands].
+    pub fn set_brands<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.brands = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -11399,6 +11432,29 @@ impl Product {
     /// Sets the value of [language_code][crate::model::Product::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
+        self
+    }
+
+    /// Sets the value of [attributes][crate::model::Product::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::CustomAttribute>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::Product::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -11447,9 +11503,31 @@ impl Product {
         self
     }
 
+    /// Sets the value of [fulfillment_info][crate::model::Product::fulfillment_info].
+    pub fn set_fulfillment_info<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FulfillmentInfo>,
+    {
+        use std::iter::Iterator;
+        self.fulfillment_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [uri][crate::model::Product::uri].
     pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.uri = v.into();
+        self
+    }
+
+    /// Sets the value of [images][crate::model::Product::images].
+    pub fn set_images<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Image>,
+    {
+        use std::iter::Iterator;
+        self.images = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -11468,91 +11546,6 @@ impl Product {
         v: T,
     ) -> Self {
         self.color_info = v.into();
-        self
-    }
-
-    /// Sets the value of [publish_time][crate::model::Product::publish_time].
-    pub fn set_publish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.publish_time = v.into();
-        self
-    }
-
-    /// Sets the value of [retrievable_fields][crate::model::Product::retrievable_fields].
-    #[deprecated]
-    pub fn set_retrievable_fields<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.retrievable_fields = v.into();
-        self
-    }
-
-    /// Sets the value of [collection_member_ids][crate::model::Product::collection_member_ids].
-    pub fn set_collection_member_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.collection_member_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [categories][crate::model::Product::categories].
-    pub fn set_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.categories = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [brands][crate::model::Product::brands].
-    pub fn set_brands<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.brands = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::Product::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [fulfillment_info][crate::model::Product::fulfillment_info].
-    pub fn set_fulfillment_info<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FulfillmentInfo>,
-    {
-        use std::iter::Iterator;
-        self.fulfillment_info = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [images][crate::model::Product::images].
-    pub fn set_images<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Image>,
-    {
-        use std::iter::Iterator;
-        self.images = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -11611,6 +11604,25 @@ impl Product {
         self
     }
 
+    /// Sets the value of [publish_time][crate::model::Product::publish_time].
+    pub fn set_publish_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.publish_time = v.into();
+        self
+    }
+
+    /// Sets the value of [retrievable_fields][crate::model::Product::retrievable_fields].
+    #[deprecated]
+    pub fn set_retrievable_fields<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.retrievable_fields = v.into();
+        self
+    }
+
     /// Sets the value of [variants][crate::model::Product::variants].
     pub fn set_variants<T, V>(mut self, v: T) -> Self
     where
@@ -11630,18 +11642,6 @@ impl Product {
     {
         use std::iter::Iterator;
         self.local_inventories = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [attributes][crate::model::Product::attributes].
-    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::CustomAttribute>,
-    {
-        use std::iter::Iterator;
-        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -11670,17 +11670,6 @@ impl Product {
         })
     }
 
-    /// The value of [expiration][crate::model::Product::expiration]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.expiration.as_ref().and_then(|v| match v {
-            crate::model::product::Expiration::Ttl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [expiration][crate::model::Product::expiration]
     /// to hold a `ExpireTime`.
     ///
@@ -11693,6 +11682,17 @@ impl Product {
         self.expiration =
             std::option::Option::Some(crate::model::product::Expiration::ExpireTime(v.into()));
         self
+    }
+
+    /// The value of [expiration][crate::model::Product::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::product::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [expiration][crate::model::Product::expiration]
@@ -12593,12 +12593,6 @@ impl ListProductsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProductsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [products][crate::model::ListProductsResponse::products].
     pub fn set_products<T, V>(mut self, v: T) -> Self
     where
@@ -12607,6 +12601,12 @@ impl ListProductsResponse {
     {
         use std::iter::Iterator;
         self.products = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProductsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -12953,6 +12953,17 @@ impl AddFulfillmentPlacesRequest {
         self
     }
 
+    /// Sets the value of [place_ids][crate::model::AddFulfillmentPlacesRequest::place_ids].
+    pub fn set_place_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.place_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [add_time][crate::model::AddFulfillmentPlacesRequest::add_time].
     pub fn set_add_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -12965,17 +12976,6 @@ impl AddFulfillmentPlacesRequest {
     /// Sets the value of [allow_missing][crate::model::AddFulfillmentPlacesRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
-        self
-    }
-
-    /// Sets the value of [place_ids][crate::model::AddFulfillmentPlacesRequest::place_ids].
-    pub fn set_place_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.place_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13119,6 +13119,17 @@ impl AddLocalInventoriesRequest {
         self
     }
 
+    /// Sets the value of [local_inventories][crate::model::AddLocalInventoriesRequest::local_inventories].
+    pub fn set_local_inventories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LocalInventory>,
+    {
+        use std::iter::Iterator;
+        self.local_inventories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [add_mask][crate::model::AddLocalInventoriesRequest::add_mask].
     pub fn set_add_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
         mut self,
@@ -13140,17 +13151,6 @@ impl AddLocalInventoriesRequest {
     /// Sets the value of [allow_missing][crate::model::AddLocalInventoriesRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
-        self
-    }
-
-    /// Sets the value of [local_inventories][crate::model::AddLocalInventoriesRequest::local_inventories].
-    pub fn set_local_inventories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LocalInventory>,
-    {
-        use std::iter::Iterator;
-        self.local_inventories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13276,6 +13276,17 @@ impl RemoveLocalInventoriesRequest {
         self
     }
 
+    /// Sets the value of [place_ids][crate::model::RemoveLocalInventoriesRequest::place_ids].
+    pub fn set_place_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.place_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [remove_time][crate::model::RemoveLocalInventoriesRequest::remove_time].
     pub fn set_remove_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -13288,17 +13299,6 @@ impl RemoveLocalInventoriesRequest {
     /// Sets the value of [allow_missing][crate::model::RemoveLocalInventoriesRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
-        self
-    }
-
-    /// Sets the value of [place_ids][crate::model::RemoveLocalInventoriesRequest::place_ids].
-    pub fn set_place_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.place_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13466,6 +13466,17 @@ impl RemoveFulfillmentPlacesRequest {
         self
     }
 
+    /// Sets the value of [place_ids][crate::model::RemoveFulfillmentPlacesRequest::place_ids].
+    pub fn set_place_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.place_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [remove_time][crate::model::RemoveFulfillmentPlacesRequest::remove_time].
     pub fn set_remove_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -13478,17 +13489,6 @@ impl RemoveFulfillmentPlacesRequest {
     /// Sets the value of [allow_missing][crate::model::RemoveFulfillmentPlacesRequest::allow_missing].
     pub fn set_allow_missing<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.allow_missing = v.into();
-        self
-    }
-
-    /// Sets the value of [place_ids][crate::model::RemoveFulfillmentPlacesRequest::place_ids].
-    pub fn set_place_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.place_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -14105,21 +14105,6 @@ impl Tile {
         })
     }
 
-    /// The value of [product_attribute][crate::model::Tile::product_attribute]
-    /// if it holds a `ProductAttributeInterval`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn product_attribute_interval(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ProductAttributeInterval>> {
-        #[allow(unreachable_patterns)]
-        self.product_attribute.as_ref().and_then(|v| match v {
-            crate::model::tile::ProductAttribute::ProductAttributeInterval(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [product_attribute][crate::model::Tile::product_attribute]
     /// to hold a `ProductAttributeValue`.
     ///
@@ -14135,6 +14120,21 @@ impl Tile {
             crate::model::tile::ProductAttribute::ProductAttributeValue(v.into()),
         );
         self
+    }
+
+    /// The value of [product_attribute][crate::model::Tile::product_attribute]
+    /// if it holds a `ProductAttributeInterval`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn product_attribute_interval(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ProductAttributeInterval>> {
+        #[allow(unreachable_patterns)]
+        self.product_attribute.as_ref().and_then(|v| match v {
+            crate::model::tile::ProductAttribute::ProductAttributeInterval(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [product_attribute][crate::model::Tile::product_attribute]
@@ -14598,6 +14598,17 @@ impl SearchRequest {
         self
     }
 
+    /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
+    pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_request::FacetSpec>,
+    {
+        use std::iter::Iterator;
+        self.facet_specs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [dynamic_facet_spec][crate::model::SearchRequest::dynamic_facet_spec].
     #[deprecated]
     pub fn set_dynamic_facet_spec<
@@ -14632,6 +14643,28 @@ impl SearchRequest {
         self
     }
 
+    /// Sets the value of [variant_rollup_keys][crate::model::SearchRequest::variant_rollup_keys].
+    pub fn set_variant_rollup_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.variant_rollup_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [page_categories][crate::model::SearchRequest::page_categories].
+    pub fn set_page_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.page_categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [search_mode][crate::model::SearchRequest::search_mode].
     pub fn set_search_mode<T: std::convert::Into<crate::model::search_request::SearchMode>>(
         mut self,
@@ -14649,6 +14682,18 @@ impl SearchRequest {
         v: T,
     ) -> Self {
         self.personalization_spec = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::SearchRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -14690,51 +14735,6 @@ impl SearchRequest {
         v: T,
     ) -> Self {
         self.tile_navigation_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [facet_specs][crate::model::SearchRequest::facet_specs].
-    pub fn set_facet_specs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_request::FacetSpec>,
-    {
-        use std::iter::Iterator;
-        self.facet_specs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [variant_rollup_keys][crate::model::SearchRequest::variant_rollup_keys].
-    pub fn set_variant_rollup_keys<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.variant_rollup_keys = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [page_categories][crate::model::SearchRequest::page_categories].
-    pub fn set_page_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.page_categories = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::SearchRequest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -14860,12 +14860,6 @@ pub mod search_request {
             self
         }
 
-        /// Sets the value of [enable_dynamic_position][crate::model::search_request::FacetSpec::enable_dynamic_position].
-        pub fn set_enable_dynamic_position<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.enable_dynamic_position = v.into();
-            self
-        }
-
         /// Sets the value of [excluded_filter_keys][crate::model::search_request::FacetSpec::excluded_filter_keys].
         pub fn set_excluded_filter_keys<T, V>(mut self, v: T) -> Self
         where
@@ -14874,6 +14868,12 @@ pub mod search_request {
         {
             use std::iter::Iterator;
             self.excluded_filter_keys = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [enable_dynamic_position][crate::model::search_request::FacetSpec::enable_dynamic_position].
+        pub fn set_enable_dynamic_position<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.enable_dynamic_position = v.into();
             self
         }
     }
@@ -15092,33 +15092,6 @@ pub mod search_request {
                 self
             }
 
-            /// Sets the value of [case_insensitive][crate::model::search_request::facet_spec::FacetKey::case_insensitive].
-            pub fn set_case_insensitive<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.case_insensitive = v.into();
-                self
-            }
-
-            /// Sets the value of [order_by][crate::model::search_request::facet_spec::FacetKey::order_by].
-            pub fn set_order_by<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.order_by = v.into();
-                self
-            }
-
-            /// Sets the value of [query][crate::model::search_request::facet_spec::FacetKey::query].
-            pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.query = v.into();
-                self
-            }
-
-            /// Sets the value of [return_min_max][crate::model::search_request::facet_spec::FacetKey::return_min_max].
-            pub fn set_return_min_max<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.return_min_max = v.into();
-                self
-            }
-
             /// Sets the value of [intervals][crate::model::search_request::facet_spec::FacetKey::intervals].
             pub fn set_intervals<T, V>(mut self, v: T) -> Self
             where
@@ -15160,6 +15133,33 @@ pub mod search_request {
             {
                 use std::iter::Iterator;
                 self.contains = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [case_insensitive][crate::model::search_request::facet_spec::FacetKey::case_insensitive].
+            pub fn set_case_insensitive<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.case_insensitive = v.into();
+                self
+            }
+
+            /// Sets the value of [order_by][crate::model::search_request::facet_spec::FacetKey::order_by].
+            pub fn set_order_by<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.order_by = v.into();
+                self
+            }
+
+            /// Sets the value of [query][crate::model::search_request::facet_spec::FacetKey::query].
+            pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+                self.query = v.into();
+                self
+            }
+
+            /// Sets the value of [return_min_max][crate::model::search_request::facet_spec::FacetKey::return_min_max].
+            pub fn set_return_min_max<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.return_min_max = v.into();
                 self
             }
         }
@@ -15387,15 +15387,6 @@ pub mod search_request {
             std::default::Default::default()
         }
 
-        /// Sets the value of [skip_boost_spec_validation][crate::model::search_request::BoostSpec::skip_boost_spec_validation].
-        pub fn set_skip_boost_spec_validation<T: std::convert::Into<std::option::Option<bool>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.skip_boost_spec_validation = v.into();
-            self
-        }
-
         /// Sets the value of [condition_boost_specs][crate::model::search_request::BoostSpec::condition_boost_specs].
         pub fn set_condition_boost_specs<T, V>(mut self, v: T) -> Self
         where
@@ -15404,6 +15395,15 @@ pub mod search_request {
         {
             use std::iter::Iterator;
             self.condition_boost_specs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [skip_boost_spec_validation][crate::model::search_request::BoostSpec::skip_boost_spec_validation].
+        pub fn set_skip_boost_spec_validation<T: std::convert::Into<std::option::Option<bool>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.skip_boost_spec_validation = v.into();
             self
         }
     }
@@ -16197,17 +16197,6 @@ pub mod search_request {
                 })
             }
 
-            /// The value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
-            /// if it holds a `SelectedAnswer`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn selected_answer(&self) -> std::option::Option<&std::boxed::Box<crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer>>{
-                #[allow(unreachable_patterns)]
-                self.r#type.as_ref().and_then(|v| match v {
-                    crate::model::search_request::conversational_search_spec::user_answer::Type::SelectedAnswer(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
             /// to hold a `TextAnswer`.
             ///
@@ -16223,6 +16212,17 @@ pub mod search_request {
                     )
                 );
                 self
+            }
+
+            /// The value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
+            /// if it holds a `SelectedAnswer`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn selected_answer(&self) -> std::option::Option<&std::boxed::Box<crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer>>{
+                #[allow(unreachable_patterns)]
+                self.r#type.as_ref().and_then(|v| match v {
+                    crate::model::search_request::conversational_search_spec::user_answer::Type::SelectedAnswer(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
@@ -16278,17 +16278,6 @@ pub mod search_request {
                     std::default::Default::default()
                 }
 
-                /// Sets the value of [product_attribute_value][crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer::product_attribute_value].
-                pub fn set_product_attribute_value<
-                    T: std::convert::Into<std::option::Option<crate::model::ProductAttributeValue>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.product_attribute_value = v.into();
-                    self
-                }
-
                 /// Sets the value of [product_attribute_values][crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer::product_attribute_values].
                 #[deprecated]
                 pub fn set_product_attribute_values<T, V>(mut self, v: T) -> Self
@@ -16298,6 +16287,17 @@ pub mod search_request {
                 {
                     use std::iter::Iterator;
                     self.product_attribute_values = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
+                /// Sets the value of [product_attribute_value][crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer::product_attribute_value].
+                pub fn set_product_attribute_value<
+                    T: std::convert::Into<std::option::Option<crate::model::ProductAttributeValue>>,
+                >(
+                    mut self,
+                    v: T,
+                ) -> Self {
+                    self.product_attribute_value = v.into();
                     self
                 }
             }
@@ -16656,6 +16656,28 @@ impl SearchResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [results][crate::model::SearchResponse::results].
+    pub fn set_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_response::SearchResult>,
+    {
+        use std::iter::Iterator;
+        self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [facets][crate::model::SearchResponse::facets].
+    pub fn set_facets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_response::Facet>,
+    {
+        use std::iter::Iterator;
+        self.facets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [total_size][crate::model::SearchResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
@@ -16700,54 +16722,6 @@ impl SearchResponse {
         self
     }
 
-    /// Sets the value of [conversational_search_result][crate::model::SearchResponse::conversational_search_result].
-    pub fn set_conversational_search_result<
-        T: std::convert::Into<
-                std::option::Option<crate::model::search_response::ConversationalSearchResult>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conversational_search_result = v.into();
-        self
-    }
-
-    /// Sets the value of [tile_navigation_result][crate::model::SearchResponse::tile_navigation_result].
-    pub fn set_tile_navigation_result<
-        T: std::convert::Into<
-                std::option::Option<crate::model::search_response::TileNavigationResult>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tile_navigation_result = v.into();
-        self
-    }
-
-    /// Sets the value of [results][crate::model::SearchResponse::results].
-    pub fn set_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_response::SearchResult>,
-    {
-        use std::iter::Iterator;
-        self.results = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [facets][crate::model::SearchResponse::facets].
-    pub fn set_facets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_response::Facet>,
-    {
-        use std::iter::Iterator;
-        self.facets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [applied_controls][crate::model::SearchResponse::applied_controls].
     pub fn set_applied_controls<T, V>(mut self, v: T) -> Self
     where
@@ -16778,6 +16752,32 @@ impl SearchResponse {
     {
         use std::iter::Iterator;
         self.experiment_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [conversational_search_result][crate::model::SearchResponse::conversational_search_result].
+    pub fn set_conversational_search_result<
+        T: std::convert::Into<
+                std::option::Option<crate::model::search_response::ConversationalSearchResult>,
+            >,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.conversational_search_result = v.into();
+        self
+    }
+
+    /// Sets the value of [tile_navigation_result][crate::model::SearchResponse::tile_navigation_result].
+    pub fn set_tile_navigation_result<
+        T: std::convert::Into<
+                std::option::Option<crate::model::search_response::TileNavigationResult>,
+            >,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.tile_navigation_result = v.into();
         self
     }
 }
@@ -16965,17 +16965,6 @@ pub mod search_response {
             self
         }
 
-        /// Sets the value of [personal_labels][crate::model::search_response::SearchResult::personal_labels].
-        pub fn set_personal_labels<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.personal_labels = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
         /// Sets the value of [matching_variant_fields][crate::model::search_response::SearchResult::matching_variant_fields].
         pub fn set_matching_variant_fields<T, K, V>(mut self, v: T) -> Self
         where
@@ -16998,6 +16987,17 @@ pub mod search_response {
         {
             use std::iter::Iterator;
             self.variant_rollup_values = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [personal_labels][crate::model::search_response::SearchResult::personal_labels].
+        pub fn set_personal_labels<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.personal_labels = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -17042,12 +17042,6 @@ pub mod search_response {
             self
         }
 
-        /// Sets the value of [dynamic_facet][crate::model::search_response::Facet::dynamic_facet].
-        pub fn set_dynamic_facet<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.dynamic_facet = v.into();
-            self
-        }
-
         /// Sets the value of [values][crate::model::search_response::Facet::values].
         pub fn set_values<T, V>(mut self, v: T) -> Self
         where
@@ -17056,6 +17050,12 @@ pub mod search_response {
         {
             use std::iter::Iterator;
             self.values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [dynamic_facet][crate::model::search_response::Facet::dynamic_facet].
+        pub fn set_dynamic_facet<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.dynamic_facet = v.into();
             self
         }
     }
@@ -17167,6 +17167,18 @@ pub mod search_response {
                 })
             }
 
+            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
+            /// to hold a `Value`.
+            ///
+            /// Note that all the setters affecting `facet_value` are
+            /// mutually exclusive.
+            pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+                self.facet_value = std::option::Option::Some(
+                    crate::model::search_response::facet::facet_value::FacetValue::Value(v.into()),
+                );
+                self
+            }
+
             /// The value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
             /// if it holds a `Interval`, `None` if the field is not set or
             /// holds a different branch.
@@ -17180,18 +17192,6 @@ pub mod search_response {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
-            /// to hold a `Value`.
-            ///
-            /// Note that all the setters affecting `facet_value` are
-            /// mutually exclusive.
-            pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.facet_value = std::option::Option::Some(
-                    crate::model::search_response::facet::facet_value::FacetValue::Value(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
@@ -17374,21 +17374,6 @@ pub mod search_response {
             self
         }
 
-        /// Sets the value of [followup_question][crate::model::search_response::ConversationalSearchResult::followup_question].
-        pub fn set_followup_question<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.followup_question = v.into();
-            self
-        }
-
-        /// Sets the value of [additional_filter][crate::model::search_response::ConversationalSearchResult::additional_filter].
-        pub fn set_additional_filter<T: std::convert::Into<std::option::Option<crate::model::search_response::conversational_search_result::AdditionalFilter>>>(mut self, v: T) -> Self{
-            self.additional_filter = v.into();
-            self
-        }
-
         /// Sets the value of [additional_filters][crate::model::search_response::ConversationalSearchResult::additional_filters].
         #[deprecated]
         pub fn set_additional_filters<T, V>(mut self, v: T) -> Self
@@ -17403,6 +17388,15 @@ pub mod search_response {
             self
         }
 
+        /// Sets the value of [followup_question][crate::model::search_response::ConversationalSearchResult::followup_question].
+        pub fn set_followup_question<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.followup_question = v.into();
+            self
+        }
+
         /// Sets the value of [suggested_answers][crate::model::search_response::ConversationalSearchResult::suggested_answers].
         pub fn set_suggested_answers<T, V>(mut self, v: T) -> Self
         where
@@ -17413,6 +17407,12 @@ pub mod search_response {
         {
             use std::iter::Iterator;
             self.suggested_answers = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [additional_filter][crate::model::search_response::ConversationalSearchResult::additional_filter].
+        pub fn set_additional_filter<T: std::convert::Into<std::option::Option<crate::model::search_response::conversational_search_result::AdditionalFilter>>>(mut self, v: T) -> Self{
+            self.additional_filter = v.into();
             self
         }
     }
@@ -18026,60 +18026,6 @@ impl ServingConfig {
         self
     }
 
-    /// Sets the value of [dynamic_facet_spec][crate::model::ServingConfig::dynamic_facet_spec].
-    pub fn set_dynamic_facet_spec<
-        T: std::convert::Into<std::option::Option<crate::model::search_request::DynamicFacetSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dynamic_facet_spec = v.into();
-        self
-    }
-
-    /// Sets the value of [diversity_level][crate::model::ServingConfig::diversity_level].
-    pub fn set_diversity_level<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.diversity_level = v.into();
-        self
-    }
-
-    /// Sets the value of [diversity_type][crate::model::ServingConfig::diversity_type].
-    pub fn set_diversity_type<
-        T: std::convert::Into<crate::model::serving_config::DiversityType>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.diversity_type = v.into();
-        self
-    }
-
-    /// Sets the value of [enable_category_filter_level][crate::model::ServingConfig::enable_category_filter_level].
-    pub fn set_enable_category_filter_level<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enable_category_filter_level = v.into();
-        self
-    }
-
-    /// Sets the value of [ignore_recs_denylist][crate::model::ServingConfig::ignore_recs_denylist].
-    pub fn set_ignore_recs_denylist<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.ignore_recs_denylist = v.into();
-        self
-    }
-
-    /// Sets the value of [personalization_spec][crate::model::ServingConfig::personalization_spec].
-    pub fn set_personalization_spec<
-        T: std::convert::Into<std::option::Option<crate::model::search_request::PersonalizationSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.personalization_spec = v.into();
-        self
-    }
-
     /// Sets the value of [facet_control_ids][crate::model::ServingConfig::facet_control_ids].
     pub fn set_facet_control_ids<T, V>(mut self, v: T) -> Self
     where
@@ -18088,6 +18034,17 @@ impl ServingConfig {
     {
         use std::iter::Iterator;
         self.facet_control_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [dynamic_facet_spec][crate::model::ServingConfig::dynamic_facet_spec].
+    pub fn set_dynamic_facet_spec<
+        T: std::convert::Into<std::option::Option<crate::model::search_request::DynamicFacetSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.dynamic_facet_spec = v.into();
         self
     }
 
@@ -18176,6 +18133,49 @@ impl ServingConfig {
     {
         use std::iter::Iterator;
         self.ignore_control_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [diversity_level][crate::model::ServingConfig::diversity_level].
+    pub fn set_diversity_level<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.diversity_level = v.into();
+        self
+    }
+
+    /// Sets the value of [diversity_type][crate::model::ServingConfig::diversity_type].
+    pub fn set_diversity_type<
+        T: std::convert::Into<crate::model::serving_config::DiversityType>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.diversity_type = v.into();
+        self
+    }
+
+    /// Sets the value of [enable_category_filter_level][crate::model::ServingConfig::enable_category_filter_level].
+    pub fn set_enable_category_filter_level<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.enable_category_filter_level = v.into();
+        self
+    }
+
+    /// Sets the value of [ignore_recs_denylist][crate::model::ServingConfig::ignore_recs_denylist].
+    pub fn set_ignore_recs_denylist<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.ignore_recs_denylist = v.into();
+        self
+    }
+
+    /// Sets the value of [personalization_spec][crate::model::ServingConfig::personalization_spec].
+    pub fn set_personalization_spec<
+        T: std::convert::Into<std::option::Option<crate::model::search_request::PersonalizationSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.personalization_spec = v.into();
         self
     }
 
@@ -18604,12 +18604,6 @@ impl ListServingConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServingConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [serving_configs][crate::model::ListServingConfigsResponse::serving_configs].
     pub fn set_serving_configs<T, V>(mut self, v: T) -> Self
     where
@@ -18618,6 +18612,12 @@ impl ListServingConfigsResponse {
     {
         use std::iter::Iterator;
         self.serving_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServingConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -19059,12 +19059,34 @@ impl UserEvent {
         self
     }
 
+    /// Sets the value of [experiment_ids][crate::model::UserEvent::experiment_ids].
+    pub fn set_experiment_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.experiment_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [attribution_token][crate::model::UserEvent::attribution_token].
     pub fn set_attribution_token<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
     ) -> Self {
         self.attribution_token = v.into();
+        self
+    }
+
+    /// Sets the value of [product_details][crate::model::UserEvent::product_details].
+    pub fn set_product_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ProductDetail>,
+    {
+        use std::iter::Iterator;
+        self.product_details = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -19076,6 +19098,18 @@ impl UserEvent {
         v: T,
     ) -> Self {
         self.completion_detail = v.into();
+        self
+    }
+
+    /// Sets the value of [attributes][crate::model::UserEvent::attributes].
+    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::CustomAttribute>,
+    {
+        use std::iter::Iterator;
+        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -19120,6 +19154,17 @@ impl UserEvent {
         self
     }
 
+    /// Sets the value of [page_categories][crate::model::UserEvent::page_categories].
+    pub fn set_page_categories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.page_categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [user_info][crate::model::UserEvent::user_info].
     pub fn set_user_info<T: std::convert::Into<std::option::Option<crate::model::UserInfo>>>(
         mut self,
@@ -19150,51 +19195,6 @@ impl UserEvent {
     /// Sets the value of [entity][crate::model::UserEvent::entity].
     pub fn set_entity<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.entity = v.into();
-        self
-    }
-
-    /// Sets the value of [experiment_ids][crate::model::UserEvent::experiment_ids].
-    pub fn set_experiment_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.experiment_ids = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [product_details][crate::model::UserEvent::product_details].
-    pub fn set_product_details<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ProductDetail>,
-    {
-        use std::iter::Iterator;
-        self.product_details = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [page_categories][crate::model::UserEvent::page_categories].
-    pub fn set_page_categories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.page_categories = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [attributes][crate::model::UserEvent::attributes].
-    pub fn set_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::CustomAttribute>,
-    {
-        use std::iter::Iterator;
-        self.attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -198,22 +198,6 @@ impl SubmitBuildRequest {
         })
     }
 
-    /// The value of [build_type][crate::model::SubmitBuildRequest::build_type]
-    /// if it holds a `DockerBuild`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn docker_build(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::submit_build_request::DockerBuild>>
-    {
-        #[allow(unreachable_patterns)]
-        self.build_type.as_ref().and_then(|v| match v {
-            crate::model::submit_build_request::BuildType::DockerBuild(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
     /// to hold a `BuildpackBuild`.
     ///
@@ -229,6 +213,22 @@ impl SubmitBuildRequest {
             crate::model::submit_build_request::BuildType::BuildpackBuild(v.into()),
         );
         self
+    }
+
+    /// The value of [build_type][crate::model::SubmitBuildRequest::build_type]
+    /// if it holds a `DockerBuild`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn docker_build(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::submit_build_request::DockerBuild>>
+    {
+        #[allow(unreachable_patterns)]
+        self.build_type.as_ref().and_then(|v| match v {
+            crate::model::submit_build_request::BuildType::DockerBuild(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
@@ -367,6 +367,18 @@ pub mod submit_build_request {
             self
         }
 
+        /// Sets the value of [environment_variables][crate::model::submit_build_request::BuildpacksBuild::environment_variables].
+        pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [enable_automatic_updates][crate::model::submit_build_request::BuildpacksBuild::enable_automatic_updates].
         pub fn set_enable_automatic_updates<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.enable_automatic_updates = v.into();
@@ -379,18 +391,6 @@ pub mod submit_build_request {
             v: T,
         ) -> Self {
             self.project_descriptor = v.into();
-            self
-        }
-
-        /// Sets the value of [environment_variables][crate::model::submit_build_request::BuildpacksBuild::environment_variables].
-        pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -651,30 +651,6 @@ impl Condition {
         })
     }
 
-    /// The value of [reasons][crate::model::Condition::reasons]
-    /// if it holds a `RevisionReason`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn revision_reason(&self) -> std::option::Option<&crate::model::condition::RevisionReason> {
-        #[allow(unreachable_patterns)]
-        self.reasons.as_ref().and_then(|v| match v {
-            crate::model::condition::Reasons::RevisionReason(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [reasons][crate::model::Condition::reasons]
-    /// if it holds a `ExecutionReason`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn execution_reason(
-        &self,
-    ) -> std::option::Option<&crate::model::condition::ExecutionReason> {
-        #[allow(unreachable_patterns)]
-        self.reasons.as_ref().and_then(|v| match v {
-            crate::model::condition::Reasons::ExecutionReason(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [reasons][crate::model::Condition::reasons]
     /// to hold a `Reason`.
     ///
@@ -689,6 +665,17 @@ impl Condition {
         self
     }
 
+    /// The value of [reasons][crate::model::Condition::reasons]
+    /// if it holds a `RevisionReason`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn revision_reason(&self) -> std::option::Option<&crate::model::condition::RevisionReason> {
+        #[allow(unreachable_patterns)]
+        self.reasons.as_ref().and_then(|v| match v {
+            crate::model::condition::Reasons::RevisionReason(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [reasons][crate::model::Condition::reasons]
     /// to hold a `RevisionReason`.
     ///
@@ -701,6 +688,19 @@ impl Condition {
         self.reasons =
             std::option::Option::Some(crate::model::condition::Reasons::RevisionReason(v.into()));
         self
+    }
+
+    /// The value of [reasons][crate::model::Condition::reasons]
+    /// if it holds a `ExecutionReason`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn execution_reason(
+        &self,
+    ) -> std::option::Option<&crate::model::condition::ExecutionReason> {
+        #[allow(unreachable_patterns)]
+        self.reasons.as_ref().and_then(|v| match v {
+            crate::model::condition::Reasons::ExecutionReason(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [reasons][crate::model::Condition::reasons]
@@ -1760,12 +1760,6 @@ impl ListExecutionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [executions][crate::model::ListExecutionsResponse::executions].
     pub fn set_executions<T, V>(mut self, v: T) -> Self
     where
@@ -1774,6 +1768,12 @@ impl ListExecutionsResponse {
     {
         use std::iter::Iterator;
         self.executions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2107,6 +2107,30 @@ impl Execution {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Execution::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Execution::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Execution::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2203,6 +2227,17 @@ impl Execution {
         self
     }
 
+    /// Sets the value of [conditions][crate::model::Execution::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [observed_generation][crate::model::Execution::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
@@ -2254,41 +2289,6 @@ impl Execution {
     /// Sets the value of [etag][crate::model::Execution::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::Execution::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Condition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Execution::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Execution::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2352,27 +2352,6 @@ impl ExecutionTemplate {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parallelism][crate::model::ExecutionTemplate::parallelism].
-    pub fn set_parallelism<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.parallelism = v.into();
-        self
-    }
-
-    /// Sets the value of [task_count][crate::model::ExecutionTemplate::task_count].
-    pub fn set_task_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.task_count = v.into();
-        self
-    }
-
-    /// Sets the value of [template][crate::model::ExecutionTemplate::template].
-    pub fn set_template<T: std::convert::Into<std::option::Option<crate::model::TaskTemplate>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.template = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::ExecutionTemplate::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -2394,6 +2373,27 @@ impl ExecutionTemplate {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [parallelism][crate::model::ExecutionTemplate::parallelism].
+    pub fn set_parallelism<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.parallelism = v.into();
+        self
+    }
+
+    /// Sets the value of [task_count][crate::model::ExecutionTemplate::task_count].
+    pub fn set_task_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.task_count = v.into();
+        self
+    }
+
+    /// Sets the value of [template][crate::model::ExecutionTemplate::template].
+    pub fn set_template<T: std::convert::Into<std::option::Option<crate::model::TaskTemplate>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.template = v.into();
         self
     }
 }
@@ -2654,12 +2654,6 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -2668,6 +2662,12 @@ impl ListJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2856,6 +2856,17 @@ pub mod run_job_request {
             std::default::Default::default()
         }
 
+        /// Sets the value of [container_overrides][crate::model::run_job_request::Overrides::container_overrides].
+        pub fn set_container_overrides<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::run_job_request::overrides::ContainerOverride>,
+        {
+            use std::iter::Iterator;
+            self.container_overrides = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [task_count][crate::model::run_job_request::Overrides::task_count].
         pub fn set_task_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.task_count = v.into();
@@ -2868,17 +2879,6 @@ pub mod run_job_request {
             v: T,
         ) -> Self {
             self.timeout = v.into();
-            self
-        }
-
-        /// Sets the value of [container_overrides][crate::model::run_job_request::Overrides::container_overrides].
-        pub fn set_container_overrides<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::run_job_request::overrides::ContainerOverride>,
-        {
-            use std::iter::Iterator;
-            self.container_overrides = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2933,12 +2933,6 @@ pub mod run_job_request {
                 self
             }
 
-            /// Sets the value of [clear_args][crate::model::run_job_request::overrides::ContainerOverride::clear_args].
-            pub fn set_clear_args<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.clear_args = v.into();
-                self
-            }
-
             /// Sets the value of [args][crate::model::run_job_request::overrides::ContainerOverride::args].
             pub fn set_args<T, V>(mut self, v: T) -> Self
             where
@@ -2958,6 +2952,12 @@ pub mod run_job_request {
             {
                 use std::iter::Iterator;
                 self.env = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [clear_args][crate::model::run_job_request::overrides::ContainerOverride::clear_args].
+            pub fn set_clear_args<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+                self.clear_args = v.into();
                 self
             }
         }
@@ -3156,6 +3156,30 @@ impl Job {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Job::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Job::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Job::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -3264,6 +3288,17 @@ impl Job {
         self
     }
 
+    /// Sets the value of [conditions][crate::model::Job::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [execution_count][crate::model::Job::execution_count].
     pub fn set_execution_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.execution_count = v.into();
@@ -3299,41 +3334,6 @@ impl Job {
         self
     }
 
-    /// Sets the value of [conditions][crate::model::Job::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Condition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Job::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Job::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [create_execution][crate::model::Job::create_execution].
     ///
     /// Note that all the setters affecting `create_execution` are mutually
@@ -3361,19 +3361,6 @@ impl Job {
         })
     }
 
-    /// The value of [create_execution][crate::model::Job::create_execution]
-    /// if it holds a `RunExecutionToken`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn run_execution_token(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.create_execution.as_ref().and_then(|v| match v {
-            crate::model::job::CreateExecution::RunExecutionToken(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [create_execution][crate::model::Job::create_execution]
     /// to hold a `StartExecutionToken`.
     ///
@@ -3387,6 +3374,19 @@ impl Job {
             crate::model::job::CreateExecution::StartExecutionToken(v.into()),
         );
         self
+    }
+
+    /// The value of [create_execution][crate::model::Job::create_execution]
+    /// if it holds a `RunExecutionToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn run_execution_token(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.create_execution.as_ref().and_then(|v| match v {
+            crate::model::job::CreateExecution::RunExecutionToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [create_execution][crate::model::Job::create_execution]
@@ -3780,56 +3780,6 @@ impl Container {
         self
     }
 
-    /// Sets the value of [resources][crate::model::Container::resources].
-    pub fn set_resources<
-        T: std::convert::Into<std::option::Option<crate::model::ResourceRequirements>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resources = v.into();
-        self
-    }
-
-    /// Sets the value of [working_dir][crate::model::Container::working_dir].
-    pub fn set_working_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.working_dir = v.into();
-        self
-    }
-
-    /// Sets the value of [liveness_probe][crate::model::Container::liveness_probe].
-    pub fn set_liveness_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.liveness_probe = v.into();
-        self
-    }
-
-    /// Sets the value of [startup_probe][crate::model::Container::startup_probe].
-    pub fn set_startup_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.startup_probe = v.into();
-        self
-    }
-
-    /// Sets the value of [base_image_uri][crate::model::Container::base_image_uri].
-    pub fn set_base_image_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.base_image_uri = v.into();
-        self
-    }
-
-    /// Sets the value of [build_info][crate::model::Container::build_info].
-    pub fn set_build_info<T: std::convert::Into<std::option::Option<crate::model::BuildInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.build_info = v.into();
-        self
-    }
-
     /// Sets the value of [command][crate::model::Container::command].
     pub fn set_command<T, V>(mut self, v: T) -> Self
     where
@@ -3863,6 +3813,17 @@ impl Container {
         self
     }
 
+    /// Sets the value of [resources][crate::model::Container::resources].
+    pub fn set_resources<
+        T: std::convert::Into<std::option::Option<crate::model::ResourceRequirements>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.resources = v.into();
+        self
+    }
+
     /// Sets the value of [ports][crate::model::Container::ports].
     pub fn set_ports<T, V>(mut self, v: T) -> Self
     where
@@ -3885,6 +3846,30 @@ impl Container {
         self
     }
 
+    /// Sets the value of [working_dir][crate::model::Container::working_dir].
+    pub fn set_working_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.working_dir = v.into();
+        self
+    }
+
+    /// Sets the value of [liveness_probe][crate::model::Container::liveness_probe].
+    pub fn set_liveness_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.liveness_probe = v.into();
+        self
+    }
+
+    /// Sets the value of [startup_probe][crate::model::Container::startup_probe].
+    pub fn set_startup_probe<T: std::convert::Into<std::option::Option<crate::model::Probe>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.startup_probe = v.into();
+        self
+    }
+
     /// Sets the value of [depends_on][crate::model::Container::depends_on].
     pub fn set_depends_on<T, V>(mut self, v: T) -> Self
     where
@@ -3893,6 +3878,21 @@ impl Container {
     {
         use std::iter::Iterator;
         self.depends_on = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [base_image_uri][crate::model::Container::base_image_uri].
+    pub fn set_base_image_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.base_image_uri = v.into();
+        self
+    }
+
+    /// Sets the value of [build_info][crate::model::Container::build_info].
+    pub fn set_build_info<T: std::convert::Into<std::option::Option<crate::model::BuildInfo>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.build_info = v.into();
         self
     }
 }
@@ -3934,18 +3934,6 @@ impl ResourceRequirements {
         std::default::Default::default()
     }
 
-    /// Sets the value of [cpu_idle][crate::model::ResourceRequirements::cpu_idle].
-    pub fn set_cpu_idle<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.cpu_idle = v.into();
-        self
-    }
-
-    /// Sets the value of [startup_cpu_boost][crate::model::ResourceRequirements::startup_cpu_boost].
-    pub fn set_startup_cpu_boost<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.startup_cpu_boost = v.into();
-        self
-    }
-
     /// Sets the value of [limits][crate::model::ResourceRequirements::limits].
     pub fn set_limits<T, K, V>(mut self, v: T) -> Self
     where
@@ -3955,6 +3943,18 @@ impl ResourceRequirements {
     {
         use std::iter::Iterator;
         self.limits = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [cpu_idle][crate::model::ResourceRequirements::cpu_idle].
+    pub fn set_cpu_idle<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.cpu_idle = v.into();
+        self
+    }
+
+    /// Sets the value of [startup_cpu_boost][crate::model::ResourceRequirements::startup_cpu_boost].
+    pub fn set_startup_cpu_boost<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.startup_cpu_boost = v.into();
         self
     }
 }
@@ -4017,6 +4017,16 @@ impl EnvVar {
         })
     }
 
+    /// Sets the value of [values][crate::model::EnvVar::values]
+    /// to hold a `Value`.
+    ///
+    /// Note that all the setters affecting `values` are
+    /// mutually exclusive.
+    pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.values = std::option::Option::Some(crate::model::env_var::Values::Value(v.into()));
+        self
+    }
+
     /// The value of [values][crate::model::EnvVar::values]
     /// if it holds a `ValueSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -4028,16 +4038,6 @@ impl EnvVar {
             crate::model::env_var::Values::ValueSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [values][crate::model::EnvVar::values]
-    /// to hold a `Value`.
-    ///
-    /// Note that all the setters affecting `values` are
-    /// mutually exclusive.
-    pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.values = std::option::Option::Some(crate::model::env_var::Values::Value(v.into()));
-        self
     }
 
     /// Sets the value of [values][crate::model::EnvVar::values]
@@ -4308,54 +4308,6 @@ impl Volume {
         })
     }
 
-    /// The value of [volume_type][crate::model::Volume::volume_type]
-    /// if it holds a `CloudSqlInstance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_sql_instance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlInstance>> {
-        #[allow(unreachable_patterns)]
-        self.volume_type.as_ref().and_then(|v| match v {
-            crate::model::volume::VolumeType::CloudSqlInstance(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [volume_type][crate::model::Volume::volume_type]
-    /// if it holds a `EmptyDir`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn empty_dir(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::EmptyDirVolumeSource>> {
-        #[allow(unreachable_patterns)]
-        self.volume_type.as_ref().and_then(|v| match v {
-            crate::model::volume::VolumeType::EmptyDir(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [volume_type][crate::model::Volume::volume_type]
-    /// if it holds a `Nfs`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn nfs(&self) -> std::option::Option<&std::boxed::Box<crate::model::NFSVolumeSource>> {
-        #[allow(unreachable_patterns)]
-        self.volume_type.as_ref().and_then(|v| match v {
-            crate::model::volume::VolumeType::Nfs(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [volume_type][crate::model::Volume::volume_type]
-    /// if it holds a `Gcs`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs(&self) -> std::option::Option<&std::boxed::Box<crate::model::GCSVolumeSource>> {
-        #[allow(unreachable_patterns)]
-        self.volume_type.as_ref().and_then(|v| match v {
-            crate::model::volume::VolumeType::Gcs(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [volume_type][crate::model::Volume::volume_type]
     /// to hold a `Secret`.
     ///
@@ -4368,6 +4320,19 @@ impl Volume {
         self.volume_type =
             std::option::Option::Some(crate::model::volume::VolumeType::Secret(v.into()));
         self
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `CloudSqlInstance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_sql_instance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlInstance>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::CloudSqlInstance(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [volume_type][crate::model::Volume::volume_type]
@@ -4386,6 +4351,19 @@ impl Volume {
         self
     }
 
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `EmptyDir`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn empty_dir(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::EmptyDirVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::EmptyDir(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [volume_type][crate::model::Volume::volume_type]
     /// to hold a `EmptyDir`.
     ///
@@ -4402,6 +4380,17 @@ impl Volume {
         self
     }
 
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `Nfs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn nfs(&self) -> std::option::Option<&std::boxed::Box<crate::model::NFSVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::Nfs(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [volume_type][crate::model::Volume::volume_type]
     /// to hold a `Nfs`.
     ///
@@ -4414,6 +4403,17 @@ impl Volume {
         self.volume_type =
             std::option::Option::Some(crate::model::volume::VolumeType::Nfs(v.into()));
         self
+    }
+
+    /// The value of [volume_type][crate::model::Volume::volume_type]
+    /// if it holds a `Gcs`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs(&self) -> std::option::Option<&std::boxed::Box<crate::model::GCSVolumeSource>> {
+        #[allow(unreachable_patterns)]
+        self.volume_type.as_ref().and_then(|v| match v {
+            crate::model::volume::VolumeType::Gcs(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [volume_type][crate::model::Volume::volume_type]
@@ -4519,12 +4519,6 @@ impl SecretVolumeSource {
         self
     }
 
-    /// Sets the value of [default_mode][crate::model::SecretVolumeSource::default_mode].
-    pub fn set_default_mode<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.default_mode = v.into();
-        self
-    }
-
     /// Sets the value of [items][crate::model::SecretVolumeSource::items].
     pub fn set_items<T, V>(mut self, v: T) -> Self
     where
@@ -4533,6 +4527,12 @@ impl SecretVolumeSource {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [default_mode][crate::model::SecretVolumeSource::default_mode].
+    pub fn set_default_mode<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.default_mode = v.into();
         self
     }
 }
@@ -5046,30 +5046,6 @@ impl Probe {
         })
     }
 
-    /// The value of [probe_type][crate::model::Probe::probe_type]
-    /// if it holds a `TcpSocket`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tcp_socket(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TCPSocketAction>> {
-        #[allow(unreachable_patterns)]
-        self.probe_type.as_ref().and_then(|v| match v {
-            crate::model::probe::ProbeType::TcpSocket(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [probe_type][crate::model::Probe::probe_type]
-    /// if it holds a `Grpc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn grpc(&self) -> std::option::Option<&std::boxed::Box<crate::model::GRPCAction>> {
-        #[allow(unreachable_patterns)]
-        self.probe_type.as_ref().and_then(|v| match v {
-            crate::model::probe::ProbeType::Grpc(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
     /// to hold a `HttpGet`.
     ///
@@ -5084,6 +5060,19 @@ impl Probe {
         self
     }
 
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `TcpSocket`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tcp_socket(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TCPSocketAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::TcpSocket(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
     /// to hold a `TcpSocket`.
     ///
@@ -5096,6 +5085,17 @@ impl Probe {
         self.probe_type =
             std::option::Option::Some(crate::model::probe::ProbeType::TcpSocket(v.into()));
         self
+    }
+
+    /// The value of [probe_type][crate::model::Probe::probe_type]
+    /// if it holds a `Grpc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn grpc(&self) -> std::option::Option<&std::boxed::Box<crate::model::GRPCAction>> {
+        #[allow(unreachable_patterns)]
+        self.probe_type.as_ref().and_then(|v| match v {
+            crate::model::probe::ProbeType::Grpc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [probe_type][crate::model::Probe::probe_type]
@@ -5175,12 +5175,6 @@ impl HTTPGetAction {
         self
     }
 
-    /// Sets the value of [port][crate::model::HTTPGetAction::port].
-    pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.port = v.into();
-        self
-    }
-
     /// Sets the value of [http_headers][crate::model::HTTPGetAction::http_headers].
     pub fn set_http_headers<T, V>(mut self, v: T) -> Self
     where
@@ -5189,6 +5183,12 @@ impl HTTPGetAction {
     {
         use std::iter::Iterator;
         self.http_headers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [port][crate::model::HTTPGetAction::port].
+    pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.port = v.into();
         self
     }
 }
@@ -5489,12 +5489,6 @@ impl ListRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [revisions][crate::model::ListRevisionsResponse::revisions].
     pub fn set_revisions<T, V>(mut self, v: T) -> Self
     where
@@ -5503,6 +5497,12 @@ impl ListRevisionsResponse {
     {
         use std::iter::Iterator;
         self.revisions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5783,6 +5783,30 @@ impl Revision {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Revision::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Revision::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Revision::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5878,6 +5902,28 @@ impl Revision {
         self
     }
 
+    /// Sets the value of [containers][crate::model::Revision::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::Revision::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [execution_environment][crate::model::Revision::execution_environment].
     pub fn set_execution_environment<T: std::convert::Into<crate::model::ExecutionEnvironment>>(
         mut self,
@@ -5932,6 +5978,17 @@ impl Revision {
         self
     }
 
+    /// Sets the value of [conditions][crate::model::Revision::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [observed_generation][crate::model::Revision::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
@@ -5981,63 +6038,6 @@ impl Revision {
     /// Sets the value of [etag][crate::model::Revision::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [containers][crate::model::Revision::containers].
-    pub fn set_containers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Container>,
-    {
-        use std::iter::Iterator;
-        self.containers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [volumes][crate::model::Revision::volumes].
-    pub fn set_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Volume>,
-    {
-        use std::iter::Iterator;
-        self.volumes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::Revision::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Condition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Revision::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Revision::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6159,6 +6159,30 @@ impl RevisionTemplate {
         self
     }
 
+    /// Sets the value of [labels][crate::model::RevisionTemplate::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::RevisionTemplate::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [scaling][crate::model::RevisionTemplate::scaling].
     pub fn set_scaling<
         T: std::convert::Into<std::option::Option<crate::model::RevisionScaling>>,
@@ -6191,6 +6215,28 @@ impl RevisionTemplate {
     /// Sets the value of [service_account][crate::model::RevisionTemplate::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
+        self
+    }
+
+    /// Sets the value of [containers][crate::model::RevisionTemplate::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::RevisionTemplate::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6271,52 +6317,6 @@ impl RevisionTemplate {
         v: T,
     ) -> Self {
         self.node_selector = v.into();
-        self
-    }
-
-    /// Sets the value of [containers][crate::model::RevisionTemplate::containers].
-    pub fn set_containers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Container>,
-    {
-        use std::iter::Iterator;
-        self.containers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [volumes][crate::model::RevisionTemplate::volumes].
-    pub fn set_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Volume>,
-    {
-        use std::iter::Iterator;
-        self.volumes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::RevisionTemplate::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::RevisionTemplate::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6558,12 +6558,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -6572,6 +6566,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6947,6 +6947,30 @@ impl Service {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Service::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Service::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Service::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -7047,6 +7071,17 @@ impl Service {
         self
     }
 
+    /// Sets the value of [traffic][crate::model::Service::traffic].
+    pub fn set_traffic<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TrafficTarget>,
+    {
+        use std::iter::Iterator;
+        self.traffic = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [scaling][crate::model::Service::scaling].
     pub fn set_scaling<T: std::convert::Into<std::option::Option<crate::model::ServiceScaling>>>(
         mut self,
@@ -7068,6 +7103,28 @@ impl Service {
         self
     }
 
+    /// Sets the value of [urls][crate::model::Service::urls].
+    pub fn set_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [custom_audiences][crate::model::Service::custom_audiences].
+    pub fn set_custom_audiences<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.custom_audiences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [observed_generation][crate::model::Service::observed_generation].
     pub fn set_observed_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.observed_generation = v.into();
@@ -7082,6 +7139,17 @@ impl Service {
         v: T,
     ) -> Self {
         self.terminal_condition = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Service::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7100,6 +7168,17 @@ impl Service {
         v: T,
     ) -> Self {
         self.latest_created_revision = v.into();
+        self
+    }
+
+    /// Sets the value of [traffic_statuses][crate::model::Service::traffic_statuses].
+    pub fn set_traffic_statuses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TrafficTargetStatus>,
+    {
+        use std::iter::Iterator;
+        self.traffic_statuses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7135,85 +7214,6 @@ impl Service {
     /// Sets the value of [etag][crate::model::Service::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [traffic][crate::model::Service::traffic].
-    pub fn set_traffic<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TrafficTarget>,
-    {
-        use std::iter::Iterator;
-        self.traffic = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [urls][crate::model::Service::urls].
-    pub fn set_urls<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.urls = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [custom_audiences][crate::model::Service::custom_audiences].
-    pub fn set_custom_audiences<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.custom_audiences = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::Service::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Condition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [traffic_statuses][crate::model::Service::traffic_statuses].
-    pub fn set_traffic_statuses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TrafficTargetStatus>,
-    {
-        use std::iter::Iterator;
-        self.traffic_statuses = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Service::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Service::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7380,12 +7380,6 @@ impl ListTasksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tasks][crate::model::ListTasksResponse::tasks].
     pub fn set_tasks<T, V>(mut self, v: T) -> Self
     where
@@ -7394,6 +7388,12 @@ impl ListTasksResponse {
     {
         use std::iter::Iterator;
         self.tasks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7614,6 +7614,30 @@ impl Task {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Task::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Task::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Task::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -7689,6 +7713,28 @@ impl Task {
         self
     }
 
+    /// Sets the value of [containers][crate::model::Task::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::Task::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [max_retries][crate::model::Task::max_retries].
     pub fn set_max_retries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_retries = v.into();
@@ -7722,6 +7768,17 @@ impl Task {
     /// Sets the value of [reconciling][crate::model::Task::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Task::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7784,63 +7841,6 @@ impl Task {
     /// Sets the value of [etag][crate::model::Task::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [containers][crate::model::Task::containers].
-    pub fn set_containers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Container>,
-    {
-        use std::iter::Iterator;
-        self.containers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [volumes][crate::model::Task::volumes].
-    pub fn set_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Volume>,
-    {
-        use std::iter::Iterator;
-        self.volumes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::Task::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Condition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Task::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Task::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7957,6 +7957,28 @@ impl TaskTemplate {
         std::default::Default::default()
     }
 
+    /// Sets the value of [containers][crate::model::TaskTemplate::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::TaskTemplate::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [timeout][crate::model::TaskTemplate::timeout].
     pub fn set_timeout<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
@@ -7993,28 +8015,6 @@ impl TaskTemplate {
         v: T,
     ) -> Self {
         self.vpc_access = v.into();
-        self
-    }
-
-    /// Sets the value of [containers][crate::model::TaskTemplate::containers].
-    pub fn set_containers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Container>,
-    {
-        use std::iter::Iterator;
-        self.containers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [volumes][crate::model::TaskTemplate::volumes].
-    pub fn set_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Volume>,
-    {
-        use std::iter::Iterator;
-        self.volumes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8550,6 +8550,18 @@ impl BinaryAuthorization {
         })
     }
 
+    /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
+    /// to hold a `UseDefault`.
+    ///
+    /// Note that all the setters affecting `binauthz_method` are
+    /// mutually exclusive.
+    pub fn set_use_default<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.binauthz_method = std::option::Option::Some(
+            crate::model::binary_authorization::BinauthzMethod::UseDefault(v.into()),
+        );
+        self
+    }
+
     /// The value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
     /// if it holds a `Policy`, `None` if the field is not set or
     /// holds a different branch.
@@ -8561,18 +8573,6 @@ impl BinaryAuthorization {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
-    /// to hold a `UseDefault`.
-    ///
-    /// Note that all the setters affecting `binauthz_method` are
-    /// mutually exclusive.
-    pub fn set_use_default<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.binauthz_method = std::option::Option::Some(
-            crate::model::binary_authorization::BinauthzMethod::UseDefault(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
@@ -9032,12 +9032,6 @@ impl BuildConfig {
         self
     }
 
-    /// Sets the value of [service_account][crate::model::BuildConfig::service_account].
-    pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.service_account = v.into();
-        self
-    }
-
     /// Sets the value of [environment_variables][crate::model::BuildConfig::environment_variables].
     pub fn set_environment_variables<T, K, V>(mut self, v: T) -> Self
     where
@@ -9047,6 +9041,12 @@ impl BuildConfig {
     {
         use std::iter::Iterator;
         self.environment_variables = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [service_account][crate::model::BuildConfig::service_account].
+    pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.service_account = v.into();
         self
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -137,12 +137,6 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -151,6 +145,12 @@ impl ListJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -741,30 +741,6 @@ impl Job {
         })
     }
 
-    /// The value of [target][crate::model::Job::target]
-    /// if it holds a `AppEngineHttpTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn app_engine_http_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AppEngineHttpTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::job::Target::AppEngineHttpTarget(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [target][crate::model::Job::target]
-    /// if it holds a `HttpTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn http_target(&self) -> std::option::Option<&std::boxed::Box<crate::model::HttpTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::job::Target::HttpTarget(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::Job::target]
     /// to hold a `PubsubTarget`.
     ///
@@ -776,6 +752,19 @@ impl Job {
     ) -> Self {
         self.target = std::option::Option::Some(crate::model::job::Target::PubsubTarget(v.into()));
         self
+    }
+
+    /// The value of [target][crate::model::Job::target]
+    /// if it holds a `AppEngineHttpTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn app_engine_http_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AppEngineHttpTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::job::Target::AppEngineHttpTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::Job::target]
@@ -792,6 +781,17 @@ impl Job {
         self.target =
             std::option::Option::Some(crate::model::job::Target::AppEngineHttpTarget(v.into()));
         self
+    }
+
+    /// The value of [target][crate::model::Job::target]
+    /// if it holds a `HttpTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn http_target(&self) -> std::option::Option<&std::boxed::Box<crate::model::HttpTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::job::Target::HttpTarget(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::Job::target]
@@ -1251,12 +1251,6 @@ impl HttpTarget {
         self
     }
 
-    /// Sets the value of [body][crate::model::HttpTarget::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::HttpTarget::headers].
     pub fn set_headers<T, K, V>(mut self, v: T) -> Self
     where
@@ -1266,6 +1260,12 @@ impl HttpTarget {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::HttpTarget::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 
@@ -1296,19 +1296,6 @@ impl HttpTarget {
         })
     }
 
-    /// The value of [authorization_header][crate::model::HttpTarget::authorization_header]
-    /// if it holds a `OidcToken`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oidc_token(&self) -> std::option::Option<&std::boxed::Box<crate::model::OidcToken>> {
-        #[allow(unreachable_patterns)]
-        self.authorization_header.as_ref().and_then(|v| match v {
-            crate::model::http_target::AuthorizationHeader::OidcToken(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [authorization_header][crate::model::HttpTarget::authorization_header]
     /// to hold a `OauthToken`.
     ///
@@ -1322,6 +1309,19 @@ impl HttpTarget {
             crate::model::http_target::AuthorizationHeader::OauthToken(v.into()),
         );
         self
+    }
+
+    /// The value of [authorization_header][crate::model::HttpTarget::authorization_header]
+    /// if it holds a `OidcToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oidc_token(&self) -> std::option::Option<&std::boxed::Box<crate::model::OidcToken>> {
+        #[allow(unreachable_patterns)]
+        self.authorization_header.as_ref().and_then(|v| match v {
+            crate::model::http_target::AuthorizationHeader::OidcToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [authorization_header][crate::model::HttpTarget::authorization_header]
@@ -1503,12 +1503,6 @@ impl AppEngineHttpTarget {
         self
     }
 
-    /// Sets the value of [body][crate::model::AppEngineHttpTarget::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::AppEngineHttpTarget::headers].
     pub fn set_headers<T, K, V>(mut self, v: T) -> Self
     where
@@ -1518,6 +1512,12 @@ impl AppEngineHttpTarget {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::AppEngineHttpTarget::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -210,38 +210,15 @@ impl Secret {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Secret::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [rotation][crate::model::Secret::rotation].
-    pub fn set_rotation<T: std::convert::Into<std::option::Option<crate::model::Rotation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rotation = v.into();
-        self
-    }
-
-    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
-    pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.version_destroy_ttl = v.into();
-        self
-    }
-
-    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
-    pub fn set_customer_managed_encryption<
-        T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.customer_managed_encryption = v.into();
+    /// Sets the value of [labels][crate::model::Secret::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -256,15 +233,18 @@ impl Secret {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Secret::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [etag][crate::model::Secret::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [rotation][crate::model::Secret::rotation].
+    pub fn set_rotation<T: std::convert::Into<std::option::Option<crate::model::Rotation>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rotation = v.into();
         self
     }
 
@@ -289,6 +269,26 @@ impl Secret {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
+    pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.version_destroy_ttl = v.into();
+        self
+    }
+
+    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
+    pub fn set_customer_managed_encryption<
+        T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.customer_managed_encryption = v.into();
         self
     }
 
@@ -317,17 +317,6 @@ impl Secret {
         })
     }
 
-    /// The value of [expiration][crate::model::Secret::expiration]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.expiration.as_ref().and_then(|v| match v {
-            crate::model::secret::Expiration::Ttl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [expiration][crate::model::Secret::expiration]
     /// to hold a `ExpireTime`.
     ///
@@ -340,6 +329,17 @@ impl Secret {
         self.expiration =
             std::option::Option::Some(crate::model::secret::Expiration::ExpireTime(v.into()));
         self
+    }
+
+    /// The value of [expiration][crate::model::Secret::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::secret::Expiration::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [expiration][crate::model::Secret::expiration]
@@ -793,19 +793,6 @@ impl Replication {
         })
     }
 
-    /// The value of [replication][crate::model::Replication::replication]
-    /// if it holds a `UserManaged`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn user_managed(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::replication::UserManaged>> {
-        #[allow(unreachable_patterns)]
-        self.replication.as_ref().and_then(|v| match v {
-            crate::model::replication::Replication::UserManaged(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [replication][crate::model::Replication::replication]
     /// to hold a `Automatic`.
     ///
@@ -820,6 +807,19 @@ impl Replication {
         self.replication =
             std::option::Option::Some(crate::model::replication::Replication::Automatic(v.into()));
         self
+    }
+
+    /// The value of [replication][crate::model::Replication::replication]
+    /// if it holds a `UserManaged`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn user_managed(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::replication::UserManaged>> {
+        #[allow(unreachable_patterns)]
+        self.replication.as_ref().and_then(|v| match v {
+            crate::model::replication::Replication::UserManaged(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [replication][crate::model::Replication::replication]
@@ -1149,22 +1149,6 @@ impl ReplicationStatus {
         })
     }
 
-    /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
-    /// if it holds a `UserManaged`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn user_managed(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::replication_status::UserManagedStatus>>
-    {
-        #[allow(unreachable_patterns)]
-        self.replication_status.as_ref().and_then(|v| match v {
-            crate::model::replication_status::ReplicationStatus::UserManaged(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
     /// to hold a `Automatic`.
     ///
@@ -1180,6 +1164,22 @@ impl ReplicationStatus {
             crate::model::replication_status::ReplicationStatus::Automatic(v.into()),
         );
         self
+    }
+
+    /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
+    /// if it holds a `UserManaged`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn user_managed(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::replication_status::UserManagedStatus>>
+    {
+        #[allow(unreachable_patterns)]
+        self.replication_status.as_ref().and_then(|v| match v {
+            crate::model::replication_status::ReplicationStatus::UserManaged(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
@@ -1759,6 +1759,17 @@ impl ListSecretsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>,
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListSecretsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -1768,17 +1779,6 @@ impl ListSecretsResponse {
     /// Sets the value of [total_size][crate::model::ListSecretsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
-    pub fn set_secrets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Secret>,
-    {
-        use std::iter::Iterator;
-        self.secrets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2090,6 +2090,17 @@ impl ListSecretVersionsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVersion>,
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListSecretVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -2099,17 +2110,6 @@ impl ListSecretVersionsResponse {
     /// Sets the value of [total_size][crate::model::ListSecretVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
-    pub fn set_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SecretVersion>,
-    {
-        use std::iter::Iterator;
-        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/model.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/model.rs
@@ -120,6 +120,18 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [private_config][crate::model::Instance::private_config].
     pub fn set_private_config<
         T: std::convert::Into<std::option::Option<crate::model::instance::PrivateConfig>>,
@@ -160,18 +172,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.host_config = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -985,6 +985,17 @@ pub mod repository {
             self
         }
 
+        /// Sets the value of [gitignores][crate::model::repository::InitialConfig::gitignores].
+        pub fn set_gitignores<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.gitignores = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [license][crate::model::repository::InitialConfig::license].
         pub fn set_license<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.license = v.into();
@@ -994,17 +1005,6 @@ pub mod repository {
         /// Sets the value of [readme][crate::model::repository::InitialConfig::readme].
         pub fn set_readme<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.readme = v.into();
-            self
-        }
-
-        /// Sets the value of [gitignores][crate::model::repository::InitialConfig::gitignores].
-        pub fn set_gitignores<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.gitignores = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1136,6 +1136,18 @@ impl BranchRule {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::BranchRule::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::BranchRule::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -1198,18 +1210,6 @@ impl BranchRule {
     {
         use std::iter::Iterator;
         self.required_status_checks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::BranchRule::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1357,12 +1357,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -1371,6 +1365,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1774,12 +1774,6 @@ impl ListRepositoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [repositories][crate::model::ListRepositoriesResponse::repositories].
     pub fn set_repositories<T, V>(mut self, v: T) -> Self
     where
@@ -1788,6 +1782,12 @@ impl ListRepositoriesResponse {
     {
         use std::iter::Iterator;
         self.repositories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2211,12 +2211,6 @@ impl ListBranchRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBranchRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [branch_rules][crate::model::ListBranchRulesResponse::branch_rules].
     pub fn set_branch_rules<T, V>(mut self, v: T) -> Self
     where
@@ -2225,6 +2219,12 @@ impl ListBranchRulesResponse {
     {
         use std::iter::Iterator;
         self.branch_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBranchRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -283,6 +283,28 @@ impl CertificateAuthority {
         self
     }
 
+    /// Sets the value of [pem_ca_certificates][crate::model::CertificateAuthority::pem_ca_certificates].
+    pub fn set_pem_ca_certificates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.pem_ca_certificates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [ca_certificate_descriptions][crate::model::CertificateAuthority::ca_certificate_descriptions].
+    pub fn set_ca_certificate_descriptions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CertificateDescription>,
+    {
+        use std::iter::Iterator;
+        self.ca_certificate_descriptions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [gcs_bucket][crate::model::CertificateAuthority::gcs_bucket].
     pub fn set_gcs_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.gcs_bucket = v.into();
@@ -333,28 +355,6 @@ impl CertificateAuthority {
         v: T,
     ) -> Self {
         self.expire_time = v.into();
-        self
-    }
-
-    /// Sets the value of [pem_ca_certificates][crate::model::CertificateAuthority::pem_ca_certificates].
-    pub fn set_pem_ca_certificates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.pem_ca_certificates = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [ca_certificate_descriptions][crate::model::CertificateAuthority::ca_certificate_descriptions].
-    pub fn set_ca_certificate_descriptions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CertificateDescription>,
-    {
-        use std::iter::Iterator;
-        self.ca_certificate_descriptions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -498,21 +498,6 @@ pub mod certificate_authority {
             })
         }
 
-        /// The value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
-        /// if it holds a `Algorithm`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn algorithm(
-            &self,
-        ) -> std::option::Option<&crate::model::certificate_authority::SignHashAlgorithm> {
-            #[allow(unreachable_patterns)]
-            self.key_version.as_ref().and_then(|v| match v {
-                crate::model::certificate_authority::key_version_spec::KeyVersion::Algorithm(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
         /// to hold a `CloudKmsKeyVersion`.
         ///
@@ -528,6 +513,21 @@ pub mod certificate_authority {
                 )
             );
             self
+        }
+
+        /// The value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
+        /// if it holds a `Algorithm`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn algorithm(
+            &self,
+        ) -> std::option::Option<&crate::model::certificate_authority::SignHashAlgorithm> {
+            #[allow(unreachable_patterns)]
+            self.key_version.as_ref().and_then(|v| match v {
+                crate::model::certificate_authority::key_version_spec::KeyVersion::Algorithm(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
@@ -1571,6 +1571,17 @@ pub mod ca_pool {
             std::default::Default::default()
         }
 
+        /// Sets the value of [allowed_key_types][crate::model::ca_pool::IssuancePolicy::allowed_key_types].
+        pub fn set_allowed_key_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ca_pool::issuance_policy::AllowedKeyType>,
+        {
+            use std::iter::Iterator;
+            self.allowed_key_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [maximum_lifetime][crate::model::ca_pool::IssuancePolicy::maximum_lifetime].
         pub fn set_maximum_lifetime<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
             mut self,
@@ -1623,17 +1634,6 @@ pub mod ca_pool {
             v: T,
         ) -> Self {
             self.passthrough_extensions = v.into();
-            self
-        }
-
-        /// Sets the value of [allowed_key_types][crate::model::ca_pool::IssuancePolicy::allowed_key_types].
-        pub fn set_allowed_key_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::ca_pool::issuance_policy::AllowedKeyType>,
-        {
-            use std::iter::Iterator;
-            self.allowed_key_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1715,23 +1715,6 @@ pub mod ca_pool {
                 })
             }
 
-            /// The value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
-            /// if it holds a `EllipticCurve`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn elliptic_curve(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<
-                    crate::model::ca_pool::issuance_policy::allowed_key_type::EcKeyType,
-                >,
-            > {
-                #[allow(unreachable_patterns)]
-                self.key_type.as_ref().and_then(|v| match v {
-                    crate::model::ca_pool::issuance_policy::allowed_key_type::KeyType::EllipticCurve(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
             /// to hold a `Rsa`.
             ///
@@ -1753,6 +1736,23 @@ pub mod ca_pool {
                     ),
                 );
                 self
+            }
+
+            /// The value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
+            /// if it holds a `EllipticCurve`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn elliptic_curve(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<
+                    crate::model::ca_pool::issuance_policy::allowed_key_type::EcKeyType,
+                >,
+            > {
+                #[allow(unreachable_patterns)]
+                self.key_type.as_ref().and_then(|v| match v {
+                    crate::model::ca_pool::issuance_policy::allowed_key_type::KeyType::EllipticCurve(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
@@ -2357,6 +2357,17 @@ impl CertificateRevocationList {
         self
     }
 
+    /// Sets the value of [revoked_certificates][crate::model::CertificateRevocationList::revoked_certificates].
+    pub fn set_revoked_certificates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::certificate_revocation_list::RevokedCertificate>,
+    {
+        use std::iter::Iterator;
+        self.revoked_certificates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [pem_crl][crate::model::CertificateRevocationList::pem_crl].
     pub fn set_pem_crl<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.pem_crl = v.into();
@@ -2399,17 +2410,6 @@ impl CertificateRevocationList {
     /// Sets the value of [revision_id][crate::model::CertificateRevocationList::revision_id].
     pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.revision_id = v.into();
-        self
-    }
-
-    /// Sets the value of [revoked_certificates][crate::model::CertificateRevocationList::revoked_certificates].
-    pub fn set_revoked_certificates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::certificate_revocation_list::RevokedCertificate>,
-    {
-        use std::iter::Iterator;
-        self.revoked_certificates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2832,6 +2832,17 @@ impl Certificate {
         self
     }
 
+    /// Sets the value of [pem_certificate_chain][crate::model::Certificate::pem_certificate_chain].
+    pub fn set_pem_certificate_chain<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.pem_certificate_chain = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Certificate::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2847,17 +2858,6 @@ impl Certificate {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [pem_certificate_chain][crate::model::Certificate::pem_certificate_chain].
-    pub fn set_pem_certificate_chain<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.pem_certificate_chain = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2898,17 +2898,6 @@ impl Certificate {
         })
     }
 
-    /// The value of [certificate_config][crate::model::Certificate::certificate_config]
-    /// if it holds a `Config`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn config(&self) -> std::option::Option<&std::boxed::Box<crate::model::CertificateConfig>> {
-        #[allow(unreachable_patterns)]
-        self.certificate_config.as_ref().and_then(|v| match v {
-            crate::model::certificate::CertificateConfig::Config(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [certificate_config][crate::model::Certificate::certificate_config]
     /// to hold a `PemCsr`.
     ///
@@ -2919,6 +2908,17 @@ impl Certificate {
             crate::model::certificate::CertificateConfig::PemCsr(v.into()),
         );
         self
+    }
+
+    /// The value of [certificate_config][crate::model::Certificate::certificate_config]
+    /// if it holds a `Config`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn config(&self) -> std::option::Option<&std::boxed::Box<crate::model::CertificateConfig>> {
+        #[allow(unreachable_patterns)]
+        self.certificate_config.as_ref().and_then(|v| match v {
+            crate::model::certificate::CertificateConfig::Config(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [certificate_config][crate::model::Certificate::certificate_config]
@@ -3311,17 +3311,6 @@ impl X509Parameters {
         self
     }
 
-    /// Sets the value of [name_constraints][crate::model::X509Parameters::name_constraints].
-    pub fn set_name_constraints<
-        T: std::convert::Into<std::option::Option<crate::model::x_509_parameters::NameConstraints>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.name_constraints = v.into();
-        self
-    }
-
     /// Sets the value of [policy_ids][crate::model::X509Parameters::policy_ids].
     pub fn set_policy_ids<T, V>(mut self, v: T) -> Self
     where
@@ -3341,6 +3330,17 @@ impl X509Parameters {
     {
         use std::iter::Iterator;
         self.aia_ocsp_servers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [name_constraints][crate::model::X509Parameters::name_constraints].
+    pub fn set_name_constraints<
+        T: std::convert::Into<std::option::Option<crate::model::x_509_parameters::NameConstraints>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.name_constraints = v.into();
         self
     }
 
@@ -3650,6 +3650,21 @@ impl SubordinateConfig {
         })
     }
 
+    /// Sets the value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
+    /// to hold a `CertificateAuthority`.
+    ///
+    /// Note that all the setters affecting `subordinate_config` are
+    /// mutually exclusive.
+    pub fn set_certificate_authority<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.subordinate_config = std::option::Option::Some(
+            crate::model::subordinate_config::SubordinateConfig::CertificateAuthority(v.into()),
+        );
+        self
+    }
+
     /// The value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
     /// if it holds a `PemIssuerChain`, `None` if the field is not set or
     /// holds a different branch.
@@ -3665,21 +3680,6 @@ impl SubordinateConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
-    /// to hold a `CertificateAuthority`.
-    ///
-    /// Note that all the setters affecting `subordinate_config` are
-    /// mutually exclusive.
-    pub fn set_certificate_authority<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.subordinate_config = std::option::Option::Some(
-            crate::model::subordinate_config::SubordinateConfig::CertificateAuthority(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
@@ -4273,19 +4273,6 @@ impl CertificateDescription {
         self
     }
 
-    /// Sets the value of [cert_fingerprint][crate::model::CertificateDescription::cert_fingerprint].
-    pub fn set_cert_fingerprint<
-        T: std::convert::Into<
-                std::option::Option<crate::model::certificate_description::CertificateFingerprint>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cert_fingerprint = v.into();
-        self
-    }
-
     /// Sets the value of [crl_distribution_points][crate::model::CertificateDescription::crl_distribution_points].
     pub fn set_crl_distribution_points<T, V>(mut self, v: T) -> Self
     where
@@ -4305,6 +4292,19 @@ impl CertificateDescription {
     {
         use std::iter::Iterator;
         self.aia_issuing_certificate_urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [cert_fingerprint][crate::model::CertificateDescription::cert_fingerprint].
+    pub fn set_cert_fingerprint<
+        T: std::convert::Into<
+                std::option::Option<crate::model::certificate_description::CertificateFingerprint>,
+            >,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.cert_fingerprint = v.into();
         self
     }
 }
@@ -5788,12 +5788,6 @@ impl ListCertificatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificates][crate::model::ListCertificatesResponse::certificates].
     pub fn set_certificates<T, V>(mut self, v: T) -> Self
     where
@@ -5802,6 +5796,12 @@ impl ListCertificatesResponse {
     {
         use std::iter::Iterator;
         self.certificates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6560,12 +6560,6 @@ impl ListCertificateAuthoritiesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificateAuthoritiesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificate_authorities][crate::model::ListCertificateAuthoritiesResponse::certificate_authorities].
     pub fn set_certificate_authorities<T, V>(mut self, v: T) -> Self
     where
@@ -6574,6 +6568,12 @@ impl ListCertificateAuthoritiesResponse {
     {
         use std::iter::Iterator;
         self.certificate_authorities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificateAuthoritiesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7395,12 +7395,6 @@ impl ListCaPoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCaPoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [ca_pools][crate::model::ListCaPoolsResponse::ca_pools].
     pub fn set_ca_pools<T, V>(mut self, v: T) -> Self
     where
@@ -7409,6 +7403,12 @@ impl ListCaPoolsResponse {
     {
         use std::iter::Iterator;
         self.ca_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCaPoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7613,12 +7613,6 @@ impl ListCertificateRevocationListsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificateRevocationListsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificate_revocation_lists][crate::model::ListCertificateRevocationListsResponse::certificate_revocation_lists].
     pub fn set_certificate_revocation_lists<T, V>(mut self, v: T) -> Self
     where
@@ -7627,6 +7621,12 @@ impl ListCertificateRevocationListsResponse {
     {
         use std::iter::Iterator;
         self.certificate_revocation_lists = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificateRevocationListsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -8064,12 +8064,6 @@ impl ListCertificateTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCertificateTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [certificate_templates][crate::model::ListCertificateTemplatesResponse::certificate_templates].
     pub fn set_certificate_templates<T, V>(mut self, v: T) -> Self
     where
@@ -8078,6 +8072,12 @@ impl ListCertificateTemplatesResponse {
     {
         use std::iter::Iterator;
         self.certificate_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCertificateTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -188,12 +188,6 @@ impl Access {
         self
     }
 
-    /// Sets the value of [user_name][crate::model::Access::user_name].
-    pub fn set_user_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.user_name = v.into();
-        self
-    }
-
     /// Sets the value of [service_account_delegation_info][crate::model::Access::service_account_delegation_info].
     pub fn set_service_account_delegation_info<T, V>(mut self, v: T) -> Self
     where
@@ -202,6 +196,12 @@ impl Access {
     {
         use std::iter::Iterator;
         self.service_account_delegation_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [user_name][crate::model::Access::user_name].
+    pub fn set_user_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.user_name = v.into();
         self
     }
 }
@@ -733,12 +733,6 @@ pub mod attack_path {
             self
         }
 
-        /// Sets the value of [uuid][crate::model::attack_path::AttackPathNode::uuid].
-        pub fn set_uuid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.uuid = v.into();
-            self
-        }
-
         /// Sets the value of [associated_findings][crate::model::attack_path::AttackPathNode::associated_findings].
         pub fn set_associated_findings<T, V>(mut self, v: T) -> Self
         where
@@ -749,6 +743,12 @@ pub mod attack_path {
         {
             use std::iter::Iterator;
             self.associated_findings = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [uuid][crate::model::attack_path::AttackPathNode::uuid].
+        pub fn set_uuid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.uuid = v.into();
             self
         }
 
@@ -895,15 +895,6 @@ pub mod attack_path {
                 self
             }
 
-            /// Sets the value of [description][crate::model::attack_path::attack_path_node::AttackStepNode::description].
-            pub fn set_description<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.description = v.into();
-                self
-            }
-
             /// Sets the value of [labels][crate::model::attack_path::attack_path_node::AttackStepNode::labels].
             pub fn set_labels<T, K, V>(mut self, v: T) -> Self
             where
@@ -913,6 +904,15 @@ pub mod attack_path {
             {
                 use std::iter::Iterator;
                 self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+                self
+            }
+
+            /// Sets the value of [description][crate::model::attack_path::attack_path_node::AttackStepNode::description].
+            pub fn set_description<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.description = v.into();
                 self
             }
         }
@@ -1206,15 +1206,48 @@ impl BackupDisasterRecovery {
         self
     }
 
+    /// Sets the value of [policies][crate::model::BackupDisasterRecovery::policies].
+    pub fn set_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [host][crate::model::BackupDisasterRecovery::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
         self
     }
 
+    /// Sets the value of [applications][crate::model::BackupDisasterRecovery::applications].
+    pub fn set_applications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.applications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [storage_pool][crate::model::BackupDisasterRecovery::storage_pool].
     pub fn set_storage_pool<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.storage_pool = v.into();
+        self
+    }
+
+    /// Sets the value of [policy_options][crate::model::BackupDisasterRecovery::policy_options].
+    pub fn set_policy_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.policy_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1242,39 +1275,6 @@ impl BackupDisasterRecovery {
         v: T,
     ) -> Self {
         self.backup_create_time = v.into();
-        self
-    }
-
-    /// Sets the value of [policies][crate::model::BackupDisasterRecovery::policies].
-    pub fn set_policies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.policies = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [applications][crate::model::BackupDisasterRecovery::applications].
-    pub fn set_applications<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.applications = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [policy_options][crate::model::BackupDisasterRecovery::policy_options].
-    pub fn set_policy_options<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.policy_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2459,15 +2459,6 @@ impl Container {
         self
     }
 
-    /// Sets the value of [create_time][crate::model::Container::create_time].
-    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_time = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Container::labels].
     pub fn set_labels<T, V>(mut self, v: T) -> Self
     where
@@ -2476,6 +2467,15 @@ impl Container {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [create_time][crate::model::Container::create_time].
+    pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.create_time = v.into();
         self
     }
 }
@@ -3228,12 +3228,6 @@ impl Database {
         self
     }
 
-    /// Sets the value of [version][crate::model::Database::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [grantees][crate::model::Database::grantees].
     pub fn set_grantees<T, V>(mut self, v: T) -> Self
     where
@@ -3242,6 +3236,12 @@ impl Database {
     {
         use std::iter::Iterator;
         self.grantees = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::Database::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 }
@@ -3319,12 +3319,6 @@ impl Exfiltration {
         std::default::Default::default()
     }
 
-    /// Sets the value of [total_exfiltrated_bytes][crate::model::Exfiltration::total_exfiltrated_bytes].
-    pub fn set_total_exfiltrated_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.total_exfiltrated_bytes = v.into();
-        self
-    }
-
     /// Sets the value of [sources][crate::model::Exfiltration::sources].
     pub fn set_sources<T, V>(mut self, v: T) -> Self
     where
@@ -3344,6 +3338,12 @@ impl Exfiltration {
     {
         use std::iter::Iterator;
         self.targets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [total_exfiltrated_bytes][crate::model::Exfiltration::total_exfiltrated_bytes].
+    pub fn set_total_exfiltrated_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.total_exfiltrated_bytes = v.into();
         self
     }
 }
@@ -3488,6 +3488,17 @@ impl ExternalSystem {
         self
     }
 
+    /// Sets the value of [assignees][crate::model::ExternalSystem::assignees].
+    pub fn set_assignees<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.assignees = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [external_uid][crate::model::ExternalSystem::external_uid].
     pub fn set_external_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.external_uid = v.into();
@@ -3558,17 +3569,6 @@ impl ExternalSystem {
         v: T,
     ) -> Self {
         self.ticket_info = v.into();
-        self
-    }
-
-    /// Sets the value of [assignees][crate::model::ExternalSystem::assignees].
-    pub fn set_assignees<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.assignees = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4217,6 +4217,18 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [source_properties][crate::model::Finding::source_properties].
+    pub fn set_source_properties<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<wkt::Value>,
+    {
+        use std::iter::Iterator;
+        self.source_properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [security_marks][crate::model::Finding::security_marks].
     pub fn set_security_marks<
         T: std::convert::Into<std::option::Option<crate::model::SecurityMarks>>,
@@ -4310,6 +4322,18 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [external_systems][crate::model::Finding::external_systems].
+    pub fn set_external_systems<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ExternalSystem>,
+    {
+        use std::iter::Iterator;
+        self.external_systems = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [mitre_attack][crate::model::Finding::mitre_attack].
     pub fn set_mitre_attack<
         T: std::convert::Into<std::option::Option<crate::model::MitreAttack>>,
@@ -4330,9 +4354,54 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [connections][crate::model::Finding::connections].
+    pub fn set_connections<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Connection>,
+    {
+        use std::iter::Iterator;
+        self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [mute_initiator][crate::model::Finding::mute_initiator].
     pub fn set_mute_initiator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mute_initiator = v.into();
+        self
+    }
+
+    /// Sets the value of [processes][crate::model::Finding::processes].
+    pub fn set_processes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Process>,
+    {
+        use std::iter::Iterator;
+        self.processes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [contacts][crate::model::Finding::contacts].
+    pub fn set_contacts<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::ContactDetails>,
+    {
+        use std::iter::Iterator;
+        self.contacts = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [compliances][crate::model::Finding::compliances].
+    pub fn set_compliances<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Compliance>,
+    {
+        use std::iter::Iterator;
+        self.compliances = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4362,6 +4431,17 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [iam_bindings][crate::model::Finding::iam_bindings].
+    pub fn set_iam_bindings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::IamBinding>,
+    {
+        use std::iter::Iterator;
+        self.iam_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_steps][crate::model::Finding::next_steps].
     pub fn set_next_steps<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_steps = v.into();
@@ -4371,6 +4451,17 @@ impl Finding {
     /// Sets the value of [module_name][crate::model::Finding::module_name].
     pub fn set_module_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.module_name = v.into();
+        self
+    }
+
+    /// Sets the value of [containers][crate::model::Finding::containers].
+    pub fn set_containers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Container>,
+    {
+        use std::iter::Iterator;
+        self.containers = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4400,6 +4491,17 @@ impl Finding {
         v: T,
     ) -> Self {
         self.attack_exposure = v.into();
+        self
+    }
+
+    /// Sets the value of [files][crate::model::Finding::files].
+    pub fn set_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::File>,
+    {
+        use std::iter::Iterator;
+        self.files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4436,6 +4538,17 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [org_policies][crate::model::Finding::org_policies].
+    pub fn set_org_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::OrgPolicy>,
+    {
+        use std::iter::Iterator;
+        self.org_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [application][crate::model::Finding::application].
     pub fn set_application<
         T: std::convert::Into<std::option::Option<crate::model::Application>>,
@@ -4469,6 +4582,28 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [log_entries][crate::model::Finding::log_entries].
+    pub fn set_log_entries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LogEntry>,
+    {
+        use std::iter::Iterator;
+        self.log_entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [load_balancers][crate::model::Finding::load_balancers].
+    pub fn set_load_balancers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LoadBalancer>,
+    {
+        use std::iter::Iterator;
+        self.load_balancers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cloud_armor][crate::model::Finding::cloud_armor].
     pub fn set_cloud_armor<T: std::convert::Into<std::option::Option<crate::model::CloudArmor>>>(
         mut self,
@@ -4498,114 +4633,6 @@ impl Finding {
         self
     }
 
-    /// Sets the value of [disk][crate::model::Finding::disk].
-    pub fn set_disk<T: std::convert::Into<std::option::Option<crate::model::Disk>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.disk = v.into();
-        self
-    }
-
-    /// Sets the value of [connections][crate::model::Finding::connections].
-    pub fn set_connections<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Connection>,
-    {
-        use std::iter::Iterator;
-        self.connections = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [processes][crate::model::Finding::processes].
-    pub fn set_processes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Process>,
-    {
-        use std::iter::Iterator;
-        self.processes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [compliances][crate::model::Finding::compliances].
-    pub fn set_compliances<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Compliance>,
-    {
-        use std::iter::Iterator;
-        self.compliances = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [iam_bindings][crate::model::Finding::iam_bindings].
-    pub fn set_iam_bindings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::IamBinding>,
-    {
-        use std::iter::Iterator;
-        self.iam_bindings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [containers][crate::model::Finding::containers].
-    pub fn set_containers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Container>,
-    {
-        use std::iter::Iterator;
-        self.containers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [files][crate::model::Finding::files].
-    pub fn set_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::File>,
-    {
-        use std::iter::Iterator;
-        self.files = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [org_policies][crate::model::Finding::org_policies].
-    pub fn set_org_policies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::OrgPolicy>,
-    {
-        use std::iter::Iterator;
-        self.org_policies = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [log_entries][crate::model::Finding::log_entries].
-    pub fn set_log_entries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LogEntry>,
-    {
-        use std::iter::Iterator;
-        self.log_entries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [load_balancers][crate::model::Finding::load_balancers].
-    pub fn set_load_balancers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LoadBalancer>,
-    {
-        use std::iter::Iterator;
-        self.load_balancers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [group_memberships][crate::model::Finding::group_memberships].
     pub fn set_group_memberships<T, V>(mut self, v: T) -> Self
     where
@@ -4614,6 +4641,15 @@ impl Finding {
     {
         use std::iter::Iterator;
         self.group_memberships = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [disk][crate::model::Finding::disk].
+    pub fn set_disk<T: std::convert::Into<std::option::Option<crate::model::Disk>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.disk = v.into();
         self
     }
 
@@ -4647,42 +4683,6 @@ impl Finding {
     {
         use std::iter::Iterator;
         self.data_retention_deletion_events = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [source_properties][crate::model::Finding::source_properties].
-    pub fn set_source_properties<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<wkt::Value>,
-    {
-        use std::iter::Iterator;
-        self.source_properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [external_systems][crate::model::Finding::external_systems].
-    pub fn set_external_systems<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::ExternalSystem>,
-    {
-        use std::iter::Iterator;
-        self.external_systems = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [contacts][crate::model::Finding::contacts].
-    pub fn set_contacts<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::ContactDetails>,
-    {
-        use std::iter::Iterator;
-        self.contacts = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6075,23 +6075,6 @@ pub mod indicator {
             })
         }
 
-        /// The value of [signature][crate::model::indicator::ProcessSignature::signature]
-        /// if it holds a `YaraRuleSignature`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn yara_rule_signature(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::indicator::process_signature::YaraRuleSignature>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.signature.as_ref().and_then(|v| match v {
-                crate::model::indicator::process_signature::Signature::YaraRuleSignature(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [signature][crate::model::indicator::ProcessSignature::signature]
         /// to hold a `MemoryHashSignature`.
         ///
@@ -6113,6 +6096,23 @@ pub mod indicator {
                 ),
             );
             self
+        }
+
+        /// The value of [signature][crate::model::indicator::ProcessSignature::signature]
+        /// if it holds a `YaraRuleSignature`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn yara_rule_signature(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::indicator::process_signature::YaraRuleSignature>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.signature.as_ref().and_then(|v| match v {
+                crate::model::indicator::process_signature::Signature::YaraRuleSignature(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [signature][crate::model::indicator::ProcessSignature::signature]
@@ -7798,12 +7798,6 @@ impl MitreAttack {
         self
     }
 
-    /// Sets the value of [version][crate::model::MitreAttack::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [primary_techniques][crate::model::MitreAttack::primary_techniques].
     pub fn set_primary_techniques<T, V>(mut self, v: T) -> Self
     where
@@ -7834,6 +7828,12 @@ impl MitreAttack {
     {
         use std::iter::Iterator;
         self.additional_techniques = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::MitreAttack::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 }
@@ -9487,6 +9487,17 @@ impl Process {
         self
     }
 
+    /// Sets the value of [libraries][crate::model::Process::libraries].
+    pub fn set_libraries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::File>,
+    {
+        use std::iter::Iterator;
+        self.libraries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [script][crate::model::Process::script].
     pub fn set_script<T: std::convert::Into<std::option::Option<crate::model::File>>>(
         mut self,
@@ -9496,9 +9507,31 @@ impl Process {
         self
     }
 
+    /// Sets the value of [args][crate::model::Process::args].
+    pub fn set_args<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.args = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [arguments_truncated][crate::model::Process::arguments_truncated].
     pub fn set_arguments_truncated<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.arguments_truncated = v.into();
+        self
+    }
+
+    /// Sets the value of [env_variables][crate::model::Process::env_variables].
+    pub fn set_env_variables<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EnvironmentVariable>,
+    {
+        use std::iter::Iterator;
+        self.env_variables = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -9517,39 +9550,6 @@ impl Process {
     /// Sets the value of [parent_pid][crate::model::Process::parent_pid].
     pub fn set_parent_pid<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.parent_pid = v.into();
-        self
-    }
-
-    /// Sets the value of [libraries][crate::model::Process::libraries].
-    pub fn set_libraries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::File>,
-    {
-        use std::iter::Iterator;
-        self.libraries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [args][crate::model::Process::args].
-    pub fn set_args<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.args = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [env_variables][crate::model::Process::env_variables].
-    pub fn set_env_variables<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EnvironmentVariable>,
-    {
-        use std::iter::Iterator;
-        self.env_variables = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9749,34 +9749,6 @@ impl Resource {
         })
     }
 
-    /// The value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
-    /// if it holds a `AwsMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws_metadata(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsMetadata>> {
-        #[allow(unreachable_patterns)]
-        self.cloud_provider_metadata.as_ref().and_then(|v| match v {
-            crate::model::resource::CloudProviderMetadata::AwsMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
-    /// if it holds a `AzureMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn azure_metadata(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureMetadata>> {
-        #[allow(unreachable_patterns)]
-        self.cloud_provider_metadata.as_ref().and_then(|v| match v {
-            crate::model::resource::CloudProviderMetadata::AzureMetadata(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
     /// to hold a `GcpMetadata`.
     ///
@@ -9792,6 +9764,19 @@ impl Resource {
         self
     }
 
+    /// The value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
+    /// if it holds a `AwsMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws_metadata(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsMetadata>> {
+        #[allow(unreachable_patterns)]
+        self.cloud_provider_metadata.as_ref().and_then(|v| match v {
+            crate::model::resource::CloudProviderMetadata::AwsMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
     /// to hold a `AwsMetadata`.
     ///
@@ -9805,6 +9790,21 @@ impl Resource {
             crate::model::resource::CloudProviderMetadata::AwsMetadata(v.into()),
         );
         self
+    }
+
+    /// The value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
+    /// if it holds a `AzureMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn azure_metadata(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureMetadata>> {
+        #[allow(unreachable_patterns)]
+        self.cloud_provider_metadata.as_ref().and_then(|v| match v {
+            crate::model::resource::CloudProviderMetadata::AzureMetadata(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
@@ -9921,12 +9921,6 @@ impl GcpMetadata {
         self
     }
 
-    /// Sets the value of [organization][crate::model::GcpMetadata::organization].
-    pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.organization = v.into();
-        self
-    }
-
     /// Sets the value of [folders][crate::model::GcpMetadata::folders].
     pub fn set_folders<T, V>(mut self, v: T) -> Self
     where
@@ -9935,6 +9929,12 @@ impl GcpMetadata {
     {
         use std::iter::Iterator;
         self.folders = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [organization][crate::model::GcpMetadata::organization].
+    pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.organization = v.into();
         self
     }
 }
@@ -9985,17 +9985,6 @@ impl AwsMetadata {
         self
     }
 
-    /// Sets the value of [account][crate::model::AwsMetadata::account].
-    pub fn set_account<
-        T: std::convert::Into<std::option::Option<crate::model::aws_metadata::AwsAccount>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.account = v.into();
-        self
-    }
-
     /// Sets the value of [organizational_units][crate::model::AwsMetadata::organizational_units].
     pub fn set_organizational_units<T, V>(mut self, v: T) -> Self
     where
@@ -10004,6 +9993,17 @@ impl AwsMetadata {
     {
         use std::iter::Iterator;
         self.organizational_units = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [account][crate::model::AwsMetadata::account].
+    pub fn set_account<
+        T: std::convert::Into<std::option::Option<crate::model::aws_metadata::AwsAccount>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.account = v.into();
         self
     }
 }
@@ -10179,6 +10179,17 @@ impl AzureMetadata {
         std::default::Default::default()
     }
 
+    /// Sets the value of [management_groups][crate::model::AzureMetadata::management_groups].
+    pub fn set_management_groups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::azure_metadata::AzureManagementGroup>,
+    {
+        use std::iter::Iterator;
+        self.management_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [subscription][crate::model::AzureMetadata::subscription].
     pub fn set_subscription<
         T: std::convert::Into<std::option::Option<crate::model::azure_metadata::AzureSubscription>>,
@@ -10209,17 +10220,6 @@ impl AzureMetadata {
         v: T,
     ) -> Self {
         self.tenant = v.into();
-        self
-    }
-
-    /// Sets the value of [management_groups][crate::model::AzureMetadata::management_groups].
-    pub fn set_management_groups<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::azure_metadata::AzureManagementGroup>,
-    {
-        use std::iter::Iterator;
-        self.management_groups = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -10797,6 +10797,17 @@ impl ResourceValueConfig {
         self
     }
 
+    /// Sets the value of [tag_values][crate::model::ResourceValueConfig::tag_values].
+    pub fn set_tag_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tag_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [resource_type][crate::model::ResourceValueConfig::resource_type].
     pub fn set_resource_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.resource_type = v.into();
@@ -10806,6 +10817,18 @@ impl ResourceValueConfig {
     /// Sets the value of [scope][crate::model::ResourceValueConfig::scope].
     pub fn set_scope<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.scope = v.into();
+        self
+    }
+
+    /// Sets the value of [resource_labels_selector][crate::model::ResourceValueConfig::resource_labels_selector].
+    pub fn set_resource_labels_selector<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_labels_selector = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -10854,29 +10877,6 @@ impl ResourceValueConfig {
         v: T,
     ) -> Self {
         self.sensitive_data_protection_mapping = v.into();
-        self
-    }
-
-    /// Sets the value of [tag_values][crate::model::ResourceValueConfig::tag_values].
-    pub fn set_tag_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tag_values = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [resource_labels_selector][crate::model::ResourceValueConfig::resource_labels_selector].
-    pub fn set_resource_labels_selector<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_labels_selector = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -11014,12 +11014,6 @@ impl SecurityMarks {
         self
     }
 
-    /// Sets the value of [canonical_name][crate::model::SecurityMarks::canonical_name].
-    pub fn set_canonical_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.canonical_name = v.into();
-        self
-    }
-
     /// Sets the value of [marks][crate::model::SecurityMarks::marks].
     pub fn set_marks<T, K, V>(mut self, v: T) -> Self
     where
@@ -11029,6 +11023,12 @@ impl SecurityMarks {
     {
         use std::iter::Iterator;
         self.marks = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [canonical_name][crate::model::SecurityMarks::canonical_name].
+    pub fn set_canonical_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.canonical_name = v.into();
         self
     }
 }
@@ -12440,6 +12440,17 @@ impl GroupFindingsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [group_by_results][crate::model::GroupFindingsResponse::group_by_results].
+    pub fn set_group_by_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::GroupResult>,
+    {
+        use std::iter::Iterator;
+        self.group_by_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::GroupFindingsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -12449,17 +12460,6 @@ impl GroupFindingsResponse {
     /// Sets the value of [total_size][crate::model::GroupFindingsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [group_by_results][crate::model::GroupFindingsResponse::group_by_results].
-    pub fn set_group_by_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::GroupResult>,
-    {
-        use std::iter::Iterator;
-        self.group_by_results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -12508,12 +12508,6 @@ impl GroupResult {
         std::default::Default::default()
     }
 
-    /// Sets the value of [count][crate::model::GroupResult::count].
-    pub fn set_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.count = v.into();
-        self
-    }
-
     /// Sets the value of [properties][crate::model::GroupResult::properties].
     pub fn set_properties<T, K, V>(mut self, v: T) -> Self
     where
@@ -12523,6 +12517,12 @@ impl GroupResult {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [count][crate::model::GroupResult::count].
+    pub fn set_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.count = v.into();
         self
     }
 }
@@ -12633,12 +12633,6 @@ impl ListAttackPathsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAttackPathsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [attack_paths][crate::model::ListAttackPathsResponse::attack_paths].
     pub fn set_attack_paths<T, V>(mut self, v: T) -> Self
     where
@@ -12647,6 +12641,12 @@ impl ListAttackPathsResponse {
     {
         use std::iter::Iterator;
         self.attack_paths = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAttackPathsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -12830,12 +12830,6 @@ impl ListBigQueryExportsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBigQueryExportsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [big_query_exports][crate::model::ListBigQueryExportsResponse::big_query_exports].
     pub fn set_big_query_exports<T, V>(mut self, v: T) -> Self
     where
@@ -12844,6 +12838,12 @@ impl ListBigQueryExportsResponse {
     {
         use std::iter::Iterator;
         self.big_query_exports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBigQueryExportsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -13079,6 +13079,17 @@ impl ListFindingsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [list_findings_results][crate::model::ListFindingsResponse::list_findings_results].
+    pub fn set_list_findings_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::list_findings_response::ListFindingsResult>,
+    {
+        use std::iter::Iterator;
+        self.list_findings_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListFindingsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -13088,17 +13099,6 @@ impl ListFindingsResponse {
     /// Sets the value of [total_size][crate::model::ListFindingsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [list_findings_results][crate::model::ListFindingsResponse::list_findings_results].
-    pub fn set_list_findings_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::list_findings_response::ListFindingsResult>,
-    {
-        use std::iter::Iterator;
-        self.list_findings_results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13339,32 +13339,6 @@ pub mod list_findings_response {
                 })
             }
 
-            /// The value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
-            /// if it holds a `AwsMetadata`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn aws_metadata(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::AwsMetadata>> {
-                #[allow(unreachable_patterns)]
-                self.cloud_provider_metadata.as_ref().and_then(|v| match v {
-                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AwsMetadata(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
-            /// if it holds a `AzureMetadata`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn azure_metadata(
-                &self,
-            ) -> std::option::Option<&std::boxed::Box<crate::model::AzureMetadata>> {
-                #[allow(unreachable_patterns)]
-                self.cloud_provider_metadata.as_ref().and_then(|v| match v {
-                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AzureMetadata(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
             /// to hold a `GcpMetadata`.
             ///
@@ -13384,6 +13358,19 @@ pub mod list_findings_response {
                 self
             }
 
+            /// The value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
+            /// if it holds a `AwsMetadata`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn aws_metadata(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::AwsMetadata>> {
+                #[allow(unreachable_patterns)]
+                self.cloud_provider_metadata.as_ref().and_then(|v| match v {
+                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AwsMetadata(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
             /// to hold a `AwsMetadata`.
             ///
@@ -13401,6 +13388,19 @@ pub mod list_findings_response {
                     )
                 );
                 self
+            }
+
+            /// The value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
+            /// if it holds a `AzureMetadata`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn azure_metadata(
+                &self,
+            ) -> std::option::Option<&std::boxed::Box<crate::model::AzureMetadata>> {
+                #[allow(unreachable_patterns)]
+                self.cloud_provider_metadata.as_ref().and_then(|v| match v {
+                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AzureMetadata(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
@@ -13539,12 +13539,6 @@ impl ListMuteConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMuteConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [mute_configs][crate::model::ListMuteConfigsResponse::mute_configs].
     pub fn set_mute_configs<T, V>(mut self, v: T) -> Self
     where
@@ -13553,6 +13547,12 @@ impl ListMuteConfigsResponse {
     {
         use std::iter::Iterator;
         self.mute_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMuteConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -13660,12 +13660,6 @@ impl ListNotificationConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNotificationConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [notification_configs][crate::model::ListNotificationConfigsResponse::notification_configs].
     pub fn set_notification_configs<T, V>(mut self, v: T) -> Self
     where
@@ -13674,6 +13668,12 @@ impl ListNotificationConfigsResponse {
     {
         use std::iter::Iterator;
         self.notification_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNotificationConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -13786,12 +13786,6 @@ impl ListResourceValueConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListResourceValueConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resource_value_configs][crate::model::ListResourceValueConfigsResponse::resource_value_configs].
     pub fn set_resource_value_configs<T, V>(mut self, v: T) -> Self
     where
@@ -13800,6 +13794,12 @@ impl ListResourceValueConfigsResponse {
     {
         use std::iter::Iterator;
         self.resource_value_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListResourceValueConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -13905,12 +13905,6 @@ impl ListSourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sources][crate::model::ListSourcesResponse::sources].
     pub fn set_sources<T, V>(mut self, v: T) -> Self
     where
@@ -13919,6 +13913,12 @@ impl ListSourcesResponse {
     {
         use std::iter::Iterator;
         self.sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -14071,6 +14071,17 @@ impl ListValuedResourcesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [valued_resources][crate::model::ListValuedResourcesResponse::valued_resources].
+    pub fn set_valued_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ValuedResource>,
+    {
+        use std::iter::Iterator;
+        self.valued_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListValuedResourcesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -14080,17 +14091,6 @@ impl ListValuedResourcesResponse {
     /// Sets the value of [total_size][crate::model::ListValuedResourcesResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [valued_resources][crate::model::ListValuedResourcesResponse::valued_resources].
-    pub fn set_valued_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ValuedResource>,
-    {
-        use std::iter::Iterator;
-        self.valued_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -14698,15 +14698,6 @@ impl Simulation {
         self
     }
 
-    /// Sets the value of [cloud_provider][crate::model::Simulation::cloud_provider].
-    pub fn set_cloud_provider<T: std::convert::Into<crate::model::CloudProvider>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cloud_provider = v.into();
-        self
-    }
-
     /// Sets the value of [resource_value_configs_metadata][crate::model::Simulation::resource_value_configs_metadata].
     pub fn set_resource_value_configs_metadata<T, V>(mut self, v: T) -> Self
     where
@@ -14715,6 +14706,15 @@ impl Simulation {
     {
         use std::iter::Iterator;
         self.resource_value_configs_metadata = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [cloud_provider][crate::model::Simulation::cloud_provider].
+    pub fn set_cloud_provider<T: std::convert::Into<crate::model::CloudProvider>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.cloud_provider = v.into();
         self
     }
 }
@@ -15294,6 +15294,17 @@ impl Cve {
         self
     }
 
+    /// Sets the value of [references][crate::model::Cve::references].
+    pub fn set_references<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Reference>,
+    {
+        use std::iter::Iterator;
+        self.references = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cvssv3][crate::model::Cve::cvssv3].
     pub fn set_cvssv3<T: std::convert::Into<std::option::Option<crate::model::Cvssv3>>>(
         mut self,
@@ -15358,17 +15369,6 @@ impl Cve {
         v: T,
     ) -> Self {
         self.first_exploitation_date = v.into();
-        self
-    }
-
-    /// Sets the value of [references][crate::model::Cve::references].
-    pub fn set_references<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Reference>,
-    {
-        use std::iter::Iterator;
-        self.references = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -101,39 +101,6 @@ impl PolicyRule {
         })
     }
 
-    /// The value of [kind][crate::model::PolicyRule::kind]
-    /// if it holds a `AllowAll`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn allow_all(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::policy_rule::Kind::AllowAll(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::PolicyRule::kind]
-    /// if it holds a `DenyAll`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deny_all(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::policy_rule::Kind::DenyAll(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [kind][crate::model::PolicyRule::kind]
-    /// if it holds a `Enforce`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn enforce(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.kind.as_ref().and_then(|v| match v {
-            crate::model::policy_rule::Kind::Enforce(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [kind][crate::model::PolicyRule::kind]
     /// to hold a `Values`.
     ///
@@ -149,6 +116,17 @@ impl PolicyRule {
         self
     }
 
+    /// The value of [kind][crate::model::PolicyRule::kind]
+    /// if it holds a `AllowAll`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn allow_all(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::policy_rule::Kind::AllowAll(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::PolicyRule::kind]
     /// to hold a `AllowAll`.
     ///
@@ -159,6 +137,17 @@ impl PolicyRule {
         self
     }
 
+    /// The value of [kind][crate::model::PolicyRule::kind]
+    /// if it holds a `DenyAll`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deny_all(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::policy_rule::Kind::DenyAll(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [kind][crate::model::PolicyRule::kind]
     /// to hold a `DenyAll`.
     ///
@@ -167,6 +156,17 @@ impl PolicyRule {
     pub fn set_deny_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::DenyAll(v.into()));
         self
+    }
+
+    /// The value of [kind][crate::model::PolicyRule::kind]
+    /// if it holds a `Enforce`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn enforce(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.kind.as_ref().and_then(|v| match v {
+            crate::model::policy_rule::Kind::Enforce(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [kind][crate::model::PolicyRule::kind]
@@ -356,6 +356,28 @@ impl CustomConstraint {
         self
     }
 
+    /// Sets the value of [resource_types][crate::model::CustomConstraint::resource_types].
+    pub fn set_resource_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [method_types][crate::model::CustomConstraint::method_types].
+    pub fn set_method_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::custom_constraint::MethodType>,
+    {
+        use std::iter::Iterator;
+        self.method_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [condition][crate::model::CustomConstraint::condition].
     pub fn set_condition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.condition = v.into();
@@ -389,28 +411,6 @@ impl CustomConstraint {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_types][crate::model::CustomConstraint::resource_types].
-    pub fn set_resource_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [method_types][crate::model::CustomConstraint::method_types].
-    pub fn set_method_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::custom_constraint::MethodType>,
-    {
-        use std::iter::Iterator;
-        self.method_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1035,18 +1035,6 @@ impl Posture {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Posture::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [reconciling][crate::model::Posture::reconciling].
-    pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.reconciling = v.into();
-        self
-    }
-
     /// Sets the value of [policy_sets][crate::model::Posture::policy_sets].
     pub fn set_policy_sets<T, V>(mut self, v: T) -> Self
     where
@@ -1055,6 +1043,12 @@ impl Posture {
     {
         use std::iter::Iterator;
         self.policy_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Posture::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 
@@ -1067,6 +1061,12 @@ impl Posture {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [reconciling][crate::model::Posture::reconciling].
+    pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.reconciling = v.into();
         self
     }
 }
@@ -1317,6 +1317,17 @@ impl Policy {
         self
     }
 
+    /// Sets the value of [compliance_standards][crate::model::Policy::compliance_standards].
+    pub fn set_compliance_standards<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::policy::ComplianceStandard>,
+    {
+        use std::iter::Iterator;
+        self.compliance_standards = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [constraint][crate::model::Policy::constraint].
     pub fn set_constraint<T: std::convert::Into<std::option::Option<crate::model::Constraint>>>(
         mut self,
@@ -1329,17 +1340,6 @@ impl Policy {
     /// Sets the value of [description][crate::model::Policy::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [compliance_standards][crate::model::Policy::compliance_standards].
-    pub fn set_compliance_standards<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::policy::ComplianceStandard>,
-    {
-        use std::iter::Iterator;
-        self.compliance_standards = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1445,52 +1445,6 @@ impl Constraint {
         })
     }
 
-    /// The value of [implementation][crate::model::Constraint::implementation]
-    /// if it holds a `SecurityHealthAnalyticsCustomModule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn security_health_analytics_custom_module(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SecurityHealthAnalyticsCustomModule>>
-    {
-        #[allow(unreachable_patterns)]
-        self.implementation.as_ref().and_then(|v| match v {
-            crate::model::constraint::Implementation::SecurityHealthAnalyticsCustomModule(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [implementation][crate::model::Constraint::implementation]
-    /// if it holds a `OrgPolicyConstraint`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn org_policy_constraint(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OrgPolicyConstraint>> {
-        #[allow(unreachable_patterns)]
-        self.implementation.as_ref().and_then(|v| match v {
-            crate::model::constraint::Implementation::OrgPolicyConstraint(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [implementation][crate::model::Constraint::implementation]
-    /// if it holds a `OrgPolicyConstraintCustom`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn org_policy_constraint_custom(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OrgPolicyConstraintCustom>> {
-        #[allow(unreachable_patterns)]
-        self.implementation.as_ref().and_then(|v| match v {
-            crate::model::constraint::Implementation::OrgPolicyConstraintCustom(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [implementation][crate::model::Constraint::implementation]
     /// to hold a `SecurityHealthAnalyticsModule`.
     ///
@@ -1506,6 +1460,22 @@ impl Constraint {
             crate::model::constraint::Implementation::SecurityHealthAnalyticsModule(v.into()),
         );
         self
+    }
+
+    /// The value of [implementation][crate::model::Constraint::implementation]
+    /// if it holds a `SecurityHealthAnalyticsCustomModule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn security_health_analytics_custom_module(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SecurityHealthAnalyticsCustomModule>>
+    {
+        #[allow(unreachable_patterns)]
+        self.implementation.as_ref().and_then(|v| match v {
+            crate::model::constraint::Implementation::SecurityHealthAnalyticsCustomModule(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [implementation][crate::model::Constraint::implementation]
@@ -1525,6 +1495,21 @@ impl Constraint {
         self
     }
 
+    /// The value of [implementation][crate::model::Constraint::implementation]
+    /// if it holds a `OrgPolicyConstraint`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn org_policy_constraint(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OrgPolicyConstraint>> {
+        #[allow(unreachable_patterns)]
+        self.implementation.as_ref().and_then(|v| match v {
+            crate::model::constraint::Implementation::OrgPolicyConstraint(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [implementation][crate::model::Constraint::implementation]
     /// to hold a `OrgPolicyConstraint`.
     ///
@@ -1540,6 +1525,21 @@ impl Constraint {
             crate::model::constraint::Implementation::OrgPolicyConstraint(v.into()),
         );
         self
+    }
+
+    /// The value of [implementation][crate::model::Constraint::implementation]
+    /// if it holds a `OrgPolicyConstraintCustom`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn org_policy_constraint_custom(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OrgPolicyConstraintCustom>> {
+        #[allow(unreachable_patterns)]
+        self.implementation.as_ref().and_then(|v| match v {
+            crate::model::constraint::Implementation::OrgPolicyConstraintCustom(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [implementation][crate::model::Constraint::implementation]
@@ -1668,12 +1668,6 @@ impl ListPosturesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPosturesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [postures][crate::model::ListPosturesResponse::postures].
     pub fn set_postures<T, V>(mut self, v: T) -> Self
     where
@@ -1682,6 +1676,12 @@ impl ListPosturesResponse {
     {
         use std::iter::Iterator;
         self.postures = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPosturesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1793,12 +1793,6 @@ impl ListPostureRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPostureRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [revisions][crate::model::ListPostureRevisionsResponse::revisions].
     pub fn set_revisions<T, V>(mut self, v: T) -> Self
     where
@@ -1807,6 +1801,12 @@ impl ListPostureRevisionsResponse {
     {
         use std::iter::Iterator;
         self.revisions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPostureRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2255,6 +2255,18 @@ impl PostureDeployment {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::PostureDeployment::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [reconciling][crate::model::PostureDeployment::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
@@ -2282,18 +2294,6 @@ impl PostureDeployment {
     /// Sets the value of [failure_message][crate::model::PostureDeployment::failure_message].
     pub fn set_failure_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.failure_message = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::PostureDeployment::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2568,12 +2568,6 @@ impl ListPostureDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPostureDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [posture_deployments][crate::model::ListPostureDeploymentsResponse::posture_deployments].
     pub fn set_posture_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -2582,6 +2576,12 @@ impl ListPostureDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.posture_deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPostureDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3115,12 +3115,6 @@ impl ListPostureTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPostureTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [posture_templates][crate::model::ListPostureTemplatesResponse::posture_templates].
     pub fn set_posture_templates<T, V>(mut self, v: T) -> Self
     where
@@ -3129,6 +3123,12 @@ impl ListPostureTemplatesResponse {
     {
         use std::iter::Iterator;
         self.posture_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPostureTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/servicedirectory/v1/src/model.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/model.rs
@@ -129,18 +129,6 @@ impl Endpoint {
         self
     }
 
-    /// Sets the value of [network][crate::model::Endpoint::network].
-    pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.network = v.into();
-        self
-    }
-
-    /// Sets the value of [uid][crate::model::Endpoint::uid].
-    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.uid = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::Endpoint::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -150,6 +138,18 @@ impl Endpoint {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [network][crate::model::Endpoint::network].
+    pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.network = v.into();
+        self
+    }
+
+    /// Sets the value of [uid][crate::model::Endpoint::uid].
+    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.uid = v.into();
         self
     }
 }
@@ -332,12 +332,6 @@ impl Namespace {
         self
     }
 
-    /// Sets the value of [uid][crate::model::Namespace::uid].
-    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.uid = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Namespace::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -347,6 +341,12 @@ impl Namespace {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [uid][crate::model::Namespace::uid].
+    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.uid = v.into();
         self
     }
 }
@@ -562,12 +562,6 @@ impl ListNamespacesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNamespacesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [namespaces][crate::model::ListNamespacesResponse::namespaces].
     pub fn set_namespaces<T, V>(mut self, v: T) -> Self
     where
@@ -576,6 +570,12 @@ impl ListNamespacesResponse {
     {
         use std::iter::Iterator;
         self.namespaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNamespacesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -928,12 +928,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -942,6 +936,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1299,12 +1299,6 @@ impl ListEndpointsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEndpointsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [endpoints][crate::model::ListEndpointsResponse::endpoints].
     pub fn set_endpoints<T, V>(mut self, v: T) -> Self
     where
@@ -1313,6 +1307,12 @@ impl ListEndpointsResponse {
     {
         use std::iter::Iterator;
         self.endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEndpointsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1529,9 +1529,15 @@ impl Service {
         self
     }
 
-    /// Sets the value of [uid][crate::model::Service::uid].
-    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.uid = v.into();
+    /// Sets the value of [annotations][crate::model::Service::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1546,15 +1552,9 @@ impl Service {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::Service::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [uid][crate::model::Service::uid].
+    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.uid = v.into();
         self
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/model.rs
+++ b/src/generated/cloud/servicehealth/v1/src/model.rs
@@ -159,12 +159,34 @@ impl Event {
         self
     }
 
+    /// Sets the value of [event_impacts][crate::model::Event::event_impacts].
+    pub fn set_event_impacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventImpact>,
+    {
+        use std::iter::Iterator;
+        self.event_impacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [relevance][crate::model::Event::relevance].
     pub fn set_relevance<T: std::convert::Into<crate::model::event::Relevance>>(
         mut self,
         v: T,
     ) -> Self {
         self.relevance = v.into();
+        self
+    }
+
+    /// Sets the value of [updates][crate::model::Event::updates].
+    pub fn set_updates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventUpdate>,
+    {
+        use std::iter::Iterator;
+        self.updates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -207,28 +229,6 @@ impl Event {
         v: T,
     ) -> Self {
         self.next_update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [event_impacts][crate::model::Event::event_impacts].
-    pub fn set_event_impacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventImpact>,
-    {
-        use std::iter::Iterator;
-        self.event_impacts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [updates][crate::model::Event::updates].
-    pub fn set_updates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventUpdate>,
-    {
-        use std::iter::Iterator;
-        self.updates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1111,6 +1111,28 @@ impl OrganizationEvent {
         self
     }
 
+    /// Sets the value of [event_impacts][crate::model::OrganizationEvent::event_impacts].
+    pub fn set_event_impacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventImpact>,
+    {
+        use std::iter::Iterator;
+        self.event_impacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [updates][crate::model::OrganizationEvent::updates].
+    pub fn set_updates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventUpdate>,
+    {
+        use std::iter::Iterator;
+        self.updates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [parent_event][crate::model::OrganizationEvent::parent_event].
     pub fn set_parent_event<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent_event = v.into();
@@ -1150,28 +1172,6 @@ impl OrganizationEvent {
         v: T,
     ) -> Self {
         self.next_update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [event_impacts][crate::model::OrganizationEvent::event_impacts].
-    pub fn set_event_impacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventImpact>,
-    {
-        use std::iter::Iterator;
-        self.event_impacts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [updates][crate::model::OrganizationEvent::updates].
-    pub fn set_updates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventUpdate>,
-    {
-        use std::iter::Iterator;
-        self.updates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2002,6 +2002,17 @@ impl OrganizationImpact {
         self
     }
 
+    /// Sets the value of [events][crate::model::OrganizationImpact::events].
+    pub fn set_events<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [asset][crate::model::OrganizationImpact::asset].
     pub fn set_asset<T: std::convert::Into<std::option::Option<crate::model::Asset>>>(
         mut self,
@@ -2017,17 +2028,6 @@ impl OrganizationImpact {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [events][crate::model::OrganizationImpact::events].
-    pub fn set_events<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.events = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2215,12 +2215,6 @@ impl ListEventsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEventsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [events][crate::model::ListEventsResponse::events].
     pub fn set_events<T, V>(mut self, v: T) -> Self
     where
@@ -2229,6 +2223,12 @@ impl ListEventsResponse {
     {
         use std::iter::Iterator;
         self.events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEventsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2441,12 +2441,6 @@ impl ListOrganizationEventsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOrganizationEventsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [organization_events][crate::model::ListOrganizationEventsResponse::organization_events].
     pub fn set_organization_events<T, V>(mut self, v: T) -> Self
     where
@@ -2455,6 +2449,12 @@ impl ListOrganizationEventsResponse {
     {
         use std::iter::Iterator;
         self.organization_events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOrganizationEventsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2660,12 +2660,6 @@ impl ListOrganizationImpactsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOrganizationImpactsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [organization_impacts][crate::model::ListOrganizationImpactsResponse::organization_impacts].
     pub fn set_organization_impacts<T, V>(mut self, v: T) -> Self
     where
@@ -2674,6 +2668,12 @@ impl ListOrganizationImpactsResponse {
     {
         use std::iter::Iterator;
         self.organization_impacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOrganizationImpactsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -795,6 +795,17 @@ pub mod speech {
             self
         }
 
+        /// Sets the value of [files][crate::model::BatchRecognizeRequest::files].
+        pub fn set_files<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::BatchRecognizeFileMetadata>,
+        {
+            use std::iter::Iterator;
+            self.0.request.files = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [recognition_output_config][crate::model::BatchRecognizeRequest::recognition_output_config].
         pub fn set_recognition_output_config<
             T: Into<std::option::Option<crate::model::RecognitionOutputConfig>>,
@@ -814,17 +825,6 @@ pub mod speech {
             v: T,
         ) -> Self {
             self.0.request.processing_strategy = v.into();
-            self
-        }
-
-        /// Sets the value of [files][crate::model::BatchRecognizeRequest::files].
-        pub fn set_files<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::BatchRecognizeFileMetadata>,
-        {
-            use std::iter::Iterator;
-            self.0.request.files = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -246,202 +246,6 @@ impl OperationMetadata {
         })
     }
 
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `CreateRecognizerRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_recognizer_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateRecognizerRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::CreateRecognizerRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UpdateRecognizerRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn update_recognizer_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateRecognizerRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UpdateRecognizerRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `DeleteRecognizerRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_recognizer_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteRecognizerRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::DeleteRecognizerRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UndeleteRecognizerRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn undelete_recognizer_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UndeleteRecognizerRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UndeleteRecognizerRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `CreateCustomClassRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_custom_class_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateCustomClassRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::CreateCustomClassRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UpdateCustomClassRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn update_custom_class_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateCustomClassRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UpdateCustomClassRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `DeleteCustomClassRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_custom_class_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteCustomClassRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::DeleteCustomClassRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UndeleteCustomClassRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn undelete_custom_class_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UndeleteCustomClassRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UndeleteCustomClassRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `CreatePhraseSetRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn create_phrase_set_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CreatePhraseSetRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::CreatePhraseSetRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UpdatePhraseSetRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn update_phrase_set_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdatePhraseSetRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UpdatePhraseSetRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `DeletePhraseSetRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_phrase_set_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeletePhraseSetRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::DeletePhraseSetRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UndeletePhraseSetRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn undelete_phrase_set_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UndeletePhraseSetRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UndeletePhraseSetRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [request][crate::model::OperationMetadata::request]
-    /// if it holds a `UpdateConfigRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    #[deprecated]
-    pub fn update_config_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateConfigRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::operation_metadata::Request::UpdateConfigRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `BatchRecognizeRequest`.
     ///
@@ -457,6 +261,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::BatchRecognizeRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `CreateRecognizerRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_recognizer_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateRecognizerRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::CreateRecognizerRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -476,6 +295,21 @@ impl OperationMetadata {
         self
     }
 
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UpdateRecognizerRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn update_recognizer_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateRecognizerRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UpdateRecognizerRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `UpdateRecognizerRequest`.
     ///
@@ -491,6 +325,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::UpdateRecognizerRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `DeleteRecognizerRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_recognizer_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteRecognizerRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::DeleteRecognizerRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -510,6 +359,21 @@ impl OperationMetadata {
         self
     }
 
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UndeleteRecognizerRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn undelete_recognizer_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UndeleteRecognizerRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UndeleteRecognizerRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `UndeleteRecognizerRequest`.
     ///
@@ -525,6 +389,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::UndeleteRecognizerRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `CreateCustomClassRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_custom_class_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreateCustomClassRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::CreateCustomClassRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -544,6 +423,21 @@ impl OperationMetadata {
         self
     }
 
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UpdateCustomClassRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn update_custom_class_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateCustomClassRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UpdateCustomClassRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `UpdateCustomClassRequest`.
     ///
@@ -559,6 +453,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::UpdateCustomClassRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `DeleteCustomClassRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_custom_class_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteCustomClassRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::DeleteCustomClassRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -578,6 +487,21 @@ impl OperationMetadata {
         self
     }
 
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UndeleteCustomClassRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn undelete_custom_class_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UndeleteCustomClassRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UndeleteCustomClassRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `UndeleteCustomClassRequest`.
     ///
@@ -593,6 +517,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::UndeleteCustomClassRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `CreatePhraseSetRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn create_phrase_set_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CreatePhraseSetRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::CreatePhraseSetRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -612,6 +551,21 @@ impl OperationMetadata {
         self
     }
 
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UpdatePhraseSetRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn update_phrase_set_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdatePhraseSetRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UpdatePhraseSetRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `UpdatePhraseSetRequest`.
     ///
@@ -627,6 +581,21 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::UpdatePhraseSetRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `DeletePhraseSetRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_phrase_set_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeletePhraseSetRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::DeletePhraseSetRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -646,6 +615,21 @@ impl OperationMetadata {
         self
     }
 
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UndeletePhraseSetRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn undelete_phrase_set_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UndeletePhraseSetRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UndeletePhraseSetRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [request][crate::model::OperationMetadata::request]
     /// to hold a `UndeletePhraseSetRequest`.
     ///
@@ -661,6 +645,22 @@ impl OperationMetadata {
             crate::model::operation_metadata::Request::UndeletePhraseSetRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::OperationMetadata::request]
+    /// if it holds a `UpdateConfigRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    #[deprecated]
+    pub fn update_config_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateConfigRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::operation_metadata::Request::UpdateConfigRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::OperationMetadata::request]
@@ -892,12 +892,6 @@ impl ListRecognizersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRecognizersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [recognizers][crate::model::ListRecognizersResponse::recognizers].
     pub fn set_recognizers<T, V>(mut self, v: T) -> Self
     where
@@ -906,6 +900,12 @@ impl ListRecognizersResponse {
     {
         use std::iter::Iterator;
         self.recognizers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRecognizersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1319,6 +1319,18 @@ impl Recognizer {
         self
     }
 
+    /// Sets the value of [language_codes][crate::model::Recognizer::language_codes].
+    #[deprecated]
+    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [default_recognition_config][crate::model::Recognizer::default_recognition_config].
     pub fn set_default_recognition_config<
         T: std::convert::Into<std::option::Option<crate::model::RecognitionConfig>>,
@@ -1327,6 +1339,18 @@ impl Recognizer {
         v: T,
     ) -> Self {
         self.default_recognition_config = v.into();
+        self
+    }
+
+    /// Sets the value of [annotations][crate::model::Recognizer::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1399,30 +1423,6 @@ impl Recognizer {
         v: T,
     ) -> Self {
         self.kms_key_version_name = v.into();
-        self
-    }
-
-    /// Sets the value of [language_codes][crate::model::Recognizer::language_codes].
-    #[deprecated]
-    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.language_codes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Recognizer::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2473,6 +2473,18 @@ pub mod speech_adaptation {
             })
         }
 
+        /// Sets the value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
+        /// to hold a `PhraseSet`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_phrase_set<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::speech_adaptation::adaptation_phrase_set::Value::PhraseSet(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
         /// if it holds a `InlinePhraseSet`, `None` if the field is not set or
         /// holds a different branch.
@@ -2486,18 +2498,6 @@ pub mod speech_adaptation {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
-        /// to hold a `PhraseSet`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_phrase_set<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::speech_adaptation::adaptation_phrase_set::Value::PhraseSet(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
@@ -2617,6 +2617,17 @@ impl RecognitionConfig {
         self
     }
 
+    /// Sets the value of [language_codes][crate::model::RecognitionConfig::language_codes].
+    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [features][crate::model::RecognitionConfig::features].
     pub fn set_features<
         T: std::convert::Into<std::option::Option<crate::model::RecognitionFeatures>>,
@@ -2661,17 +2672,6 @@ impl RecognitionConfig {
         self
     }
 
-    /// Sets the value of [language_codes][crate::model::RecognitionConfig::language_codes].
-    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.language_codes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [decoding_config][crate::model::RecognitionConfig::decoding_config].
     ///
     /// Note that all the setters affecting `decoding_config` are mutually
@@ -2701,21 +2701,6 @@ impl RecognitionConfig {
         })
     }
 
-    /// The value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
-    /// if it holds a `ExplicitDecodingConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn explicit_decoding_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExplicitDecodingConfig>> {
-        #[allow(unreachable_patterns)]
-        self.decoding_config.as_ref().and_then(|v| match v {
-            crate::model::recognition_config::DecodingConfig::ExplicitDecodingConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
     /// to hold a `AutoDecodingConfig`.
     ///
@@ -2731,6 +2716,21 @@ impl RecognitionConfig {
             crate::model::recognition_config::DecodingConfig::AutoDecodingConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
+    /// if it holds a `ExplicitDecodingConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn explicit_decoding_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExplicitDecodingConfig>> {
+        #[allow(unreachable_patterns)]
+        self.decoding_config.as_ref().and_then(|v| match v {
+            crate::model::recognition_config::DecodingConfig::ExplicitDecodingConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
@@ -2893,17 +2893,6 @@ impl RecognizeRequest {
         })
     }
 
-    /// The value of [audio_source][crate::model::RecognizeRequest::audio_source]
-    /// if it holds a `Uri`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn uri(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.audio_source.as_ref().and_then(|v| match v {
-            crate::model::recognize_request::AudioSource::Uri(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [audio_source][crate::model::RecognizeRequest::audio_source]
     /// to hold a `Content`.
     ///
@@ -2914,6 +2903,17 @@ impl RecognizeRequest {
             crate::model::recognize_request::AudioSource::Content(v.into()),
         );
         self
+    }
+
+    /// The value of [audio_source][crate::model::RecognizeRequest::audio_source]
+    /// if it holds a `Uri`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn uri(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.audio_source.as_ref().and_then(|v| match v {
+            crate::model::recognize_request::AudioSource::Uri(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [audio_source][crate::model::RecognizeRequest::audio_source]
@@ -3228,6 +3228,17 @@ impl SpeechRecognitionResult {
         std::default::Default::default()
     }
 
+    /// Sets the value of [alternatives][crate::model::SpeechRecognitionResult::alternatives].
+    pub fn set_alternatives<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SpeechRecognitionAlternative>,
+    {
+        use std::iter::Iterator;
+        self.alternatives = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [channel_tag][crate::model::SpeechRecognitionResult::channel_tag].
     pub fn set_channel_tag<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.channel_tag = v.into();
@@ -3246,17 +3257,6 @@ impl SpeechRecognitionResult {
     /// Sets the value of [language_code][crate::model::SpeechRecognitionResult::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [alternatives][crate::model::SpeechRecognitionResult::alternatives].
-    pub fn set_alternatives<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SpeechRecognitionAlternative>,
-    {
-        use std::iter::Iterator;
-        self.alternatives = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3294,17 +3294,6 @@ impl RecognizeResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [metadata][crate::model::RecognizeResponse::metadata].
-    pub fn set_metadata<
-        T: std::convert::Into<std::option::Option<crate::model::RecognitionResponseMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::RecognizeResponse::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -3313,6 +3302,17 @@ impl RecognizeResponse {
     {
         use std::iter::Iterator;
         self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::RecognizeResponse::metadata].
+    pub fn set_metadata<
+        T: std::convert::Into<std::option::Option<crate::model::RecognitionResponseMetadata>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -3627,19 +3627,6 @@ impl StreamingRecognizeRequest {
         })
     }
 
-    /// The value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
-    /// if it holds a `Audio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn audio(&self) -> std::option::Option<&::bytes::Bytes> {
-        #[allow(unreachable_patterns)]
-        self.streaming_request.as_ref().and_then(|v| match v {
-            crate::model::streaming_recognize_request::StreamingRequest::Audio(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
     /// to hold a `StreamingConfig`.
     ///
@@ -3655,6 +3642,19 @@ impl StreamingRecognizeRequest {
             crate::model::streaming_recognize_request::StreamingRequest::StreamingConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
+    /// if it holds a `Audio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn audio(&self) -> std::option::Option<&::bytes::Bytes> {
+        #[allow(unreachable_patterns)]
+        self.streaming_request.as_ref().and_then(|v| match v {
+            crate::model::streaming_recognize_request::StreamingRequest::Audio(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
@@ -3790,6 +3790,17 @@ impl BatchRecognizeRequest {
         self
     }
 
+    /// Sets the value of [files][crate::model::BatchRecognizeRequest::files].
+    pub fn set_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BatchRecognizeFileMetadata>,
+    {
+        use std::iter::Iterator;
+        self.files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [recognition_output_config][crate::model::BatchRecognizeRequest::recognition_output_config].
     pub fn set_recognition_output_config<
         T: std::convert::Into<std::option::Option<crate::model::RecognitionOutputConfig>>,
@@ -3809,17 +3820,6 @@ impl BatchRecognizeRequest {
         v: T,
     ) -> Self {
         self.processing_strategy = v.into();
-        self
-    }
-
-    /// Sets the value of [files][crate::model::BatchRecognizeRequest::files].
-    pub fn set_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BatchRecognizeFileMetadata>,
-    {
-        use std::iter::Iterator;
-        self.files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4221,21 +4221,6 @@ impl RecognitionOutputConfig {
         })
     }
 
-    /// The value of [output][crate::model::RecognitionOutputConfig::output]
-    /// if it holds a `InlineResponseConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn inline_response_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineOutputConfig>> {
-        #[allow(unreachable_patterns)]
-        self.output.as_ref().and_then(|v| match v {
-            crate::model::recognition_output_config::Output::InlineResponseConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [output][crate::model::RecognitionOutputConfig::output]
     /// to hold a `GcsOutputConfig`.
     ///
@@ -4251,6 +4236,21 @@ impl RecognitionOutputConfig {
             crate::model::recognition_output_config::Output::GcsOutputConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [output][crate::model::RecognitionOutputConfig::output]
+    /// if it holds a `InlineResponseConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn inline_response_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineOutputConfig>> {
+        #[allow(unreachable_patterns)]
+        self.output.as_ref().and_then(|v| match v {
+            crate::model::recognition_output_config::Output::InlineResponseConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [output][crate::model::RecognitionOutputConfig::output]
@@ -4330,15 +4330,6 @@ impl BatchRecognizeResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [total_billed_duration][crate::model::BatchRecognizeResponse::total_billed_duration].
-    pub fn set_total_billed_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.total_billed_duration = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::BatchRecognizeResponse::results].
     pub fn set_results<T, K, V>(mut self, v: T) -> Self
     where
@@ -4348,6 +4339,15 @@ impl BatchRecognizeResponse {
     {
         use std::iter::Iterator;
         self.results = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [total_billed_duration][crate::model::BatchRecognizeResponse::total_billed_duration].
+    pub fn set_total_billed_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.total_billed_duration = v.into();
         self
     }
 }
@@ -4384,17 +4384,6 @@ impl BatchRecognizeResults {
         std::default::Default::default()
     }
 
-    /// Sets the value of [metadata][crate::model::BatchRecognizeResults::metadata].
-    pub fn set_metadata<
-        T: std::convert::Into<std::option::Option<crate::model::RecognitionResponseMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [results][crate::model::BatchRecognizeResults::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -4403,6 +4392,17 @@ impl BatchRecognizeResults {
     {
         use std::iter::Iterator;
         self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::BatchRecognizeResults::metadata].
+    pub fn set_metadata<
+        T: std::convert::Into<std::option::Option<crate::model::RecognitionResponseMetadata>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -4629,21 +4629,6 @@ impl BatchRecognizeFileResult {
         })
     }
 
-    /// The value of [result][crate::model::BatchRecognizeFileResult::result]
-    /// if it holds a `InlineResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn inline_result(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineResult>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::batch_recognize_file_result::Result::InlineResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::BatchRecognizeFileResult::result]
     /// to hold a `CloudStorageResult`.
     ///
@@ -4659,6 +4644,21 @@ impl BatchRecognizeFileResult {
             crate::model::batch_recognize_file_result::Result::CloudStorageResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::BatchRecognizeFileResult::result]
+    /// if it holds a `InlineResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn inline_result(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InlineResult>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::batch_recognize_file_result::Result::InlineResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::BatchRecognizeFileResult::result]
@@ -5008,6 +5008,17 @@ impl StreamingRecognitionResult {
         std::default::Default::default()
     }
 
+    /// Sets the value of [alternatives][crate::model::StreamingRecognitionResult::alternatives].
+    pub fn set_alternatives<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SpeechRecognitionAlternative>,
+    {
+        use std::iter::Iterator;
+        self.alternatives = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [is_final][crate::model::StreamingRecognitionResult::is_final].
     pub fn set_is_final<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.is_final = v.into();
@@ -5038,17 +5049,6 @@ impl StreamingRecognitionResult {
     /// Sets the value of [language_code][crate::model::StreamingRecognitionResult::language_code].
     pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [alternatives][crate::model::StreamingRecognitionResult::alternatives].
-    pub fn set_alternatives<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SpeechRecognitionAlternative>,
-    {
-        use std::iter::Iterator;
-        self.alternatives = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5146,6 +5146,17 @@ impl StreamingRecognizeResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [results][crate::model::StreamingRecognizeResponse::results].
+    pub fn set_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::StreamingRecognitionResult>,
+    {
+        use std::iter::Iterator;
+        self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [speech_event_type][crate::model::StreamingRecognizeResponse::speech_event_type].
     pub fn set_speech_event_type<
         T: std::convert::Into<crate::model::streaming_recognize_response::SpeechEventType>,
@@ -5174,17 +5185,6 @@ impl StreamingRecognizeResponse {
         v: T,
     ) -> Self {
         self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [results][crate::model::StreamingRecognizeResponse::results].
-    pub fn set_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::StreamingRecognitionResult>,
-    {
-        use std::iter::Iterator;
-        self.results = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5612,6 +5612,17 @@ impl CustomClass {
         self
     }
 
+    /// Sets the value of [items][crate::model::CustomClass::items].
+    pub fn set_items<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::custom_class::ClassItem>,
+    {
+        use std::iter::Iterator;
+        self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::CustomClass::state].
     pub fn set_state<T: std::convert::Into<crate::model::custom_class::State>>(
         mut self,
@@ -5657,6 +5668,18 @@ impl CustomClass {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::CustomClass::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::CustomClass::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -5681,29 +5704,6 @@ impl CustomClass {
         v: T,
     ) -> Self {
         self.kms_key_version_name = v.into();
-        self
-    }
-
-    /// Sets the value of [items][crate::model::CustomClass::items].
-    pub fn set_items<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::custom_class::ClassItem>,
-    {
-        use std::iter::Iterator;
-        self.items = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::CustomClass::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5991,6 +5991,17 @@ impl PhraseSet {
         self
     }
 
+    /// Sets the value of [phrases][crate::model::PhraseSet::phrases].
+    pub fn set_phrases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::phrase_set::Phrase>,
+    {
+        use std::iter::Iterator;
+        self.phrases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [boost][crate::model::PhraseSet::boost].
     pub fn set_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.boost = v.into();
@@ -6048,6 +6059,18 @@ impl PhraseSet {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::PhraseSet::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::PhraseSet::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -6072,29 +6095,6 @@ impl PhraseSet {
         v: T,
     ) -> Self {
         self.kms_key_version_name = v.into();
-        self
-    }
-
-    /// Sets the value of [phrases][crate::model::PhraseSet::phrases].
-    pub fn set_phrases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::phrase_set::Phrase>,
-    {
-        use std::iter::Iterator;
-        self.phrases = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::PhraseSet::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6486,12 +6486,6 @@ impl ListCustomClassesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCustomClassesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [custom_classes][crate::model::ListCustomClassesResponse::custom_classes].
     pub fn set_custom_classes<T, V>(mut self, v: T) -> Self
     where
@@ -6500,6 +6494,12 @@ impl ListCustomClassesResponse {
     {
         use std::iter::Iterator;
         self.custom_classes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCustomClassesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6942,12 +6942,6 @@ impl ListPhraseSetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPhraseSetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [phrase_sets][crate::model::ListPhraseSetsResponse::phrase_sets].
     pub fn set_phrase_sets<T, V>(mut self, v: T) -> Self
     where
@@ -6956,6 +6950,12 @@ impl ListPhraseSetsResponse {
     {
         use std::iter::Iterator;
         self.phrase_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPhraseSetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -508,12 +508,6 @@ impl BackupRunsListResponse {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::BackupRunsListResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [items][crate::model::BackupRunsListResponse::items].
     pub fn set_items<T, V>(mut self, v: T) -> Self
     where
@@ -522,6 +516,12 @@ impl BackupRunsListResponse {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::BackupRunsListResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -661,6 +661,17 @@ impl ConnectSettings {
         self
     }
 
+    /// Sets the value of [ip_addresses][crate::model::ConnectSettings::ip_addresses].
+    pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::IpMapping>
+    {
+        use std::iter::Iterator;
+        self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [region][crate::model::ConnectSettings::region].
     pub fn set_region<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.region = v.into();
@@ -694,17 +705,6 @@ impl ConnectSettings {
     /// Sets the value of [server_ca_mode][crate::model::ConnectSettings::server_ca_mode].
     pub fn set_server_ca_mode<T: std::convert::Into<crate::model::connect_settings::CaMode>>(mut self, v: T) -> Self {
         self.server_ca_mode = v.into();
-        self
-    }
-
-    /// Sets the value of [ip_addresses][crate::model::ConnectSettings::ip_addresses].
-    pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::IpMapping>
-    {
-        use std::iter::Iterator;
-        self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1447,6 +1447,28 @@ impl Flag {
         self
     }
 
+    /// Sets the value of [applies_to][crate::model::Flag::applies_to].
+    pub fn set_applies_to<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SqlDatabaseVersion>
+    {
+        use std::iter::Iterator;
+        self.applies_to = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [allowed_string_values][crate::model::Flag::allowed_string_values].
+    pub fn set_allowed_string_values<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.allowed_string_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [min_value][crate::model::Flag::min_value].
     pub fn set_min_value<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.min_value = v.into();
@@ -1474,28 +1496,6 @@ impl Flag {
     /// Sets the value of [in_beta][crate::model::Flag::in_beta].
     pub fn set_in_beta<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.in_beta = v.into();
-        self
-    }
-
-    /// Sets the value of [applies_to][crate::model::Flag::applies_to].
-    pub fn set_applies_to<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SqlDatabaseVersion>
-    {
-        use std::iter::Iterator;
-        self.applies_to = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [allowed_string_values][crate::model::Flag::allowed_string_values].
-    pub fn set_allowed_string_values<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>
-    {
-        use std::iter::Iterator;
-        self.allowed_string_values = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3994,12 +3994,6 @@ impl InstancesListResponse {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::InstancesListResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [warnings][crate::model::InstancesListResponse::warnings].
     pub fn set_warnings<T, V>(mut self, v: T) -> Self
     where
@@ -4019,6 +4013,12 @@ impl InstancesListResponse {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::InstancesListResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4056,6 +4056,17 @@ impl InstancesListServerCasResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [certs][crate::model::InstancesListServerCasResponse::certs].
+    pub fn set_certs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SslCert>
+    {
+        use std::iter::Iterator;
+        self.certs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [active_version][crate::model::InstancesListServerCasResponse::active_version].
     pub fn set_active_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.active_version = v.into();
@@ -4065,17 +4076,6 @@ impl InstancesListServerCasResponse {
     /// Sets the value of [kind][crate::model::InstancesListServerCasResponse::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
-        self
-    }
-
-    /// Sets the value of [certs][crate::model::InstancesListServerCasResponse::certs].
-    pub fn set_certs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SslCert>
-    {
-        use std::iter::Iterator;
-        self.certs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4518,12 +4518,6 @@ impl CloneContext {
         self
     }
 
-    /// Sets the value of [preferred_zone][crate::model::CloneContext::preferred_zone].
-    pub fn set_preferred_zone<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
-        self.preferred_zone = v.into();
-        self
-    }
-
     /// Sets the value of [database_names][crate::model::CloneContext::database_names].
     pub fn set_database_names<T, V>(mut self, v: T) -> Self
     where
@@ -4532,6 +4526,12 @@ impl CloneContext {
     {
         use std::iter::Iterator;
         self.database_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [preferred_zone][crate::model::CloneContext::preferred_zone].
+    pub fn set_preferred_zone<T: std::convert::Into<std::option::Option<std::string::String>>>(mut self, v: T) -> Self {
+        self.preferred_zone = v.into();
         self
     }
 }
@@ -4887,6 +4887,17 @@ impl DatabaseInstance {
         self
     }
 
+    /// Sets the value of [replica_names][crate::model::DatabaseInstance::replica_names].
+    pub fn set_replica_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.replica_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [max_disk_size][crate::model::DatabaseInstance::max_disk_size].
     #[deprecated]
     pub fn set_max_disk_size<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
@@ -4898,6 +4909,17 @@ impl DatabaseInstance {
     #[deprecated]
     pub fn set_current_disk_size<T: std::convert::Into<std::option::Option<wkt::Int64Value>>>(mut self, v: T) -> Self {
         self.current_disk_size = v.into();
+        self
+    }
+
+    /// Sets the value of [ip_addresses][crate::model::DatabaseInstance::ip_addresses].
+    pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::IpMapping>
+    {
+        use std::iter::Iterator;
+        self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4953,6 +4975,17 @@ impl DatabaseInstance {
     /// Sets the value of [self_link][crate::model::DatabaseInstance::self_link].
     pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.self_link = v.into();
+        self
+    }
+
+    /// Sets the value of [suspension_reason][crate::model::DatabaseInstance::suspension_reason].
+    pub fn set_suspension_reason<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SqlSuspensionReason>
+    {
+        use std::iter::Iterator;
+        self.suspension_reason = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5034,9 +5067,31 @@ impl DatabaseInstance {
         self
     }
 
+    /// Sets the value of [available_maintenance_versions][crate::model::DatabaseInstance::available_maintenance_versions].
+    pub fn set_available_maintenance_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.available_maintenance_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [maintenance_version][crate::model::DatabaseInstance::maintenance_version].
     pub fn set_maintenance_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.maintenance_version = v.into();
+        self
+    }
+
+    /// Sets the value of [upgradable_database_versions][crate::model::DatabaseInstance::upgradable_database_versions].
+    pub fn set_upgradable_database_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AvailableDatabaseVersion>
+    {
+        use std::iter::Iterator;
+        self.upgradable_database_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5092,61 +5147,6 @@ impl DatabaseInstance {
     /// Sets the value of [switch_transaction_logs_to_cloud_storage_enabled][crate::model::DatabaseInstance::switch_transaction_logs_to_cloud_storage_enabled].
     pub fn set_switch_transaction_logs_to_cloud_storage_enabled<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.switch_transaction_logs_to_cloud_storage_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [replica_names][crate::model::DatabaseInstance::replica_names].
-    pub fn set_replica_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>
-    {
-        use std::iter::Iterator;
-        self.replica_names = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [ip_addresses][crate::model::DatabaseInstance::ip_addresses].
-    pub fn set_ip_addresses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::IpMapping>
-    {
-        use std::iter::Iterator;
-        self.ip_addresses = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [suspension_reason][crate::model::DatabaseInstance::suspension_reason].
-    pub fn set_suspension_reason<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SqlSuspensionReason>
-    {
-        use std::iter::Iterator;
-        self.suspension_reason = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [available_maintenance_versions][crate::model::DatabaseInstance::available_maintenance_versions].
-    pub fn set_available_maintenance_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>
-    {
-        use std::iter::Iterator;
-        self.available_maintenance_versions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [upgradable_database_versions][crate::model::DatabaseInstance::upgradable_database_versions].
-    pub fn set_upgradable_database_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AvailableDatabaseVersion>
-    {
-        use std::iter::Iterator;
-        self.upgradable_database_versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7530,12 +7530,6 @@ impl OperationsListResponse {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::OperationsListResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [items][crate::model::OperationsListResponse::items].
     pub fn set_items<T, V>(mut self, v: T) -> Self
     where
@@ -7544,6 +7538,12 @@ impl OperationsListResponse {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::OperationsListResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8988,6 +8988,17 @@ impl ExportContext {
         self
     }
 
+    /// Sets the value of [databases][crate::model::ExportContext::databases].
+    pub fn set_databases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [kind][crate::model::ExportContext::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
@@ -9021,17 +9032,6 @@ impl ExportContext {
     /// Sets the value of [bak_export_options][crate::model::ExportContext::bak_export_options].
     pub fn set_bak_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::SqlBakExportOptions>>>(mut self, v: T) -> Self {
         self.bak_export_options = v.into();
-        self
-    }
-
-    /// Sets the value of [databases][crate::model::ExportContext::databases].
-    pub fn set_databases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>
-    {
-        use std::iter::Iterator;
-        self.databases = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -9163,6 +9163,17 @@ pub mod export_context {
             std::default::Default::default()
         }
 
+        /// Sets the value of [tables][crate::model::export_context::SqlExportOptions::tables].
+        pub fn set_tables<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.tables = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [schema_only][crate::model::export_context::SqlExportOptions::schema_only].
         pub fn set_schema_only<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
             self.schema_only = v.into();
@@ -9190,17 +9201,6 @@ pub mod export_context {
         /// Sets the value of [postgres_export_options][crate::model::export_context::SqlExportOptions::postgres_export_options].
         pub fn set_postgres_export_options<T: std::convert::Into<std::option::Option<crate::model::export_context::sql_export_options::PostgresExportOptions>>>(mut self, v: T) -> Self {
             self.postgres_export_options = v.into();
-            self
-        }
-
-        /// Sets the value of [tables][crate::model::export_context::SqlExportOptions::tables].
-        pub fn set_tables<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>
-        {
-            use std::iter::Iterator;
-            self.tables = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -9647,6 +9647,17 @@ pub mod import_context {
             self
         }
 
+        /// Sets the value of [columns][crate::model::import_context::SqlCsvImportOptions::columns].
+        pub fn set_columns<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>
+        {
+            use std::iter::Iterator;
+            self.columns = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [escape_character][crate::model::import_context::SqlCsvImportOptions::escape_character].
         pub fn set_escape_character<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.escape_character = v.into();
@@ -9668,17 +9679,6 @@ pub mod import_context {
         /// Sets the value of [lines_terminated_by][crate::model::import_context::SqlCsvImportOptions::lines_terminated_by].
         pub fn set_lines_terminated_by<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.lines_terminated_by = v.into();
-            self
-        }
-
-        /// Sets the value of [columns][crate::model::import_context::SqlCsvImportOptions::columns].
-        pub fn set_columns<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>
-        {
-            use std::iter::Iterator;
-            self.columns = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -9963,6 +9963,17 @@ impl IpConfiguration {
         self
     }
 
+    /// Sets the value of [authorized_networks][crate::model::IpConfiguration::authorized_networks].
+    pub fn set_authorized_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AclEntry>
+    {
+        use std::iter::Iterator;
+        self.authorized_networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [allocated_ip_range][crate::model::IpConfiguration::allocated_ip_range].
     pub fn set_allocated_ip_range<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.allocated_ip_range = v.into();
@@ -9990,17 +10001,6 @@ impl IpConfiguration {
     /// Sets the value of [server_ca_mode][crate::model::IpConfiguration::server_ca_mode].
     pub fn set_server_ca_mode<T: std::convert::Into<std::option::Option<crate::model::ip_configuration::CaMode>>>(mut self, v: T) -> Self {
         self.server_ca_mode = v.into();
-        self
-    }
-
-    /// Sets the value of [authorized_networks][crate::model::IpConfiguration::authorized_networks].
-    pub fn set_authorized_networks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AclEntry>
-    {
-        use std::iter::Iterator;
-        self.authorized_networks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -12299,6 +12299,18 @@ impl Settings {
         self
     }
 
+    /// Sets the value of [authorized_gae_applications][crate::model::Settings::authorized_gae_applications].
+    #[deprecated]
+    pub fn set_authorized_gae_applications<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>
+    {
+        use std::iter::Iterator;
+        self.authorized_gae_applications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [tier][crate::model::Settings::tier].
     pub fn set_tier<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tier = v.into();
@@ -12308,6 +12320,18 @@ impl Settings {
     /// Sets the value of [kind][crate::model::Settings::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
+        self
+    }
+
+    /// Sets the value of [user_labels][crate::model::Settings::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -12360,6 +12384,17 @@ impl Settings {
         self
     }
 
+    /// Sets the value of [database_flags][crate::model::Settings::database_flags].
+    pub fn set_database_flags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DatabaseFlags>
+    {
+        use std::iter::Iterator;
+        self.database_flags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [data_disk_type][crate::model::Settings::data_disk_type].
     pub fn set_data_disk_type<T: std::convert::Into<crate::model::SqlDataDiskType>>(mut self, v: T) -> Self {
         self.data_disk_type = v.into();
@@ -12406,6 +12441,17 @@ impl Settings {
     /// Sets the value of [collation][crate::model::Settings::collation].
     pub fn set_collation<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.collation = v.into();
+        self
+    }
+
+    /// Sets the value of [deny_maintenance_periods][crate::model::Settings::deny_maintenance_periods].
+    pub fn set_deny_maintenance_periods<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DenyMaintenancePeriod>
+    {
+        use std::iter::Iterator;
+        self.deny_maintenance_periods = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -12472,52 +12518,6 @@ impl Settings {
     /// Sets the value of [enable_dataplex_integration][crate::model::Settings::enable_dataplex_integration].
     pub fn set_enable_dataplex_integration<T: std::convert::Into<std::option::Option<wkt::BoolValue>>>(mut self, v: T) -> Self {
         self.enable_dataplex_integration = v.into();
-        self
-    }
-
-    /// Sets the value of [authorized_gae_applications][crate::model::Settings::authorized_gae_applications].
-    #[deprecated]
-    pub fn set_authorized_gae_applications<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>
-    {
-        use std::iter::Iterator;
-        self.authorized_gae_applications = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [database_flags][crate::model::Settings::database_flags].
-    pub fn set_database_flags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DatabaseFlags>
-    {
-        use std::iter::Iterator;
-        self.database_flags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [deny_maintenance_periods][crate::model::Settings::deny_maintenance_periods].
-    pub fn set_deny_maintenance_periods<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DenyMaintenancePeriod>
-    {
-        use std::iter::Iterator;
-        self.deny_maintenance_periods = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [user_labels][crate::model::Settings::user_labels].
-    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -14758,13 +14758,6 @@ impl UsersListResponse {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::UsersListResponse::next_page_token].
-    #[deprecated]
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [items][crate::model::UsersListResponse::items].
     pub fn set_items<T, V>(mut self, v: T) -> Self
     where
@@ -14773,6 +14766,13 @@ impl UsersListResponse {
     {
         use std::iter::Iterator;
         self.items = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::UsersListResponse::next_page_token].
+    #[deprecated]
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/storagebatchoperations/v1/src/model.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/model.rs
@@ -133,12 +133,6 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -147,6 +141,12 @@ impl ListJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -625,12 +625,6 @@ impl Job {
         self
     }
 
-    /// Sets the value of [state][crate::model::Job::state].
-    pub fn set_state<T: std::convert::Into<crate::model::job::State>>(mut self, v: T) -> Self {
-        self.state = v.into();
-        self
-    }
-
     /// Sets the value of [error_summaries][crate::model::Job::error_summaries].
     pub fn set_error_summaries<T, V>(mut self, v: T) -> Self
     where
@@ -639,6 +633,12 @@ impl Job {
     {
         use std::iter::Iterator;
         self.error_summaries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Job::state].
+    pub fn set_state<T: std::convert::Into<crate::model::job::State>>(mut self, v: T) -> Self {
+        self.state = v.into();
         self
     }
 
@@ -705,43 +705,6 @@ impl Job {
         })
     }
 
-    /// The value of [transformation][crate::model::Job::transformation]
-    /// if it holds a `DeleteObject`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_object(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteObject>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::job::Transformation::DeleteObject(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::Job::transformation]
-    /// if it holds a `PutMetadata`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn put_metadata(&self) -> std::option::Option<&std::boxed::Box<crate::model::PutMetadata>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::job::Transformation::PutMetadata(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::Job::transformation]
-    /// if it holds a `RewriteObject`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn rewrite_object(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RewriteObject>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::job::Transformation::RewriteObject(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [transformation][crate::model::Job::transformation]
     /// to hold a `PutObjectHold`.
     ///
@@ -758,6 +721,19 @@ impl Job {
         self
     }
 
+    /// The value of [transformation][crate::model::Job::transformation]
+    /// if it holds a `DeleteObject`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_object(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteObject>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::job::Transformation::DeleteObject(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::Job::transformation]
     /// to hold a `DeleteObject`.
     ///
@@ -772,6 +748,17 @@ impl Job {
         self
     }
 
+    /// The value of [transformation][crate::model::Job::transformation]
+    /// if it holds a `PutMetadata`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn put_metadata(&self) -> std::option::Option<&std::boxed::Box<crate::model::PutMetadata>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::job::Transformation::PutMetadata(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::Job::transformation]
     /// to hold a `PutMetadata`.
     ///
@@ -784,6 +771,19 @@ impl Job {
         self.transformation =
             std::option::Option::Some(crate::model::job::Transformation::PutMetadata(v.into()));
         self
+    }
+
+    /// The value of [transformation][crate::model::Job::transformation]
+    /// if it holds a `RewriteObject`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn rewrite_object(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RewriteObject>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::job::Transformation::RewriteObject(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::Job::transformation]
@@ -1093,19 +1093,6 @@ pub mod bucket_list {
             })
         }
 
-        /// The value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]
-        /// if it holds a `Manifest`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn manifest(&self) -> std::option::Option<&std::boxed::Box<crate::model::Manifest>> {
-            #[allow(unreachable_patterns)]
-            self.object_configuration.as_ref().and_then(|v| match v {
-                crate::model::bucket_list::bucket::ObjectConfiguration::Manifest(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]
         /// to hold a `PrefixList`.
         ///
@@ -1119,6 +1106,19 @@ pub mod bucket_list {
                 crate::model::bucket_list::bucket::ObjectConfiguration::PrefixList(v.into()),
             );
             self
+        }
+
+        /// The value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]
+        /// if it holds a `Manifest`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn manifest(&self) -> std::option::Option<&std::boxed::Box<crate::model::Manifest>> {
+            #[allow(unreachable_patterns)]
+            self.object_configuration.as_ref().and_then(|v| match v {
+                crate::model::bucket_list::bucket::ObjectConfiguration::Manifest(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -134,12 +134,6 @@ impl ListReportConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReportConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [report_configs][crate::model::ListReportConfigsResponse::report_configs].
     pub fn set_report_configs<T, V>(mut self, v: T) -> Self
     where
@@ -148,6 +142,12 @@ impl ListReportConfigsResponse {
     {
         use std::iter::Iterator;
         self.report_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReportConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -522,6 +522,18 @@ impl ReportDetail {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ReportDetail::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [target_datetime][crate::model::ReportDetail::target_datetime].
     pub fn set_target_datetime<
         T: std::convert::Into<std::option::Option<gtype::model::DateTime>>,
@@ -541,18 +553,6 @@ impl ReportDetail {
         v: T,
     ) -> Self {
         self.report_metrics = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ReportDetail::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -702,12 +702,6 @@ impl ListReportDetailsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReportDetailsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [report_details][crate::model::ListReportDetailsResponse::report_details].
     pub fn set_report_details<T, V>(mut self, v: T) -> Self
     where
@@ -716,6 +710,12 @@ impl ListReportDetailsResponse {
     {
         use std::iter::Iterator;
         self.report_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReportDetailsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1504,12 +1504,6 @@ impl ReportConfig {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::ReportConfig::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::ReportConfig::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -1519,6 +1513,12 @@ impl ReportConfig {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::ReportConfig::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 
@@ -1549,21 +1549,6 @@ impl ReportConfig {
         })
     }
 
-    /// The value of [report_format][crate::model::ReportConfig::report_format]
-    /// if it holds a `ParquetOptions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn parquet_options(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ParquetOptions>> {
-        #[allow(unreachable_patterns)]
-        self.report_format.as_ref().and_then(|v| match v {
-            crate::model::report_config::ReportFormat::ParquetOptions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [report_format][crate::model::ReportConfig::report_format]
     /// to hold a `CsvOptions`.
     ///
@@ -1577,6 +1562,21 @@ impl ReportConfig {
             crate::model::report_config::ReportFormat::CsvOptions(v.into()),
         );
         self
+    }
+
+    /// The value of [report_format][crate::model::ReportConfig::report_format]
+    /// if it holds a `ParquetOptions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn parquet_options(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ParquetOptions>> {
+        #[allow(unreachable_patterns)]
+        self.report_format.as_ref().and_then(|v| match v {
+            crate::model::report_config::ReportFormat::ParquetOptions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [report_format][crate::model::ReportConfig::report_format]

--- a/src/generated/cloud/support/v2/src/model.rs
+++ b/src/generated/cloud/support/v2/src/model.rs
@@ -261,12 +261,6 @@ impl ListAttachmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAttachmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [attachments][crate::model::ListAttachmentsResponse::attachments].
     pub fn set_attachments<T, V>(mut self, v: T) -> Self
     where
@@ -275,6 +269,12 @@ impl ListAttachmentsResponse {
     {
         use std::iter::Iterator;
         self.attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAttachmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -422,6 +422,17 @@ impl Case {
         self
     }
 
+    /// Sets the value of [subscriber_email_addresses][crate::model::Case::subscriber_email_addresses].
+    pub fn set_subscriber_email_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.subscriber_email_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Case::state].
     pub fn set_state<T: std::convert::Into<crate::model::case::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -485,17 +496,6 @@ impl Case {
         v: T,
     ) -> Self {
         self.priority = v.into();
-        self
-    }
-
-    /// Sets the value of [subscriber_email_addresses][crate::model::Case::subscriber_email_addresses].
-    pub fn set_subscriber_email_addresses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.subscriber_email_addresses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1051,12 +1051,6 @@ impl ListCasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cases][crate::model::ListCasesResponse::cases].
     pub fn set_cases<T, V>(mut self, v: T) -> Self
     where
@@ -1065,6 +1059,12 @@ impl ListCasesResponse {
     {
         use std::iter::Iterator;
         self.cases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1213,12 +1213,6 @@ impl SearchCasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchCasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cases][crate::model::SearchCasesResponse::cases].
     pub fn set_cases<T, V>(mut self, v: T) -> Self
     where
@@ -1227,6 +1221,12 @@ impl SearchCasesResponse {
     {
         use std::iter::Iterator;
         self.cases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchCasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1464,12 +1464,6 @@ impl SearchCaseClassificationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchCaseClassificationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [case_classifications][crate::model::SearchCaseClassificationsResponse::case_classifications].
     pub fn set_case_classifications<T, V>(mut self, v: T) -> Self
     where
@@ -1478,6 +1472,12 @@ impl SearchCaseClassificationsResponse {
     {
         use std::iter::Iterator;
         self.case_classifications = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchCaseClassificationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1661,12 +1661,6 @@ impl ListCommentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCommentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [comments][crate::model::ListCommentsResponse::comments].
     pub fn set_comments<T, V>(mut self, v: T) -> Self
     where
@@ -1675,6 +1669,12 @@ impl ListCommentsResponse {
     {
         use std::iter::Iterator;
         self.comments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCommentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/talent/v4/src/builder.rs
+++ b/src/generated/cloud/talent/v4/src/builder.rs
@@ -509,6 +509,17 @@ pub mod completion {
             self
         }
 
+        /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
+        pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.language_codes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_size][crate::model::CompleteQueryRequest::page_size].
         ///
         /// This is a **required** field for requests.
@@ -538,17 +549,6 @@ pub mod completion {
             v: T,
         ) -> Self {
             self.0.request.r#type = v.into();
-            self
-        }
-
-        /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
-        pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.language_codes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1166,15 +1166,6 @@ pub mod job_service {
             self
         }
 
-        /// Sets the value of [update_mask][crate::model::BatchUpdateJobsRequest::update_mask].
-        pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.update_mask = v.into();
-            self
-        }
-
         /// Sets the value of [jobs][crate::model::BatchUpdateJobsRequest::jobs].
         ///
         /// This is a **required** field for requests.
@@ -1185,6 +1176,15 @@ pub mod job_service {
         {
             use std::iter::Iterator;
             self.0.request.jobs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [update_mask][crate::model::BatchUpdateJobsRequest::update_mask].
+        pub fn set_update_mask<T: Into<std::option::Option<wkt::FieldMask>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.update_mask = v.into();
             self
         }
     }
@@ -1504,6 +1504,17 @@ pub mod job_service {
             self
         }
 
+        /// Sets the value of [histogram_queries][crate::model::SearchJobsRequest::histogram_queries].
+        pub fn set_histogram_queries<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::HistogramQuery>,
+        {
+            use std::iter::Iterator;
+            self.0.request.histogram_queries = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [job_view][crate::model::SearchJobsRequest::job_view].
         pub fn set_job_view<T: Into<crate::model::JobView>>(mut self, v: T) -> Self {
             self.0.request.job_view = v.into();
@@ -1582,17 +1593,6 @@ pub mod job_service {
             v: T,
         ) -> Self {
             self.0.request.relevance_threshold = v.into();
-            self
-        }
-
-        /// Sets the value of [histogram_queries][crate::model::SearchJobsRequest::histogram_queries].
-        pub fn set_histogram_queries<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::HistogramQuery>,
-        {
-            use std::iter::Iterator;
-            self.0.request.histogram_queries = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1678,6 +1678,17 @@ pub mod job_service {
             self
         }
 
+        /// Sets the value of [histogram_queries][crate::model::SearchJobsRequest::histogram_queries].
+        pub fn set_histogram_queries<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::HistogramQuery>,
+        {
+            use std::iter::Iterator;
+            self.0.request.histogram_queries = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [job_view][crate::model::SearchJobsRequest::job_view].
         pub fn set_job_view<T: Into<crate::model::JobView>>(mut self, v: T) -> Self {
             self.0.request.job_view = v.into();
@@ -1756,17 +1767,6 @@ pub mod job_service {
             v: T,
         ) -> Self {
             self.0.request.relevance_threshold = v.into();
-            self
-        }
-
-        /// Sets the value of [histogram_queries][crate::model::SearchJobsRequest::histogram_queries].
-        pub fn set_histogram_queries<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::HistogramQuery>,
-        {
-            use std::iter::Iterator;
-            self.0.request.histogram_queries = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -828,18 +828,6 @@ impl CustomAttribute {
         std::default::Default::default()
     }
 
-    /// Sets the value of [filterable][crate::model::CustomAttribute::filterable].
-    pub fn set_filterable<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.filterable = v.into();
-        self
-    }
-
-    /// Sets the value of [keyword_searchable][crate::model::CustomAttribute::keyword_searchable].
-    pub fn set_keyword_searchable<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.keyword_searchable = v.into();
-        self
-    }
-
     /// Sets the value of [string_values][crate::model::CustomAttribute::string_values].
     pub fn set_string_values<T, V>(mut self, v: T) -> Self
     where
@@ -859,6 +847,18 @@ impl CustomAttribute {
     {
         use std::iter::Iterator;
         self.long_values = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [filterable][crate::model::CustomAttribute::filterable].
+    pub fn set_filterable<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.filterable = v.into();
+        self
+    }
+
+    /// Sets the value of [keyword_searchable][crate::model::CustomAttribute::keyword_searchable].
+    pub fn set_keyword_searchable<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.keyword_searchable = v.into();
         self
     }
 }
@@ -986,6 +986,17 @@ impl CompensationInfo {
         std::default::Default::default()
     }
 
+    /// Sets the value of [entries][crate::model::CompensationInfo::entries].
+    pub fn set_entries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::compensation_info::CompensationEntry>,
+    {
+        use std::iter::Iterator;
+        self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [annualized_base_compensation_range][crate::model::CompensationInfo::annualized_base_compensation_range].
     pub fn set_annualized_base_compensation_range<
         T: std::convert::Into<std::option::Option<crate::model::compensation_info::CompensationRange>>,
@@ -1005,17 +1016,6 @@ impl CompensationInfo {
         v: T,
     ) -> Self {
         self.annualized_total_compensation_range = v.into();
-        self
-    }
-
-    /// Sets the value of [entries][crate::model::CompensationInfo::entries].
-    pub fn set_entries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::compensation_info::CompensationEntry>,
-    {
-        use std::iter::Iterator;
-        self.entries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1182,22 +1182,6 @@ pub mod compensation_info {
             })
         }
 
-        /// The value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
-        /// if it holds a `Range`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn range(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::compensation_info::CompensationRange>>
-        {
-            #[allow(unreachable_patterns)]
-            self.compensation_amount.as_ref().and_then(|v| match v {
-                crate::model::compensation_info::compensation_entry::CompensationAmount::Range(
-                    v,
-                ) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
         /// to hold a `Amount`.
         ///
@@ -1213,6 +1197,22 @@ pub mod compensation_info {
                 ),
             );
             self
+        }
+
+        /// The value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
+        /// if it holds a `Range`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn range(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::compensation_info::CompensationRange>>
+        {
+            #[allow(unreachable_patterns)]
+            self.compensation_amount.as_ref().and_then(|v| match v {
+                crate::model::compensation_info::compensation_entry::CompensationAmount::Range(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
@@ -2168,6 +2168,18 @@ impl Company {
         self
     }
 
+    /// Sets the value of [keyword_searchable_job_custom_attributes][crate::model::Company::keyword_searchable_job_custom_attributes].
+    #[deprecated]
+    pub fn set_keyword_searchable_job_custom_attributes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.keyword_searchable_job_custom_attributes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [derived_info][crate::model::Company::derived_info].
     pub fn set_derived_info<
         T: std::convert::Into<std::option::Option<crate::model::company::DerivedInfo>>,
@@ -2182,18 +2194,6 @@ impl Company {
     /// Sets the value of [suspended][crate::model::Company::suspended].
     pub fn set_suspended<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.suspended = v.into();
-        self
-    }
-
-    /// Sets the value of [keyword_searchable_job_custom_attributes][crate::model::Company::keyword_searchable_job_custom_attributes].
-    #[deprecated]
-    pub fn set_keyword_searchable_job_custom_attributes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.keyword_searchable_job_custom_attributes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2535,6 +2535,17 @@ impl ListCompaniesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [companies][crate::model::ListCompaniesResponse::companies].
+    pub fn set_companies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Company>,
+    {
+        use std::iter::Iterator;
+        self.companies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListCompaniesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -2549,17 +2560,6 @@ impl ListCompaniesResponse {
         v: T,
     ) -> Self {
         self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [companies][crate::model::ListCompaniesResponse::companies].
-    pub fn set_companies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Company>,
-    {
-        use std::iter::Iterator;
-        self.companies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2660,6 +2660,17 @@ impl CompleteQueryRequest {
         self
     }
 
+    /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
+    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::CompleteQueryRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -2689,17 +2700,6 @@ impl CompleteQueryRequest {
         v: T,
     ) -> Self {
         self.r#type = v.into();
-        self
-    }
-
-    /// Sets the value of [language_codes][crate::model::CompleteQueryRequest::language_codes].
-    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.language_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3041,17 +3041,6 @@ impl CompleteQueryResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [metadata][crate::model::CompleteQueryResponse::metadata].
-    pub fn set_metadata<
-        T: std::convert::Into<std::option::Option<crate::model::ResponseMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [completion_results][crate::model::CompleteQueryResponse::completion_results].
     pub fn set_completion_results<T, V>(mut self, v: T) -> Self
     where
@@ -3060,6 +3049,17 @@ impl CompleteQueryResponse {
     {
         use std::iter::Iterator;
         self.completion_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::CompleteQueryResponse::metadata].
+    pub fn set_metadata<
+        T: std::convert::Into<std::option::Option<crate::model::ResponseMetadata>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -3916,54 +3916,6 @@ impl JobQuery {
         self
     }
 
-    /// Sets the value of [commute_filter][crate::model::JobQuery::commute_filter].
-    pub fn set_commute_filter<
-        T: std::convert::Into<std::option::Option<crate::model::CommuteFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.commute_filter = v.into();
-        self
-    }
-
-    /// Sets the value of [compensation_filter][crate::model::JobQuery::compensation_filter].
-    pub fn set_compensation_filter<
-        T: std::convert::Into<std::option::Option<crate::model::CompensationFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.compensation_filter = v.into();
-        self
-    }
-
-    /// Sets the value of [custom_attribute_filter][crate::model::JobQuery::custom_attribute_filter].
-    pub fn set_custom_attribute_filter<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.custom_attribute_filter = v.into();
-        self
-    }
-
-    /// Sets the value of [disable_spell_check][crate::model::JobQuery::disable_spell_check].
-    pub fn set_disable_spell_check<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.disable_spell_check = v.into();
-        self
-    }
-
-    /// Sets the value of [publish_time_range][crate::model::JobQuery::publish_time_range].
-    pub fn set_publish_time_range<
-        T: std::convert::Into<std::option::Option<crate::model::TimestampRange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.publish_time_range = v.into();
-        self
-    }
-
     /// Sets the value of [companies][crate::model::JobQuery::companies].
     pub fn set_companies<T, V>(mut self, v: T) -> Self
     where
@@ -3997,6 +3949,17 @@ impl JobQuery {
         self
     }
 
+    /// Sets the value of [commute_filter][crate::model::JobQuery::commute_filter].
+    pub fn set_commute_filter<
+        T: std::convert::Into<std::option::Option<crate::model::CommuteFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.commute_filter = v.into();
+        self
+    }
+
     /// Sets the value of [company_display_names][crate::model::JobQuery::company_display_names].
     pub fn set_company_display_names<T, V>(mut self, v: T) -> Self
     where
@@ -4005,6 +3968,32 @@ impl JobQuery {
     {
         use std::iter::Iterator;
         self.company_display_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [compensation_filter][crate::model::JobQuery::compensation_filter].
+    pub fn set_compensation_filter<
+        T: std::convert::Into<std::option::Option<crate::model::CompensationFilter>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.compensation_filter = v.into();
+        self
+    }
+
+    /// Sets the value of [custom_attribute_filter][crate::model::JobQuery::custom_attribute_filter].
+    pub fn set_custom_attribute_filter<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.custom_attribute_filter = v.into();
+        self
+    }
+
+    /// Sets the value of [disable_spell_check][crate::model::JobQuery::disable_spell_check].
+    pub fn set_disable_spell_check<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.disable_spell_check = v.into();
         self
     }
 
@@ -4027,6 +4016,17 @@ impl JobQuery {
     {
         use std::iter::Iterator;
         self.language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [publish_time_range][crate::model::JobQuery::publish_time_range].
+    pub fn set_publish_time_range<
+        T: std::convert::Into<std::option::Option<crate::model::TimestampRange>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.publish_time_range = v.into();
         self
     }
 
@@ -4373,6 +4373,17 @@ impl CompensationFilter {
         self
     }
 
+    /// Sets the value of [units][crate::model::CompensationFilter::units].
+    pub fn set_units<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::compensation_info::CompensationUnit>,
+    {
+        use std::iter::Iterator;
+        self.units = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [range][crate::model::CompensationFilter::range].
     pub fn set_range<
         T: std::convert::Into<std::option::Option<crate::model::compensation_info::CompensationRange>>,
@@ -4390,17 +4401,6 @@ impl CompensationFilter {
         v: T,
     ) -> Self {
         self.include_jobs_with_unspecified_compensation_range = v.into();
-        self
-    }
-
-    /// Sets the value of [units][crate::model::CompensationFilter::units].
-    pub fn set_units<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::compensation_info::CompensationUnit>,
-    {
-        use std::iter::Iterator;
-        self.units = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4706,19 +4706,6 @@ impl CommuteFilter {
         })
     }
 
-    /// The value of [traffic_option][crate::model::CommuteFilter::traffic_option]
-    /// if it holds a `DepartureTime`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn departure_time(&self) -> std::option::Option<&std::boxed::Box<gtype::model::TimeOfDay>> {
-        #[allow(unreachable_patterns)]
-        self.traffic_option.as_ref().and_then(|v| match v {
-            crate::model::commute_filter::TrafficOption::DepartureTime(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [traffic_option][crate::model::CommuteFilter::traffic_option]
     /// to hold a `RoadTraffic`.
     ///
@@ -4732,6 +4719,19 @@ impl CommuteFilter {
             crate::model::commute_filter::TrafficOption::RoadTraffic(v.into()),
         );
         self
+    }
+
+    /// The value of [traffic_option][crate::model::CommuteFilter::traffic_option]
+    /// if it holds a `DepartureTime`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn departure_time(&self) -> std::option::Option<&std::boxed::Box<gtype::model::TimeOfDay>> {
+        #[allow(unreachable_patterns)]
+        self.traffic_option.as_ref().and_then(|v| match v {
+            crate::model::commute_filter::TrafficOption::DepartureTime(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [traffic_option][crate::model::CommuteFilter::traffic_option]
@@ -5413,6 +5413,17 @@ impl Job {
         self
     }
 
+    /// Sets the value of [addresses][crate::model::Job::addresses].
+    pub fn set_addresses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [application_info][crate::model::Job::application_info].
     pub fn set_application_info<
         T: std::convert::Into<std::option::Option<crate::model::job::ApplicationInfo>>,
@@ -5421,6 +5432,17 @@ impl Job {
         v: T,
     ) -> Self {
         self.application_info = v.into();
+        self
+    }
+
+    /// Sets the value of [job_benefits][crate::model::Job::job_benefits].
+    pub fn set_job_benefits<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::JobBenefit>,
+    {
+        use std::iter::Iterator;
+        self.job_benefits = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5435,9 +5457,43 @@ impl Job {
         self
     }
 
+    /// Sets the value of [custom_attributes][crate::model::Job::custom_attributes].
+    pub fn set_custom_attributes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::CustomAttribute>,
+    {
+        use std::iter::Iterator;
+        self.custom_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [degree_types][crate::model::Job::degree_types].
+    pub fn set_degree_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DegreeType>,
+    {
+        use std::iter::Iterator;
+        self.degree_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [department][crate::model::Job::department].
     pub fn set_department<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.department = v.into();
+        self
+    }
+
+    /// Sets the value of [employment_types][crate::model::Job::employment_types].
+    pub fn set_employment_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EmploymentType>,
+    {
+        use std::iter::Iterator;
+        self.employment_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5580,62 +5636,6 @@ impl Job {
         self.processing_options = v.into();
         self
     }
-
-    /// Sets the value of [addresses][crate::model::Job::addresses].
-    pub fn set_addresses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.addresses = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [job_benefits][crate::model::Job::job_benefits].
-    pub fn set_job_benefits<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::JobBenefit>,
-    {
-        use std::iter::Iterator;
-        self.job_benefits = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [degree_types][crate::model::Job::degree_types].
-    pub fn set_degree_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DegreeType>,
-    {
-        use std::iter::Iterator;
-        self.degree_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [employment_types][crate::model::Job::employment_types].
-    pub fn set_employment_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EmploymentType>,
-    {
-        use std::iter::Iterator;
-        self.employment_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [custom_attributes][crate::model::Job::custom_attributes].
-    pub fn set_custom_attributes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::CustomAttribute>,
-    {
-        use std::iter::Iterator;
-        self.custom_attributes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
 }
 
 impl wkt::message::Message for Job {
@@ -5688,12 +5688,6 @@ pub mod job {
             std::default::Default::default()
         }
 
-        /// Sets the value of [instruction][crate::model::job::ApplicationInfo::instruction].
-        pub fn set_instruction<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.instruction = v.into();
-            self
-        }
-
         /// Sets the value of [emails][crate::model::job::ApplicationInfo::emails].
         pub fn set_emails<T, V>(mut self, v: T) -> Self
         where
@@ -5702,6 +5696,12 @@ pub mod job {
         {
             use std::iter::Iterator;
             self.emails = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [instruction][crate::model::job::ApplicationInfo::instruction].
+        pub fn set_instruction<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.instruction = v.into();
             self
         }
 
@@ -6172,6 +6172,17 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
+    pub fn set_jobs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Job>,
+    {
+        use std::iter::Iterator;
+        self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -6186,17 +6197,6 @@ impl ListJobsResponse {
         v: T,
     ) -> Self {
         self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
-    pub fn set_jobs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Job>,
-    {
-        use std::iter::Iterator;
-        self.jobs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6627,6 +6627,17 @@ impl SearchJobsRequest {
         self
     }
 
+    /// Sets the value of [histogram_queries][crate::model::SearchJobsRequest::histogram_queries].
+    pub fn set_histogram_queries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HistogramQuery>,
+    {
+        use std::iter::Iterator;
+        self.histogram_queries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [job_view][crate::model::SearchJobsRequest::job_view].
     pub fn set_job_view<T: std::convert::Into<crate::model::JobView>>(mut self, v: T) -> Self {
         self.job_view = v.into();
@@ -6707,17 +6718,6 @@ impl SearchJobsRequest {
         v: T,
     ) -> Self {
         self.relevance_threshold = v.into();
-        self
-    }
-
-    /// Sets the value of [histogram_queries][crate::model::SearchJobsRequest::histogram_queries].
-    pub fn set_histogram_queries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::HistogramQuery>,
-    {
-        use std::iter::Iterator;
-        self.histogram_queries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7725,9 +7725,42 @@ impl SearchJobsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [matching_jobs][crate::model::SearchJobsResponse::matching_jobs].
+    pub fn set_matching_jobs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::search_jobs_response::MatchingJob>,
+    {
+        use std::iter::Iterator;
+        self.matching_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [histogram_query_results][crate::model::SearchJobsResponse::histogram_query_results].
+    pub fn set_histogram_query_results<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::HistogramQueryResult>,
+    {
+        use std::iter::Iterator;
+        self.histogram_query_results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::SearchJobsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
+        self
+    }
+
+    /// Sets the value of [location_filters][crate::model::SearchJobsResponse::location_filters].
+    pub fn set_location_filters<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Location>,
+    {
+        use std::iter::Iterator;
+        self.location_filters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -7762,39 +7795,6 @@ impl SearchJobsResponse {
         v: T,
     ) -> Self {
         self.spell_correction = v.into();
-        self
-    }
-
-    /// Sets the value of [matching_jobs][crate::model::SearchJobsResponse::matching_jobs].
-    pub fn set_matching_jobs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::search_jobs_response::MatchingJob>,
-    {
-        use std::iter::Iterator;
-        self.matching_jobs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [histogram_query_results][crate::model::SearchJobsResponse::histogram_query_results].
-    pub fn set_histogram_query_results<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::HistogramQueryResult>,
-    {
-        use std::iter::Iterator;
-        self.histogram_query_results = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [location_filters][crate::model::SearchJobsResponse::location_filters].
-    pub fn set_location_filters<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Location>,
-    {
-        use std::iter::Iterator;
-        self.location_filters = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8080,15 +8080,6 @@ impl BatchUpdateJobsRequest {
         self
     }
 
-    /// Sets the value of [update_mask][crate::model::BatchUpdateJobsRequest::update_mask].
-    pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.update_mask = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::BatchUpdateJobsRequest::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -8097,6 +8088,15 @@ impl BatchUpdateJobsRequest {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [update_mask][crate::model::BatchUpdateJobsRequest::update_mask].
+    pub fn set_update_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.update_mask = v.into();
         self
     }
 }
@@ -8678,6 +8678,17 @@ impl ListTenantsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [tenants][crate::model::ListTenantsResponse::tenants].
+    pub fn set_tenants<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Tenant>,
+    {
+        use std::iter::Iterator;
+        self.tenants = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListTenantsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -8692,17 +8703,6 @@ impl ListTenantsResponse {
         v: T,
     ) -> Self {
         self.metadata = v.into();
-        self
-    }
-
-    /// Sets the value of [tenants][crate::model::ListTenantsResponse::tenants].
-    pub fn set_tenants<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Tenant>,
-    {
-        use std::iter::Iterator;
-        self.tenants = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -168,12 +168,6 @@ impl ListQueuesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListQueuesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [queues][crate::model::ListQueuesResponse::queues].
     pub fn set_queues<T, V>(mut self, v: T) -> Self
     where
@@ -182,6 +176,12 @@ impl ListQueuesResponse {
     {
         use std::iter::Iterator;
         self.queues = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListQueuesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -642,12 +642,6 @@ impl ListTasksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tasks][crate::model::ListTasksResponse::tasks].
     pub fn set_tasks<T, V>(mut self, v: T) -> Self
     where
@@ -656,6 +650,12 @@ impl ListTasksResponse {
     {
         use std::iter::Iterator;
         self.tasks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTasksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1812,12 +1812,6 @@ impl HttpRequest {
         self
     }
 
-    /// Sets the value of [body][crate::model::HttpRequest::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::HttpRequest::headers].
     pub fn set_headers<T, K, V>(mut self, v: T) -> Self
     where
@@ -1827,6 +1821,12 @@ impl HttpRequest {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::HttpRequest::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 
@@ -1857,19 +1857,6 @@ impl HttpRequest {
         })
     }
 
-    /// The value of [authorization_header][crate::model::HttpRequest::authorization_header]
-    /// if it holds a `OidcToken`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn oidc_token(&self) -> std::option::Option<&std::boxed::Box<crate::model::OidcToken>> {
-        #[allow(unreachable_patterns)]
-        self.authorization_header.as_ref().and_then(|v| match v {
-            crate::model::http_request::AuthorizationHeader::OidcToken(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [authorization_header][crate::model::HttpRequest::authorization_header]
     /// to hold a `OauthToken`.
     ///
@@ -1883,6 +1870,19 @@ impl HttpRequest {
             crate::model::http_request::AuthorizationHeader::OauthToken(v.into()),
         );
         self
+    }
+
+    /// The value of [authorization_header][crate::model::HttpRequest::authorization_header]
+    /// if it holds a `OidcToken`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn oidc_token(&self) -> std::option::Option<&std::boxed::Box<crate::model::OidcToken>> {
+        #[allow(unreachable_patterns)]
+        self.authorization_header.as_ref().and_then(|v| match v {
+            crate::model::http_request::AuthorizationHeader::OidcToken(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [authorization_header][crate::model::HttpRequest::authorization_header]
@@ -2148,12 +2148,6 @@ impl AppEngineHttpRequest {
         self
     }
 
-    /// Sets the value of [body][crate::model::AppEngineHttpRequest::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::AppEngineHttpRequest::headers].
     pub fn set_headers<T, K, V>(mut self, v: T) -> Self
     where
@@ -2163,6 +2157,12 @@ impl AppEngineHttpRequest {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::AppEngineHttpRequest::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 }
@@ -2663,17 +2663,6 @@ impl Task {
         })
     }
 
-    /// The value of [message_type][crate::model::Task::message_type]
-    /// if it holds a `HttpRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn http_request(&self) -> std::option::Option<&std::boxed::Box<crate::model::HttpRequest>> {
-        #[allow(unreachable_patterns)]
-        self.message_type.as_ref().and_then(|v| match v {
-            crate::model::task::MessageType::HttpRequest(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [message_type][crate::model::Task::message_type]
     /// to hold a `AppEngineHttpRequest`.
     ///
@@ -2689,6 +2678,17 @@ impl Task {
             crate::model::task::MessageType::AppEngineHttpRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [message_type][crate::model::Task::message_type]
+    /// if it holds a `HttpRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn http_request(&self) -> std::option::Option<&std::boxed::Box<crate::model::HttpRequest>> {
+        #[allow(unreachable_patterns)]
+        self.message_type.as_ref().and_then(|v| match v {
+            crate::model::task::MessageType::HttpRequest(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [message_type][crate::model::Task::message_type]

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -112,6 +112,18 @@ impl OrchestrationCluster {
         self
     }
 
+    /// Sets the value of [labels][crate::model::OrchestrationCluster::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [tna_version][crate::model::OrchestrationCluster::tna_version].
     pub fn set_tna_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tna_version = v.into();
@@ -124,18 +136,6 @@ impl OrchestrationCluster {
         v: T,
     ) -> Self {
         self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::OrchestrationCluster::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -383,6 +383,18 @@ impl EdgeSlm {
         self
     }
 
+    /// Sets the value of [labels][crate::model::EdgeSlm::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [tna_version][crate::model::EdgeSlm::tna_version].
     pub fn set_tna_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tna_version = v.into();
@@ -403,18 +415,6 @@ impl EdgeSlm {
         v: T,
     ) -> Self {
         self.workload_cluster_type = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::EdgeSlm::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -848,6 +848,29 @@ impl Blueprint {
         self
     }
 
+    /// Sets the value of [files][crate::model::Blueprint::files].
+    pub fn set_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::File>,
+    {
+        use std::iter::Iterator;
+        self.files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Blueprint::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Blueprint::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -884,29 +907,6 @@ impl Blueprint {
     /// Sets the value of [rollback_support][crate::model::Blueprint::rollback_support].
     pub fn set_rollback_support<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.rollback_support = v.into();
-        self
-    }
-
-    /// Sets the value of [files][crate::model::Blueprint::files].
-    pub fn set_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::File>,
-    {
-        use std::iter::Iterator;
-        self.files = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Blueprint::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1298,6 +1298,29 @@ impl Deployment {
         self
     }
 
+    /// Sets the value of [files][crate::model::Deployment::files].
+    pub fn set_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::File>,
+    {
+        use std::iter::Iterator;
+        self.files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Deployment::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Deployment::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1343,29 +1366,6 @@ impl Deployment {
     /// Sets the value of [rollback_support][crate::model::Deployment::rollback_support].
     pub fn set_rollback_support<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.rollback_support = v.into();
-        self
-    }
-
-    /// Sets the value of [files][crate::model::Deployment::files].
-    pub fn set_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::File>,
-    {
-        use std::iter::Iterator;
-        self.files = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Deployment::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1580,15 +1580,6 @@ impl HydratedDeployment {
         self
     }
 
-    /// Sets the value of [workload_cluster][crate::model::HydratedDeployment::workload_cluster].
-    pub fn set_workload_cluster<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.workload_cluster = v.into();
-        self
-    }
-
     /// Sets the value of [files][crate::model::HydratedDeployment::files].
     pub fn set_files<T, V>(mut self, v: T) -> Self
     where
@@ -1597,6 +1588,15 @@ impl HydratedDeployment {
     {
         use std::iter::Iterator;
         self.files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [workload_cluster][crate::model::HydratedDeployment::workload_cluster].
+    pub fn set_workload_cluster<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.workload_cluster = v.into();
         self
     }
 }
@@ -1847,12 +1847,6 @@ impl ListOrchestrationClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOrchestrationClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [orchestration_clusters][crate::model::ListOrchestrationClustersResponse::orchestration_clusters].
     pub fn set_orchestration_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -1861,6 +1855,12 @@ impl ListOrchestrationClustersResponse {
     {
         use std::iter::Iterator;
         self.orchestration_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOrchestrationClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2166,12 +2166,6 @@ impl ListEdgeSlmsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEdgeSlmsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [edge_slms][crate::model::ListEdgeSlmsResponse::edge_slms].
     pub fn set_edge_slms<T, V>(mut self, v: T) -> Self
     where
@@ -2180,6 +2174,12 @@ impl ListEdgeSlmsResponse {
     {
         use std::iter::Iterator;
         self.edge_slms = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEdgeSlmsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2658,12 +2658,6 @@ impl ListBlueprintsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBlueprintsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [blueprints][crate::model::ListBlueprintsResponse::blueprints].
     pub fn set_blueprints<T, V>(mut self, v: T) -> Self
     where
@@ -2672,6 +2666,12 @@ impl ListBlueprintsResponse {
     {
         use std::iter::Iterator;
         self.blueprints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBlueprintsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2870,12 +2870,6 @@ impl ListBlueprintRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBlueprintRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [blueprints][crate::model::ListBlueprintRevisionsResponse::blueprints].
     pub fn set_blueprints<T, V>(mut self, v: T) -> Self
     where
@@ -2884,6 +2878,12 @@ impl ListBlueprintRevisionsResponse {
     {
         use std::iter::Iterator;
         self.blueprints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBlueprintRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3005,12 +3005,6 @@ impl SearchBlueprintRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchBlueprintRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [blueprints][crate::model::SearchBlueprintRevisionsResponse::blueprints].
     pub fn set_blueprints<T, V>(mut self, v: T) -> Self
     where
@@ -3019,6 +3013,12 @@ impl SearchBlueprintRevisionsResponse {
     {
         use std::iter::Iterator;
         self.blueprints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchBlueprintRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3176,12 +3176,6 @@ impl ListPublicBlueprintsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPublicBlueprintsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [public_blueprints][crate::model::ListPublicBlueprintsResponse::public_blueprints].
     pub fn set_public_blueprints<T, V>(mut self, v: T) -> Self
     where
@@ -3190,6 +3184,12 @@ impl ListPublicBlueprintsResponse {
     {
         use std::iter::Iterator;
         self.public_blueprints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPublicBlueprintsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3522,12 +3522,6 @@ impl ListDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::ListDeploymentsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -3536,6 +3530,12 @@ impl ListDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3637,12 +3637,6 @@ impl ListDeploymentRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeploymentRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::ListDeploymentRevisionsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -3651,6 +3645,12 @@ impl ListDeploymentRevisionsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeploymentRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3773,12 +3773,6 @@ impl SearchDeploymentRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchDeploymentRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deployments][crate::model::SearchDeploymentRevisionsResponse::deployments].
     pub fn set_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -3787,6 +3781,12 @@ impl SearchDeploymentRevisionsResponse {
     {
         use std::iter::Iterator;
         self.deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchDeploymentRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4248,12 +4248,6 @@ impl ListHydratedDeploymentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHydratedDeploymentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [hydrated_deployments][crate::model::ListHydratedDeploymentsResponse::hydrated_deployments].
     pub fn set_hydrated_deployments<T, V>(mut self, v: T) -> Self
     where
@@ -4262,6 +4256,12 @@ impl ListHydratedDeploymentsResponse {
     {
         use std::iter::Iterator;
         self.hydrated_deployments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHydratedDeploymentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4418,21 +4418,6 @@ impl ManagementConfig {
         })
     }
 
-    /// The value of [oneof_config][crate::model::ManagementConfig::oneof_config]
-    /// if it holds a `FullManagementConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn full_management_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FullManagementConfig>> {
-        #[allow(unreachable_patterns)]
-        self.oneof_config.as_ref().and_then(|v| match v {
-            crate::model::management_config::OneofConfig::FullManagementConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [oneof_config][crate::model::ManagementConfig::oneof_config]
     /// to hold a `StandardManagementConfig`.
     ///
@@ -4448,6 +4433,21 @@ impl ManagementConfig {
             crate::model::management_config::OneofConfig::StandardManagementConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [oneof_config][crate::model::ManagementConfig::oneof_config]
+    /// if it holds a `FullManagementConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn full_management_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FullManagementConfig>> {
+        #[allow(unreachable_patterns)]
+        self.oneof_config.as_ref().and_then(|v| match v {
+            crate::model::management_config::OneofConfig::FullManagementConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [oneof_config][crate::model::ManagementConfig::oneof_config]

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -140,6 +140,17 @@ impl Voice {
         std::default::Default::default()
     }
 
+    /// Sets the value of [language_codes][crate::model::Voice::language_codes].
+    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [name][crate::model::Voice::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
@@ -158,17 +169,6 @@ impl Voice {
     /// Sets the value of [natural_sample_rate_hertz][crate::model::Voice::natural_sample_rate_hertz].
     pub fn set_natural_sample_rate_hertz<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.natural_sample_rate_hertz = v.into();
-        self
-    }
-
-    /// Sets the value of [language_codes][crate::model::Voice::language_codes].
-    pub fn set_language_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.language_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -698,6 +698,17 @@ impl SynthesisInput {
         })
     }
 
+    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
+    /// to hold a `Text`.
+    ///
+    /// Note that all the setters affecting `input_source` are
+    /// mutually exclusive.
+    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.input_source =
+            std::option::Option::Some(crate::model::synthesis_input::InputSource::Text(v.into()));
+        self
+    }
+
     /// The value of [input_source][crate::model::SynthesisInput::input_source]
     /// if it holds a `Ssml`, `None` if the field is not set or
     /// holds a different branch.
@@ -707,6 +718,17 @@ impl SynthesisInput {
             crate::model::synthesis_input::InputSource::Ssml(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
+    /// to hold a `Ssml`.
+    ///
+    /// Note that all the setters affecting `input_source` are
+    /// mutually exclusive.
+    pub fn set_ssml<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.input_source =
+            std::option::Option::Some(crate::model::synthesis_input::InputSource::Ssml(v.into()));
+        self
     }
 
     /// The value of [input_source][crate::model::SynthesisInput::input_source]
@@ -722,28 +744,6 @@ impl SynthesisInput {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source =
-            std::option::Option::Some(crate::model::synthesis_input::InputSource::Text(v.into()));
-        self
-    }
-
-    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
-    /// to hold a `Ssml`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_ssml<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source =
-            std::option::Option::Some(crate::model::synthesis_input::InputSource::Ssml(v.into()));
-        self
     }
 
     /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
@@ -1545,21 +1545,6 @@ impl StreamingSynthesizeRequest {
         })
     }
 
-    /// The value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]
-    /// if it holds a `Input`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn input(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StreamingSynthesisInput>> {
-        #[allow(unreachable_patterns)]
-        self.streaming_request.as_ref().and_then(|v| match v {
-            crate::model::streaming_synthesize_request::StreamingRequest::Input(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]
     /// to hold a `StreamingConfig`.
     ///
@@ -1575,6 +1560,21 @@ impl StreamingSynthesizeRequest {
             crate::model::streaming_synthesize_request::StreamingRequest::StreamingConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]
+    /// if it holds a `Input`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn input(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StreamingSynthesisInput>> {
+        #[allow(unreachable_patterns)]
+        self.streaming_request.as_ref().and_then(|v| match v {
+            crate::model::streaming_synthesize_request::StreamingRequest::Input(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]

--- a/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
@@ -278,14 +278,6 @@ pub mod timeseries_insights_controller {
                 .map(gax::response::Response::into_body)
         }
 
-        /// Sets the value of [dataset][crate::model::AppendEventsRequest::dataset].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_dataset<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.dataset = v.into();
-            self
-        }
-
         /// Sets the value of [events][crate::model::AppendEventsRequest::events].
         pub fn set_events<T, V>(mut self, v: T) -> Self
         where
@@ -294,6 +286,14 @@ pub mod timeseries_insights_controller {
         {
             use std::iter::Iterator;
             self.0.request.events = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [dataset][crate::model::AppendEventsRequest::dataset].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_dataset<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.dataset = v.into();
             self
         }
     }
@@ -443,6 +443,19 @@ pub mod timeseries_insights_controller {
             self
         }
 
+        /// Sets the value of [pinned_dimensions][crate::model::EvaluateSliceRequest::pinned_dimensions].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_pinned_dimensions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::PinnedDimension>,
+        {
+            use std::iter::Iterator;
+            self.0.request.pinned_dimensions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [detection_time][crate::model::EvaluateSliceRequest::detection_time].
         ///
         /// This is a **required** field for requests.
@@ -471,19 +484,6 @@ pub mod timeseries_insights_controller {
             v: T,
         ) -> Self {
             self.0.request.forecast_params = v.into();
-            self
-        }
-
-        /// Sets the value of [pinned_dimensions][crate::model::EvaluateSliceRequest::pinned_dimensions].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_pinned_dimensions<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::PinnedDimension>,
-        {
-            use std::iter::Iterator;
-            self.0.request.pinned_dimensions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -209,6 +209,28 @@ impl DataSet {
         self
     }
 
+    /// Sets the value of [data_names][crate::model::DataSet::data_names].
+    pub fn set_data_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.data_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [data_sources][crate::model::DataSet::data_sources].
+    pub fn set_data_sources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataSource>,
+    {
+        use std::iter::Iterator;
+        self.data_sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::DataSet::state].
     pub fn set_state<T: std::convert::Into<crate::model::data_set::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -230,28 +252,6 @@ impl DataSet {
         v: T,
     ) -> Self {
         self.ttl = v.into();
-        self
-    }
-
-    /// Sets the value of [data_names][crate::model::DataSet::data_names].
-    pub fn set_data_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.data_names = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [data_sources][crate::model::DataSet::data_sources].
-    pub fn set_data_sources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataSource>,
-    {
-        use std::iter::Iterator;
-        self.data_sources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -497,39 +497,6 @@ impl EventDimension {
         })
     }
 
-    /// The value of [value][crate::model::EventDimension::value]
-    /// if it holds a `LongVal`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn long_val(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::event_dimension::Value::LongVal(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::EventDimension::value]
-    /// if it holds a `BoolVal`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bool_val(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::event_dimension::Value::BoolVal(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::EventDimension::value]
-    /// if it holds a `DoubleVal`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_val(&self) -> std::option::Option<&f64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::event_dimension::Value::DoubleVal(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::EventDimension::value]
     /// to hold a `StringVal`.
     ///
@@ -539,6 +506,17 @@ impl EventDimension {
         self.value =
             std::option::Option::Some(crate::model::event_dimension::Value::StringVal(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::EventDimension::value]
+    /// if it holds a `LongVal`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn long_val(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::event_dimension::Value::LongVal(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::EventDimension::value]
@@ -552,6 +530,17 @@ impl EventDimension {
         self
     }
 
+    /// The value of [value][crate::model::EventDimension::value]
+    /// if it holds a `BoolVal`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bool_val(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::event_dimension::Value::BoolVal(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::EventDimension::value]
     /// to hold a `BoolVal`.
     ///
@@ -561,6 +550,17 @@ impl EventDimension {
         self.value =
             std::option::Option::Some(crate::model::event_dimension::Value::BoolVal(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::EventDimension::value]
+    /// if it holds a `DoubleVal`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_val(&self) -> std::option::Option<&f64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::event_dimension::Value::DoubleVal(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::EventDimension::value]
@@ -661,6 +661,17 @@ impl Event {
         std::default::Default::default()
     }
 
+    /// Sets the value of [dimensions][crate::model::Event::dimensions].
+    pub fn set_dimensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EventDimension>,
+    {
+        use std::iter::Iterator;
+        self.dimensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [group_id][crate::model::Event::group_id].
     pub fn set_group_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.group_id = v.into();
@@ -673,17 +684,6 @@ impl Event {
         v: T,
     ) -> Self {
         self.event_time = v.into();
-        self
-    }
-
-    /// Sets the value of [dimensions][crate::model::Event::dimensions].
-    pub fn set_dimensions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EventDimension>,
-    {
-        use std::iter::Iterator;
-        self.dimensions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -737,12 +737,6 @@ impl AppendEventsRequest {
         std::default::Default::default()
     }
 
-    /// Sets the value of [dataset][crate::model::AppendEventsRequest::dataset].
-    pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.dataset = v.into();
-        self
-    }
-
     /// Sets the value of [events][crate::model::AppendEventsRequest::events].
     pub fn set_events<T, V>(mut self, v: T) -> Self
     where
@@ -751,6 +745,12 @@ impl AppendEventsRequest {
     {
         use std::iter::Iterator;
         self.events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [dataset][crate::model::AppendEventsRequest::dataset].
+    pub fn set_dataset<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.dataset = v.into();
         self
     }
 }
@@ -951,12 +951,6 @@ impl ListDataSetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDataSetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [datasets][crate::model::ListDataSetsResponse::datasets].
     pub fn set_datasets<T, V>(mut self, v: T) -> Self
     where
@@ -965,6 +959,12 @@ impl ListDataSetsResponse {
     {
         use std::iter::Iterator;
         self.datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDataSetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1046,17 +1046,6 @@ impl PinnedDimension {
         })
     }
 
-    /// The value of [value][crate::model::PinnedDimension::value]
-    /// if it holds a `BoolVal`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bool_val(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::pinned_dimension::Value::BoolVal(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::PinnedDimension::value]
     /// to hold a `StringVal`.
     ///
@@ -1066,6 +1055,17 @@ impl PinnedDimension {
         self.value =
             std::option::Option::Some(crate::model::pinned_dimension::Value::StringVal(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::PinnedDimension::value]
+    /// if it holds a `BoolVal`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bool_val(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::pinned_dimension::Value::BoolVal(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::PinnedDimension::value]
@@ -1597,6 +1597,17 @@ impl EvaluatedSlice {
         std::default::Default::default()
     }
 
+    /// Sets the value of [dimensions][crate::model::EvaluatedSlice::dimensions].
+    pub fn set_dimensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PinnedDimension>,
+    {
+        use std::iter::Iterator;
+        self.dimensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [detection_point_actual][crate::model::EvaluatedSlice::detection_point_actual].
     pub fn set_detection_point_actual<T: std::convert::Into<std::option::Option<f64>>>(
         mut self,
@@ -1657,17 +1668,6 @@ impl EvaluatedSlice {
         v: T,
     ) -> Self {
         self.status = v.into();
-        self
-    }
-
-    /// Sets the value of [dimensions][crate::model::EvaluatedSlice::dimensions].
-    pub fn set_dimensions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PinnedDimension>,
-    {
-        use std::iter::Iterator;
-        self.dimensions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2375,6 +2375,17 @@ impl EvaluateSliceRequest {
         self
     }
 
+    /// Sets the value of [pinned_dimensions][crate::model::EvaluateSliceRequest::pinned_dimensions].
+    pub fn set_pinned_dimensions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::PinnedDimension>,
+    {
+        use std::iter::Iterator;
+        self.pinned_dimensions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [detection_time][crate::model::EvaluateSliceRequest::detection_time].
     pub fn set_detection_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2403,17 +2414,6 @@ impl EvaluateSliceRequest {
         v: T,
     ) -> Self {
         self.forecast_params = v.into();
-        self
-    }
-
-    /// Sets the value of [pinned_dimensions][crate::model::EvaluateSliceRequest::pinned_dimensions].
-    pub fn set_pinned_dimensions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::PinnedDimension>,
-    {
-        use std::iter::Iterator;
-        self.pinned_dimensions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -816,6 +816,17 @@ impl Node {
         self
     }
 
+    /// Sets the value of [network_configs][crate::model::Node::network_configs].
+    pub fn set_network_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkConfig>,
+    {
+        use std::iter::Iterator;
+        self.network_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cidr_block][crate::model::Node::cidr_block].
     pub fn set_cidr_block<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.cidr_block = v.into();
@@ -853,9 +864,55 @@ impl Node {
         self
     }
 
+    /// Sets the value of [network_endpoints][crate::model::Node::network_endpoints].
+    pub fn set_network_endpoints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkEndpoint>,
+    {
+        use std::iter::Iterator;
+        self.network_endpoints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [health][crate::model::Node::health].
     pub fn set_health<T: std::convert::Into<crate::model::node::Health>>(mut self, v: T) -> Self {
         self.health = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Node::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::Node::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::Node::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -865,12 +922,34 @@ impl Node {
         self
     }
 
+    /// Sets the value of [data_disks][crate::model::Node::data_disks].
+    pub fn set_data_disks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AttachedDisk>,
+    {
+        use std::iter::Iterator;
+        self.data_disks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [api_version][crate::model::Node::api_version].
     pub fn set_api_version<T: std::convert::Into<crate::model::node::ApiVersion>>(
         mut self,
         v: T,
     ) -> Self {
         self.api_version = v.into();
+        self
+    }
+
+    /// Sets the value of [symptoms][crate::model::Node::symptoms].
+    pub fn set_symptoms<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Symptom>,
+    {
+        use std::iter::Iterator;
+        self.symptoms = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -905,85 +984,6 @@ impl Node {
     /// Sets the value of [multislice_node][crate::model::Node::multislice_node].
     pub fn set_multislice_node<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.multislice_node = v.into();
-        self
-    }
-
-    /// Sets the value of [network_configs][crate::model::Node::network_configs].
-    pub fn set_network_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkConfig>,
-    {
-        use std::iter::Iterator;
-        self.network_configs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [network_endpoints][crate::model::Node::network_endpoints].
-    pub fn set_network_endpoints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkEndpoint>,
-    {
-        use std::iter::Iterator;
-        self.network_endpoints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::Node::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [data_disks][crate::model::Node::data_disks].
-    pub fn set_data_disks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AttachedDisk>,
-    {
-        use std::iter::Iterator;
-        self.data_disks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [symptoms][crate::model::Node::symptoms].
-    pub fn set_symptoms<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Symptom>,
-    {
-        use std::iter::Iterator;
-        self.symptoms = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Node::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::Node::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1677,19 +1677,6 @@ impl QueuedResource {
         })
     }
 
-    /// The value of [tier][crate::model::QueuedResource::tier]
-    /// if it holds a `Guaranteed`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn guaranteed(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource::Guaranteed>> {
-        #[allow(unreachable_patterns)]
-        self.tier.as_ref().and_then(|v| match v {
-            crate::model::queued_resource::Tier::Guaranteed(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [tier][crate::model::QueuedResource::tier]
     /// to hold a `Spot`.
     ///
@@ -1701,6 +1688,19 @@ impl QueuedResource {
     ) -> Self {
         self.tier = std::option::Option::Some(crate::model::queued_resource::Tier::Spot(v.into()));
         self
+    }
+
+    /// The value of [tier][crate::model::QueuedResource::tier]
+    /// if it holds a `Guaranteed`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn guaranteed(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource::Guaranteed>> {
+        #[allow(unreachable_patterns)]
+        self.tier.as_ref().and_then(|v| match v {
+            crate::model::queued_resource::Tier::Guaranteed(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [tier][crate::model::QueuedResource::tier]
@@ -1849,6 +1849,18 @@ pub mod queued_resource {
                 })
             }
 
+            /// Sets the value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
+            /// to hold a `NodeId`.
+            ///
+            /// Note that all the setters affecting `name_strategy` are
+            /// mutually exclusive.
+            pub fn set_node_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+                self.name_strategy = std::option::Option::Some(
+                    crate::model::queued_resource::tpu::node_spec::NameStrategy::NodeId(v.into()),
+                );
+                self
+            }
+
             /// The value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
             /// if it holds a `MultisliceParams`, `None` if the field is not set or
             /// holds a different branch.
@@ -1862,18 +1874,6 @@ pub mod queued_resource {
                     crate::model::queued_resource::tpu::node_spec::NameStrategy::MultisliceParams(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
-            /// to hold a `NodeId`.
-            ///
-            /// Note that all the setters affecting `name_strategy` are
-            /// mutually exclusive.
-            pub fn set_node_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.name_strategy = std::option::Option::Some(
-                    crate::model::queued_resource::tpu::node_spec::NameStrategy::NodeId(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
@@ -2093,52 +2093,6 @@ pub mod queued_resource {
             })
         }
 
-        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// if it holds a `ValidUntilTime`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn valid_until_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-            #[allow(unreachable_patterns)]
-            self.start_timing_constraints.as_ref().and_then(|v| match v {
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidUntilTime(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// if it holds a `ValidAfterDuration`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn valid_after_duration(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-            #[allow(unreachable_patterns)]
-            self.start_timing_constraints.as_ref().and_then(|v| match v {
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterDuration(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// if it holds a `ValidAfterTime`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn valid_after_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
-            #[allow(unreachable_patterns)]
-            self.start_timing_constraints.as_ref().and_then(|v| match v {
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterTime(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// if it holds a `ValidInterval`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn valid_interval(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<gtype::model::Interval>> {
-            #[allow(unreachable_patterns)]
-            self.start_timing_constraints.as_ref().and_then(|v| match v {
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidInterval(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
         /// to hold a `ValidUntilDuration`.
         ///
@@ -2154,6 +2108,17 @@ pub mod queued_resource {
                 )
             );
             self
+        }
+
+        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
+        /// if it holds a `ValidUntilTime`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn valid_until_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+            #[allow(unreachable_patterns)]
+            self.start_timing_constraints.as_ref().and_then(|v| match v {
+                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidUntilTime(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
@@ -2173,6 +2138,17 @@ pub mod queued_resource {
             self
         }
 
+        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
+        /// if it holds a `ValidAfterDuration`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn valid_after_duration(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+            #[allow(unreachable_patterns)]
+            self.start_timing_constraints.as_ref().and_then(|v| match v {
+                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterDuration(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
         /// to hold a `ValidAfterDuration`.
         ///
@@ -2190,6 +2166,17 @@ pub mod queued_resource {
             self
         }
 
+        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
+        /// if it holds a `ValidAfterTime`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn valid_after_time(&self) -> std::option::Option<&std::boxed::Box<wkt::Timestamp>> {
+            #[allow(unreachable_patterns)]
+            self.start_timing_constraints.as_ref().and_then(|v| match v {
+                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterTime(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
         /// to hold a `ValidAfterTime`.
         ///
@@ -2205,6 +2192,19 @@ pub mod queued_resource {
                 )
             );
             self
+        }
+
+        /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
+        /// if it holds a `ValidInterval`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn valid_interval(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<gtype::model::Interval>> {
+            #[allow(unreachable_patterns)]
+            self.start_timing_constraints.as_ref().and_then(|v| match v {
+                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidInterval(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
@@ -2359,118 +2359,6 @@ impl QueuedResourceState {
         })
     }
 
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `AcceptedData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn accepted_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::AcceptedData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::AcceptedData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `ProvisioningData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn provisioning_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::ProvisioningData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::ProvisioningData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `FailedData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn failed_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::FailedData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::FailedData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `DeletingData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deleting_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::DeletingData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::DeletingData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `ActiveData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn active_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::ActiveData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::ActiveData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `SuspendingData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suspending_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::SuspendingData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::SuspendingData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// if it holds a `SuspendedData`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn suspended_data(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::SuspendedData>>
-    {
-        #[allow(unreachable_patterns)]
-        self.state_data.as_ref().and_then(|v| match v {
-            crate::model::queued_resource_state::StateData::SuspendedData(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
     /// to hold a `CreatingData`.
     ///
@@ -2486,6 +2374,22 @@ impl QueuedResourceState {
             crate::model::queued_resource_state::StateData::CreatingData(v.into()),
         );
         self
+    }
+
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `AcceptedData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn accepted_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::AcceptedData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::AcceptedData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -2505,6 +2409,22 @@ impl QueuedResourceState {
         self
     }
 
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `ProvisioningData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn provisioning_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::ProvisioningData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::ProvisioningData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
     /// to hold a `ProvisioningData`.
     ///
@@ -2520,6 +2440,22 @@ impl QueuedResourceState {
             crate::model::queued_resource_state::StateData::ProvisioningData(v.into()),
         );
         self
+    }
+
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `FailedData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn failed_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::FailedData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::FailedData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -2539,6 +2475,22 @@ impl QueuedResourceState {
         self
     }
 
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `DeletingData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deleting_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::DeletingData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::DeletingData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
     /// to hold a `DeletingData`.
     ///
@@ -2554,6 +2506,22 @@ impl QueuedResourceState {
             crate::model::queued_resource_state::StateData::DeletingData(v.into()),
         );
         self
+    }
+
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `ActiveData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn active_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::ActiveData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::ActiveData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -2573,6 +2541,22 @@ impl QueuedResourceState {
         self
     }
 
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `SuspendingData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suspending_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::SuspendingData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::SuspendingData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
     /// to hold a `SuspendingData`.
     ///
@@ -2588,6 +2572,22 @@ impl QueuedResourceState {
             crate::model::queued_resource_state::StateData::SuspendingData(v.into()),
         );
         self
+    }
+
+    /// The value of [state_data][crate::model::QueuedResourceState::state_data]
+    /// if it holds a `SuspendedData`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn suspended_data(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::queued_resource_state::SuspendedData>>
+    {
+        #[allow(unreachable_patterns)]
+        self.state_data.as_ref().and_then(|v| match v {
+            crate::model::queued_resource_state::StateData::SuspendedData(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -3248,12 +3248,6 @@ impl ListNodesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNodesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [nodes][crate::model::ListNodesResponse::nodes].
     pub fn set_nodes<T, V>(mut self, v: T) -> Self
     where
@@ -3262,6 +3256,12 @@ impl ListNodesResponse {
     {
         use std::iter::Iterator;
         self.nodes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNodesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3628,12 +3628,6 @@ impl ListQueuedResourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListQueuedResourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [queued_resources][crate::model::ListQueuedResourcesResponse::queued_resources].
     pub fn set_queued_resources<T, V>(mut self, v: T) -> Self
     where
@@ -3642,6 +3636,12 @@ impl ListQueuedResourcesResponse {
     {
         use std::iter::Iterator;
         self.queued_resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListQueuedResourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4183,12 +4183,6 @@ impl ListAcceleratorTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAcceleratorTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [accelerator_types][crate::model::ListAcceleratorTypesResponse::accelerator_types].
     pub fn set_accelerator_types<T, V>(mut self, v: T) -> Self
     where
@@ -4197,6 +4191,12 @@ impl ListAcceleratorTypesResponse {
     {
         use std::iter::Iterator;
         self.accelerator_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAcceleratorTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4413,12 +4413,6 @@ impl ListRuntimeVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRuntimeVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [runtime_versions][crate::model::ListRuntimeVersionsResponse::runtime_versions].
     pub fn set_runtime_versions<T, V>(mut self, v: T) -> Self
     where
@@ -4427,6 +4421,12 @@ impl ListRuntimeVersionsResponse {
     {
         use std::iter::Iterator;
         self.runtime_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRuntimeVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -99,6 +99,19 @@ pub mod translation_service {
                 .map(gax::response::Response::into_body)
         }
 
+        /// Sets the value of [contents][crate::model::TranslateTextRequest::contents].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_contents<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [mime_type][crate::model::TranslateTextRequest::mime_type].
         pub fn set_mime_type<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.mime_type = v.into();
@@ -152,19 +165,6 @@ pub mod translation_service {
             v: T,
         ) -> Self {
             self.0.request.transliteration_config = v.into();
-            self
-        }
-
-        /// Sets the value of [contents][crate::model::TranslateTextRequest::contents].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_contents<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -226,12 +226,6 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of [source_language_code][crate::model::RomanizeTextRequest::source_language_code].
-        pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.source_language_code = v.into();
-            self
-        }
-
         /// Sets the value of [contents][crate::model::RomanizeTextRequest::contents].
         ///
         /// This is a **required** field for requests.
@@ -242,6 +236,12 @@ pub mod translation_service {
         {
             use std::iter::Iterator;
             self.0.request.contents = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [source_language_code][crate::model::RomanizeTextRequest::source_language_code].
+        pub fn set_source_language_code<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.source_language_code = v.into();
             self
         }
     }
@@ -504,6 +504,17 @@ pub mod translation_service {
             self
         }
 
+        /// Sets the value of [labels][crate::model::TranslateDocumentRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [customized_attribution][crate::model::TranslateDocumentRequest::customized_attribution].
         pub fn set_customized_attribution<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.customized_attribution = v.into();
@@ -525,17 +536,6 @@ pub mod translation_service {
         /// Sets the value of [enable_rotation_correction][crate::model::TranslateDocumentRequest::enable_rotation_correction].
         pub fn set_enable_rotation_correction<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.enable_rotation_correction = v.into();
-            self
-        }
-
-        /// Sets the value of [labels][crate::model::TranslateDocumentRequest::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -638,17 +638,6 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of [output_config][crate::model::BatchTranslateTextRequest::output_config].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_output_config<T: Into<std::option::Option<crate::model::OutputConfig>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.output_config = v.into();
-            self
-        }
-
         /// Sets the value of [target_language_codes][crate::model::BatchTranslateTextRequest::target_language_codes].
         ///
         /// This is a **required** field for requests.
@@ -659,6 +648,17 @@ pub mod translation_service {
         {
             use std::iter::Iterator;
             self.0.request.target_language_codes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [models][crate::model::BatchTranslateTextRequest::models].
+        pub fn set_models<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -675,14 +675,14 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of [models][crate::model::BatchTranslateTextRequest::models].
-        pub fn set_models<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        /// Sets the value of [output_config][crate::model::BatchTranslateTextRequest::output_config].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_output_config<T: Into<std::option::Option<crate::model::OutputConfig>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.output_config = v.into();
             self
         }
 
@@ -809,37 +809,6 @@ pub mod translation_service {
             self
         }
 
-        /// Sets the value of [output_config][crate::model::BatchTranslateDocumentRequest::output_config].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_output_config<
-            T: Into<std::option::Option<crate::model::BatchDocumentOutputConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.output_config = v.into();
-            self
-        }
-
-        /// Sets the value of [customized_attribution][crate::model::BatchTranslateDocumentRequest::customized_attribution].
-        pub fn set_customized_attribution<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.customized_attribution = v.into();
-            self
-        }
-
-        /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::BatchTranslateDocumentRequest::enable_shadow_removal_native_pdf].
-        pub fn set_enable_shadow_removal_native_pdf<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.enable_shadow_removal_native_pdf = v.into();
-            self
-        }
-
-        /// Sets the value of [enable_rotation_correction][crate::model::BatchTranslateDocumentRequest::enable_rotation_correction].
-        pub fn set_enable_rotation_correction<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.enable_rotation_correction = v.into();
-            self
-        }
-
         /// Sets the value of [target_language_codes][crate::model::BatchTranslateDocumentRequest::target_language_codes].
         ///
         /// This is a **required** field for requests.
@@ -863,6 +832,19 @@ pub mod translation_service {
         {
             use std::iter::Iterator;
             self.0.request.input_configs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [output_config][crate::model::BatchTranslateDocumentRequest::output_config].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_output_config<
+            T: Into<std::option::Option<crate::model::BatchDocumentOutputConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.output_config = v.into();
             self
         }
 
@@ -897,6 +879,24 @@ pub mod translation_service {
         {
             self.0.request.format_conversions =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [customized_attribution][crate::model::BatchTranslateDocumentRequest::customized_attribution].
+        pub fn set_customized_attribution<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.customized_attribution = v.into();
+            self
+        }
+
+        /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::BatchTranslateDocumentRequest::enable_shadow_removal_native_pdf].
+        pub fn set_enable_shadow_removal_native_pdf<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.enable_shadow_removal_native_pdf = v.into();
+            self
+        }
+
+        /// Sets the value of [enable_rotation_correction][crate::model::BatchTranslateDocumentRequest::enable_rotation_correction].
+        pub fn set_enable_rotation_correction<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.enable_rotation_correction = v.into();
             self
         }
     }
@@ -2210,6 +2210,19 @@ pub mod translation_service {
             self
         }
 
+        /// Sets the value of [content][crate::model::AdaptiveMtTranslateRequest::content].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_content<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.content = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [reference_sentence_config][crate::model::AdaptiveMtTranslateRequest::reference_sentence_config].
         pub fn set_reference_sentence_config<
             T: Into<
@@ -2233,19 +2246,6 @@ pub mod translation_service {
             v: T,
         ) -> Self {
             self.0.request.glossary_config = v.into();
-            self
-        }
-
-        /// Sets the value of [content][crate::model::AdaptiveMtTranslateRequest::content].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_content<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.content = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -350,12 +350,6 @@ impl ListAdaptiveMtDatasetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtDatasetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [adaptive_mt_datasets][crate::model::ListAdaptiveMtDatasetsResponse::adaptive_mt_datasets].
     pub fn set_adaptive_mt_datasets<T, V>(mut self, v: T) -> Self
     where
@@ -364,6 +358,12 @@ impl ListAdaptiveMtDatasetsResponse {
     {
         use std::iter::Iterator;
         self.adaptive_mt_datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -442,6 +442,17 @@ impl AdaptiveMtTranslateRequest {
         self
     }
 
+    /// Sets the value of [content][crate::model::AdaptiveMtTranslateRequest::content].
+    pub fn set_content<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.content = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [reference_sentence_config][crate::model::AdaptiveMtTranslateRequest::reference_sentence_config].
     pub fn set_reference_sentence_config<
         T: std::convert::Into<
@@ -467,17 +478,6 @@ impl AdaptiveMtTranslateRequest {
         v: T,
     ) -> Self {
         self.glossary_config = v.into();
-        self
-    }
-
-    /// Sets the value of [content][crate::model::AdaptiveMtTranslateRequest::content].
-    pub fn set_content<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.content = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -612,6 +612,19 @@ pub mod adaptive_mt_translate_request {
             std::default::Default::default()
         }
 
+        /// Sets the value of [reference_sentence_pair_lists][crate::model::adaptive_mt_translate_request::ReferenceSentenceConfig::reference_sentence_pair_lists].
+        pub fn set_reference_sentence_pair_lists<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<
+                    crate::model::adaptive_mt_translate_request::ReferenceSentencePairList,
+                >,
+        {
+            use std::iter::Iterator;
+            self.reference_sentence_pair_lists = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [source_language_code][crate::model::adaptive_mt_translate_request::ReferenceSentenceConfig::source_language_code].
         pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
             mut self,
@@ -627,19 +640,6 @@ pub mod adaptive_mt_translate_request {
             v: T,
         ) -> Self {
             self.target_language_code = v.into();
-            self
-        }
-
-        /// Sets the value of [reference_sentence_pair_lists][crate::model::adaptive_mt_translate_request::ReferenceSentenceConfig::reference_sentence_pair_lists].
-        pub fn set_reference_sentence_pair_lists<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<
-                    crate::model::adaptive_mt_translate_request::ReferenceSentencePairList,
-                >,
-        {
-            use std::iter::Iterator;
-            self.reference_sentence_pair_lists = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -775,12 +775,6 @@ impl AdaptiveMtTranslateResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [language_code][crate::model::AdaptiveMtTranslateResponse::language_code].
-    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.language_code = v.into();
-        self
-    }
-
     /// Sets the value of [translations][crate::model::AdaptiveMtTranslateResponse::translations].
     pub fn set_translations<T, V>(mut self, v: T) -> Self
     where
@@ -789,6 +783,12 @@ impl AdaptiveMtTranslateResponse {
     {
         use std::iter::Iterator;
         self.translations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [language_code][crate::model::AdaptiveMtTranslateResponse::language_code].
+    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.language_code = v.into();
         self
     }
 
@@ -1016,21 +1016,6 @@ impl ImportAdaptiveMtFileRequest {
         })
     }
 
-    /// The value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
-    /// if it holds a `GcsInputSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gcs_input_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsInputSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::import_adaptive_mt_file_request::Source::GcsInputSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
     /// to hold a `FileInputSource`.
     ///
@@ -1046,6 +1031,21 @@ impl ImportAdaptiveMtFileRequest {
             crate::model::import_adaptive_mt_file_request::Source::FileInputSource(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
+    /// if it holds a `GcsInputSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gcs_input_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GcsInputSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::import_adaptive_mt_file_request::Source::GcsInputSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
@@ -1209,12 +1209,6 @@ impl ListAdaptiveMtFilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtFilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [adaptive_mt_files][crate::model::ListAdaptiveMtFilesResponse::adaptive_mt_files].
     pub fn set_adaptive_mt_files<T, V>(mut self, v: T) -> Self
     where
@@ -1223,6 +1217,12 @@ impl ListAdaptiveMtFilesResponse {
     {
         use std::iter::Iterator;
         self.adaptive_mt_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtFilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1408,12 +1408,6 @@ impl ListAdaptiveMtSentencesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtSentencesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [adaptive_mt_sentences][crate::model::ListAdaptiveMtSentencesResponse::adaptive_mt_sentences].
     pub fn set_adaptive_mt_sentences<T, V>(mut self, v: T) -> Self
     where
@@ -1422,6 +1416,12 @@ impl ListAdaptiveMtSentencesResponse {
     {
         use std::iter::Iterator;
         self.adaptive_mt_sentences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAdaptiveMtSentencesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2131,12 +2131,6 @@ impl ListDatasetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [datasets][crate::model::ListDatasetsResponse::datasets].
     pub fn set_datasets<T, V>(mut self, v: T) -> Self
     where
@@ -2145,6 +2139,12 @@ impl ListDatasetsResponse {
     {
         use std::iter::Iterator;
         self.datasets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatasetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2378,12 +2378,6 @@ impl ListExamplesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExamplesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [examples][crate::model::ListExamplesResponse::examples].
     pub fn set_examples<T, V>(mut self, v: T) -> Self
     where
@@ -2392,6 +2386,12 @@ impl ListExamplesResponse {
     {
         use std::iter::Iterator;
         self.examples = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExamplesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2928,12 +2928,6 @@ impl ListModelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [models][crate::model::ListModelsResponse::models].
     pub fn set_models<T, V>(mut self, v: T) -> Self
     where
@@ -2942,6 +2936,12 @@ impl ListModelsResponse {
     {
         use std::iter::Iterator;
         self.models = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListModelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3432,19 +3432,6 @@ impl GlossaryEntry {
         })
     }
 
-    /// The value of [data][crate::model::GlossaryEntry::data]
-    /// if it holds a `TermsSet`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn terms_set(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary_entry::GlossaryTermsSet>> {
-        #[allow(unreachable_patterns)]
-        self.data.as_ref().and_then(|v| match v {
-            crate::model::glossary_entry::Data::TermsSet(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data][crate::model::GlossaryEntry::data]
     /// to hold a `TermsPair`.
     ///
@@ -3459,6 +3446,19 @@ impl GlossaryEntry {
         self.data =
             std::option::Option::Some(crate::model::glossary_entry::Data::TermsPair(v.into()));
         self
+    }
+
+    /// The value of [data][crate::model::GlossaryEntry::data]
+    /// if it holds a `TermsSet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn terms_set(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary_entry::GlossaryTermsSet>> {
+        #[allow(unreachable_patterns)]
+        self.data.as_ref().and_then(|v| match v {
+            crate::model::glossary_entry::Data::TermsSet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data][crate::model::GlossaryEntry::data]
@@ -3769,6 +3769,17 @@ impl TranslateTextRequest {
         std::default::Default::default()
     }
 
+    /// Sets the value of [contents][crate::model::TranslateTextRequest::contents].
+    pub fn set_contents<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [mime_type][crate::model::TranslateTextRequest::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
@@ -3824,17 +3835,6 @@ impl TranslateTextRequest {
         v: T,
     ) -> Self {
         self.transliteration_config = v.into();
-        self
-    }
-
-    /// Sets the value of [contents][crate::model::TranslateTextRequest::contents].
-    pub fn set_contents<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.contents = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4044,15 +4044,6 @@ impl RomanizeTextRequest {
         self
     }
 
-    /// Sets the value of [source_language_code][crate::model::RomanizeTextRequest::source_language_code].
-    pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_language_code = v.into();
-        self
-    }
-
     /// Sets the value of [contents][crate::model::RomanizeTextRequest::contents].
     pub fn set_contents<T, V>(mut self, v: T) -> Self
     where
@@ -4061,6 +4052,15 @@ impl RomanizeTextRequest {
     {
         use std::iter::Iterator;
         self.contents = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [source_language_code][crate::model::RomanizeTextRequest::source_language_code].
+    pub fn set_source_language_code<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_language_code = v.into();
         self
     }
 }
@@ -4991,6 +4991,18 @@ impl DocumentInputConfig {
         })
     }
 
+    /// Sets the value of [source][crate::model::DocumentInputConfig::source]
+    /// to hold a `Content`.
+    ///
+    /// Note that all the setters affecting `source` are
+    /// mutually exclusive.
+    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.source = std::option::Option::Some(
+            crate::model::document_input_config::Source::Content(v.into()),
+        );
+        self
+    }
+
     /// The value of [source][crate::model::DocumentInputConfig::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -5002,18 +5014,6 @@ impl DocumentInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::DocumentInputConfig::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::document_input_config::Source::Content(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [source][crate::model::DocumentInputConfig::source]
@@ -5399,6 +5399,18 @@ impl TranslateDocumentRequest {
         self
     }
 
+    /// Sets the value of [labels][crate::model::TranslateDocumentRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [customized_attribution][crate::model::TranslateDocumentRequest::customized_attribution].
     pub fn set_customized_attribution<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -5426,18 +5438,6 @@ impl TranslateDocumentRequest {
     /// Sets the value of [enable_rotation_correction][crate::model::TranslateDocumentRequest::enable_rotation_correction].
     pub fn set_enable_rotation_correction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_rotation_correction = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::TranslateDocumentRequest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5482,6 +5482,17 @@ impl DocumentTranslation {
         std::default::Default::default()
     }
 
+    /// Sets the value of [byte_stream_outputs][crate::model::DocumentTranslation::byte_stream_outputs].
+    pub fn set_byte_stream_outputs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<::bytes::Bytes>,
+    {
+        use std::iter::Iterator;
+        self.byte_stream_outputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [mime_type][crate::model::DocumentTranslation::mime_type].
     pub fn set_mime_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.mime_type = v.into();
@@ -5494,17 +5505,6 @@ impl DocumentTranslation {
         v: T,
     ) -> Self {
         self.detected_language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [byte_stream_outputs][crate::model::DocumentTranslation::byte_stream_outputs].
-    pub fn set_byte_stream_outputs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<::bytes::Bytes>,
-    {
-        use std::iter::Iterator;
-        self.byte_stream_outputs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5700,17 +5700,6 @@ impl BatchTranslateTextRequest {
         self
     }
 
-    /// Sets the value of [output_config][crate::model::BatchTranslateTextRequest::output_config].
-    pub fn set_output_config<
-        T: std::convert::Into<std::option::Option<crate::model::OutputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_config = v.into();
-        self
-    }
-
     /// Sets the value of [target_language_codes][crate::model::BatchTranslateTextRequest::target_language_codes].
     pub fn set_target_language_codes<T, V>(mut self, v: T) -> Self
     where
@@ -5719,6 +5708,18 @@ impl BatchTranslateTextRequest {
     {
         use std::iter::Iterator;
         self.target_language_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [models][crate::model::BatchTranslateTextRequest::models].
+    pub fn set_models<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5733,15 +5734,14 @@ impl BatchTranslateTextRequest {
         self
     }
 
-    /// Sets the value of [models][crate::model::BatchTranslateTextRequest::models].
-    pub fn set_models<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.models = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [output_config][crate::model::BatchTranslateTextRequest::output_config].
+    pub fn set_output_config<
+        T: std::convert::Into<std::option::Option<crate::model::OutputConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_config = v.into();
         self
     }
 
@@ -6335,19 +6335,6 @@ impl Glossary {
         })
     }
 
-    /// The value of [languages][crate::model::Glossary::languages]
-    /// if it holds a `LanguageCodesSet`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn language_codes_set(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary::LanguageCodesSet>> {
-        #[allow(unreachable_patterns)]
-        self.languages.as_ref().and_then(|v| match v {
-            crate::model::glossary::Languages::LanguageCodesSet(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [languages][crate::model::Glossary::languages]
     /// to hold a `LanguagePair`.
     ///
@@ -6362,6 +6349,19 @@ impl Glossary {
         self.languages =
             std::option::Option::Some(crate::model::glossary::Languages::LanguagePair(v.into()));
         self
+    }
+
+    /// The value of [languages][crate::model::Glossary::languages]
+    /// if it holds a `LanguageCodesSet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn language_codes_set(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::glossary::LanguageCodesSet>> {
+        #[allow(unreachable_patterns)]
+        self.languages.as_ref().and_then(|v| match v {
+            crate::model::glossary::Languages::LanguageCodesSet(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [languages][crate::model::Glossary::languages]
@@ -6758,12 +6758,6 @@ impl ListGlossariesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGlossariesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [glossaries][crate::model::ListGlossariesResponse::glossaries].
     pub fn set_glossaries<T, V>(mut self, v: T) -> Self
     where
@@ -6772,6 +6766,12 @@ impl ListGlossariesResponse {
     {
         use std::iter::Iterator;
         self.glossaries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGlossariesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6941,12 +6941,6 @@ impl ListGlossaryEntriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGlossaryEntriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [glossary_entries][crate::model::ListGlossaryEntriesResponse::glossary_entries].
     pub fn set_glossary_entries<T, V>(mut self, v: T) -> Self
     where
@@ -6955,6 +6949,12 @@ impl ListGlossaryEntriesResponse {
     {
         use std::iter::Iterator;
         self.glossary_entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGlossaryEntriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7917,41 +7917,6 @@ impl BatchTranslateDocumentRequest {
         self
     }
 
-    /// Sets the value of [output_config][crate::model::BatchTranslateDocumentRequest::output_config].
-    pub fn set_output_config<
-        T: std::convert::Into<std::option::Option<crate::model::BatchDocumentOutputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_config = v.into();
-        self
-    }
-
-    /// Sets the value of [customized_attribution][crate::model::BatchTranslateDocumentRequest::customized_attribution].
-    pub fn set_customized_attribution<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.customized_attribution = v.into();
-        self
-    }
-
-    /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::BatchTranslateDocumentRequest::enable_shadow_removal_native_pdf].
-    pub fn set_enable_shadow_removal_native_pdf<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enable_shadow_removal_native_pdf = v.into();
-        self
-    }
-
-    /// Sets the value of [enable_rotation_correction][crate::model::BatchTranslateDocumentRequest::enable_rotation_correction].
-    pub fn set_enable_rotation_correction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_rotation_correction = v.into();
-        self
-    }
-
     /// Sets the value of [target_language_codes][crate::model::BatchTranslateDocumentRequest::target_language_codes].
     pub fn set_target_language_codes<T, V>(mut self, v: T) -> Self
     where
@@ -7971,6 +7936,17 @@ impl BatchTranslateDocumentRequest {
     {
         use std::iter::Iterator;
         self.input_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [output_config][crate::model::BatchTranslateDocumentRequest::output_config].
+    pub fn set_output_config<
+        T: std::convert::Into<std::option::Option<crate::model::BatchDocumentOutputConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_config = v.into();
         self
     }
 
@@ -8007,6 +7983,30 @@ impl BatchTranslateDocumentRequest {
     {
         use std::iter::Iterator;
         self.format_conversions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [customized_attribution][crate::model::BatchTranslateDocumentRequest::customized_attribution].
+    pub fn set_customized_attribution<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.customized_attribution = v.into();
+        self
+    }
+
+    /// Sets the value of [enable_shadow_removal_native_pdf][crate::model::BatchTranslateDocumentRequest::enable_shadow_removal_native_pdf].
+    pub fn set_enable_shadow_removal_native_pdf<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.enable_shadow_removal_native_pdf = v.into();
+        self
+    }
+
+    /// Sets the value of [enable_rotation_correction][crate::model::BatchTranslateDocumentRequest::enable_rotation_correction].
+    pub fn set_enable_rotation_correction<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_rotation_correction = v.into();
         self
     }
 }

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -95,32 +95,6 @@ impl ElementaryStream {
         })
     }
 
-    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// if it holds a `AudioStream`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn audio_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioStream>> {
-        #[allow(unreachable_patterns)]
-        self.elementary_stream.as_ref().and_then(|v| match v {
-            crate::model::elementary_stream::ElementaryStream::AudioStream(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// if it holds a `TextStream`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::TextStream>> {
-        #[allow(unreachable_patterns)]
-        self.elementary_stream.as_ref().and_then(|v| match v {
-            crate::model::elementary_stream::ElementaryStream::TextStream(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// to hold a `VideoStream`.
     ///
@@ -136,6 +110,19 @@ impl ElementaryStream {
         self
     }
 
+    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
+    /// if it holds a `AudioStream`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn audio_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioStream>> {
+        #[allow(unreachable_patterns)]
+        self.elementary_stream.as_ref().and_then(|v| match v {
+            crate::model::elementary_stream::ElementaryStream::AudioStream(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// to hold a `AudioStream`.
     ///
@@ -149,6 +136,19 @@ impl ElementaryStream {
             crate::model::elementary_stream::ElementaryStream::AudioStream(v.into()),
         );
         self
+    }
+
+    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
+    /// if it holds a `TextStream`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::TextStream>> {
+        #[allow(unreachable_patterns)]
+        self.elementary_stream.as_ref().and_then(|v| match v {
+            crate::model::elementary_stream::ElementaryStream::TextStream(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
@@ -255,6 +255,17 @@ impl MuxStream {
         self
     }
 
+    /// Sets the value of [elementary_streams][crate::model::MuxStream::elementary_streams].
+    pub fn set_elementary_streams<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.elementary_streams = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [segment_settings][crate::model::MuxStream::segment_settings].
     pub fn set_segment_settings<
         T: std::convert::Into<std::option::Option<crate::model::SegmentSettings>>,
@@ -269,17 +280,6 @@ impl MuxStream {
     /// Sets the value of [encryption_id][crate::model::MuxStream::encryption_id].
     pub fn set_encryption_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.encryption_id = v.into();
-        self
-    }
-
-    /// Sets the value of [elementary_streams][crate::model::MuxStream::elementary_streams].
-    pub fn set_elementary_streams<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.elementary_streams = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -383,6 +383,17 @@ impl Manifest {
         self
     }
 
+    /// Sets the value of [mux_streams][crate::model::Manifest::mux_streams].
+    pub fn set_mux_streams<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.mux_streams = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [max_segment_count][crate::model::Manifest::max_segment_count].
     pub fn set_max_segment_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_segment_count = v.into();
@@ -407,17 +418,6 @@ impl Manifest {
     /// Sets the value of [key][crate::model::Manifest::key].
     pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.key = v.into();
-        self
-    }
-
-    /// Sets the value of [mux_streams][crate::model::Manifest::mux_streams].
-    pub fn set_mux_streams<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.mux_streams = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1238,6 +1238,18 @@ pub mod video_stream {
             })
         }
 
+        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
+        /// to hold a `GopFrameCount`.
+        ///
+        /// Note that all the setters affecting `gop_mode` are
+        /// mutually exclusive.
+        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.gop_mode = std::option::Option::Some(
+                crate::model::video_stream::h_264_codec_settings::GopMode::GopFrameCount(v.into()),
+            );
+            self
+        }
+
         /// The value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -1249,18 +1261,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_264_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
@@ -1410,12 +1410,6 @@ impl AudioStream {
         self
     }
 
-    /// Sets the value of [sample_rate_hertz][crate::model::AudioStream::sample_rate_hertz].
-    pub fn set_sample_rate_hertz<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.sample_rate_hertz = v.into();
-        self
-    }
-
     /// Sets the value of [channel_layout][crate::model::AudioStream::channel_layout].
     pub fn set_channel_layout<T, V>(mut self, v: T) -> Self
     where
@@ -1435,6 +1429,12 @@ impl AudioStream {
     {
         use std::iter::Iterator;
         self.mapping = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [sample_rate_hertz][crate::model::AudioStream::sample_rate_hertz].
+    pub fn set_sample_rate_hertz<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.sample_rate_hertz = v.into();
         self
     }
 }
@@ -1683,17 +1683,6 @@ impl TimecodeConfig {
         })
     }
 
-    /// The value of [time_offset][crate::model::TimecodeConfig::time_offset]
-    /// if it holds a `TimeZone`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_zone(&self) -> std::option::Option<&std::boxed::Box<gtype::model::TimeZone>> {
-        #[allow(unreachable_patterns)]
-        self.time_offset.as_ref().and_then(|v| match v {
-            crate::model::timecode_config::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [time_offset][crate::model::TimecodeConfig::time_offset]
     /// to hold a `UtcOffset`.
     ///
@@ -1707,6 +1696,17 @@ impl TimecodeConfig {
             crate::model::timecode_config::TimeOffset::UtcOffset(v.into()),
         );
         self
+    }
+
+    /// The value of [time_offset][crate::model::TimecodeConfig::time_offset]
+    /// if it holds a `TimeZone`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_zone(&self) -> std::option::Option<&std::boxed::Box<gtype::model::TimeZone>> {
+        #[allow(unreachable_patterns)]
+        self.time_offset.as_ref().and_then(|v| match v {
+            crate::model::timecode_config::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [time_offset][crate::model::TimecodeConfig::time_offset]
@@ -1973,6 +1973,18 @@ impl Input {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Input::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [r#type][crate::model::Input::type].
     pub fn set_type<T: std::convert::Into<crate::model::input::Type>>(mut self, v: T) -> Self {
         self.r#type = v.into();
@@ -2021,18 +2033,6 @@ impl Input {
         v: T,
     ) -> Self {
         self.input_stream_property = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Input::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2503,6 +2503,29 @@ impl Channel {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Channel::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [input_attachments][crate::model::Channel::input_attachments].
+    pub fn set_input_attachments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InputAttachment>,
+    {
+        use std::iter::Iterator;
+        self.input_attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [active_input][crate::model::Channel::active_input].
     pub fn set_active_input<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.active_input = v.into();
@@ -2515,77 +2538,6 @@ impl Channel {
         v: T,
     ) -> Self {
         self.output = v.into();
-        self
-    }
-
-    /// Sets the value of [streaming_state][crate::model::Channel::streaming_state].
-    pub fn set_streaming_state<T: std::convert::Into<crate::model::channel::StreamingState>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.streaming_state = v.into();
-        self
-    }
-
-    /// Sets the value of [streaming_error][crate::model::Channel::streaming_error].
-    pub fn set_streaming_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.streaming_error = v.into();
-        self
-    }
-
-    /// Sets the value of [log_config][crate::model::Channel::log_config].
-    pub fn set_log_config<T: std::convert::Into<std::option::Option<crate::model::LogConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.log_config = v.into();
-        self
-    }
-
-    /// Sets the value of [timecode_config][crate::model::Channel::timecode_config].
-    pub fn set_timecode_config<
-        T: std::convert::Into<std::option::Option<crate::model::TimecodeConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.timecode_config = v.into();
-        self
-    }
-
-    /// Sets the value of [input_config][crate::model::Channel::input_config].
-    pub fn set_input_config<
-        T: std::convert::Into<std::option::Option<crate::model::InputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_config = v.into();
-        self
-    }
-
-    /// Sets the value of [retention_config][crate::model::Channel::retention_config].
-    pub fn set_retention_config<
-        T: std::convert::Into<std::option::Option<crate::model::RetentionConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.retention_config = v.into();
-        self
-    }
-
-    /// Sets the value of [input_attachments][crate::model::Channel::input_attachments].
-    pub fn set_input_attachments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InputAttachment>,
-    {
-        use std::iter::Iterator;
-        self.input_attachments = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2633,6 +2585,44 @@ impl Channel {
         self
     }
 
+    /// Sets the value of [streaming_state][crate::model::Channel::streaming_state].
+    pub fn set_streaming_state<T: std::convert::Into<crate::model::channel::StreamingState>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.streaming_state = v.into();
+        self
+    }
+
+    /// Sets the value of [streaming_error][crate::model::Channel::streaming_error].
+    pub fn set_streaming_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.streaming_error = v.into();
+        self
+    }
+
+    /// Sets the value of [log_config][crate::model::Channel::log_config].
+    pub fn set_log_config<T: std::convert::Into<std::option::Option<crate::model::LogConfig>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.log_config = v.into();
+        self
+    }
+
+    /// Sets the value of [timecode_config][crate::model::Channel::timecode_config].
+    pub fn set_timecode_config<
+        T: std::convert::Into<std::option::Option<crate::model::TimecodeConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.timecode_config = v.into();
+        self
+    }
+
     /// Sets the value of [encryptions][crate::model::Channel::encryptions].
     pub fn set_encryptions<T, V>(mut self, v: T) -> Self
     where
@@ -2644,6 +2634,28 @@ impl Channel {
         self
     }
 
+    /// Sets the value of [input_config][crate::model::Channel::input_config].
+    pub fn set_input_config<
+        T: std::convert::Into<std::option::Option<crate::model::InputConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.input_config = v.into();
+        self
+    }
+
+    /// Sets the value of [retention_config][crate::model::Channel::retention_config].
+    pub fn set_retention_config<
+        T: std::convert::Into<std::option::Option<crate::model::RetentionConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.retention_config = v.into();
+        self
+    }
+
     /// Sets the value of [static_overlays][crate::model::Channel::static_overlays].
     pub fn set_static_overlays<T, V>(mut self, v: T) -> Self
     where
@@ -2652,18 +2664,6 @@ impl Channel {
     {
         use std::iter::Iterator;
         self.static_overlays = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Channel::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -3974,6 +3974,18 @@ impl Event {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Event::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [execute_now][crate::model::Event::execute_now].
     pub fn set_execute_now<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.execute_now = v.into();
@@ -4004,18 +4016,6 @@ impl Event {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Event::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [task][crate::model::Event::task].
     ///
     /// Note that all the setters affecting `task` are mutually
@@ -4041,65 +4041,6 @@ impl Event {
         })
     }
 
-    /// The value of [task][crate::model::Event::task]
-    /// if it holds a `AdBreak`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ad_break(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::event::AdBreakTask>> {
-        #[allow(unreachable_patterns)]
-        self.task.as_ref().and_then(|v| match v {
-            crate::model::event::Task::AdBreak(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [task][crate::model::Event::task]
-    /// if it holds a `ReturnToProgram`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn return_to_program(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::event::ReturnToProgramTask>> {
-        #[allow(unreachable_patterns)]
-        self.task.as_ref().and_then(|v| match v {
-            crate::model::event::Task::ReturnToProgram(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [task][crate::model::Event::task]
-    /// if it holds a `Slate`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn slate(&self) -> std::option::Option<&std::boxed::Box<crate::model::event::SlateTask>> {
-        #[allow(unreachable_patterns)]
-        self.task.as_ref().and_then(|v| match v {
-            crate::model::event::Task::Slate(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [task][crate::model::Event::task]
-    /// if it holds a `Mute`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mute(&self) -> std::option::Option<&std::boxed::Box<crate::model::event::MuteTask>> {
-        #[allow(unreachable_patterns)]
-        self.task.as_ref().and_then(|v| match v {
-            crate::model::event::Task::Mute(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [task][crate::model::Event::task]
-    /// if it holds a `Unmute`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn unmute(&self) -> std::option::Option<&std::boxed::Box<crate::model::event::UnmuteTask>> {
-        #[allow(unreachable_patterns)]
-        self.task.as_ref().and_then(|v| match v {
-            crate::model::event::Task::Unmute(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [task][crate::model::Event::task]
     /// to hold a `InputSwitch`.
     ///
@@ -4113,6 +4054,19 @@ impl Event {
     ) -> Self {
         self.task = std::option::Option::Some(crate::model::event::Task::InputSwitch(v.into()));
         self
+    }
+
+    /// The value of [task][crate::model::Event::task]
+    /// if it holds a `AdBreak`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ad_break(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::event::AdBreakTask>> {
+        #[allow(unreachable_patterns)]
+        self.task.as_ref().and_then(|v| match v {
+            crate::model::event::Task::AdBreak(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [task][crate::model::Event::task]
@@ -4130,6 +4084,19 @@ impl Event {
         self
     }
 
+    /// The value of [task][crate::model::Event::task]
+    /// if it holds a `ReturnToProgram`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn return_to_program(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::event::ReturnToProgramTask>> {
+        #[allow(unreachable_patterns)]
+        self.task.as_ref().and_then(|v| match v {
+            crate::model::event::Task::ReturnToProgram(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [task][crate::model::Event::task]
     /// to hold a `ReturnToProgram`.
     ///
@@ -4145,6 +4112,17 @@ impl Event {
         self
     }
 
+    /// The value of [task][crate::model::Event::task]
+    /// if it holds a `Slate`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn slate(&self) -> std::option::Option<&std::boxed::Box<crate::model::event::SlateTask>> {
+        #[allow(unreachable_patterns)]
+        self.task.as_ref().and_then(|v| match v {
+            crate::model::event::Task::Slate(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [task][crate::model::Event::task]
     /// to hold a `Slate`.
     ///
@@ -4158,6 +4136,17 @@ impl Event {
         self
     }
 
+    /// The value of [task][crate::model::Event::task]
+    /// if it holds a `Mute`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mute(&self) -> std::option::Option<&std::boxed::Box<crate::model::event::MuteTask>> {
+        #[allow(unreachable_patterns)]
+        self.task.as_ref().and_then(|v| match v {
+            crate::model::event::Task::Mute(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [task][crate::model::Event::task]
     /// to hold a `Mute`.
     ///
@@ -4169,6 +4158,17 @@ impl Event {
     ) -> Self {
         self.task = std::option::Option::Some(crate::model::event::Task::Mute(v.into()));
         self
+    }
+
+    /// The value of [task][crate::model::Event::task]
+    /// if it holds a `Unmute`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn unmute(&self) -> std::option::Option<&std::boxed::Box<crate::model::event::UnmuteTask>> {
+        #[allow(unreachable_patterns)]
+        self.task.as_ref().and_then(|v| match v {
+            crate::model::event::Task::Unmute(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [task][crate::model::Event::task]
@@ -4681,6 +4681,18 @@ impl Clip {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Clip::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Clip::state].
     pub fn set_state<T: std::convert::Into<crate::model::clip::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -4721,18 +4733,6 @@ impl Clip {
     {
         use std::iter::Iterator;
         self.clip_manifests = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Clip::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5170,6 +5170,18 @@ impl Asset {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Asset::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [crc32c][crate::model::Asset::crc32c].
     pub fn set_crc32c<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.crc32c = v.into();
@@ -5188,18 +5200,6 @@ impl Asset {
         v: T,
     ) -> Self {
         self.error = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Asset::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -5228,17 +5228,6 @@ impl Asset {
         })
     }
 
-    /// The value of [resource][crate::model::Asset::resource]
-    /// if it holds a `Image`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn image(&self) -> std::option::Option<&std::boxed::Box<crate::model::asset::ImageAsset>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::asset::Resource::Image(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [resource][crate::model::Asset::resource]
     /// to hold a `Video`.
     ///
@@ -5250,6 +5239,17 @@ impl Asset {
     ) -> Self {
         self.resource = std::option::Option::Some(crate::model::asset::Resource::Video(v.into()));
         self
+    }
+
+    /// The value of [resource][crate::model::Asset::resource]
+    /// if it holds a `Image`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn image(&self) -> std::option::Option<&std::boxed::Box<crate::model::asset::ImageAsset>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::asset::Resource::Image(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource][crate::model::Asset::resource]
@@ -5626,32 +5626,6 @@ impl Encryption {
         })
     }
 
-    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// if it holds a `SampleAes`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sample_aes(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::SampleAesEncryption>> {
-        #[allow(unreachable_patterns)]
-        self.encryption_mode.as_ref().and_then(|v| match v {
-            crate::model::encryption::EncryptionMode::SampleAes(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// if it holds a `MpegCenc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mpeg_cenc(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::MpegCommonEncryption>> {
-        #[allow(unreachable_patterns)]
-        self.encryption_mode.as_ref().and_then(|v| match v {
-            crate::model::encryption::EncryptionMode::MpegCenc(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
     /// to hold a `Aes128`.
     ///
@@ -5666,6 +5640,19 @@ impl Encryption {
         self.encryption_mode =
             std::option::Option::Some(crate::model::encryption::EncryptionMode::Aes128(v.into()));
         self
+    }
+
+    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
+    /// if it holds a `SampleAes`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sample_aes(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::SampleAesEncryption>> {
+        #[allow(unreachable_patterns)]
+        self.encryption_mode.as_ref().and_then(|v| match v {
+            crate::model::encryption::EncryptionMode::SampleAes(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
@@ -5683,6 +5670,19 @@ impl Encryption {
             crate::model::encryption::EncryptionMode::SampleAes(v.into()),
         );
         self
+    }
+
+    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
+    /// if it holds a `MpegCenc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mpeg_cenc(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::MpegCommonEncryption>> {
+        #[allow(unreachable_patterns)]
+        self.encryption_mode.as_ref().and_then(|v| match v {
+            crate::model::encryption::EncryptionMode::MpegCenc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
@@ -6085,17 +6085,6 @@ impl Pool {
         self
     }
 
-    /// Sets the value of [network_config][crate::model::Pool::network_config].
-    pub fn set_network_config<
-        T: std::convert::Into<std::option::Option<crate::model::pool::NetworkConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.network_config = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Pool::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -6105,6 +6094,17 @@ impl Pool {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [network_config][crate::model::Pool::network_config].
+    pub fn set_network_config<
+        T: std::convert::Into<std::option::Option<crate::model::pool::NetworkConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.network_config = v.into();
         self
     }
 }
@@ -6398,12 +6398,6 @@ impl ListAssetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [assets][crate::model::ListAssetsResponse::assets].
     pub fn set_assets<T, V>(mut self, v: T) -> Self
     where
@@ -6412,6 +6406,12 @@ impl ListAssetsResponse {
     {
         use std::iter::Iterator;
         self.assets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAssetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6668,12 +6668,6 @@ impl ListChannelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListChannelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [channels][crate::model::ListChannelsResponse::channels].
     pub fn set_channels<T, V>(mut self, v: T) -> Self
     where
@@ -6682,6 +6676,12 @@ impl ListChannelsResponse {
     {
         use std::iter::Iterator;
         self.channels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListChannelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7205,12 +7205,6 @@ impl ListInputsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInputsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [inputs][crate::model::ListInputsResponse::inputs].
     pub fn set_inputs<T, V>(mut self, v: T) -> Self
     where
@@ -7219,6 +7213,12 @@ impl ListInputsResponse {
     {
         use std::iter::Iterator;
         self.inputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInputsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7611,12 +7611,6 @@ impl ListEventsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListEventsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [events][crate::model::ListEventsResponse::events].
     pub fn set_events<T, V>(mut self, v: T) -> Self
     where
@@ -7625,6 +7619,12 @@ impl ListEventsResponse {
     {
         use std::iter::Iterator;
         self.events = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListEventsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7870,12 +7870,6 @@ impl ListClipsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClipsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clips][crate::model::ListClipsResponse::clips].
     pub fn set_clips<T, V>(mut self, v: T) -> Self
     where
@@ -7884,6 +7878,12 @@ impl ListClipsResponse {
     {
         use std::iter::Iterator;
         self.clips = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClipsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -387,32 +387,6 @@ impl CdnKey {
         })
     }
 
-    /// The value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
-    /// if it holds a `AkamaiCdnKey`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn akamai_cdn_key(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AkamaiCdnKey>> {
-        #[allow(unreachable_patterns)]
-        self.cdn_key_config.as_ref().and_then(|v| match v {
-            crate::model::cdn_key::CdnKeyConfig::AkamaiCdnKey(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
-    /// if it holds a `MediaCdnKey`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn media_cdn_key(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MediaCdnKey>> {
-        #[allow(unreachable_patterns)]
-        self.cdn_key_config.as_ref().and_then(|v| match v {
-            crate::model::cdn_key::CdnKeyConfig::MediaCdnKey(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
     /// to hold a `GoogleCdnKey`.
     ///
@@ -429,6 +403,19 @@ impl CdnKey {
         self
     }
 
+    /// The value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
+    /// if it holds a `AkamaiCdnKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn akamai_cdn_key(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AkamaiCdnKey>> {
+        #[allow(unreachable_patterns)]
+        self.cdn_key_config.as_ref().and_then(|v| match v {
+            crate::model::cdn_key::CdnKeyConfig::AkamaiCdnKey(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
     /// to hold a `AkamaiCdnKey`.
     ///
@@ -443,6 +430,19 @@ impl CdnKey {
         self.cdn_key_config =
             std::option::Option::Some(crate::model::cdn_key::CdnKeyConfig::AkamaiCdnKey(v.into()));
         self
+    }
+
+    /// The value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
+    /// if it holds a `MediaCdnKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn media_cdn_key(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MediaCdnKey>> {
+        #[allow(unreachable_patterns)]
+        self.cdn_key_config.as_ref().and_then(|v| match v {
+            crate::model::cdn_key::CdnKeyConfig::MediaCdnKey(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
@@ -1009,34 +1009,6 @@ impl Companion {
         })
     }
 
-    /// The value of [ad_resource][crate::model::Companion::ad_resource]
-    /// if it holds a `StaticAdResource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn static_ad_resource(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StaticAdResource>> {
-        #[allow(unreachable_patterns)]
-        self.ad_resource.as_ref().and_then(|v| match v {
-            crate::model::companion::AdResource::StaticAdResource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [ad_resource][crate::model::Companion::ad_resource]
-    /// if it holds a `HtmlAdResource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn html_ad_resource(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::HtmlAdResource>> {
-        #[allow(unreachable_patterns)]
-        self.ad_resource.as_ref().and_then(|v| match v {
-            crate::model::companion::AdResource::HtmlAdResource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [ad_resource][crate::model::Companion::ad_resource]
     /// to hold a `IframeAdResource`.
     ///
@@ -1054,6 +1026,21 @@ impl Companion {
         self
     }
 
+    /// The value of [ad_resource][crate::model::Companion::ad_resource]
+    /// if it holds a `StaticAdResource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn static_ad_resource(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StaticAdResource>> {
+        #[allow(unreachable_patterns)]
+        self.ad_resource.as_ref().and_then(|v| match v {
+            crate::model::companion::AdResource::StaticAdResource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [ad_resource][crate::model::Companion::ad_resource]
     /// to hold a `StaticAdResource`.
     ///
@@ -1069,6 +1056,19 @@ impl Companion {
             crate::model::companion::AdResource::StaticAdResource(v.into()),
         );
         self
+    }
+
+    /// The value of [ad_resource][crate::model::Companion::ad_resource]
+    /// if it holds a `HtmlAdResource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn html_ad_resource(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HtmlAdResource>> {
+        #[allow(unreachable_patterns)]
+        self.ad_resource.as_ref().and_then(|v| match v {
+            crate::model::companion::AdResource::HtmlAdResource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [ad_resource][crate::model::Companion::ad_resource]
@@ -2326,6 +2326,18 @@ impl VodSession {
         self
     }
 
+    /// Sets the value of [ad_tag_macro_map][crate::model::VodSession::ad_tag_macro_map].
+    pub fn set_ad_tag_macro_map<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ad_tag_macro_map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [manifest_options][crate::model::VodSession::manifest_options].
     pub fn set_manifest_options<
         T: std::convert::Into<std::option::Option<crate::model::ManifestOptions>>,
@@ -2366,18 +2378,6 @@ impl VodSession {
     /// Sets the value of [vod_config][crate::model::VodSession::vod_config].
     pub fn set_vod_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.vod_config = v.into();
-        self
-    }
-
-    /// Sets the value of [ad_tag_macro_map][crate::model::VodSession::ad_tag_macro_map].
-    pub fn set_ad_tag_macro_map<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.ad_tag_macro_map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2463,17 +2463,6 @@ impl Interstitials {
         std::default::Default::default()
     }
 
-    /// Sets the value of [session_content][crate::model::Interstitials::session_content].
-    pub fn set_session_content<
-        T: std::convert::Into<std::option::Option<crate::model::VodSessionContent>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.session_content = v.into();
-        self
-    }
-
     /// Sets the value of [ad_breaks][crate::model::Interstitials::ad_breaks].
     pub fn set_ad_breaks<T, V>(mut self, v: T) -> Self
     where
@@ -2482,6 +2471,17 @@ impl Interstitials {
     {
         use std::iter::Iterator;
         self.ad_breaks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [session_content][crate::model::Interstitials::session_content].
+    pub fn set_session_content<
+        T: std::convert::Into<std::option::Option<crate::model::VodSessionContent>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.session_content = v.into();
         self
     }
 }
@@ -2628,24 +2628,6 @@ impl VodSessionAdBreak {
         std::default::Default::default()
     }
 
-    /// Sets the value of [end_time_offset][crate::model::VodSessionAdBreak::end_time_offset].
-    pub fn set_end_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.end_time_offset = v.into();
-        self
-    }
-
-    /// Sets the value of [start_time_offset][crate::model::VodSessionAdBreak::start_time_offset].
-    pub fn set_start_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_time_offset = v.into();
-        self
-    }
-
     /// Sets the value of [progress_events][crate::model::VodSessionAdBreak::progress_events].
     pub fn set_progress_events<T, V>(mut self, v: T) -> Self
     where
@@ -2665,6 +2647,24 @@ impl VodSessionAdBreak {
     {
         use std::iter::Iterator;
         self.ads = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [end_time_offset][crate::model::VodSessionAdBreak::end_time_offset].
+    pub fn set_end_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.end_time_offset = v.into();
+        self
+    }
+
+    /// Sets the value of [start_time_offset][crate::model::VodSessionAdBreak::start_time_offset].
+    pub fn set_start_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.start_time_offset = v.into();
         self
     }
 }
@@ -2746,6 +2746,18 @@ impl LiveSession {
         self
     }
 
+    /// Sets the value of [ad_tag_macros][crate::model::LiveSession::ad_tag_macros].
+    pub fn set_ad_tag_macros<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ad_tag_macros = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [manifest_options][crate::model::LiveSession::manifest_options].
     pub fn set_manifest_options<
         T: std::convert::Into<std::option::Option<crate::model::ManifestOptions>>,
@@ -2780,18 +2792,6 @@ impl LiveSession {
         v: T,
     ) -> Self {
         self.ad_tracking = v.into();
-        self
-    }
-
-    /// Sets the value of [ad_tag_macros][crate::model::LiveSession::ad_tag_macros].
-    pub fn set_ad_tag_macros<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.ad_tag_macros = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2885,15 +2885,6 @@ impl ManifestOptions {
         std::default::Default::default()
     }
 
-    /// Sets the value of [bitrate_order][crate::model::ManifestOptions::bitrate_order].
-    pub fn set_bitrate_order<T: std::convert::Into<crate::model::manifest_options::OrderPolicy>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bitrate_order = v.into();
-        self
-    }
-
     /// Sets the value of [include_renditions][crate::model::ManifestOptions::include_renditions].
     pub fn set_include_renditions<T, V>(mut self, v: T) -> Self
     where
@@ -2902,6 +2893,15 @@ impl ManifestOptions {
     {
         use std::iter::Iterator;
         self.include_renditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [bitrate_order][crate::model::ManifestOptions::bitrate_order].
+    pub fn set_bitrate_order<T: std::convert::Into<crate::model::manifest_options::OrderPolicy>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.bitrate_order = v.into();
         self
     }
 }
@@ -3499,12 +3499,6 @@ impl ListCdnKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCdnKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cdn_keys][crate::model::ListCdnKeysResponse::cdn_keys].
     pub fn set_cdn_keys<T, V>(mut self, v: T) -> Self
     where
@@ -3513,6 +3507,12 @@ impl ListCdnKeysResponse {
     {
         use std::iter::Iterator;
         self.cdn_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCdnKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3819,12 +3819,6 @@ impl ListVodStitchDetailsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVodStitchDetailsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vod_stitch_details][crate::model::ListVodStitchDetailsResponse::vod_stitch_details].
     pub fn set_vod_stitch_details<T, V>(mut self, v: T) -> Self
     where
@@ -3833,6 +3827,12 @@ impl ListVodStitchDetailsResponse {
     {
         use std::iter::Iterator;
         self.vod_stitch_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVodStitchDetailsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3967,12 +3967,6 @@ impl ListVodAdTagDetailsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVodAdTagDetailsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vod_ad_tag_details][crate::model::ListVodAdTagDetailsResponse::vod_ad_tag_details].
     pub fn set_vod_ad_tag_details<T, V>(mut self, v: T) -> Self
     where
@@ -3981,6 +3975,12 @@ impl ListVodAdTagDetailsResponse {
     {
         use std::iter::Iterator;
         self.vod_ad_tag_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVodAdTagDetailsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4115,12 +4115,6 @@ impl ListLiveAdTagDetailsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLiveAdTagDetailsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [live_ad_tag_details][crate::model::ListLiveAdTagDetailsResponse::live_ad_tag_details].
     pub fn set_live_ad_tag_details<T, V>(mut self, v: T) -> Self
     where
@@ -4129,6 +4123,12 @@ impl ListLiveAdTagDetailsResponse {
     {
         use std::iter::Iterator;
         self.live_ad_tag_details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLiveAdTagDetailsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4401,12 +4401,6 @@ impl ListSlatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSlatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [slates][crate::model::ListSlatesResponse::slates].
     pub fn set_slates<T, V>(mut self, v: T) -> Self
     where
@@ -4415,6 +4409,12 @@ impl ListSlatesResponse {
     {
         use std::iter::Iterator;
         self.slates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSlatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4793,12 +4793,6 @@ impl ListLiveConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLiveConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [live_configs][crate::model::ListLiveConfigsResponse::live_configs].
     pub fn set_live_configs<T, V>(mut self, v: T) -> Self
     where
@@ -4807,6 +4801,12 @@ impl ListLiveConfigsResponse {
     {
         use std::iter::Iterator;
         self.live_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLiveConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5142,12 +5142,6 @@ impl ListVodConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVodConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vod_configs][crate::model::ListVodConfigsResponse::vod_configs].
     pub fn set_vod_configs<T, V>(mut self, v: T) -> Self
     where
@@ -5156,6 +5150,12 @@ impl ListVodConfigsResponse {
     {
         use std::iter::Iterator;
         self.vod_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVodConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -181,6 +181,18 @@ impl Job {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Job::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [error][crate::model::Job::error].
     pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
         mut self,
@@ -214,18 +226,6 @@ impl Job {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Job::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [job_config][crate::model::Job::job_config].
     ///
     /// Note that all the setters affecting `job_config` are mutually
@@ -251,17 +251,6 @@ impl Job {
         })
     }
 
-    /// The value of [job_config][crate::model::Job::job_config]
-    /// if it holds a `Config`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn config(&self) -> std::option::Option<&std::boxed::Box<crate::model::JobConfig>> {
-        #[allow(unreachable_patterns)]
-        self.job_config.as_ref().and_then(|v| match v {
-            crate::model::job::JobConfig::Config(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [job_config][crate::model::Job::job_config]
     /// to hold a `TemplateId`.
     ///
@@ -271,6 +260,17 @@ impl Job {
         self.job_config =
             std::option::Option::Some(crate::model::job::JobConfig::TemplateId(v.into()));
         self
+    }
+
+    /// The value of [job_config][crate::model::Job::job_config]
+    /// if it holds a `Config`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn config(&self) -> std::option::Option<&std::boxed::Box<crate::model::JobConfig>> {
+        #[allow(unreachable_patterns)]
+        self.job_config.as_ref().and_then(|v| match v {
+            crate::model::job::JobConfig::Config(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job_config][crate::model::Job::job_config]
@@ -861,26 +861,6 @@ impl JobConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [output][crate::model::JobConfig::output].
-    pub fn set_output<T: std::convert::Into<std::option::Option<crate::model::Output>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output = v.into();
-        self
-    }
-
-    /// Sets the value of [pubsub_destination][crate::model::JobConfig::pubsub_destination].
-    pub fn set_pubsub_destination<
-        T: std::convert::Into<std::option::Option<crate::model::PubsubDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pubsub_destination = v.into();
-        self
-    }
-
     /// Sets the value of [inputs][crate::model::JobConfig::inputs].
     pub fn set_inputs<T, V>(mut self, v: T) -> Self
     where
@@ -936,6 +916,15 @@ impl JobConfig {
         self
     }
 
+    /// Sets the value of [output][crate::model::JobConfig::output].
+    pub fn set_output<T: std::convert::Into<std::option::Option<crate::model::Output>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output = v.into();
+        self
+    }
+
     /// Sets the value of [ad_breaks][crate::model::JobConfig::ad_breaks].
     pub fn set_ad_breaks<T, V>(mut self, v: T) -> Self
     where
@@ -944,6 +933,17 @@ impl JobConfig {
     {
         use std::iter::Iterator;
         self.ad_breaks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [pubsub_destination][crate::model::JobConfig::pubsub_destination].
+    pub fn set_pubsub_destination<
+        T: std::convert::Into<std::option::Option<crate::model::PubsubDestination>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.pubsub_destination = v.into();
         self
     }
 
@@ -1126,6 +1126,17 @@ impl EditAtom {
         self
     }
 
+    /// Sets the value of [inputs][crate::model::EditAtom::inputs].
+    pub fn set_inputs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.inputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [end_time_offset][crate::model::EditAtom::end_time_offset].
     pub fn set_end_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
@@ -1141,17 +1152,6 @@ impl EditAtom {
         v: T,
     ) -> Self {
         self.start_time_offset = v.into();
-        self
-    }
-
-    /// Sets the value of [inputs][crate::model::EditAtom::inputs].
-    pub fn set_inputs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.inputs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1256,32 +1256,6 @@ impl ElementaryStream {
         })
     }
 
-    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// if it holds a `AudioStream`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn audio_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioStream>> {
-        #[allow(unreachable_patterns)]
-        self.elementary_stream.as_ref().and_then(|v| match v {
-            crate::model::elementary_stream::ElementaryStream::AudioStream(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// if it holds a `TextStream`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::TextStream>> {
-        #[allow(unreachable_patterns)]
-        self.elementary_stream.as_ref().and_then(|v| match v {
-            crate::model::elementary_stream::ElementaryStream::TextStream(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// to hold a `VideoStream`.
     ///
@@ -1297,6 +1271,19 @@ impl ElementaryStream {
         self
     }
 
+    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
+    /// if it holds a `AudioStream`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn audio_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::AudioStream>> {
+        #[allow(unreachable_patterns)]
+        self.elementary_stream.as_ref().and_then(|v| match v {
+            crate::model::elementary_stream::ElementaryStream::AudioStream(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// to hold a `AudioStream`.
     ///
@@ -1310,6 +1297,19 @@ impl ElementaryStream {
             crate::model::elementary_stream::ElementaryStream::AudioStream(v.into()),
         );
         self
+    }
+
+    /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
+    /// if it holds a `TextStream`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text_stream(&self) -> std::option::Option<&std::boxed::Box<crate::model::TextStream>> {
+        #[allow(unreachable_patterns)]
+        self.elementary_stream.as_ref().and_then(|v| match v {
+            crate::model::elementary_stream::ElementaryStream::TextStream(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
@@ -1427,6 +1427,17 @@ impl MuxStream {
         self
     }
 
+    /// Sets the value of [elementary_streams][crate::model::MuxStream::elementary_streams].
+    pub fn set_elementary_streams<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.elementary_streams = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [segment_settings][crate::model::MuxStream::segment_settings].
     pub fn set_segment_settings<
         T: std::convert::Into<std::option::Option<crate::model::SegmentSettings>>,
@@ -1441,17 +1452,6 @@ impl MuxStream {
     /// Sets the value of [encryption_id][crate::model::MuxStream::encryption_id].
     pub fn set_encryption_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.encryption_id = v.into();
-        self
-    }
-
-    /// Sets the value of [elementary_streams][crate::model::MuxStream::elementary_streams].
-    pub fn set_elementary_streams<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.elementary_streams = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2120,6 +2120,18 @@ impl SpriteSheet {
         })
     }
 
+    /// Sets the value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
+    /// to hold a `TotalCount`.
+    ///
+    /// Note that all the setters affecting `extraction_strategy` are
+    /// mutually exclusive.
+    pub fn set_total_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.extraction_strategy = std::option::Option::Some(
+            crate::model::sprite_sheet::ExtractionStrategy::TotalCount(v.into()),
+        );
+        self
+    }
+
     /// The value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
     /// if it holds a `Interval`, `None` if the field is not set or
     /// holds a different branch.
@@ -2131,18 +2143,6 @@ impl SpriteSheet {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
-    /// to hold a `TotalCount`.
-    ///
-    /// Note that all the setters affecting `extraction_strategy` are
-    /// mutually exclusive.
-    pub fn set_total_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.extraction_strategy = std::option::Option::Some(
-            crate::model::sprite_sheet::ExtractionStrategy::TotalCount(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
@@ -2568,36 +2568,6 @@ pub mod overlay {
             })
         }
 
-        /// The value of [animation_type][crate::model::overlay::Animation::animation_type]
-        /// if it holds a `AnimationFade`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn animation_fade(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::overlay::AnimationFade>> {
-            #[allow(unreachable_patterns)]
-            self.animation_type.as_ref().and_then(|v| match v {
-                crate::model::overlay::animation::AnimationType::AnimationFade(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [animation_type][crate::model::overlay::Animation::animation_type]
-        /// if it holds a `AnimationEnd`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn animation_end(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::overlay::AnimationEnd>> {
-            #[allow(unreachable_patterns)]
-            self.animation_type.as_ref().and_then(|v| match v {
-                crate::model::overlay::animation::AnimationType::AnimationEnd(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [animation_type][crate::model::overlay::Animation::animation_type]
         /// to hold a `AnimationStatic`.
         ///
@@ -2615,6 +2585,21 @@ pub mod overlay {
             self
         }
 
+        /// The value of [animation_type][crate::model::overlay::Animation::animation_type]
+        /// if it holds a `AnimationFade`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn animation_fade(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::overlay::AnimationFade>> {
+            #[allow(unreachable_patterns)]
+            self.animation_type.as_ref().and_then(|v| match v {
+                crate::model::overlay::animation::AnimationType::AnimationFade(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [animation_type][crate::model::overlay::Animation::animation_type]
         /// to hold a `AnimationFade`.
         ///
@@ -2630,6 +2615,21 @@ pub mod overlay {
                 crate::model::overlay::animation::AnimationType::AnimationFade(v.into()),
             );
             self
+        }
+
+        /// The value of [animation_type][crate::model::overlay::Animation::animation_type]
+        /// if it holds a `AnimationEnd`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn animation_end(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::overlay::AnimationEnd>> {
+            #[allow(unreachable_patterns)]
+            self.animation_type.as_ref().and_then(|v| match v {
+                crate::model::overlay::animation::AnimationType::AnimationEnd(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [animation_type][crate::model::overlay::Animation::animation_type]
@@ -3344,23 +3344,6 @@ pub mod preprocessing_config {
             })
         }
 
-        /// The value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
-        /// if it holds a `Bwdif`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn bwdif(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::preprocessing_config::deinterlace::BwdifConfig>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.deinterlacing_filter.as_ref().and_then(|v| match v {
-                crate::model::preprocessing_config::deinterlace::DeinterlacingFilter::Bwdif(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
         /// to hold a `Yadif`.
         ///
@@ -3380,6 +3363,23 @@ pub mod preprocessing_config {
                 ),
             );
             self
+        }
+
+        /// The value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
+        /// if it holds a `Bwdif`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn bwdif(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::preprocessing_config::deinterlace::BwdifConfig>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.deinterlacing_filter.as_ref().and_then(|v| match v {
+                crate::model::preprocessing_config::deinterlace::DeinterlacingFilter::Bwdif(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
@@ -3616,32 +3616,6 @@ impl VideoStream {
         })
     }
 
-    /// The value of [codec_settings][crate::model::VideoStream::codec_settings]
-    /// if it holds a `H265`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn h265(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::video_stream::H265CodecSettings>> {
-        #[allow(unreachable_patterns)]
-        self.codec_settings.as_ref().and_then(|v| match v {
-            crate::model::video_stream::CodecSettings::H265(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [codec_settings][crate::model::VideoStream::codec_settings]
-    /// if it holds a `Vp9`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vp9(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::video_stream::Vp9CodecSettings>> {
-        #[allow(unreachable_patterns)]
-        self.codec_settings.as_ref().and_then(|v| match v {
-            crate::model::video_stream::CodecSettings::Vp9(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
     /// to hold a `H264`.
     ///
@@ -3658,6 +3632,19 @@ impl VideoStream {
         self
     }
 
+    /// The value of [codec_settings][crate::model::VideoStream::codec_settings]
+    /// if it holds a `H265`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn h265(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::video_stream::H265CodecSettings>> {
+        #[allow(unreachable_patterns)]
+        self.codec_settings.as_ref().and_then(|v| match v {
+            crate::model::video_stream::CodecSettings::H265(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
     /// to hold a `H265`.
     ///
@@ -3672,6 +3659,19 @@ impl VideoStream {
         self.codec_settings =
             std::option::Option::Some(crate::model::video_stream::CodecSettings::H265(v.into()));
         self
+    }
+
+    /// The value of [codec_settings][crate::model::VideoStream::codec_settings]
+    /// if it holds a `Vp9`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vp9(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::video_stream::Vp9CodecSettings>> {
+        #[allow(unreachable_patterns)]
+        self.codec_settings.as_ref().and_then(|v| match v {
+            crate::model::video_stream::CodecSettings::Vp9(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
@@ -4014,6 +4014,18 @@ pub mod video_stream {
             })
         }
 
+        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
+        /// to hold a `GopFrameCount`.
+        ///
+        /// Note that all the setters affecting `gop_mode` are
+        /// mutually exclusive.
+        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.gop_mode = std::option::Option::Some(
+                crate::model::video_stream::h_264_codec_settings::GopMode::GopFrameCount(v.into()),
+            );
+            self
+        }
+
         /// The value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -4025,18 +4037,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_264_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
@@ -4392,6 +4392,18 @@ pub mod video_stream {
             })
         }
 
+        /// Sets the value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
+        /// to hold a `GopFrameCount`.
+        ///
+        /// Note that all the setters affecting `gop_mode` are
+        /// mutually exclusive.
+        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.gop_mode = std::option::Option::Some(
+                crate::model::video_stream::h_265_codec_settings::GopMode::GopFrameCount(v.into()),
+            );
+            self
+        }
+
         /// The value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -4403,18 +4415,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_265_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
@@ -4647,6 +4647,18 @@ pub mod video_stream {
             })
         }
 
+        /// Sets the value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
+        /// to hold a `GopFrameCount`.
+        ///
+        /// Note that all the setters affecting `gop_mode` are
+        /// mutually exclusive.
+        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.gop_mode = std::option::Option::Some(
+                crate::model::video_stream::vp_9_codec_settings::GopMode::GopFrameCount(v.into()),
+            );
+            self
+        }
+
         /// The value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -4658,18 +4670,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::vp_9_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
@@ -4820,24 +4820,6 @@ impl AudioStream {
         self
     }
 
-    /// Sets the value of [sample_rate_hertz][crate::model::AudioStream::sample_rate_hertz].
-    pub fn set_sample_rate_hertz<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.sample_rate_hertz = v.into();
-        self
-    }
-
-    /// Sets the value of [language_code][crate::model::AudioStream::language_code].
-    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.language_code = v.into();
-        self
-    }
-
-    /// Sets the value of [display_name][crate::model::AudioStream::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
     /// Sets the value of [channel_layout][crate::model::AudioStream::channel_layout].
     pub fn set_channel_layout<T, V>(mut self, v: T) -> Self
     where
@@ -4857,6 +4839,24 @@ impl AudioStream {
     {
         use std::iter::Iterator;
         self.mapping = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [sample_rate_hertz][crate::model::AudioStream::sample_rate_hertz].
+    pub fn set_sample_rate_hertz<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.sample_rate_hertz = v.into();
+        self
+    }
+
+    /// Sets the value of [language_code][crate::model::AudioStream::language_code].
+    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.language_code = v.into();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::AudioStream::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 }
@@ -5012,12 +5012,6 @@ impl TextStream {
         self
     }
 
-    /// Sets the value of [display_name][crate::model::TextStream::display_name].
-    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.display_name = v.into();
-        self
-    }
-
     /// Sets the value of [mapping][crate::model::TextStream::mapping].
     pub fn set_mapping<T, V>(mut self, v: T) -> Self
     where
@@ -5026,6 +5020,12 @@ impl TextStream {
     {
         use std::iter::Iterator;
         self.mapping = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [display_name][crate::model::TextStream::display_name].
+    pub fn set_display_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.display_name = v.into();
         self
     }
 }
@@ -5219,32 +5219,6 @@ impl Encryption {
         })
     }
 
-    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// if it holds a `SampleAes`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sample_aes(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::SampleAesEncryption>> {
-        #[allow(unreachable_patterns)]
-        self.encryption_mode.as_ref().and_then(|v| match v {
-            crate::model::encryption::EncryptionMode::SampleAes(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// if it holds a `MpegCenc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mpeg_cenc(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::MpegCommonEncryption>> {
-        #[allow(unreachable_patterns)]
-        self.encryption_mode.as_ref().and_then(|v| match v {
-            crate::model::encryption::EncryptionMode::MpegCenc(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
     /// to hold a `Aes128`.
     ///
@@ -5259,6 +5233,19 @@ impl Encryption {
         self.encryption_mode =
             std::option::Option::Some(crate::model::encryption::EncryptionMode::Aes128(v.into()));
         self
+    }
+
+    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
+    /// if it holds a `SampleAes`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sample_aes(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::SampleAesEncryption>> {
+        #[allow(unreachable_patterns)]
+        self.encryption_mode.as_ref().and_then(|v| match v {
+            crate::model::encryption::EncryptionMode::SampleAes(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
@@ -5276,6 +5263,19 @@ impl Encryption {
             crate::model::encryption::EncryptionMode::SampleAes(v.into()),
         );
         self
+    }
+
+    /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
+    /// if it holds a `MpegCenc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mpeg_cenc(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::encryption::MpegCommonEncryption>> {
+        #[allow(unreachable_patterns)]
+        self.encryption_mode.as_ref().and_then(|v| match v {
+            crate::model::encryption::EncryptionMode::MpegCenc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
@@ -5892,12 +5892,6 @@ impl ListJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -5906,6 +5900,12 @@ impl ListJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6184,12 +6184,6 @@ impl ListJobTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [job_templates][crate::model::ListJobTemplatesResponse::job_templates].
     pub fn set_job_templates<T, V>(mut self, v: T) -> Self
     where
@@ -6198,6 +6192,12 @@ impl ListJobTemplatesResponse {
     {
         use std::iter::Iterator;
         self.job_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/videointelligence/v1/src/builder.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builder.rs
@@ -152,6 +152,19 @@ pub mod video_intelligence_service {
             self
         }
 
+        /// Sets the value of [features][crate::model::AnnotateVideoRequest::features].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_features<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Feature>,
+        {
+            use std::iter::Iterator;
+            self.0.request.features = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [video_context][crate::model::AnnotateVideoRequest::video_context].
         pub fn set_video_context<T: Into<std::option::Option<crate::model::VideoContext>>>(
             mut self,
@@ -170,19 +183,6 @@ pub mod video_intelligence_service {
         /// Sets the value of [location_id][crate::model::AnnotateVideoRequest::location_id].
         pub fn set_location_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location_id = v.into();
-            self
-        }
-
-        /// Sets the value of [features][crate::model::AnnotateVideoRequest::features].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_features<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::Feature>,
-        {
-            use std::iter::Iterator;
-            self.0.request.features = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -106,6 +106,17 @@ impl AnnotateVideoRequest {
         self
     }
 
+    /// Sets the value of [features][crate::model::AnnotateVideoRequest::features].
+    pub fn set_features<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Feature>,
+    {
+        use std::iter::Iterator;
+        self.features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [video_context][crate::model::AnnotateVideoRequest::video_context].
     pub fn set_video_context<
         T: std::convert::Into<std::option::Option<crate::model::VideoContext>>,
@@ -126,17 +137,6 @@ impl AnnotateVideoRequest {
     /// Sets the value of [location_id][crate::model::AnnotateVideoRequest::location_id].
     pub fn set_location_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location_id = v.into();
-        self
-    }
-
-    /// Sets the value of [features][crate::model::AnnotateVideoRequest::features].
-    pub fn set_features<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Feature>,
-    {
-        use std::iter::Iterator;
-        self.features = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -199,6 +199,17 @@ pub struct VideoContext {
 impl VideoContext {
     pub fn new() -> Self {
         std::default::Default::default()
+    }
+
+    /// Sets the value of [segments][crate::model::VideoContext::segments].
+    pub fn set_segments<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::VideoSegment>,
+    {
+        use std::iter::Iterator;
+        self.segments = v.into_iter().map(|i| i.into()).collect();
+        self
     }
 
     /// Sets the value of [label_detection_config][crate::model::VideoContext::label_detection_config].
@@ -286,17 +297,6 @@ impl VideoContext {
         v: T,
     ) -> Self {
         self.object_tracking_config = v.into();
-        self
-    }
-
-    /// Sets the value of [segments][crate::model::VideoContext::segments].
-    pub fn set_segments<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::VideoSegment>,
-    {
-        use std::iter::Iterator;
-        self.segments = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -640,12 +640,6 @@ impl TextDetectionConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [model][crate::model::TextDetectionConfig::model].
-    pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.model = v.into();
-        self
-    }
-
     /// Sets the value of [language_hints][crate::model::TextDetectionConfig::language_hints].
     pub fn set_language_hints<T, V>(mut self, v: T) -> Self
     where
@@ -654,6 +648,12 @@ impl TextDetectionConfig {
     {
         use std::iter::Iterator;
         self.language_hints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [model][crate::model::TextDetectionConfig::model].
+    pub fn set_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.model = v.into();
         self
     }
 }
@@ -906,12 +906,6 @@ impl LabelAnnotation {
         self
     }
 
-    /// Sets the value of [version][crate::model::LabelAnnotation::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [category_entities][crate::model::LabelAnnotation::category_entities].
     pub fn set_category_entities<T, V>(mut self, v: T) -> Self
     where
@@ -942,6 +936,12 @@ impl LabelAnnotation {
     {
         use std::iter::Iterator;
         self.frames = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::LabelAnnotation::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 }
@@ -1025,12 +1025,6 @@ impl ExplicitContentAnnotation {
         std::default::Default::default()
     }
 
-    /// Sets the value of [version][crate::model::ExplicitContentAnnotation::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [frames][crate::model::ExplicitContentAnnotation::frames].
     pub fn set_frames<T, V>(mut self, v: T) -> Self
     where
@@ -1039,6 +1033,12 @@ impl ExplicitContentAnnotation {
     {
         use std::iter::Iterator;
         self.frames = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::ExplicitContentAnnotation::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 }
@@ -1141,6 +1141,17 @@ impl FaceDetectionAnnotation {
         std::default::Default::default()
     }
 
+    /// Sets the value of [tracks][crate::model::FaceDetectionAnnotation::tracks].
+    pub fn set_tracks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Track>,
+    {
+        use std::iter::Iterator;
+        self.tracks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [thumbnail][crate::model::FaceDetectionAnnotation::thumbnail].
     pub fn set_thumbnail<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.thumbnail = v.into();
@@ -1150,17 +1161,6 @@ impl FaceDetectionAnnotation {
     /// Sets the value of [version][crate::model::FaceDetectionAnnotation::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
-        self
-    }
-
-    /// Sets the value of [tracks][crate::model::FaceDetectionAnnotation::tracks].
-    pub fn set_tracks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Track>,
-    {
-        use std::iter::Iterator;
-        self.tracks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1194,12 +1194,6 @@ impl PersonDetectionAnnotation {
         std::default::Default::default()
     }
 
-    /// Sets the value of [version][crate::model::PersonDetectionAnnotation::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [tracks][crate::model::PersonDetectionAnnotation::tracks].
     pub fn set_tracks<T, V>(mut self, v: T) -> Self
     where
@@ -1208,6 +1202,12 @@ impl PersonDetectionAnnotation {
     {
         use std::iter::Iterator;
         self.tracks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::PersonDetectionAnnotation::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 }
@@ -1280,15 +1280,6 @@ impl FaceFrame {
         std::default::Default::default()
     }
 
-    /// Sets the value of [time_offset][crate::model::FaceFrame::time_offset].
-    pub fn set_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_offset = v.into();
-        self
-    }
-
     /// Sets the value of [normalized_bounding_boxes][crate::model::FaceFrame::normalized_bounding_boxes].
     pub fn set_normalized_bounding_boxes<T, V>(mut self, v: T) -> Self
     where
@@ -1297,6 +1288,15 @@ impl FaceFrame {
     {
         use std::iter::Iterator;
         self.normalized_bounding_boxes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [time_offset][crate::model::FaceFrame::time_offset].
+    pub fn set_time_offset<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.time_offset = v.into();
         self
     }
 }
@@ -1494,12 +1494,6 @@ impl Track {
         self
     }
 
-    /// Sets the value of [confidence][crate::model::Track::confidence].
-    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.confidence = v.into();
-        self
-    }
-
     /// Sets the value of [timestamped_objects][crate::model::Track::timestamped_objects].
     pub fn set_timestamped_objects<T, V>(mut self, v: T) -> Self
     where
@@ -1519,6 +1513,12 @@ impl Track {
     {
         use std::iter::Iterator;
         self.attributes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [confidence][crate::model::Track::confidence].
+    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.confidence = v.into();
         self
     }
 }
@@ -1755,26 +1755,6 @@ impl VideoAnnotationResults {
         self
     }
 
-    /// Sets the value of [explicit_annotation][crate::model::VideoAnnotationResults::explicit_annotation].
-    pub fn set_explicit_annotation<
-        T: std::convert::Into<std::option::Option<crate::model::ExplicitContentAnnotation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.explicit_annotation = v.into();
-        self
-    }
-
-    /// Sets the value of [error][crate::model::VideoAnnotationResults::error].
-    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error = v.into();
-        self
-    }
-
     /// Sets the value of [segment_label_annotations][crate::model::VideoAnnotationResults::segment_label_annotations].
     pub fn set_segment_label_annotations<T, V>(mut self, v: T) -> Self
     where
@@ -1864,6 +1844,17 @@ impl VideoAnnotationResults {
         self
     }
 
+    /// Sets the value of [explicit_annotation][crate::model::VideoAnnotationResults::explicit_annotation].
+    pub fn set_explicit_annotation<
+        T: std::convert::Into<std::option::Option<crate::model::ExplicitContentAnnotation>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.explicit_annotation = v.into();
+        self
+    }
+
     /// Sets the value of [speech_transcriptions][crate::model::VideoAnnotationResults::speech_transcriptions].
     pub fn set_speech_transcriptions<T, V>(mut self, v: T) -> Self
     where
@@ -1916,6 +1907,15 @@ impl VideoAnnotationResults {
     {
         use std::iter::Iterator;
         self.person_detection_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error][crate::model::VideoAnnotationResults::error].
+    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error = v.into();
         self
     }
 }
@@ -2194,9 +2194,31 @@ impl SpeechTranscriptionConfig {
         self
     }
 
+    /// Sets the value of [speech_contexts][crate::model::SpeechTranscriptionConfig::speech_contexts].
+    pub fn set_speech_contexts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SpeechContext>,
+    {
+        use std::iter::Iterator;
+        self.speech_contexts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [enable_automatic_punctuation][crate::model::SpeechTranscriptionConfig::enable_automatic_punctuation].
     pub fn set_enable_automatic_punctuation<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_automatic_punctuation = v.into();
+        self
+    }
+
+    /// Sets the value of [audio_tracks][crate::model::SpeechTranscriptionConfig::audio_tracks].
+    pub fn set_audio_tracks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.audio_tracks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2215,28 +2237,6 @@ impl SpeechTranscriptionConfig {
     /// Sets the value of [enable_word_confidence][crate::model::SpeechTranscriptionConfig::enable_word_confidence].
     pub fn set_enable_word_confidence<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_word_confidence = v.into();
-        self
-    }
-
-    /// Sets the value of [speech_contexts][crate::model::SpeechTranscriptionConfig::speech_contexts].
-    pub fn set_speech_contexts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SpeechContext>,
-    {
-        use std::iter::Iterator;
-        self.speech_contexts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [audio_tracks][crate::model::SpeechTranscriptionConfig::audio_tracks].
-    pub fn set_audio_tracks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.audio_tracks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2318,12 +2318,6 @@ impl SpeechTranscription {
         std::default::Default::default()
     }
 
-    /// Sets the value of [language_code][crate::model::SpeechTranscription::language_code].
-    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.language_code = v.into();
-        self
-    }
-
     /// Sets the value of [alternatives][crate::model::SpeechTranscription::alternatives].
     pub fn set_alternatives<T, V>(mut self, v: T) -> Self
     where
@@ -2332,6 +2326,12 @@ impl SpeechTranscription {
     {
         use std::iter::Iterator;
         self.alternatives = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [language_code][crate::model::SpeechTranscription::language_code].
+    pub fn set_language_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.language_code = v.into();
         self
     }
 }
@@ -2745,12 +2745,6 @@ impl TextAnnotation {
         self
     }
 
-    /// Sets the value of [version][crate::model::TextAnnotation::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [segments][crate::model::TextAnnotation::segments].
     pub fn set_segments<T, V>(mut self, v: T) -> Self
     where
@@ -2759,6 +2753,12 @@ impl TextAnnotation {
     {
         use std::iter::Iterator;
         self.segments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::TextAnnotation::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 }
@@ -2874,12 +2874,6 @@ impl ObjectTrackingAnnotation {
         self
     }
 
-    /// Sets the value of [version][crate::model::ObjectTrackingAnnotation::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
     /// Sets the value of [frames][crate::model::ObjectTrackingAnnotation::frames].
     pub fn set_frames<T, V>(mut self, v: T) -> Self
     where
@@ -2888,6 +2882,12 @@ impl ObjectTrackingAnnotation {
     {
         use std::iter::Iterator;
         self.frames = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [version][crate::model::ObjectTrackingAnnotation::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
         self
     }
 
@@ -2920,19 +2920,6 @@ impl ObjectTrackingAnnotation {
         })
     }
 
-    /// The value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]
-    /// if it holds a `TrackId`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn track_id(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.track_info.as_ref().and_then(|v| match v {
-            crate::model::object_tracking_annotation::TrackInfo::TrackId(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]
     /// to hold a `Segment`.
     ///
@@ -2946,6 +2933,19 @@ impl ObjectTrackingAnnotation {
             crate::model::object_tracking_annotation::TrackInfo::Segment(v.into()),
         );
         self
+    }
+
+    /// The value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]
+    /// if it holds a `TrackId`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn track_id(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.track_info.as_ref().and_then(|v| match v {
+            crate::model::object_tracking_annotation::TrackInfo::TrackId(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -102,12 +102,6 @@ pub mod image_annotator {
                 .map(gax::response::Response::into_body)
         }
 
-        /// Sets the value of [parent][crate::model::BatchAnnotateImagesRequest::parent].
-        pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.parent = v.into();
-            self
-        }
-
         /// Sets the value of [requests][crate::model::BatchAnnotateImagesRequest::requests].
         ///
         /// This is a **required** field for requests.
@@ -118,6 +112,12 @@ pub mod image_annotator {
         {
             use std::iter::Iterator;
             self.0.request.requests = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parent][crate::model::BatchAnnotateImagesRequest::parent].
+        pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.parent = v.into();
             self
         }
 
@@ -174,12 +174,6 @@ pub mod image_annotator {
                 .map(gax::response::Response::into_body)
         }
 
-        /// Sets the value of [parent][crate::model::BatchAnnotateFilesRequest::parent].
-        pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.parent = v.into();
-            self
-        }
-
         /// Sets the value of [requests][crate::model::BatchAnnotateFilesRequest::requests].
         ///
         /// This is a **required** field for requests.
@@ -190,6 +184,12 @@ pub mod image_annotator {
         {
             use std::iter::Iterator;
             self.0.request.requests = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parent][crate::model::BatchAnnotateFilesRequest::parent].
+        pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.parent = v.into();
             self
         }
 
@@ -291,6 +291,19 @@ pub mod image_annotator {
             lro::new_poller(polling_error_policy, polling_backoff_policy, start, query)
         }
 
+        /// Sets the value of [requests][crate::model::AsyncBatchAnnotateImagesRequest::requests].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_requests<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::AnnotateImageRequest>,
+        {
+            use std::iter::Iterator;
+            self.0.request.requests = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [output_config][crate::model::AsyncBatchAnnotateImagesRequest::output_config].
         ///
         /// This is a **required** field for requests.
@@ -305,19 +318,6 @@ pub mod image_annotator {
         /// Sets the value of [parent][crate::model::AsyncBatchAnnotateImagesRequest::parent].
         pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.parent = v.into();
-            self
-        }
-
-        /// Sets the value of [requests][crate::model::AsyncBatchAnnotateImagesRequest::requests].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_requests<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::AnnotateImageRequest>,
-        {
-            use std::iter::Iterator;
-            self.0.request.requests = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -419,12 +419,6 @@ pub mod image_annotator {
             lro::new_poller(polling_error_policy, polling_backoff_policy, start, query)
         }
 
-        /// Sets the value of [parent][crate::model::AsyncBatchAnnotateFilesRequest::parent].
-        pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.parent = v.into();
-            self
-        }
-
         /// Sets the value of [requests][crate::model::AsyncBatchAnnotateFilesRequest::requests].
         ///
         /// This is a **required** field for requests.
@@ -435,6 +429,12 @@ pub mod image_annotator {
         {
             use std::iter::Iterator;
             self.0.request.requests = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [parent][crate::model::AsyncBatchAnnotateFilesRequest::parent].
+        pub fn set_parent<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.parent = v.into();
             self
         }
 

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -721,6 +721,17 @@ impl FaceAnnotation {
         self
     }
 
+    /// Sets the value of [landmarks][crate::model::FaceAnnotation::landmarks].
+    pub fn set_landmarks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::face_annotation::Landmark>,
+    {
+        use std::iter::Iterator;
+        self.landmarks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [roll_angle][crate::model::FaceAnnotation::roll_angle].
     pub fn set_roll_angle<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.roll_angle = v.into();
@@ -811,17 +822,6 @@ impl FaceAnnotation {
         v: T,
     ) -> Self {
         self.headwear_likelihood = v.into();
-        self
-    }
-
-    /// Sets the value of [landmarks][crate::model::FaceAnnotation::landmarks].
-    pub fn set_landmarks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::face_annotation::Landmark>,
-    {
-        use std::iter::Iterator;
-        self.landmarks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2140,6 +2140,17 @@ impl ImageContext {
         self
     }
 
+    /// Sets the value of [language_hints][crate::model::ImageContext::language_hints].
+    pub fn set_language_hints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.language_hints = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [crop_hints_params][crate::model::ImageContext::crop_hints_params].
     pub fn set_crop_hints_params<
         T: std::convert::Into<std::option::Option<crate::model::CropHintsParams>>,
@@ -2181,17 +2192,6 @@ impl ImageContext {
         v: T,
     ) -> Self {
         self.text_detection_params = v.into();
-        self
-    }
-
-    /// Sets the value of [language_hints][crate::model::ImageContext::language_hints].
-    pub fn set_language_hints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.language_hints = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2239,17 +2239,6 @@ impl AnnotateImageRequest {
         self
     }
 
-    /// Sets the value of [image_context][crate::model::AnnotateImageRequest::image_context].
-    pub fn set_image_context<
-        T: std::convert::Into<std::option::Option<crate::model::ImageContext>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.image_context = v.into();
-        self
-    }
-
     /// Sets the value of [features][crate::model::AnnotateImageRequest::features].
     pub fn set_features<T, V>(mut self, v: T) -> Self
     where
@@ -2258,6 +2247,17 @@ impl AnnotateImageRequest {
     {
         use std::iter::Iterator;
         self.features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [image_context][crate::model::AnnotateImageRequest::image_context].
+    pub fn set_image_context<
+        T: std::convert::Into<std::option::Option<crate::model::ImageContext>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.image_context = v.into();
         self
     }
 }
@@ -2390,6 +2390,72 @@ impl AnnotateImageResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [face_annotations][crate::model::AnnotateImageResponse::face_annotations].
+    pub fn set_face_annotations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FaceAnnotation>,
+    {
+        use std::iter::Iterator;
+        self.face_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [landmark_annotations][crate::model::AnnotateImageResponse::landmark_annotations].
+    pub fn set_landmark_annotations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EntityAnnotation>,
+    {
+        use std::iter::Iterator;
+        self.landmark_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [logo_annotations][crate::model::AnnotateImageResponse::logo_annotations].
+    pub fn set_logo_annotations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EntityAnnotation>,
+    {
+        use std::iter::Iterator;
+        self.logo_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [label_annotations][crate::model::AnnotateImageResponse::label_annotations].
+    pub fn set_label_annotations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EntityAnnotation>,
+    {
+        use std::iter::Iterator;
+        self.label_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [localized_object_annotations][crate::model::AnnotateImageResponse::localized_object_annotations].
+    pub fn set_localized_object_annotations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LocalizedObjectAnnotation>,
+    {
+        use std::iter::Iterator;
+        self.localized_object_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [text_annotations][crate::model::AnnotateImageResponse::text_annotations].
+    pub fn set_text_annotations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EntityAnnotation>,
+    {
+        use std::iter::Iterator;
+        self.text_annotations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [full_text_annotation][crate::model::AnnotateImageResponse::full_text_annotation].
     pub fn set_full_text_annotation<
         T: std::convert::Into<std::option::Option<crate::model::TextAnnotation>>,
@@ -2475,72 +2541,6 @@ impl AnnotateImageResponse {
         self.context = v.into();
         self
     }
-
-    /// Sets the value of [face_annotations][crate::model::AnnotateImageResponse::face_annotations].
-    pub fn set_face_annotations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FaceAnnotation>,
-    {
-        use std::iter::Iterator;
-        self.face_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [landmark_annotations][crate::model::AnnotateImageResponse::landmark_annotations].
-    pub fn set_landmark_annotations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EntityAnnotation>,
-    {
-        use std::iter::Iterator;
-        self.landmark_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [logo_annotations][crate::model::AnnotateImageResponse::logo_annotations].
-    pub fn set_logo_annotations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EntityAnnotation>,
-    {
-        use std::iter::Iterator;
-        self.logo_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [label_annotations][crate::model::AnnotateImageResponse::label_annotations].
-    pub fn set_label_annotations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EntityAnnotation>,
-    {
-        use std::iter::Iterator;
-        self.label_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [localized_object_annotations][crate::model::AnnotateImageResponse::localized_object_annotations].
-    pub fn set_localized_object_annotations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LocalizedObjectAnnotation>,
-    {
-        use std::iter::Iterator;
-        self.localized_object_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [text_annotations][crate::model::AnnotateImageResponse::text_annotations].
-    pub fn set_text_annotations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EntityAnnotation>,
-    {
-        use std::iter::Iterator;
-        self.text_annotations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
 }
 
 impl wkt::message::Message for AnnotateImageResponse {
@@ -2592,12 +2592,6 @@ impl BatchAnnotateImagesRequest {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parent][crate::model::BatchAnnotateImagesRequest::parent].
-    pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.parent = v.into();
-        self
-    }
-
     /// Sets the value of [requests][crate::model::BatchAnnotateImagesRequest::requests].
     pub fn set_requests<T, V>(mut self, v: T) -> Self
     where
@@ -2606,6 +2600,12 @@ impl BatchAnnotateImagesRequest {
     {
         use std::iter::Iterator;
         self.requests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parent][crate::model::BatchAnnotateImagesRequest::parent].
+    pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.parent = v.into();
         self
     }
 
@@ -2720,17 +2720,6 @@ impl AnnotateFileRequest {
         self
     }
 
-    /// Sets the value of [image_context][crate::model::AnnotateFileRequest::image_context].
-    pub fn set_image_context<
-        T: std::convert::Into<std::option::Option<crate::model::ImageContext>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.image_context = v.into();
-        self
-    }
-
     /// Sets the value of [features][crate::model::AnnotateFileRequest::features].
     pub fn set_features<T, V>(mut self, v: T) -> Self
     where
@@ -2739,6 +2728,17 @@ impl AnnotateFileRequest {
     {
         use std::iter::Iterator;
         self.features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [image_context][crate::model::AnnotateFileRequest::image_context].
+    pub fn set_image_context<
+        T: std::convert::Into<std::option::Option<crate::model::ImageContext>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.image_context = v.into();
         self
     }
 
@@ -2805,6 +2805,17 @@ impl AnnotateFileResponse {
         self
     }
 
+    /// Sets the value of [responses][crate::model::AnnotateFileResponse::responses].
+    pub fn set_responses<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AnnotateImageResponse>,
+    {
+        use std::iter::Iterator;
+        self.responses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [total_pages][crate::model::AnnotateFileResponse::total_pages].
     pub fn set_total_pages<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_pages = v.into();
@@ -2817,17 +2828,6 @@ impl AnnotateFileResponse {
         v: T,
     ) -> Self {
         self.error = v.into();
-        self
-    }
-
-    /// Sets the value of [responses][crate::model::AnnotateFileResponse::responses].
-    pub fn set_responses<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AnnotateImageResponse>,
-    {
-        use std::iter::Iterator;
-        self.responses = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2882,12 +2882,6 @@ impl BatchAnnotateFilesRequest {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parent][crate::model::BatchAnnotateFilesRequest::parent].
-    pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.parent = v.into();
-        self
-    }
-
     /// Sets the value of [requests][crate::model::BatchAnnotateFilesRequest::requests].
     pub fn set_requests<T, V>(mut self, v: T) -> Self
     where
@@ -2896,6 +2890,12 @@ impl BatchAnnotateFilesRequest {
     {
         use std::iter::Iterator;
         self.requests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parent][crate::model::BatchAnnotateFilesRequest::parent].
+    pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.parent = v.into();
         self
     }
 
@@ -2998,6 +2998,17 @@ impl AsyncAnnotateFileRequest {
         self
     }
 
+    /// Sets the value of [features][crate::model::AsyncAnnotateFileRequest::features].
+    pub fn set_features<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Feature>,
+    {
+        use std::iter::Iterator;
+        self.features = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [image_context][crate::model::AsyncAnnotateFileRequest::image_context].
     pub fn set_image_context<
         T: std::convert::Into<std::option::Option<crate::model::ImageContext>>,
@@ -3017,17 +3028,6 @@ impl AsyncAnnotateFileRequest {
         v: T,
     ) -> Self {
         self.output_config = v.into();
-        self
-    }
-
-    /// Sets the value of [features][crate::model::AsyncAnnotateFileRequest::features].
-    pub fn set_features<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Feature>,
-    {
-        use std::iter::Iterator;
-        self.features = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3122,6 +3122,17 @@ impl AsyncBatchAnnotateImagesRequest {
         std::default::Default::default()
     }
 
+    /// Sets the value of [requests][crate::model::AsyncBatchAnnotateImagesRequest::requests].
+    pub fn set_requests<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AnnotateImageRequest>,
+    {
+        use std::iter::Iterator;
+        self.requests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [output_config][crate::model::AsyncBatchAnnotateImagesRequest::output_config].
     pub fn set_output_config<
         T: std::convert::Into<std::option::Option<crate::model::OutputConfig>>,
@@ -3136,17 +3147,6 @@ impl AsyncBatchAnnotateImagesRequest {
     /// Sets the value of [parent][crate::model::AsyncBatchAnnotateImagesRequest::parent].
     pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parent = v.into();
-        self
-    }
-
-    /// Sets the value of [requests][crate::model::AsyncBatchAnnotateImagesRequest::requests].
-    pub fn set_requests<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AnnotateImageRequest>,
-    {
-        use std::iter::Iterator;
-        self.requests = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -3250,12 +3250,6 @@ impl AsyncBatchAnnotateFilesRequest {
         std::default::Default::default()
     }
 
-    /// Sets the value of [parent][crate::model::AsyncBatchAnnotateFilesRequest::parent].
-    pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.parent = v.into();
-        self
-    }
-
     /// Sets the value of [requests][crate::model::AsyncBatchAnnotateFilesRequest::requests].
     pub fn set_requests<T, V>(mut self, v: T) -> Self
     where
@@ -3264,6 +3258,12 @@ impl AsyncBatchAnnotateFilesRequest {
     {
         use std::iter::Iterator;
         self.requests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [parent][crate::model::AsyncBatchAnnotateFilesRequest::parent].
+    pub fn set_parent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.parent = v.into();
         self
     }
 
@@ -3810,12 +3810,6 @@ impl ProductSearchParams {
         self
     }
 
-    /// Sets the value of [filter][crate::model::ProductSearchParams::filter].
-    pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.filter = v.into();
-        self
-    }
-
     /// Sets the value of [product_categories][crate::model::ProductSearchParams::product_categories].
     pub fn set_product_categories<T, V>(mut self, v: T) -> Self
     where
@@ -3824,6 +3818,12 @@ impl ProductSearchParams {
     {
         use std::iter::Iterator;
         self.product_categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [filter][crate::model::ProductSearchParams::filter].
+    pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.filter = v.into();
         self
     }
 }
@@ -4552,12 +4552,6 @@ impl ListProductsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProductsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [products][crate::model::ListProductsResponse::products].
     pub fn set_products<T, V>(mut self, v: T) -> Self
     where
@@ -4566,6 +4560,12 @@ impl ListProductsResponse {
     {
         use std::iter::Iterator;
         self.products = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProductsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4853,12 +4853,6 @@ impl ListProductSetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProductSetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [product_sets][crate::model::ListProductSetsResponse::product_sets].
     pub fn set_product_sets<T, V>(mut self, v: T) -> Self
     where
@@ -4867,6 +4861,12 @@ impl ListProductSetsResponse {
     {
         use std::iter::Iterator;
         self.product_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProductSetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5167,6 +5167,17 @@ impl ListReferenceImagesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [reference_images][crate::model::ListReferenceImagesResponse::reference_images].
+    pub fn set_reference_images<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReferenceImage>,
+    {
+        use std::iter::Iterator;
+        self.reference_images = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::ListReferenceImagesResponse::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -5176,17 +5187,6 @@ impl ListReferenceImagesResponse {
     /// Sets the value of [next_page_token][crate::model::ListReferenceImagesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [reference_images][crate::model::ListReferenceImagesResponse::reference_images].
-    pub fn set_reference_images<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ReferenceImage>,
-    {
-        use std::iter::Iterator;
-        self.reference_images = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5457,12 +5457,6 @@ impl ListProductsInProductSetResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProductsInProductSetResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [products][crate::model::ListProductsInProductSetResponse::products].
     pub fn set_products<T, V>(mut self, v: T) -> Self
     where
@@ -5471,6 +5465,12 @@ impl ListProductsInProductSetResponse {
     {
         use std::iter::Iterator;
         self.products = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProductsInProductSetResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6127,19 +6127,6 @@ impl PurgeProductsRequest {
         })
     }
 
-    /// The value of [target][crate::model::PurgeProductsRequest::target]
-    /// if it holds a `DeleteOrphanProducts`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_orphan_products(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::purge_products_request::Target::DeleteOrphanProducts(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::PurgeProductsRequest::target]
     /// to hold a `ProductSetPurgeConfig`.
     ///
@@ -6155,6 +6142,19 @@ impl PurgeProductsRequest {
             crate::model::purge_products_request::Target::ProductSetPurgeConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [target][crate::model::PurgeProductsRequest::target]
+    /// if it holds a `DeleteOrphanProducts`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_orphan_products(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::purge_products_request::Target::DeleteOrphanProducts(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::PurgeProductsRequest::target]
@@ -6226,12 +6226,6 @@ impl TextAnnotation {
         std::default::Default::default()
     }
 
-    /// Sets the value of [text][crate::model::TextAnnotation::text].
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.text = v.into();
-        self
-    }
-
     /// Sets the value of [pages][crate::model::TextAnnotation::pages].
     pub fn set_pages<T, V>(mut self, v: T) -> Self
     where
@@ -6240,6 +6234,12 @@ impl TextAnnotation {
     {
         use std::iter::Iterator;
         self.pages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [text][crate::model::TextAnnotation::text].
+    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.text = v.into();
         self
     }
 }
@@ -6535,17 +6535,6 @@ pub mod text_annotation {
             std::default::Default::default()
         }
 
-        /// Sets the value of [detected_break][crate::model::text_annotation::TextProperty::detected_break].
-        pub fn set_detected_break<
-            T: std::convert::Into<std::option::Option<crate::model::text_annotation::DetectedBreak>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.detected_break = v.into();
-            self
-        }
-
         /// Sets the value of [detected_languages][crate::model::text_annotation::TextProperty::detected_languages].
         pub fn set_detected_languages<T, V>(mut self, v: T) -> Self
         where
@@ -6554,6 +6543,17 @@ pub mod text_annotation {
         {
             use std::iter::Iterator;
             self.detected_languages = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [detected_break][crate::model::text_annotation::TextProperty::detected_break].
+        pub fn set_detected_break<
+            T: std::convert::Into<std::option::Option<crate::model::text_annotation::DetectedBreak>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.detected_break = v.into();
             self
         }
     }
@@ -6625,12 +6625,6 @@ impl Page {
         self
     }
 
-    /// Sets the value of [confidence][crate::model::Page::confidence].
-    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.confidence = v.into();
-        self
-    }
-
     /// Sets the value of [blocks][crate::model::Page::blocks].
     pub fn set_blocks<T, V>(mut self, v: T) -> Self
     where
@@ -6639,6 +6633,12 @@ impl Page {
     {
         use std::iter::Iterator;
         self.blocks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [confidence][crate::model::Page::confidence].
+    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.confidence = v.into();
         self
     }
 }
@@ -6729,6 +6729,17 @@ impl Block {
         self
     }
 
+    /// Sets the value of [paragraphs][crate::model::Block::paragraphs].
+    pub fn set_paragraphs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Paragraph>,
+    {
+        use std::iter::Iterator;
+        self.paragraphs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [block_type][crate::model::Block::block_type].
     pub fn set_block_type<T: std::convert::Into<crate::model::block::BlockType>>(
         mut self,
@@ -6741,17 +6752,6 @@ impl Block {
     /// Sets the value of [confidence][crate::model::Block::confidence].
     pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
         self.confidence = v.into();
-        self
-    }
-
-    /// Sets the value of [paragraphs][crate::model::Block::paragraphs].
-    pub fn set_paragraphs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Paragraph>,
-    {
-        use std::iter::Iterator;
-        self.paragraphs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6989,12 +6989,6 @@ impl Paragraph {
         self
     }
 
-    /// Sets the value of [confidence][crate::model::Paragraph::confidence].
-    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.confidence = v.into();
-        self
-    }
-
     /// Sets the value of [words][crate::model::Paragraph::words].
     pub fn set_words<T, V>(mut self, v: T) -> Self
     where
@@ -7003,6 +6997,12 @@ impl Paragraph {
     {
         use std::iter::Iterator;
         self.words = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [confidence][crate::model::Paragraph::confidence].
+    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.confidence = v.into();
         self
     }
 }
@@ -7082,12 +7082,6 @@ impl Word {
         self
     }
 
-    /// Sets the value of [confidence][crate::model::Word::confidence].
-    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.confidence = v.into();
-        self
-    }
-
     /// Sets the value of [symbols][crate::model::Word::symbols].
     pub fn set_symbols<T, V>(mut self, v: T) -> Self
     where
@@ -7096,6 +7090,12 @@ impl Word {
     {
         use std::iter::Iterator;
         self.symbols = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [confidence][crate::model::Word::confidence].
+    pub fn set_confidence<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+        self.confidence = v.into();
         self
     }
 }

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -134,6 +134,17 @@ impl ReplicationCycle {
         self
     }
 
+    /// Sets the value of [steps][crate::model::ReplicationCycle::steps].
+    pub fn set_steps<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::CycleStep>,
+    {
+        use std::iter::Iterator;
+        self.steps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::ReplicationCycle::state].
     pub fn set_state<T: std::convert::Into<crate::model::replication_cycle::State>>(
         mut self,
@@ -149,17 +160,6 @@ impl ReplicationCycle {
         v: T,
     ) -> Self {
         self.error = v.into();
-        self
-    }
-
-    /// Sets the value of [steps][crate::model::ReplicationCycle::steps].
-    pub fn set_steps<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::CycleStep>,
-    {
-        use std::iter::Iterator;
-        self.steps = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -394,32 +394,6 @@ impl CycleStep {
         })
     }
 
-    /// The value of [step][crate::model::CycleStep::step]
-    /// if it holds a `Replicating`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn replicating(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplicatingStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::cycle_step::Step::Replicating(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step][crate::model::CycleStep::step]
-    /// if it holds a `PostProcessing`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn post_processing(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PostProcessingStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::cycle_step::Step::PostProcessing(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [step][crate::model::CycleStep::step]
     /// to hold a `InitializingReplication`.
     ///
@@ -437,6 +411,19 @@ impl CycleStep {
         self
     }
 
+    /// The value of [step][crate::model::CycleStep::step]
+    /// if it holds a `Replicating`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn replicating(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplicatingStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::cycle_step::Step::Replicating(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step][crate::model::CycleStep::step]
     /// to hold a `Replicating`.
     ///
@@ -451,6 +438,19 @@ impl CycleStep {
         self.step =
             std::option::Option::Some(crate::model::cycle_step::Step::Replicating(v.into()));
         self
+    }
+
+    /// The value of [step][crate::model::CycleStep::step]
+    /// if it holds a `PostProcessing`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn post_processing(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PostProcessingStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::cycle_step::Step::PostProcessing(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step][crate::model::CycleStep::step]
@@ -853,12 +853,15 @@ impl MigratingVm {
         self
     }
 
-    /// Sets the value of [error][crate::model::MigratingVm::error].
-    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error = v.into();
+    /// Sets the value of [labels][crate::model::MigratingVm::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -873,6 +876,15 @@ impl MigratingVm {
         self
     }
 
+    /// Sets the value of [error][crate::model::MigratingVm::error].
+    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error = v.into();
+        self
+    }
+
     /// Sets the value of [recent_cutover_jobs][crate::model::MigratingVm::recent_cutover_jobs].
     pub fn set_recent_cutover_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -881,18 +893,6 @@ impl MigratingVm {
     {
         use std::iter::Iterator;
         self.recent_cutover_jobs = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::MigratingVm::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -1647,34 +1647,6 @@ impl CloneStep {
         })
     }
 
-    /// The value of [step][crate::model::CloneStep::step]
-    /// if it holds a `PreparingVmDisks`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn preparing_vm_disks(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PreparingVMDisksStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::clone_step::Step::PreparingVmDisks(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step][crate::model::CloneStep::step]
-    /// if it holds a `InstantiatingMigratedVm`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn instantiating_migrated_vm(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InstantiatingMigratedVMStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::clone_step::Step::InstantiatingMigratedVm(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [step][crate::model::CloneStep::step]
     /// to hold a `AdaptingOs`.
     ///
@@ -1686,6 +1658,19 @@ impl CloneStep {
     ) -> Self {
         self.step = std::option::Option::Some(crate::model::clone_step::Step::AdaptingOs(v.into()));
         self
+    }
+
+    /// The value of [step][crate::model::CloneStep::step]
+    /// if it holds a `PreparingVmDisks`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn preparing_vm_disks(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PreparingVMDisksStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::clone_step::Step::PreparingVmDisks(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step][crate::model::CloneStep::step]
@@ -1702,6 +1687,21 @@ impl CloneStep {
         self.step =
             std::option::Option::Some(crate::model::clone_step::Step::PreparingVmDisks(v.into()));
         self
+    }
+
+    /// The value of [step][crate::model::CloneStep::step]
+    /// if it holds a `InstantiatingMigratedVm`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn instantiating_migrated_vm(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InstantiatingMigratedVMStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::clone_step::Step::InstantiatingMigratedVm(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step][crate::model::CloneStep::step]
@@ -2254,62 +2254,6 @@ impl CutoverStep {
         })
     }
 
-    /// The value of [step][crate::model::CutoverStep::step]
-    /// if it holds a `ShuttingDownSourceVm`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn shutting_down_source_vm(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ShuttingDownSourceVMStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::cutover_step::Step::ShuttingDownSourceVm(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step][crate::model::CutoverStep::step]
-    /// if it holds a `FinalSync`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn final_sync(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplicationCycle>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::cutover_step::Step::FinalSync(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step][crate::model::CutoverStep::step]
-    /// if it holds a `PreparingVmDisks`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn preparing_vm_disks(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PreparingVMDisksStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::cutover_step::Step::PreparingVmDisks(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [step][crate::model::CutoverStep::step]
-    /// if it holds a `InstantiatingMigratedVm`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn instantiating_migrated_vm(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InstantiatingMigratedVMStep>> {
-        #[allow(unreachable_patterns)]
-        self.step.as_ref().and_then(|v| match v {
-            crate::model::cutover_step::Step::InstantiatingMigratedVm(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [step][crate::model::CutoverStep::step]
     /// to hold a `PreviousReplicationCycle`.
     ///
@@ -2325,6 +2269,21 @@ impl CutoverStep {
             crate::model::cutover_step::Step::PreviousReplicationCycle(v.into()),
         );
         self
+    }
+
+    /// The value of [step][crate::model::CutoverStep::step]
+    /// if it holds a `ShuttingDownSourceVm`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn shutting_down_source_vm(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ShuttingDownSourceVMStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::cutover_step::Step::ShuttingDownSourceVm(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step][crate::model::CutoverStep::step]
@@ -2344,6 +2303,19 @@ impl CutoverStep {
         self
     }
 
+    /// The value of [step][crate::model::CutoverStep::step]
+    /// if it holds a `FinalSync`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn final_sync(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplicationCycle>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::cutover_step::Step::FinalSync(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step][crate::model::CutoverStep::step]
     /// to hold a `FinalSync`.
     ///
@@ -2360,6 +2332,19 @@ impl CutoverStep {
         self
     }
 
+    /// The value of [step][crate::model::CutoverStep::step]
+    /// if it holds a `PreparingVmDisks`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn preparing_vm_disks(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PreparingVMDisksStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::cutover_step::Step::PreparingVmDisks(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [step][crate::model::CutoverStep::step]
     /// to hold a `PreparingVmDisks`.
     ///
@@ -2374,6 +2359,21 @@ impl CutoverStep {
         self.step =
             std::option::Option::Some(crate::model::cutover_step::Step::PreparingVmDisks(v.into()));
         self
+    }
+
+    /// The value of [step][crate::model::CutoverStep::step]
+    /// if it holds a `InstantiatingMigratedVm`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn instantiating_migrated_vm(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InstantiatingMigratedVMStep>> {
+        #[allow(unreachable_patterns)]
+        self.step.as_ref().and_then(|v| match v {
+            crate::model::cutover_step::Step::InstantiatingMigratedVm(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step][crate::model::CutoverStep::step]
@@ -2682,12 +2682,6 @@ impl ListCloneJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCloneJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clone_jobs][crate::model::ListCloneJobsResponse::clone_jobs].
     pub fn set_clone_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -2696,6 +2690,12 @@ impl ListCloneJobsResponse {
     {
         use std::iter::Iterator;
         self.clone_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCloneJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2826,12 +2826,6 @@ impl Source {
         self
     }
 
-    /// Sets the value of [description][crate::model::Source::description].
-    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.description = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Source::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -2841,6 +2835,12 @@ impl Source {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [description][crate::model::Source::description].
+    pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.description = v.into();
         self
     }
 
@@ -2871,17 +2871,6 @@ impl Source {
         })
     }
 
-    /// The value of [source_details][crate::model::Source::source_details]
-    /// if it holds a `Aws`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsSourceDetails>> {
-        #[allow(unreachable_patterns)]
-        self.source_details.as_ref().and_then(|v| match v {
-            crate::model::source::SourceDetails::Aws(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_details][crate::model::Source::source_details]
     /// to hold a `Vmware`.
     ///
@@ -2894,6 +2883,17 @@ impl Source {
         self.source_details =
             std::option::Option::Some(crate::model::source::SourceDetails::Vmware(v.into()));
         self
+    }
+
+    /// The value of [source_details][crate::model::Source::source_details]
+    /// if it holds a `Aws`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsSourceDetails>> {
+        #[allow(unreachable_patterns)]
+        self.source_details.as_ref().and_then(|v| match v {
+            crate::model::source::SourceDetails::Aws(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_details][crate::model::Source::source_details]
@@ -3074,12 +3074,6 @@ impl AwsSourceDetails {
         self
     }
 
-    /// Sets the value of [public_ip][crate::model::AwsSourceDetails::public_ip].
-    pub fn set_public_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.public_ip = v.into();
-        self
-    }
-
     /// Sets the value of [inventory_tag_list][crate::model::AwsSourceDetails::inventory_tag_list].
     pub fn set_inventory_tag_list<T, V>(mut self, v: T) -> Self
     where
@@ -3112,6 +3106,12 @@ impl AwsSourceDetails {
         use std::iter::Iterator;
         self.migration_resources_user_tags =
             v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [public_ip][crate::model::AwsSourceDetails::public_ip].
+    pub fn set_public_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.public_ip = v.into();
         self
     }
 
@@ -4233,12 +4233,6 @@ impl ListSourcesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSourcesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sources][crate::model::ListSourcesResponse::sources].
     pub fn set_sources<T, V>(mut self, v: T) -> Self
     where
@@ -4247,6 +4241,12 @@ impl ListSourcesResponse {
     {
         use std::iter::Iterator;
         self.sources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSourcesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5169,6 +5169,29 @@ impl AwsVmDetails {
         self
     }
 
+    /// Sets the value of [security_groups][crate::model::AwsVmDetails::security_groups].
+    pub fn set_security_groups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AwsSecurityGroup>,
+    {
+        use std::iter::Iterator;
+        self.security_groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::AwsVmDetails::tags].
+    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [zone][crate::model::AwsVmDetails::zone].
     pub fn set_zone<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.zone = v.into();
@@ -5192,29 +5215,6 @@ impl AwsVmDetails {
         v: T,
     ) -> Self {
         self.architecture = v.into();
-        self
-    }
-
-    /// Sets the value of [security_groups][crate::model::AwsVmDetails::security_groups].
-    pub fn set_security_groups<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AwsSecurityGroup>,
-    {
-        use std::iter::Iterator;
-        self.security_groups = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::AwsVmDetails::tags].
-    pub fn set_tags<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5970,19 +5970,6 @@ impl FetchInventoryResponse {
         })
     }
 
-    /// The value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
-    /// if it holds a `AwsVms`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws_vms(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsVmsDetails>> {
-        #[allow(unreachable_patterns)]
-        self.source_vms.as_ref().and_then(|v| match v {
-            crate::model::fetch_inventory_response::SourceVms::AwsVms(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
     /// to hold a `VmwareVms`.
     ///
@@ -5998,6 +5985,19 @@ impl FetchInventoryResponse {
             crate::model::fetch_inventory_response::SourceVms::VmwareVms(v.into()),
         );
         self
+    }
+
+    /// The value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
+    /// if it holds a `AwsVms`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws_vms(&self) -> std::option::Option<&std::boxed::Box<crate::model::AwsVmsDetails>> {
+        #[allow(unreachable_patterns)]
+        self.source_vms.as_ref().and_then(|v| match v {
+            crate::model::fetch_inventory_response::SourceVms::AwsVms(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
@@ -6812,12 +6812,6 @@ impl ListUtilizationReportsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUtilizationReportsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [utilization_reports][crate::model::ListUtilizationReportsResponse::utilization_reports].
     pub fn set_utilization_reports<T, V>(mut self, v: T) -> Self
     where
@@ -6826,6 +6820,12 @@ impl ListUtilizationReportsResponse {
     {
         use std::iter::Iterator;
         self.utilization_reports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUtilizationReportsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7075,12 +7075,6 @@ impl ListDatacenterConnectorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatacenterConnectorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [datacenter_connectors][crate::model::ListDatacenterConnectorsResponse::datacenter_connectors].
     pub fn set_datacenter_connectors<T, V>(mut self, v: T) -> Self
     where
@@ -7089,6 +7083,12 @@ impl ListDatacenterConnectorsResponse {
     {
         use std::iter::Iterator;
         self.datacenter_connectors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatacenterConnectorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7574,6 +7574,28 @@ impl ComputeEngineTargetDefaults {
         self
     }
 
+    /// Sets the value of [network_tags][crate::model::ComputeEngineTargetDefaults::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [network_interfaces][crate::model::ComputeEngineTargetDefaults::network_interfaces].
+    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkInterface>,
+    {
+        use std::iter::Iterator;
+        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::ComputeEngineTargetDefaults::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
@@ -7586,6 +7608,18 @@ impl ComputeEngineTargetDefaults {
         v: T,
     ) -> Self {
         self.disk_type = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::ComputeEngineTargetDefaults::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -7635,31 +7669,15 @@ impl ComputeEngineTargetDefaults {
         self
     }
 
-    /// Sets the value of [hostname][crate::model::ComputeEngineTargetDefaults::hostname].
-    pub fn set_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.hostname = v.into();
-        self
-    }
-
-    /// Sets the value of [network_tags][crate::model::ComputeEngineTargetDefaults::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    /// Sets the value of [metadata][crate::model::ComputeEngineTargetDefaults::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
-        T: std::iter::IntoIterator<Item = V>,
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
         V: std::convert::Into<std::string::String>,
     {
         use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [network_interfaces][crate::model::ComputeEngineTargetDefaults::network_interfaces].
-    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkInterface>,
-    {
-        use std::iter::Iterator;
-        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -7674,27 +7692,9 @@ impl ComputeEngineTargetDefaults {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ComputeEngineTargetDefaults::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::ComputeEngineTargetDefaults::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [hostname][crate::model::ComputeEngineTargetDefaults::hostname].
+    pub fn set_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.hostname = v.into();
         self
     }
 }
@@ -7824,6 +7824,28 @@ impl ComputeEngineTargetDetails {
         self
     }
 
+    /// Sets the value of [network_tags][crate::model::ComputeEngineTargetDetails::network_tags].
+    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.network_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [network_interfaces][crate::model::ComputeEngineTargetDetails::network_interfaces].
+    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NetworkInterface>,
+    {
+        use std::iter::Iterator;
+        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::ComputeEngineTargetDetails::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
@@ -7836,6 +7858,18 @@ impl ComputeEngineTargetDetails {
         v: T,
     ) -> Self {
         self.disk_type = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::ComputeEngineTargetDetails::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -7885,31 +7919,15 @@ impl ComputeEngineTargetDetails {
         self
     }
 
-    /// Sets the value of [hostname][crate::model::ComputeEngineTargetDetails::hostname].
-    pub fn set_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.hostname = v.into();
-        self
-    }
-
-    /// Sets the value of [network_tags][crate::model::ComputeEngineTargetDetails::network_tags].
-    pub fn set_network_tags<T, V>(mut self, v: T) -> Self
+    /// Sets the value of [metadata][crate::model::ComputeEngineTargetDetails::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
     where
-        T: std::iter::IntoIterator<Item = V>,
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
         V: std::convert::Into<std::string::String>,
     {
         use std::iter::Iterator;
-        self.network_tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [network_interfaces][crate::model::ComputeEngineTargetDetails::network_interfaces].
-    pub fn set_network_interfaces<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NetworkInterface>,
-    {
-        use std::iter::Iterator;
-        self.network_interfaces = v.into_iter().map(|i| i.into()).collect();
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -7924,27 +7942,9 @@ impl ComputeEngineTargetDetails {
         self
     }
 
-    /// Sets the value of [labels][crate::model::ComputeEngineTargetDetails::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::ComputeEngineTargetDetails::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [hostname][crate::model::ComputeEngineTargetDetails::hostname].
+    pub fn set_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.hostname = v.into();
         self
     }
 }
@@ -8471,12 +8471,6 @@ impl ComputeScheduling {
         self
     }
 
-    /// Sets the value of [min_node_cpus][crate::model::ComputeScheduling::min_node_cpus].
-    pub fn set_min_node_cpus<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.min_node_cpus = v.into();
-        self
-    }
-
     /// Sets the value of [node_affinities][crate::model::ComputeScheduling::node_affinities].
     pub fn set_node_affinities<T, V>(mut self, v: T) -> Self
     where
@@ -8485,6 +8479,12 @@ impl ComputeScheduling {
     {
         use std::iter::Iterator;
         self.node_affinities = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [min_node_cpus][crate::model::ComputeScheduling::min_node_cpus].
+    pub fn set_min_node_cpus<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.min_node_cpus = v.into();
         self
     }
 }
@@ -9009,12 +9009,6 @@ impl ListMigratingVmsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMigratingVmsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [migrating_vms][crate::model::ListMigratingVmsResponse::migrating_vms].
     pub fn set_migrating_vms<T, V>(mut self, v: T) -> Self
     where
@@ -9023,6 +9017,12 @@ impl ListMigratingVmsResponse {
     {
         use std::iter::Iterator;
         self.migrating_vms = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMigratingVmsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -9642,12 +9642,6 @@ impl ListTargetProjectsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTargetProjectsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [target_projects][crate::model::ListTargetProjectsResponse::target_projects].
     pub fn set_target_projects<T, V>(mut self, v: T) -> Self
     where
@@ -9656,6 +9650,12 @@ impl ListTargetProjectsResponse {
     {
         use std::iter::Iterator;
         self.target_projects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTargetProjectsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -10089,12 +10089,6 @@ impl ListGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [groups][crate::model::ListGroupsResponse::groups].
     pub fn set_groups<T, V>(mut self, v: T) -> Self
     where
@@ -10103,6 +10097,12 @@ impl ListGroupsResponse {
     {
         use std::iter::Iterator;
         self.groups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -10741,12 +10741,6 @@ impl ListCutoverJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCutoverJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [cutover_jobs][crate::model::ListCutoverJobsResponse::cutover_jobs].
     pub fn set_cutover_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -10755,6 +10749,12 @@ impl ListCutoverJobsResponse {
     {
         use std::iter::Iterator;
         self.cutover_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCutoverJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -10994,15 +10994,6 @@ impl MigrationError {
         self
     }
 
-    /// Sets the value of [error_time][crate::model::MigrationError::error_time].
-    pub fn set_error_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error_time = v.into();
-        self
-    }
-
     /// Sets the value of [help_links][crate::model::MigrationError::help_links].
     pub fn set_help_links<T, V>(mut self, v: T) -> Self
     where
@@ -11011,6 +11002,15 @@ impl MigrationError {
     {
         use std::iter::Iterator;
         self.help_links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_time][crate::model::MigrationError::error_time].
+    pub fn set_error_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error_time = v.into();
         self
     }
 }
@@ -11506,12 +11506,6 @@ impl ListReplicationCyclesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListReplicationCyclesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [replication_cycles][crate::model::ListReplicationCyclesResponse::replication_cycles].
     pub fn set_replication_cycles<T, V>(mut self, v: T) -> Self
     where
@@ -11520,6 +11514,12 @@ impl ListReplicationCyclesResponse {
     {
         use std::iter::Iterator;
         self.replication_cycles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListReplicationCyclesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -183,12 +183,6 @@ impl ListPrivateCloudsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPrivateCloudsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [private_clouds][crate::model::ListPrivateCloudsResponse::private_clouds].
     pub fn set_private_clouds<T, V>(mut self, v: T) -> Self
     where
@@ -197,6 +191,12 @@ impl ListPrivateCloudsResponse {
     {
         use std::iter::Iterator;
         self.private_clouds = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPrivateCloudsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -710,12 +710,6 @@ impl ListClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [clusters][crate::model::ListClustersResponse::clusters].
     pub fn set_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -724,6 +718,12 @@ impl ListClustersResponse {
     {
         use std::iter::Iterator;
         self.clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1113,12 +1113,6 @@ impl ListNodesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNodesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [nodes][crate::model::ListNodesResponse::nodes].
     pub fn set_nodes<T, V>(mut self, v: T) -> Self
     where
@@ -1127,6 +1121,12 @@ impl ListNodesResponse {
     {
         use std::iter::Iterator;
         self.nodes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNodesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1337,12 +1337,6 @@ impl ListExternalAddressesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExternalAddressesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [external_addresses][crate::model::ListExternalAddressesResponse::external_addresses].
     pub fn set_external_addresses<T, V>(mut self, v: T) -> Self
     where
@@ -1351,6 +1345,12 @@ impl ListExternalAddressesResponse {
     {
         use std::iter::Iterator;
         self.external_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExternalAddressesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1482,12 +1482,6 @@ impl FetchNetworkPolicyExternalAddressesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchNetworkPolicyExternalAddressesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [external_addresses][crate::model::FetchNetworkPolicyExternalAddressesResponse::external_addresses].
     pub fn set_external_addresses<T, V>(mut self, v: T) -> Self
     where
@@ -1496,6 +1490,12 @@ impl FetchNetworkPolicyExternalAddressesResponse {
     {
         use std::iter::Iterator;
         self.external_addresses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchNetworkPolicyExternalAddressesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1901,12 +1901,6 @@ impl ListSubnetsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSubnetsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [subnets][crate::model::ListSubnetsResponse::subnets].
     pub fn set_subnets<T, V>(mut self, v: T) -> Self
     where
@@ -1915,6 +1909,12 @@ impl ListSubnetsResponse {
     {
         use std::iter::Iterator;
         self.subnets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSubnetsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2193,12 +2193,6 @@ impl ListExternalAccessRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExternalAccessRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [external_access_rules][crate::model::ListExternalAccessRulesResponse::external_access_rules].
     pub fn set_external_access_rules<T, V>(mut self, v: T) -> Self
     where
@@ -2207,6 +2201,12 @@ impl ListExternalAccessRulesResponse {
     {
         use std::iter::Iterator;
         self.external_access_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExternalAccessRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2674,12 +2674,6 @@ impl ListLoggingServersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLoggingServersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [logging_servers][crate::model::ListLoggingServersResponse::logging_servers].
     pub fn set_logging_servers<T, V>(mut self, v: T) -> Self
     where
@@ -2688,6 +2682,12 @@ impl ListLoggingServersResponse {
     {
         use std::iter::Iterator;
         self.logging_servers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLoggingServersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3244,12 +3244,6 @@ impl ListNodeTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNodeTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [node_types][crate::model::ListNodeTypesResponse::node_types].
     pub fn set_node_types<T, V>(mut self, v: T) -> Self
     where
@@ -3258,6 +3252,12 @@ impl ListNodeTypesResponse {
     {
         use std::iter::Iterator;
         self.node_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNodeTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3607,12 +3607,6 @@ impl ListHcxActivationKeysResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListHcxActivationKeysResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [hcx_activation_keys][crate::model::ListHcxActivationKeysResponse::hcx_activation_keys].
     pub fn set_hcx_activation_keys<T, V>(mut self, v: T) -> Self
     where
@@ -3621,6 +3615,12 @@ impl ListHcxActivationKeysResponse {
     {
         use std::iter::Iterator;
         self.hcx_activation_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListHcxActivationKeysResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4407,12 +4407,6 @@ impl ListNetworkPeeringsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNetworkPeeringsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [network_peerings][crate::model::ListNetworkPeeringsResponse::network_peerings].
     pub fn set_network_peerings<T, V>(mut self, v: T) -> Self
     where
@@ -4421,6 +4415,12 @@ impl ListNetworkPeeringsResponse {
     {
         use std::iter::Iterator;
         self.network_peerings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNetworkPeeringsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4561,12 +4561,6 @@ impl ListPeeringRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPeeringRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [peering_routes][crate::model::ListPeeringRoutesResponse::peering_routes].
     pub fn set_peering_routes<T, V>(mut self, v: T) -> Self
     where
@@ -4575,6 +4569,12 @@ impl ListPeeringRoutesResponse {
     {
         use std::iter::Iterator;
         self.peering_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPeeringRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4747,12 +4747,6 @@ impl ListNetworkPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNetworkPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [network_policies][crate::model::ListNetworkPoliciesResponse::network_policies].
     pub fn set_network_policies<T, V>(mut self, v: T) -> Self
     where
@@ -4761,6 +4755,12 @@ impl ListNetworkPoliciesResponse {
     {
         use std::iter::Iterator;
         self.network_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNetworkPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5229,12 +5229,6 @@ impl ListManagementDnsZoneBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListManagementDnsZoneBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [management_dns_zone_bindings][crate::model::ListManagementDnsZoneBindingsResponse::management_dns_zone_bindings].
     pub fn set_management_dns_zone_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -5243,6 +5237,12 @@ impl ListManagementDnsZoneBindingsResponse {
     {
         use std::iter::Iterator;
         self.management_dns_zone_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListManagementDnsZoneBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6063,12 +6063,6 @@ impl ListVmwareEngineNetworksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVmwareEngineNetworksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [vmware_engine_networks][crate::model::ListVmwareEngineNetworksResponse::vmware_engine_networks].
     pub fn set_vmware_engine_networks<T, V>(mut self, v: T) -> Self
     where
@@ -6077,6 +6071,12 @@ impl ListVmwareEngineNetworksResponse {
     {
         use std::iter::Iterator;
         self.vmware_engine_networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVmwareEngineNetworksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6397,12 +6397,6 @@ impl ListPrivateConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [private_connections][crate::model::ListPrivateConnectionsResponse::private_connections].
     pub fn set_private_connections<T, V>(mut self, v: T) -> Self
     where
@@ -6411,6 +6405,12 @@ impl ListPrivateConnectionsResponse {
     {
         use std::iter::Iterator;
         self.private_connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -6679,12 +6679,6 @@ impl ListPrivateConnectionPeeringRoutesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionPeeringRoutesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [peering_routes][crate::model::ListPrivateConnectionPeeringRoutesResponse::peering_routes].
     pub fn set_peering_routes<T, V>(mut self, v: T) -> Self
     where
@@ -6693,6 +6687,12 @@ impl ListPrivateConnectionPeeringRoutesResponse {
     {
         use std::iter::Iterator;
         self.peering_routes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPrivateConnectionPeeringRoutesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7370,17 +7370,6 @@ pub mod private_cloud {
             self
         }
 
-        /// Sets the value of [stretched_cluster_config][crate::model::private_cloud::ManagementCluster::stretched_cluster_config].
-        pub fn set_stretched_cluster_config<
-            T: std::convert::Into<std::option::Option<crate::model::StretchedClusterConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.stretched_cluster_config = v.into();
-            self
-        }
-
         /// Sets the value of [node_type_configs][crate::model::private_cloud::ManagementCluster::node_type_configs].
         pub fn set_node_type_configs<T, K, V>(mut self, v: T) -> Self
         where
@@ -7390,6 +7379,17 @@ pub mod private_cloud {
         {
             use std::iter::Iterator;
             self.node_type_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [stretched_cluster_config][crate::model::private_cloud::ManagementCluster::stretched_cluster_config].
+        pub fn set_stretched_cluster_config<
+            T: std::convert::Into<std::option::Option<crate::model::StretchedClusterConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.stretched_cluster_config = v.into();
             self
         }
     }
@@ -7811,17 +7811,6 @@ impl Cluster {
         self
     }
 
-    /// Sets the value of [stretched_cluster_config][crate::model::Cluster::stretched_cluster_config].
-    pub fn set_stretched_cluster_config<
-        T: std::convert::Into<std::option::Option<crate::model::StretchedClusterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.stretched_cluster_config = v.into();
-        self
-    }
-
     /// Sets the value of [node_type_configs][crate::model::Cluster::node_type_configs].
     pub fn set_node_type_configs<T, K, V>(mut self, v: T) -> Self
     where
@@ -7831,6 +7820,17 @@ impl Cluster {
     {
         use std::iter::Iterator;
         self.node_type_configs = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [stretched_cluster_config][crate::model::Cluster::stretched_cluster_config].
+    pub fn set_stretched_cluster_config<
+        T: std::convert::Into<std::option::Option<crate::model::StretchedClusterConfig>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.stretched_cluster_config = v.into();
         self
     }
 }
@@ -8924,21 +8924,6 @@ impl ExternalAccessRule {
         self
     }
 
-    /// Sets the value of [state][crate::model::ExternalAccessRule::state].
-    pub fn set_state<T: std::convert::Into<crate::model::external_access_rule::State>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state = v.into();
-        self
-    }
-
-    /// Sets the value of [uid][crate::model::ExternalAccessRule::uid].
-    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.uid = v.into();
-        self
-    }
-
     /// Sets the value of [source_ip_ranges][crate::model::ExternalAccessRule::source_ip_ranges].
     pub fn set_source_ip_ranges<T, V>(mut self, v: T) -> Self
     where
@@ -8980,6 +8965,21 @@ impl ExternalAccessRule {
     {
         use std::iter::Iterator;
         self.destination_ports = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::ExternalAccessRule::state].
+    pub fn set_state<T: std::convert::Into<crate::model::external_access_rule::State>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.state = v.into();
+        self
+    }
+
+    /// Sets the value of [uid][crate::model::ExternalAccessRule::uid].
+    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.uid = v.into();
         self
     }
 }
@@ -9042,6 +9042,18 @@ pub mod external_access_rule {
             })
         }
 
+        /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
+        /// to hold a `IpAddress`.
+        ///
+        /// Note that all the setters affecting `ip_range` are
+        /// mutually exclusive.
+        pub fn set_ip_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.ip_range = std::option::Option::Some(
+                crate::model::external_access_rule::ip_range::IpRange::IpAddress(v.into()),
+            );
+            self
+        }
+
         /// The value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
         /// if it holds a `IpAddressRange`, `None` if the field is not set or
         /// holds a different branch.
@@ -9053,31 +9065,6 @@ pub mod external_access_rule {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
-        /// if it holds a `ExternalAddress`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn external_address(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.ip_range.as_ref().and_then(|v| match v {
-                crate::model::external_access_rule::ip_range::IpRange::ExternalAddress(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
-        /// to hold a `IpAddress`.
-        ///
-        /// Note that all the setters affecting `ip_range` are
-        /// mutually exclusive.
-        pub fn set_ip_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.ip_range = std::option::Option::Some(
-                crate::model::external_access_rule::ip_range::IpRange::IpAddress(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
@@ -9093,6 +9080,19 @@ pub mod external_access_rule {
                 crate::model::external_access_rule::ip_range::IpRange::IpAddressRange(v.into()),
             );
             self
+        }
+
+        /// The value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
+        /// if it holds a `ExternalAddress`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn external_address(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.ip_range.as_ref().and_then(|v| match v {
+                crate::model::external_access_rule::ip_range::IpRange::ExternalAddress(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
@@ -9938,12 +9938,6 @@ impl NodeType {
         self
     }
 
-    /// Sets the value of [kind][crate::model::NodeType::kind].
-    pub fn set_kind<T: std::convert::Into<crate::model::node_type::Kind>>(mut self, v: T) -> Self {
-        self.kind = v.into();
-        self
-    }
-
     /// Sets the value of [available_custom_core_counts][crate::model::NodeType::available_custom_core_counts].
     pub fn set_available_custom_core_counts<T, V>(mut self, v: T) -> Self
     where
@@ -9952,6 +9946,12 @@ impl NodeType {
     {
         use std::iter::Iterator;
         self.available_custom_core_counts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [kind][crate::model::NodeType::kind].
+    pub fn set_kind<T: std::convert::Into<crate::model::node_type::Kind>>(mut self, v: T) -> Self {
+        self.kind = v.into();
         self
     }
 
@@ -11182,6 +11182,18 @@ impl AutoscalingSettings {
         std::default::Default::default()
     }
 
+    /// Sets the value of [autoscaling_policies][crate::model::AutoscalingSettings::autoscaling_policies].
+    pub fn set_autoscaling_policies<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::autoscaling_settings::AutoscalingPolicy>,
+    {
+        use std::iter::Iterator;
+        self.autoscaling_policies = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [min_cluster_node_count][crate::model::AutoscalingSettings::min_cluster_node_count].
     pub fn set_min_cluster_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.min_cluster_node_count = v.into();
@@ -11200,18 +11212,6 @@ impl AutoscalingSettings {
         v: T,
     ) -> Self {
         self.cool_down_period = v.into();
-        self
-    }
-
-    /// Sets the value of [autoscaling_policies][crate::model::AutoscalingSettings::autoscaling_policies].
-    pub fn set_autoscaling_policies<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::autoscaling_settings::AutoscalingPolicy>,
-    {
-        use std::iter::Iterator;
-        self.autoscaling_policies = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -12970,6 +12970,18 @@ impl ManagementDnsZoneBinding {
         })
     }
 
+    /// Sets the value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
+    /// to hold a `VpcNetwork`.
+    ///
+    /// Note that all the setters affecting `bind_network` are
+    /// mutually exclusive.
+    pub fn set_vpc_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.bind_network = std::option::Option::Some(
+            crate::model::management_dns_zone_binding::BindNetwork::VpcNetwork(v.into()),
+        );
+        self
+    }
+
     /// The value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
     /// if it holds a `VmwareEngineNetwork`, `None` if the field is not set or
     /// holds a different branch.
@@ -12981,18 +12993,6 @@ impl ManagementDnsZoneBinding {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
-    /// to hold a `VpcNetwork`.
-    ///
-    /// Note that all the setters affecting `bind_network` are
-    /// mutually exclusive.
-    pub fn set_vpc_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.bind_network = std::option::Option::Some(
-            crate::model::management_dns_zone_binding::BindNetwork::VpcNetwork(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
@@ -13286,6 +13286,17 @@ impl VmwareEngineNetwork {
         self
     }
 
+    /// Sets the value of [vpc_networks][crate::model::VmwareEngineNetwork::vpc_networks].
+    pub fn set_vpc_networks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::vmware_engine_network::VpcNetwork>,
+    {
+        use std::iter::Iterator;
+        self.vpc_networks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::VmwareEngineNetwork::state].
     pub fn set_state<T: std::convert::Into<crate::model::vmware_engine_network::State>>(
         mut self,
@@ -13313,17 +13324,6 @@ impl VmwareEngineNetwork {
     /// Sets the value of [etag][crate::model::VmwareEngineNetwork::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [vpc_networks][crate::model::VmwareEngineNetwork::vpc_networks].
-    pub fn set_vpc_networks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::vmware_engine_network::VpcNetwork>,
-    {
-        use std::iter::Iterator;
-        self.vpc_networks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -14884,17 +14884,6 @@ impl Principal {
         })
     }
 
-    /// The value of [principal][crate::model::Principal::principal]
-    /// if it holds a `ServiceAccount`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn service_account(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.principal.as_ref().and_then(|v| match v {
-            crate::model::principal::Principal::ServiceAccount(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [principal][crate::model::Principal::principal]
     /// to hold a `User`.
     ///
@@ -14904,6 +14893,17 @@ impl Principal {
         self.principal =
             std::option::Option::Some(crate::model::principal::Principal::User(v.into()));
         self
+    }
+
+    /// The value of [principal][crate::model::Principal::principal]
+    /// if it holds a `ServiceAccount`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn service_account(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.principal.as_ref().and_then(|v| match v {
+            crate::model::principal::Principal::ServiceAccount(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [principal][crate::model::Principal::principal]

--- a/src/generated/cloud/vpcaccess/v1/src/model.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/model.rs
@@ -131,6 +131,17 @@ impl Connector {
         self
     }
 
+    /// Sets the value of [connected_projects][crate::model::Connector::connected_projects].
+    pub fn set_connected_projects<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.connected_projects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [subnet][crate::model::Connector::subnet].
     pub fn set_subnet<
         T: std::convert::Into<std::option::Option<crate::model::connector::Subnet>>,
@@ -157,17 +168,6 @@ impl Connector {
     /// Sets the value of [max_instances][crate::model::Connector::max_instances].
     pub fn set_max_instances<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.max_instances = v.into();
-        self
-    }
-
-    /// Sets the value of [connected_projects][crate::model::Connector::connected_projects].
-    pub fn set_connected_projects<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.connected_projects = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -547,12 +547,6 @@ impl ListConnectorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connectors][crate::model::ListConnectorsResponse::connectors].
     pub fn set_connectors<T, V>(mut self, v: T) -> Self
     where
@@ -561,6 +555,12 @@ impl ListConnectorsResponse {
     {
         use std::iter::Iterator;
         self.connectors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -571,15 +571,6 @@ pub mod search_uris_response {
             std::default::Default::default()
         }
 
-        /// Sets the value of [expire_time][crate::model::search_uris_response::ThreatUri::expire_time].
-        pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.expire_time = v.into();
-            self
-        }
-
         /// Sets the value of [threat_types][crate::model::search_uris_response::ThreatUri::threat_types].
         pub fn set_threat_types<T, V>(mut self, v: T) -> Self
         where
@@ -588,6 +579,15 @@ pub mod search_uris_response {
         {
             use std::iter::Iterator;
             self.threat_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [expire_time][crate::model::search_uris_response::ThreatUri::expire_time].
+        pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.expire_time = v.into();
             self
         }
     }
@@ -675,15 +675,6 @@ impl SearchHashesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [negative_expire_time][crate::model::SearchHashesResponse::negative_expire_time].
-    pub fn set_negative_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.negative_expire_time = v.into();
-        self
-    }
-
     /// Sets the value of [threats][crate::model::SearchHashesResponse::threats].
     pub fn set_threats<T, V>(mut self, v: T) -> Self
     where
@@ -692,6 +683,15 @@ impl SearchHashesResponse {
     {
         use std::iter::Iterator;
         self.threats = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [negative_expire_time][crate::model::SearchHashesResponse::negative_expire_time].
+    pub fn set_negative_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.negative_expire_time = v.into();
         self
     }
 }
@@ -738,6 +738,17 @@ pub mod search_hashes_response {
             std::default::Default::default()
         }
 
+        /// Sets the value of [threat_types][crate::model::search_hashes_response::ThreatHash::threat_types].
+        pub fn set_threat_types<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::ThreatType>,
+        {
+            use std::iter::Iterator;
+            self.threat_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [hash][crate::model::search_hashes_response::ThreatHash::hash].
         pub fn set_hash<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
             self.hash = v.into();
@@ -750,17 +761,6 @@ pub mod search_hashes_response {
             v: T,
         ) -> Self {
             self.expire_time = v.into();
-            self
-        }
-
-        /// Sets the value of [threat_types][crate::model::search_hashes_response::ThreatHash::threat_types].
-        pub fn set_threat_types<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::ThreatType>,
-        {
-            use std::iter::Iterator;
-            self.threat_types = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -799,17 +799,6 @@ impl ThreatEntryAdditions {
         std::default::Default::default()
     }
 
-    /// Sets the value of [rice_hashes][crate::model::ThreatEntryAdditions::rice_hashes].
-    pub fn set_rice_hashes<
-        T: std::convert::Into<std::option::Option<crate::model::RiceDeltaEncoding>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rice_hashes = v.into();
-        self
-    }
-
     /// Sets the value of [raw_hashes][crate::model::ThreatEntryAdditions::raw_hashes].
     pub fn set_raw_hashes<T, V>(mut self, v: T) -> Self
     where
@@ -818,6 +807,17 @@ impl ThreatEntryAdditions {
     {
         use std::iter::Iterator;
         self.raw_hashes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [rice_hashes][crate::model::ThreatEntryAdditions::rice_hashes].
+    pub fn set_rice_hashes<
+        T: std::convert::Into<std::option::Option<crate::model::RiceDeltaEncoding>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.rice_hashes = v.into();
         self
     }
 }
@@ -1207,6 +1207,18 @@ pub mod threat_info {
             })
         }
 
+        /// Sets the value of [value][crate::model::threat_info::Confidence::value]
+        /// to hold a `Score`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::threat_info::confidence::Value::Score(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::threat_info::Confidence::value]
         /// if it holds a `Level`, `None` if the field is not set or
         /// holds a different branch.
@@ -1220,18 +1232,6 @@ pub mod threat_info {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::threat_info::Confidence::value]
-        /// to hold a `Score`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::threat_info::confidence::Value::Score(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::threat_info::Confidence::value]

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -800,6 +800,17 @@ impl Xss {
         std::default::Default::default()
     }
 
+    /// Sets the value of [stack_traces][crate::model::Xss::stack_traces].
+    pub fn set_stack_traces<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.stack_traces = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [error_message][crate::model::Xss::error_message].
     pub fn set_error_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.error_message = v.into();
@@ -821,17 +832,6 @@ impl Xss {
         v: T,
     ) -> Self {
         self.stored_xss_seeding_url = v.into();
-        self
-    }
-
-    /// Sets the value of [stack_traces][crate::model::Xss::stack_traces].
-    pub fn set_stack_traces<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.stack_traces = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1383,6 +1383,17 @@ impl ScanConfig {
         self
     }
 
+    /// Sets the value of [starting_urls][crate::model::ScanConfig::starting_urls].
+    pub fn set_starting_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.starting_urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [authentication][crate::model::ScanConfig::authentication].
     pub fn set_authentication<
         T: std::convert::Into<std::option::Option<crate::model::scan_config::Authentication>>,
@@ -1400,6 +1411,17 @@ impl ScanConfig {
         v: T,
     ) -> Self {
         self.user_agent = v.into();
+        self
+    }
+
+    /// Sets the value of [blacklist_patterns][crate::model::ScanConfig::blacklist_patterns].
+    pub fn set_blacklist_patterns<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.blacklist_patterns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1449,28 +1471,6 @@ impl ScanConfig {
     /// Sets the value of [ignore_http_status_errors][crate::model::ScanConfig::ignore_http_status_errors].
     pub fn set_ignore_http_status_errors<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.ignore_http_status_errors = v.into();
-        self
-    }
-
-    /// Sets the value of [starting_urls][crate::model::ScanConfig::starting_urls].
-    pub fn set_starting_urls<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.starting_urls = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [blacklist_patterns][crate::model::ScanConfig::blacklist_patterns].
-    pub fn set_blacklist_patterns<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.blacklist_patterns = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1541,40 +1541,6 @@ pub mod scan_config {
             })
         }
 
-        /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
-        /// if it holds a `CustomAccount`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_account(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::scan_config::authentication::CustomAccount>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.authentication.as_ref().and_then(|v| match v {
-                crate::model::scan_config::authentication::Authentication::CustomAccount(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
-        /// if it holds a `IapCredential`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn iap_credential(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::scan_config::authentication::IapCredential>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.authentication.as_ref().and_then(|v| match v {
-                crate::model::scan_config::authentication::Authentication::IapCredential(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [authentication][crate::model::scan_config::Authentication::authentication]
         /// to hold a `GoogleAccount`.
         ///
@@ -1595,6 +1561,23 @@ pub mod scan_config {
             self
         }
 
+        /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
+        /// if it holds a `CustomAccount`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_account(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::scan_config::authentication::CustomAccount>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.authentication.as_ref().and_then(|v| match v {
+                crate::model::scan_config::authentication::Authentication::CustomAccount(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [authentication][crate::model::scan_config::Authentication::authentication]
         /// to hold a `CustomAccount`.
         ///
@@ -1612,6 +1595,23 @@ pub mod scan_config {
                 crate::model::scan_config::authentication::Authentication::CustomAccount(v.into()),
             );
             self
+        }
+
+        /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
+        /// if it holds a `IapCredential`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn iap_credential(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::scan_config::authentication::IapCredential>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.authentication.as_ref().and_then(|v| match v {
+                crate::model::scan_config::authentication::Authentication::IapCredential(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [authentication][crate::model::scan_config::Authentication::authentication]
@@ -4158,12 +4158,6 @@ impl ListScanConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListScanConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [scan_configs][crate::model::ListScanConfigsResponse::scan_configs].
     pub fn set_scan_configs<T, V>(mut self, v: T) -> Self
     where
@@ -4172,6 +4166,12 @@ impl ListScanConfigsResponse {
     {
         use std::iter::Iterator;
         self.scan_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListScanConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4344,12 +4344,6 @@ impl ListScanRunsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListScanRunsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [scan_runs][crate::model::ListScanRunsResponse::scan_runs].
     pub fn set_scan_runs<T, V>(mut self, v: T) -> Self
     where
@@ -4358,6 +4352,12 @@ impl ListScanRunsResponse {
     {
         use std::iter::Iterator;
         self.scan_runs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListScanRunsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4498,12 +4498,6 @@ impl ListCrawledUrlsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListCrawledUrlsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [crawled_urls][crate::model::ListCrawledUrlsResponse::crawled_urls].
     pub fn set_crawled_urls<T, V>(mut self, v: T) -> Self
     where
@@ -4512,6 +4506,12 @@ impl ListCrawledUrlsResponse {
     {
         use std::iter::Iterator;
         self.crawled_urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListCrawledUrlsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4665,12 +4665,6 @@ impl ListFindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [findings][crate::model::ListFindingsResponse::findings].
     pub fn set_findings<T, V>(mut self, v: T) -> Self
     where
@@ -4679,6 +4673,12 @@ impl ListFindingsResponse {
     {
         use std::iter::Iterator;
         self.findings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/model.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/model.rs
@@ -207,17 +207,6 @@ impl Execution {
         self
     }
 
-    /// Sets the value of [state_error][crate::model::Execution::state_error].
-    pub fn set_state_error<
-        T: std::convert::Into<std::option::Option<crate::model::execution::StateError>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_error = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Execution::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -227,6 +216,17 @@ impl Execution {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state_error][crate::model::Execution::state_error].
+    pub fn set_state_error<
+        T: std::convert::Into<std::option::Option<crate::model::execution::StateError>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.state_error = v.into();
         self
     }
 }
@@ -1162,12 +1162,6 @@ impl ListExecutionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [executions][crate::model::ListExecutionsResponse::executions].
     pub fn set_executions<T, V>(mut self, v: T) -> Self
     where
@@ -1176,6 +1170,12 @@ impl ListExecutionsResponse {
     {
         use std::iter::Iterator;
         self.executions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExecutionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -236,6 +236,18 @@ impl Workflow {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Workflow::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::Workflow::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
@@ -268,6 +280,18 @@ impl Workflow {
         self
     }
 
+    /// Sets the value of [user_env_vars][crate::model::Workflow::user_env_vars].
+    pub fn set_user_env_vars<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_env_vars = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [execution_history_level][crate::model::Workflow::execution_history_level].
     pub fn set_execution_history_level<
         T: std::convert::Into<crate::model::ExecutionHistoryLevel>,
@@ -276,15 +300,6 @@ impl Workflow {
         v: T,
     ) -> Self {
         self.execution_history_level = v.into();
-        self
-    }
-
-    /// Sets the value of [crypto_key_version][crate::model::Workflow::crypto_key_version].
-    pub fn set_crypto_key_version<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.crypto_key_version = v.into();
         self
     }
 
@@ -310,27 +325,12 @@ impl Workflow {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Workflow::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [user_env_vars][crate::model::Workflow::user_env_vars].
-    pub fn set_user_env_vars<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_env_vars = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [crypto_key_version][crate::model::Workflow::crypto_key_version].
+    pub fn set_crypto_key_version<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.crypto_key_version = v.into();
         self
     }
 
@@ -987,12 +987,6 @@ impl ListWorkflowsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkflowsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workflows][crate::model::ListWorkflowsResponse::workflows].
     pub fn set_workflows<T, V>(mut self, v: T) -> Self
     where
@@ -1001,6 +995,12 @@ impl ListWorkflowsResponse {
     {
         use std::iter::Iterator;
         self.workflows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkflowsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -1409,12 +1409,6 @@ impl ListWorkflowRevisionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkflowRevisionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workflows][crate::model::ListWorkflowRevisionsResponse::workflows].
     pub fn set_workflows<T, V>(mut self, v: T) -> Self
     where
@@ -1423,6 +1417,12 @@ impl ListWorkflowRevisionsResponse {
     {
         use std::iter::Iterator;
         self.workflows = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkflowRevisionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -160,6 +160,30 @@ impl WorkstationCluster {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::WorkstationCluster::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::WorkstationCluster::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::WorkstationCluster::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -241,30 +265,6 @@ impl WorkstationCluster {
     {
         use std::iter::Iterator;
         self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::WorkstationCluster::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::WorkstationCluster::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -565,6 +565,30 @@ impl WorkstationConfig {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::WorkstationConfig::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::WorkstationConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::WorkstationConfig::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -627,6 +651,17 @@ impl WorkstationConfig {
         self
     }
 
+    /// Sets the value of [persistent_directories][crate::model::WorkstationConfig::persistent_directories].
+    pub fn set_persistent_directories<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::workstation_config::PersistentDirectory>,
+    {
+        use std::iter::Iterator;
+        self.persistent_directories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [container][crate::model::WorkstationConfig::container].
     pub fn set_container<
         T: std::convert::Into<std::option::Option<crate::model::workstation_config::Container>>,
@@ -648,23 +683,6 @@ impl WorkstationConfig {
         v: T,
     ) -> Self {
         self.encryption_key = v.into();
-        self
-    }
-
-    /// Sets the value of [degraded][crate::model::WorkstationConfig::degraded].
-    pub fn set_degraded<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.degraded = v.into();
-        self
-    }
-
-    /// Sets the value of [persistent_directories][crate::model::WorkstationConfig::persistent_directories].
-    pub fn set_persistent_directories<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::workstation_config::PersistentDirectory>,
-    {
-        use std::iter::Iterator;
-        self.persistent_directories = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -690,6 +708,12 @@ impl WorkstationConfig {
         self
     }
 
+    /// Sets the value of [degraded][crate::model::WorkstationConfig::degraded].
+    pub fn set_degraded<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.degraded = v.into();
+        self
+    }
+
     /// Sets the value of [conditions][crate::model::WorkstationConfig::conditions].
     pub fn set_conditions<T, V>(mut self, v: T) -> Self
     where
@@ -698,30 +722,6 @@ impl WorkstationConfig {
     {
         use std::iter::Iterator;
         self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::WorkstationConfig::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::WorkstationConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -976,6 +976,28 @@ pub mod workstation_config {
                 self
             }
 
+            /// Sets the value of [service_account_scopes][crate::model::workstation_config::host::GceInstance::service_account_scopes].
+            pub fn set_service_account_scopes<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.service_account_scopes = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [tags][crate::model::workstation_config::host::GceInstance::tags].
+            pub fn set_tags<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.tags = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [pool_size][crate::model::workstation_config::host::GceInstance::pool_size].
             pub fn set_pool_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
                 self.pool_size = v.into();
@@ -1021,28 +1043,6 @@ pub mod workstation_config {
             /// Sets the value of [boot_disk_size_gb][crate::model::workstation_config::host::GceInstance::boot_disk_size_gb].
             pub fn set_boot_disk_size_gb<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
                 self.boot_disk_size_gb = v.into();
-                self
-            }
-
-            /// Sets the value of [service_account_scopes][crate::model::workstation_config::host::GceInstance::service_account_scopes].
-            pub fn set_service_account_scopes<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.service_account_scopes = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [tags][crate::model::workstation_config::host::GceInstance::tags].
-            pub fn set_tags<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.tags = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -1584,18 +1584,6 @@ pub mod workstation_config {
             self
         }
 
-        /// Sets the value of [working_dir][crate::model::workstation_config::Container::working_dir].
-        pub fn set_working_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.working_dir = v.into();
-            self
-        }
-
-        /// Sets the value of [run_as_user][crate::model::workstation_config::Container::run_as_user].
-        pub fn set_run_as_user<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.run_as_user = v.into();
-            self
-        }
-
         /// Sets the value of [command][crate::model::workstation_config::Container::command].
         pub fn set_command<T, V>(mut self, v: T) -> Self
         where
@@ -1627,6 +1615,18 @@ pub mod workstation_config {
         {
             use std::iter::Iterator;
             self.env = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [working_dir][crate::model::workstation_config::Container::working_dir].
+        pub fn set_working_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.working_dir = v.into();
+            self
+        }
+
+        /// Sets the value of [run_as_user][crate::model::workstation_config::Container::run_as_user].
+        pub fn set_run_as_user<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.run_as_user = v.into();
             self
         }
     }
@@ -1839,6 +1839,30 @@ impl Workstation {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Workstation::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Workstation::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Workstation::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1893,30 +1917,6 @@ impl Workstation {
     /// Sets the value of [host][crate::model::Workstation::host].
     pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.host = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::Workstation::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Workstation::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2194,12 +2194,6 @@ impl ListWorkstationClustersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkstationClustersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workstation_clusters][crate::model::ListWorkstationClustersResponse::workstation_clusters].
     pub fn set_workstation_clusters<T, V>(mut self, v: T) -> Self
     where
@@ -2208,6 +2202,12 @@ impl ListWorkstationClustersResponse {
     {
         use std::iter::Iterator;
         self.workstation_clusters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkstationClustersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2567,12 +2567,6 @@ impl ListWorkstationConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkstationConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workstation_configs][crate::model::ListWorkstationConfigsResponse::workstation_configs].
     pub fn set_workstation_configs<T, V>(mut self, v: T) -> Self
     where
@@ -2581,6 +2575,12 @@ impl ListWorkstationConfigsResponse {
     {
         use std::iter::Iterator;
         self.workstation_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkstationConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -2697,12 +2697,6 @@ impl ListUsableWorkstationConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUsableWorkstationConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workstation_configs][crate::model::ListUsableWorkstationConfigsResponse::workstation_configs].
     pub fn set_workstation_configs<T, V>(mut self, v: T) -> Self
     where
@@ -2711,6 +2705,12 @@ impl ListUsableWorkstationConfigsResponse {
     {
         use std::iter::Iterator;
         self.workstation_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUsableWorkstationConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3070,12 +3070,6 @@ impl ListWorkstationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkstationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workstations][crate::model::ListWorkstationsResponse::workstations].
     pub fn set_workstations<T, V>(mut self, v: T) -> Self
     where
@@ -3084,6 +3078,12 @@ impl ListWorkstationsResponse {
     {
         use std::iter::Iterator;
         self.workstations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkstationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3200,12 +3200,6 @@ impl ListUsableWorkstationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUsableWorkstationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [workstations][crate::model::ListUsableWorkstationsResponse::workstations].
     pub fn set_workstations<T, V>(mut self, v: T) -> Self
     where
@@ -3214,6 +3208,12 @@ impl ListUsableWorkstationsResponse {
     {
         use std::iter::Iterator;
         self.workstations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUsableWorkstationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -3612,19 +3612,6 @@ impl GenerateAccessTokenRequest {
         })
     }
 
-    /// The value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.expiration.as_ref().and_then(|v| match v {
-            crate::model::generate_access_token_request::Expiration::Ttl(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
     /// to hold a `ExpireTime`.
     ///
@@ -3638,6 +3625,19 @@ impl GenerateAccessTokenRequest {
             crate::model::generate_access_token_request::Expiration::ExpireTime(v.into()),
         );
         self
+    }
+
+    /// The value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.expiration.as_ref().and_then(|v| match v {
+            crate::model::generate_access_token_request::Expiration::Ttl(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]

--- a/src/generated/container/v1/src/builder.rs
+++ b/src/generated/container/v1/src/builder.rs
@@ -421,6 +421,17 @@ pub mod cluster_manager {
             self
         }
 
+        /// Sets the value of [locations][crate::model::UpdateNodePoolRequest::locations].
+        pub fn set_locations<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.locations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [workload_metadata_config][crate::model::UpdateNodePoolRequest::workload_metadata_config].
         pub fn set_workload_metadata_config<
             T: Into<std::option::Option<crate::model::WorkloadMetadataConfig>>,
@@ -576,6 +587,17 @@ pub mod cluster_manager {
             self
         }
 
+        /// Sets the value of [accelerators][crate::model::UpdateNodePoolRequest::accelerators].
+        pub fn set_accelerators<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::AcceleratorConfig>,
+        {
+            use std::iter::Iterator;
+            self.0.request.accelerators = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [machine_type][crate::model::UpdateNodePoolRequest::machine_type].
         pub fn set_machine_type<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.machine_type = v.into();
@@ -624,28 +646,6 @@ pub mod cluster_manager {
             v: T,
         ) -> Self {
             self.0.request.queued_provisioning = v.into();
-            self
-        }
-
-        /// Sets the value of [locations][crate::model::UpdateNodePoolRequest::locations].
-        pub fn set_locations<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.locations = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [accelerators][crate::model::UpdateNodePoolRequest::accelerators].
-        pub fn set_accelerators<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::AcceleratorConfig>,
-        {
-            use std::iter::Iterator;
-            self.0.request.accelerators = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -1038,12 +1038,6 @@ pub mod cluster_manager {
             self
         }
 
-        /// Sets the value of [name][crate::model::SetLocationsRequest::name].
-        pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.name = v.into();
-            self
-        }
-
         /// Sets the value of [locations][crate::model::SetLocationsRequest::locations].
         ///
         /// This is a **required** field for requests.
@@ -1054,6 +1048,12 @@ pub mod cluster_manager {
         {
             use std::iter::Iterator;
             self.0.request.locations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [name][crate::model::SetLocationsRequest::name].
+        pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.name = v.into();
             self
         }
     }
@@ -2150,20 +2150,6 @@ pub mod cluster_manager {
             self
         }
 
-        /// Sets the value of [label_fingerprint][crate::model::SetLabelsRequest::label_fingerprint].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_label_fingerprint<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.label_fingerprint = v.into();
-            self
-        }
-
-        /// Sets the value of [name][crate::model::SetLabelsRequest::name].
-        pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.name = v.into();
-            self
-        }
-
         /// Sets the value of [resource_labels][crate::model::SetLabelsRequest::resource_labels].
         ///
         /// This is a **required** field for requests.
@@ -2175,6 +2161,20 @@ pub mod cluster_manager {
         {
             self.0.request.resource_labels =
                 v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [label_fingerprint][crate::model::SetLabelsRequest::label_fingerprint].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_label_fingerprint<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.label_fingerprint = v.into();
+            self
+        }
+
+        /// Sets the value of [name][crate::model::SetLabelsRequest::name].
+        pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.name = v.into();
             self
         }
     }

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -75,6 +75,18 @@ impl LinuxNodeConfig {
         std::default::Default::default()
     }
 
+    /// Sets the value of [sysctls][crate::model::LinuxNodeConfig::sysctls].
+    pub fn set_sysctls<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.sysctls = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [cgroup_mode][crate::model::LinuxNodeConfig::cgroup_mode].
     pub fn set_cgroup_mode<T: std::convert::Into<crate::model::linux_node_config::CgroupMode>>(
         mut self,
@@ -92,18 +104,6 @@ impl LinuxNodeConfig {
         v: T,
     ) -> Self {
         self.hugepages = v.into();
-        self
-    }
-
-    /// Sets the value of [sysctls][crate::model::LinuxNodeConfig::sysctls].
-    pub fn set_sysctls<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.sysctls = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -904,9 +904,32 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the value of [oauth_scopes][crate::model::NodeConfig::oauth_scopes].
+    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::NodeConfig::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::NodeConfig::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -916,15 +939,49 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NodeConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [local_ssd_count][crate::model::NodeConfig::local_ssd_count].
     pub fn set_local_ssd_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.local_ssd_count = v.into();
         self
     }
 
+    /// Sets the value of [tags][crate::model::NodeConfig::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [preemptible][crate::model::NodeConfig::preemptible].
     pub fn set_preemptible<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.preemptible = v.into();
+        self
+    }
+
+    /// Sets the value of [accelerators][crate::model::NodeConfig::accelerators].
+    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AcceleratorConfig>,
+    {
+        use std::iter::Iterator;
+        self.accelerators = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -951,6 +1008,17 @@ impl NodeConfig {
         v: T,
     ) -> Self {
         self.workload_metadata_config = v.into();
+        self
+    }
+
+    /// Sets the value of [taints][crate::model::NodeConfig::taints].
+    pub fn set_taints<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NodeTaint>,
+    {
+        use std::iter::Iterator;
+        self.taints = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1079,6 +1147,18 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the value of [resource_labels][crate::model::NodeConfig::resource_labels].
+    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [logging_config][crate::model::NodeConfig::logging_config].
     pub fn set_logging_config<
         T: std::convert::Into<std::option::Option<crate::model::NodePoolLoggingConfig>>,
@@ -1162,6 +1242,28 @@ impl NodeConfig {
         self
     }
 
+    /// Sets the value of [secondary_boot_disks][crate::model::NodeConfig::secondary_boot_disks].
+    pub fn set_secondary_boot_disks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecondaryBootDisk>,
+    {
+        use std::iter::Iterator;
+        self.secondary_boot_disks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [storage_pools][crate::model::NodeConfig::storage_pools].
+    pub fn set_storage_pools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.storage_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [secondary_boot_disk_update_strategy][crate::model::NodeConfig::secondary_boot_disk_update_strategy].
     pub fn set_secondary_boot_disk_update_strategy<
         T: std::convert::Into<std::option::Option<crate::model::SecondaryBootDiskUpdateStrategy>>,
@@ -1192,108 +1294,6 @@ impl NodeConfig {
         v: T,
     ) -> Self {
         self.effective_cgroup_mode = v.into();
-        self
-    }
-
-    /// Sets the value of [oauth_scopes][crate::model::NodeConfig::oauth_scopes].
-    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::NodeConfig::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [accelerators][crate::model::NodeConfig::accelerators].
-    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AcceleratorConfig>,
-    {
-        use std::iter::Iterator;
-        self.accelerators = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [taints][crate::model::NodeConfig::taints].
-    pub fn set_taints<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NodeTaint>,
-    {
-        use std::iter::Iterator;
-        self.taints = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [secondary_boot_disks][crate::model::NodeConfig::secondary_boot_disks].
-    pub fn set_secondary_boot_disks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SecondaryBootDisk>,
-    {
-        use std::iter::Iterator;
-        self.secondary_boot_disks = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [storage_pools][crate::model::NodeConfig::storage_pools].
-    pub fn set_storage_pools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.storage_pools = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::NodeConfig::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NodeConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [resource_labels][crate::model::NodeConfig::resource_labels].
-    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1796,12 +1796,6 @@ impl NodeNetworkConfig {
         self
     }
 
-    /// Sets the value of [pod_ipv4_range_utilization][crate::model::NodeNetworkConfig::pod_ipv4_range_utilization].
-    pub fn set_pod_ipv4_range_utilization<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.pod_ipv4_range_utilization = v.into();
-        self
-    }
-
     /// Sets the value of [additional_node_network_configs][crate::model::NodeNetworkConfig::additional_node_network_configs].
     pub fn set_additional_node_network_configs<T, V>(mut self, v: T) -> Self
     where
@@ -1821,6 +1815,12 @@ impl NodeNetworkConfig {
     {
         use std::iter::Iterator;
         self.additional_pod_network_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [pod_ipv4_range_utilization][crate::model::NodeNetworkConfig::pod_ipv4_range_utilization].
+    pub fn set_pod_ipv4_range_utilization<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.pod_ipv4_range_utilization = v.into();
         self
     }
 }
@@ -4762,6 +4762,17 @@ impl MasterAuthorizedNetworksConfig {
         self
     }
 
+    /// Sets the value of [cidr_blocks][crate::model::MasterAuthorizedNetworksConfig::cidr_blocks].
+    pub fn set_cidr_blocks<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::master_authorized_networks_config::CidrBlock>,
+    {
+        use std::iter::Iterator;
+        self.cidr_blocks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [gcp_public_cidrs_access_enabled][crate::model::MasterAuthorizedNetworksConfig::gcp_public_cidrs_access_enabled].
     pub fn set_gcp_public_cidrs_access_enabled<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
@@ -4779,17 +4790,6 @@ impl MasterAuthorizedNetworksConfig {
         v: T,
     ) -> Self {
         self.private_endpoint_enforcement_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [cidr_blocks][crate::model::MasterAuthorizedNetworksConfig::cidr_blocks].
-    pub fn set_cidr_blocks<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::master_authorized_networks_config::CidrBlock>,
-    {
-        use std::iter::Iterator;
-        self.cidr_blocks = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6200,9 +6200,43 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [node_pools][crate::model::Cluster::node_pools].
+    pub fn set_node_pools<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NodePool>,
+    {
+        use std::iter::Iterator;
+        self.node_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [locations][crate::model::Cluster::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [enable_kubernetes_alpha][crate::model::Cluster::enable_kubernetes_alpha].
     pub fn set_enable_kubernetes_alpha<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.enable_kubernetes_alpha = v.into();
+        self
+    }
+
+    /// Sets the value of [resource_labels][crate::model::Cluster::resource_labels].
+    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -6540,6 +6574,18 @@ impl Cluster {
         self
     }
 
+    /// Sets the value of [instance_group_urls][crate::model::Cluster::instance_group_urls].
+    #[deprecated]
+    pub fn set_instance_group_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.instance_group_urls = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [current_node_count][crate::model::Cluster::current_node_count].
     #[deprecated]
     pub fn set_current_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
@@ -6571,6 +6617,17 @@ impl Cluster {
         v: T,
     ) -> Self {
         self.tpu_ipv4_cidr_block = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::Cluster::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::StatusCondition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6751,63 +6808,6 @@ impl Cluster {
         v: T,
     ) -> Self {
         self.rbac_binding_config = v.into();
-        self
-    }
-
-    /// Sets the value of [node_pools][crate::model::Cluster::node_pools].
-    pub fn set_node_pools<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NodePool>,
-    {
-        use std::iter::Iterator;
-        self.node_pools = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [locations][crate::model::Cluster::locations].
-    pub fn set_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.locations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [instance_group_urls][crate::model::Cluster::instance_group_urls].
-    #[deprecated]
-    pub fn set_instance_group_urls<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.instance_group_urls = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::Cluster::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::StatusCondition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [resource_labels][crate::model::Cluster::resource_labels].
-    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7124,6 +7124,28 @@ impl UserManagedKeysConfig {
         self
     }
 
+    /// Sets the value of [service_account_signing_keys][crate::model::UserManagedKeysConfig::service_account_signing_keys].
+    pub fn set_service_account_signing_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.service_account_signing_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [service_account_verification_keys][crate::model::UserManagedKeysConfig::service_account_verification_keys].
+    pub fn set_service_account_verification_keys<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.service_account_verification_keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [aggregation_ca][crate::model::UserManagedKeysConfig::aggregation_ca].
     pub fn set_aggregation_ca<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.aggregation_ca = v.into();
@@ -7145,28 +7167,6 @@ impl UserManagedKeysConfig {
         v: T,
     ) -> Self {
         self.gkeops_etcd_backup_encryption_key = v.into();
-        self
-    }
-
-    /// Sets the value of [service_account_signing_keys][crate::model::UserManagedKeysConfig::service_account_signing_keys].
-    pub fn set_service_account_signing_keys<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.service_account_signing_keys = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [service_account_verification_keys][crate::model::UserManagedKeysConfig::service_account_verification_keys].
-    pub fn set_service_account_verification_keys<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.service_account_verification_keys = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8504,6 +8504,17 @@ impl ClusterUpdate {
         self
     }
 
+    /// Sets the value of [desired_locations][crate::model::ClusterUpdate::desired_locations].
+    pub fn set_desired_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.desired_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [desired_master_authorized_networks_config][crate::model::ClusterUpdate::desired_master_authorized_networks_config].
     #[deprecated]
     pub fn set_desired_master_authorized_networks_config<
@@ -9050,17 +9061,6 @@ impl ClusterUpdate {
         self.desired_node_pool_auto_config_linux_node_config = v.into();
         self
     }
-
-    /// Sets the value of [desired_locations][crate::model::ClusterUpdate::desired_locations].
-    pub fn set_desired_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.desired_locations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
 }
 
 impl wkt::message::Message for ClusterUpdate {
@@ -9389,15 +9389,6 @@ impl Operation {
         self
     }
 
-    /// Sets the value of [error][crate::model::Operation::error].
-    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.error = v.into();
-        self
-    }
-
     /// Sets the value of [cluster_conditions][crate::model::Operation::cluster_conditions].
     #[deprecated]
     pub fn set_cluster_conditions<T, V>(mut self, v: T) -> Self
@@ -9419,6 +9410,15 @@ impl Operation {
     {
         use std::iter::Iterator;
         self.nodepool_conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error][crate::model::Operation::error].
+    pub fn set_error<T: std::convert::Into<std::option::Option<rpc::model::Status>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.error = v.into();
         self
     }
 }
@@ -10062,6 +10062,18 @@ pub mod operation_progress {
             })
         }
 
+        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
+        /// to hold a `IntValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::operation_progress::metric::Value::IntValue(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::operation_progress::Metric::value]
         /// if it holds a `DoubleValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -10075,6 +10087,18 @@ pub mod operation_progress {
             })
         }
 
+        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
+        /// to hold a `DoubleValue`.
+        ///
+        /// Note that all the setters affecting `value` are
+        /// mutually exclusive.
+        pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+            self.value = std::option::Option::Some(
+                crate::model::operation_progress::metric::Value::DoubleValue(v.into()),
+            );
+            self
+        }
+
         /// The value of [value][crate::model::operation_progress::Metric::value]
         /// if it holds a `StringValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -10086,30 +10110,6 @@ pub mod operation_progress {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
-        /// to hold a `IntValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::operation_progress::metric::Value::IntValue(v.into()),
-            );
-            self
-        }
-
-        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
-        /// to hold a `DoubleValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::operation_progress::metric::Value::DoubleValue(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [value][crate::model::operation_progress::Metric::value]
@@ -10638,6 +10638,17 @@ impl UpdateNodePoolRequest {
         self
     }
 
+    /// Sets the value of [locations][crate::model::UpdateNodePoolRequest::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [workload_metadata_config][crate::model::UpdateNodePoolRequest::workload_metadata_config].
     pub fn set_workload_metadata_config<
         T: std::convert::Into<std::option::Option<crate::model::WorkloadMetadataConfig>>,
@@ -10797,6 +10808,17 @@ impl UpdateNodePoolRequest {
         self
     }
 
+    /// Sets the value of [accelerators][crate::model::UpdateNodePoolRequest::accelerators].
+    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AcceleratorConfig>,
+    {
+        use std::iter::Iterator;
+        self.accelerators = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [machine_type][crate::model::UpdateNodePoolRequest::machine_type].
     pub fn set_machine_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.machine_type = v.into();
@@ -10845,28 +10867,6 @@ impl UpdateNodePoolRequest {
         v: T,
     ) -> Self {
         self.queued_provisioning = v.into();
-        self
-    }
-
-    /// Sets the value of [locations][crate::model::UpdateNodePoolRequest::locations].
-    pub fn set_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.locations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [accelerators][crate::model::UpdateNodePoolRequest::accelerators].
-    pub fn set_accelerators<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AcceleratorConfig>,
-    {
-        use std::iter::Iterator;
-        self.accelerators = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -11348,12 +11348,6 @@ impl SetLocationsRequest {
         self
     }
 
-    /// Sets the value of [name][crate::model::SetLocationsRequest::name].
-    pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.name = v.into();
-        self
-    }
-
     /// Sets the value of [locations][crate::model::SetLocationsRequest::locations].
     pub fn set_locations<T, V>(mut self, v: T) -> Self
     where
@@ -11362,6 +11356,12 @@ impl SetLocationsRequest {
     {
         use std::iter::Iterator;
         self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [name][crate::model::SetLocationsRequest::name].
+    pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.name = v.into();
         self
     }
 }
@@ -12282,15 +12282,6 @@ impl ServerConfig {
         self
     }
 
-    /// Sets the value of [default_image_type][crate::model::ServerConfig::default_image_type].
-    pub fn set_default_image_type<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.default_image_type = v.into();
-        self
-    }
-
     /// Sets the value of [valid_node_versions][crate::model::ServerConfig::valid_node_versions].
     pub fn set_valid_node_versions<T, V>(mut self, v: T) -> Self
     where
@@ -12299,6 +12290,15 @@ impl ServerConfig {
     {
         use std::iter::Iterator;
         self.valid_node_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [default_image_type][crate::model::ServerConfig::default_image_type].
+    pub fn set_default_image_type<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.default_image_type = v.into();
         self
     }
 
@@ -12395,15 +12395,6 @@ pub mod server_config {
             self
         }
 
-        /// Sets the value of [upgrade_target_version][crate::model::server_config::ReleaseChannelConfig::upgrade_target_version].
-        pub fn set_upgrade_target_version<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upgrade_target_version = v.into();
-            self
-        }
-
         /// Sets the value of [valid_versions][crate::model::server_config::ReleaseChannelConfig::valid_versions].
         pub fn set_valid_versions<T, V>(mut self, v: T) -> Self
         where
@@ -12412,6 +12403,15 @@ pub mod server_config {
         {
             use std::iter::Iterator;
             self.valid_versions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [upgrade_target_version][crate::model::server_config::ReleaseChannelConfig::upgrade_target_version].
+        pub fn set_upgrade_target_version<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.upgrade_target_version = v.into();
             self
         }
     }
@@ -12927,17 +12927,6 @@ pub mod blue_green_settings {
             })
         }
 
-        /// The value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
-        /// if it holds a `BatchNodeCount`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn batch_node_count(&self) -> std::option::Option<&i32> {
-            #[allow(unreachable_patterns)]
-            self.update_batch_size.as_ref().and_then(|v| match v {
-                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchNodeCount(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
         /// to hold a `BatchPercentage`.
         ///
@@ -12950,6 +12939,17 @@ pub mod blue_green_settings {
                 )
             );
             self
+        }
+
+        /// The value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
+        /// if it holds a `BatchNodeCount`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn batch_node_count(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.update_batch_size.as_ref().and_then(|v| match v {
+                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchNodeCount(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
@@ -13154,6 +13154,17 @@ impl NodePool {
         self
     }
 
+    /// Sets the value of [locations][crate::model::NodePool::locations].
+    pub fn set_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [network_config][crate::model::NodePool::network_config].
     pub fn set_network_config<
         T: std::convert::Into<std::option::Option<crate::model::NodeNetworkConfig>>,
@@ -13174,6 +13185,17 @@ impl NodePool {
     /// Sets the value of [version][crate::model::NodePool::version].
     pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.version = v.into();
+        self
+    }
+
+    /// Sets the value of [instance_group_urls][crate::model::NodePool::instance_group_urls].
+    pub fn set_instance_group_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.instance_group_urls = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -13223,6 +13245,17 @@ impl NodePool {
         v: T,
     ) -> Self {
         self.max_pods_constraint = v.into();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::NodePool::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::StatusCondition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -13290,39 +13323,6 @@ impl NodePool {
         v: T,
     ) -> Self {
         self.best_effort_provisioning = v.into();
-        self
-    }
-
-    /// Sets the value of [locations][crate::model::NodePool::locations].
-    pub fn set_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.locations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [instance_group_urls][crate::model::NodePool::instance_group_urls].
-    pub fn set_instance_group_urls<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.instance_group_urls = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::NodePool::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::StatusCondition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13556,24 +13556,6 @@ pub mod node_pool {
                 self
             }
 
-            /// Sets the value of [blue_pool_deletion_start_time][crate::model::node_pool::update_info::BlueGreenInfo::blue_pool_deletion_start_time].
-            pub fn set_blue_pool_deletion_start_time<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.blue_pool_deletion_start_time = v.into();
-                self
-            }
-
-            /// Sets the value of [green_pool_version][crate::model::node_pool::update_info::BlueGreenInfo::green_pool_version].
-            pub fn set_green_pool_version<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.green_pool_version = v.into();
-                self
-            }
-
             /// Sets the value of [blue_instance_group_urls][crate::model::node_pool::update_info::BlueGreenInfo::blue_instance_group_urls].
             pub fn set_blue_instance_group_urls<T, V>(mut self, v: T) -> Self
             where
@@ -13593,6 +13575,24 @@ pub mod node_pool {
             {
                 use std::iter::Iterator;
                 self.green_instance_group_urls = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [blue_pool_deletion_start_time][crate::model::node_pool::update_info::BlueGreenInfo::blue_pool_deletion_start_time].
+            pub fn set_blue_pool_deletion_start_time<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.blue_pool_deletion_start_time = v.into();
+                self
+            }
+
+            /// Sets the value of [green_pool_version][crate::model::node_pool::update_info::BlueGreenInfo::green_pool_version].
+            pub fn set_green_pool_version<T: std::convert::Into<std::string::String>>(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.green_pool_version = v.into();
                 self
             }
         }
@@ -14456,21 +14456,6 @@ impl MaintenanceWindow {
         })
     }
 
-    /// The value of [policy][crate::model::MaintenanceWindow::policy]
-    /// if it holds a `RecurringWindow`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn recurring_window(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RecurringTimeWindow>> {
-        #[allow(unreachable_patterns)]
-        self.policy.as_ref().and_then(|v| match v {
-            crate::model::maintenance_window::Policy::RecurringWindow(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [policy][crate::model::MaintenanceWindow::policy]
     /// to hold a `DailyMaintenanceWindow`.
     ///
@@ -14486,6 +14471,21 @@ impl MaintenanceWindow {
             crate::model::maintenance_window::Policy::DailyMaintenanceWindow(v.into()),
         );
         self
+    }
+
+    /// The value of [policy][crate::model::MaintenanceWindow::policy]
+    /// if it holds a `RecurringWindow`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn recurring_window(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RecurringTimeWindow>> {
+        #[allow(unreachable_patterns)]
+        self.policy.as_ref().and_then(|v| match v {
+            crate::model::maintenance_window::Policy::RecurringWindow(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [policy][crate::model::MaintenanceWindow::policy]
@@ -15374,6 +15374,17 @@ impl ClusterAutoscaling {
         self
     }
 
+    /// Sets the value of [resource_limits][crate::model::ClusterAutoscaling::resource_limits].
+    pub fn set_resource_limits<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ResourceLimit>,
+    {
+        use std::iter::Iterator;
+        self.resource_limits = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [autoscaling_profile][crate::model::ClusterAutoscaling::autoscaling_profile].
     pub fn set_autoscaling_profile<
         T: std::convert::Into<crate::model::cluster_autoscaling::AutoscalingProfile>,
@@ -15393,17 +15404,6 @@ impl ClusterAutoscaling {
         v: T,
     ) -> Self {
         self.autoprovisioning_node_pool_defaults = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_limits][crate::model::ClusterAutoscaling::resource_limits].
-    pub fn set_resource_limits<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ResourceLimit>,
-    {
-        use std::iter::Iterator;
-        self.resource_limits = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -15647,6 +15647,17 @@ impl AutoprovisioningNodePoolDefaults {
         std::default::Default::default()
     }
 
+    /// Sets the value of [oauth_scopes][crate::model::AutoprovisioningNodePoolDefaults::oauth_scopes].
+    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [service_account][crate::model::AutoprovisioningNodePoolDefaults::service_account].
     pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.service_account = v.into();
@@ -15731,17 +15742,6 @@ impl AutoprovisioningNodePoolDefaults {
         v: T,
     ) -> Self {
         self.insecure_kubelet_readonly_port_enabled = v.into();
-        self
-    }
-
-    /// Sets the value of [oauth_scopes][crate::model::AutoprovisioningNodePoolDefaults::oauth_scopes].
-    pub fn set_oauth_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.oauth_scopes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -16129,6 +16129,18 @@ impl SetLabelsRequest {
         self
     }
 
+    /// Sets the value of [resource_labels][crate::model::SetLabelsRequest::resource_labels].
+    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [label_fingerprint][crate::model::SetLabelsRequest::label_fingerprint].
     pub fn set_label_fingerprint<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -16141,18 +16153,6 @@ impl SetLabelsRequest {
     /// Sets the value of [name][crate::model::SetLabelsRequest::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_labels][crate::model::SetLabelsRequest::resource_labels].
-    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -18547,6 +18547,17 @@ impl AutopilotCompatibilityIssue {
         self
     }
 
+    /// Sets the value of [subjects][crate::model::AutopilotCompatibilityIssue::subjects].
+    pub fn set_subjects<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.subjects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [documentation_url][crate::model::AutopilotCompatibilityIssue::documentation_url].
     pub fn set_documentation_url<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -18559,17 +18570,6 @@ impl AutopilotCompatibilityIssue {
     /// Sets the value of [description][crate::model::AutopilotCompatibilityIssue::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [subjects][crate::model::AutopilotCompatibilityIssue::subjects].
-    pub fn set_subjects<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.subjects = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -18756,12 +18756,6 @@ impl CheckAutopilotCompatibilityResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [summary][crate::model::CheckAutopilotCompatibilityResponse::summary].
-    pub fn set_summary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.summary = v.into();
-        self
-    }
-
     /// Sets the value of [issues][crate::model::CheckAutopilotCompatibilityResponse::issues].
     pub fn set_issues<T, V>(mut self, v: T) -> Self
     where
@@ -18770,6 +18764,12 @@ impl CheckAutopilotCompatibilityResponse {
     {
         use std::iter::Iterator;
         self.issues = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [summary][crate::model::CheckAutopilotCompatibilityResponse::summary].
+    pub fn set_summary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.summary = v.into();
         self
     }
 }
@@ -20132,12 +20132,6 @@ impl ListUsableSubnetworksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUsableSubnetworksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [subnetworks][crate::model::ListUsableSubnetworksResponse::subnetworks].
     pub fn set_subnetworks<T, V>(mut self, v: T) -> Self
     where
@@ -20146,6 +20140,12 @@ impl ListUsableSubnetworksResponse {
     {
         use std::iter::Iterator;
         self.subnetworks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUsableSubnetworksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -20443,12 +20443,6 @@ impl UsableSubnetwork {
         self
     }
 
-    /// Sets the value of [status_message][crate::model::UsableSubnetwork::status_message].
-    pub fn set_status_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.status_message = v.into();
-        self
-    }
-
     /// Sets the value of [secondary_ip_ranges][crate::model::UsableSubnetwork::secondary_ip_ranges].
     pub fn set_secondary_ip_ranges<T, V>(mut self, v: T) -> Self
     where
@@ -20457,6 +20451,12 @@ impl UsableSubnetwork {
     {
         use std::iter::Iterator;
         self.secondary_ip_ranges = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [status_message][crate::model::UsableSubnetwork::status_message].
+    pub fn set_status_message<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.status_message = v.into();
         self
     }
 }
@@ -21607,6 +21607,17 @@ impl SecurityBulletinEvent {
         self
     }
 
+    /// Sets the value of [cve_ids][crate::model::SecurityBulletinEvent::cve_ids].
+    pub fn set_cve_ids<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.cve_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [severity][crate::model::SecurityBulletinEvent::severity].
     pub fn set_severity<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.severity = v.into();
@@ -21625,32 +21636,6 @@ impl SecurityBulletinEvent {
         v: T,
     ) -> Self {
         self.brief_description = v.into();
-        self
-    }
-
-    /// Sets the value of [suggested_upgrade_target][crate::model::SecurityBulletinEvent::suggested_upgrade_target].
-    pub fn set_suggested_upgrade_target<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggested_upgrade_target = v.into();
-        self
-    }
-
-    /// Sets the value of [manual_steps_required][crate::model::SecurityBulletinEvent::manual_steps_required].
-    pub fn set_manual_steps_required<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.manual_steps_required = v.into();
-        self
-    }
-
-    /// Sets the value of [cve_ids][crate::model::SecurityBulletinEvent::cve_ids].
-    pub fn set_cve_ids<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.cve_ids = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -21673,6 +21658,21 @@ impl SecurityBulletinEvent {
     {
         use std::iter::Iterator;
         self.patched_versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [suggested_upgrade_target][crate::model::SecurityBulletinEvent::suggested_upgrade_target].
+    pub fn set_suggested_upgrade_target<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.suggested_upgrade_target = v.into();
+        self
+    }
+
+    /// Sets the value of [manual_steps_required][crate::model::SecurityBulletinEvent::manual_steps_required].
+    pub fn set_manual_steps_required<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.manual_steps_required = v.into();
         self
     }
 }

--- a/src/generated/datastore/admin/v1/src/builder.rs
+++ b/src/generated/datastore/admin/v1/src/builder.rs
@@ -148,6 +148,17 @@ pub mod datastore_admin {
             self
         }
 
+        /// Sets the value of [labels][crate::model::ExportEntitiesRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [entity_filter][crate::model::ExportEntitiesRequest::entity_filter].
         pub fn set_entity_filter<T: Into<std::option::Option<crate::model::EntityFilter>>>(
             mut self,
@@ -162,17 +173,6 @@ pub mod datastore_admin {
         /// This is a **required** field for requests.
         pub fn set_output_url_prefix<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.output_url_prefix = v.into();
-            self
-        }
-
-        /// Sets the value of [labels][crate::model::ExportEntitiesRequest::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -258,6 +258,17 @@ pub mod datastore_admin {
             self
         }
 
+        /// Sets the value of [labels][crate::model::ImportEntitiesRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [input_url][crate::model::ImportEntitiesRequest::input_url].
         ///
         /// This is a **required** field for requests.
@@ -272,17 +283,6 @@ pub mod datastore_admin {
             v: T,
         ) -> Self {
             self.0.request.entity_filter = v.into();
-            self
-        }
-
-        /// Sets the value of [labels][crate::model::ImportEntitiesRequest::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -94,15 +94,6 @@ impl CommonMetadata {
         self
     }
 
-    /// Sets the value of [state][crate::model::CommonMetadata::state].
-    pub fn set_state<T: std::convert::Into<crate::model::common_metadata::State>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::CommonMetadata::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -112,6 +103,15 @@ impl CommonMetadata {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::CommonMetadata::state].
+    pub fn set_state<T: std::convert::Into<crate::model::common_metadata::State>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.state = v.into();
         self
     }
 }
@@ -402,6 +402,18 @@ impl ExportEntitiesRequest {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ExportEntitiesRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [entity_filter][crate::model::ExportEntitiesRequest::entity_filter].
     pub fn set_entity_filter<
         T: std::convert::Into<std::option::Option<crate::model::EntityFilter>>,
@@ -419,18 +431,6 @@ impl ExportEntitiesRequest {
         v: T,
     ) -> Self {
         self.output_url_prefix = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ExportEntitiesRequest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -499,6 +499,18 @@ impl ImportEntitiesRequest {
         self
     }
 
+    /// Sets the value of [labels][crate::model::ImportEntitiesRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [input_url][crate::model::ImportEntitiesRequest::input_url].
     pub fn set_input_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.input_url = v.into();
@@ -513,18 +525,6 @@ impl ImportEntitiesRequest {
         v: T,
     ) -> Self {
         self.entity_filter = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::ImportEntitiesRequest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1076,12 +1076,6 @@ impl ListIndexesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIndexesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [indexes][crate::model::ListIndexesResponse::indexes].
     pub fn set_indexes<T, V>(mut self, v: T) -> Self
     where
@@ -1090,6 +1084,12 @@ impl ListIndexesResponse {
     {
         use std::iter::Iterator;
         self.indexes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIndexesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1298,12 +1298,6 @@ impl Index {
         self
     }
 
-    /// Sets the value of [state][crate::model::Index::state].
-    pub fn set_state<T: std::convert::Into<crate::model::index::State>>(mut self, v: T) -> Self {
-        self.state = v.into();
-        self
-    }
-
     /// Sets the value of [properties][crate::model::Index::properties].
     pub fn set_properties<T, V>(mut self, v: T) -> Self
     where
@@ -1312,6 +1306,12 @@ impl Index {
     {
         use std::iter::Iterator;
         self.properties = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [state][crate::model::Index::state].
+    pub fn set_state<T: std::convert::Into<crate::model::index::State>>(mut self, v: T) -> Self {
+        self.state = v.into();
         self
     }
 }
@@ -1898,23 +1898,6 @@ impl MigrationProgressEvent {
         })
     }
 
-    /// The value of [step_details][crate::model::MigrationProgressEvent::step_details]
-    /// if it holds a `RedirectWritesStepDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redirect_writes_step_details(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::migration_progress_event::RedirectWritesStepDetails>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.step_details.as_ref().and_then(|v| match v {
-            crate::model::migration_progress_event::StepDetails::RedirectWritesStepDetails(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [step_details][crate::model::MigrationProgressEvent::step_details]
     /// to hold a `PrepareStepDetails`.
     ///
@@ -1932,6 +1915,23 @@ impl MigrationProgressEvent {
             crate::model::migration_progress_event::StepDetails::PrepareStepDetails(v.into()),
         );
         self
+    }
+
+    /// The value of [step_details][crate::model::MigrationProgressEvent::step_details]
+    /// if it holds a `RedirectWritesStepDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redirect_writes_step_details(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::migration_progress_event::RedirectWritesStepDetails>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.step_details.as_ref().and_then(|v| match v {
+            crate::model::migration_progress_event::StepDetails::RedirectWritesStepDetails(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [step_details][crate::model::MigrationProgressEvent::step_details]

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -1716,12 +1716,6 @@ pub mod artifact_registry {
             self
         }
 
-        /// Sets the value of [validate_only][crate::model::BatchDeleteVersionsRequest::validate_only].
-        pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.validate_only = v.into();
-            self
-        }
-
         /// Sets the value of [names][crate::model::BatchDeleteVersionsRequest::names].
         ///
         /// This is a **required** field for requests.
@@ -1732,6 +1726,12 @@ pub mod artifact_registry {
         {
             use std::iter::Iterator;
             self.0.request.names = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [validate_only][crate::model::BatchDeleteVersionsRequest::validate_only].
+        pub fn set_validate_only<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.validate_only = v.into();
             self
         }
     }

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -284,12 +284,6 @@ impl ImportAptArtifactsGcsSource {
         std::default::Default::default()
     }
 
-    /// Sets the value of [use_wildcards][crate::model::ImportAptArtifactsGcsSource::use_wildcards].
-    pub fn set_use_wildcards<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.use_wildcards = v.into();
-        self
-    }
-
     /// Sets the value of [uris][crate::model::ImportAptArtifactsGcsSource::uris].
     pub fn set_uris<T, V>(mut self, v: T) -> Self
     where
@@ -298,6 +292,12 @@ impl ImportAptArtifactsGcsSource {
     {
         use std::iter::Iterator;
         self.uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [use_wildcards][crate::model::ImportAptArtifactsGcsSource::use_wildcards].
+    pub fn set_use_wildcards<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.use_wildcards = v.into();
         self
     }
 }
@@ -667,6 +667,17 @@ impl DockerImage {
         self
     }
 
+    /// Sets the value of [tags][crate::model::DockerImage::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [image_size_bytes][crate::model::DockerImage::image_size_bytes].
     pub fn set_image_size_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.image_size_bytes = v.into();
@@ -703,17 +714,6 @@ impl DockerImage {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::DockerImage::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -811,12 +811,6 @@ impl ListDockerImagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDockerImagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [docker_images][crate::model::ListDockerImagesResponse::docker_images].
     pub fn set_docker_images<T, V>(mut self, v: T) -> Self
     where
@@ -825,6 +819,12 @@ impl ListDockerImagesResponse {
     {
         use std::iter::Iterator;
         self.docker_images = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDockerImagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1067,12 +1067,6 @@ impl ListMavenArtifactsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMavenArtifactsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [maven_artifacts][crate::model::ListMavenArtifactsResponse::maven_artifacts].
     pub fn set_maven_artifacts<T, V>(mut self, v: T) -> Self
     where
@@ -1081,6 +1075,12 @@ impl ListMavenArtifactsResponse {
     {
         use std::iter::Iterator;
         self.maven_artifacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMavenArtifactsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1200,6 +1200,17 @@ impl NpmPackage {
         self
     }
 
+    /// Sets the value of [tags][crate::model::NpmPackage::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::NpmPackage::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1215,17 +1226,6 @@ impl NpmPackage {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::NpmPackage::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1313,12 +1313,6 @@ impl ListNpmPackagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNpmPackagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [npm_packages][crate::model::ListNpmPackagesResponse::npm_packages].
     pub fn set_npm_packages<T, V>(mut self, v: T) -> Self
     where
@@ -1327,6 +1321,12 @@ impl ListNpmPackagesResponse {
     {
         use std::iter::Iterator;
         self.npm_packages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNpmPackagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1558,12 +1558,6 @@ impl ListPythonPackagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPythonPackagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [python_packages][crate::model::ListPythonPackagesResponse::python_packages].
     pub fn set_python_packages<T, V>(mut self, v: T) -> Self
     where
@@ -1572,6 +1566,12 @@ impl ListPythonPackagesResponse {
     {
         use std::iter::Iterator;
         self.python_packages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPythonPackagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1721,6 +1721,18 @@ impl Attachment {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Attachment::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Attachment::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1739,15 +1751,6 @@ impl Attachment {
         self
     }
 
-    /// Sets the value of [oci_version_name][crate::model::Attachment::oci_version_name].
-    pub fn set_oci_version_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.oci_version_name = v.into();
-        self
-    }
-
     /// Sets the value of [files][crate::model::Attachment::files].
     pub fn set_files<T, V>(mut self, v: T) -> Self
     where
@@ -1759,15 +1762,12 @@ impl Attachment {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::Attachment::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [oci_version_name][crate::model::Attachment::oci_version_name].
+    pub fn set_oci_version_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.oci_version_name = v.into();
         self
     }
 }
@@ -1869,12 +1869,6 @@ impl ListAttachmentsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAttachmentsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [attachments][crate::model::ListAttachmentsResponse::attachments].
     pub fn set_attachments<T, V>(mut self, v: T) -> Self
     where
@@ -1883,6 +1877,12 @@ impl ListAttachmentsResponse {
     {
         use std::iter::Iterator;
         self.attachments = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAttachmentsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2271,6 +2271,17 @@ impl File {
         self
     }
 
+    /// Sets the value of [hashes][crate::model::File::hashes].
+    pub fn set_hashes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Hash>,
+    {
+        use std::iter::Iterator;
+        self.hashes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::File::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2301,17 +2312,6 @@ impl File {
         v: T,
     ) -> Self {
         self.fetch_time = v.into();
-        self
-    }
-
-    /// Sets the value of [hashes][crate::model::File::hashes].
-    pub fn set_hashes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Hash>,
-    {
-        use std::iter::Iterator;
-        self.hashes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2480,12 +2480,6 @@ impl ListFilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [files][crate::model::ListFilesResponse::files].
     pub fn set_files<T, V>(mut self, v: T) -> Self
     where
@@ -2494,6 +2488,12 @@ impl ListFilesResponse {
     {
         use std::iter::Iterator;
         self.files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3046,12 +3046,6 @@ impl ListPackagesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPackagesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [packages][crate::model::ListPackagesResponse::packages].
     pub fn set_packages<T, V>(mut self, v: T) -> Self
     where
@@ -3060,6 +3054,12 @@ impl ListPackagesResponse {
     {
         use std::iter::Iterator;
         self.packages = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPackagesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3303,24 +3303,6 @@ impl CleanupPolicyCondition {
         self
     }
 
-    /// Sets the value of [older_than][crate::model::CleanupPolicyCondition::older_than].
-    pub fn set_older_than<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.older_than = v.into();
-        self
-    }
-
-    /// Sets the value of [newer_than][crate::model::CleanupPolicyCondition::newer_than].
-    pub fn set_newer_than<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.newer_than = v.into();
-        self
-    }
-
     /// Sets the value of [tag_prefixes][crate::model::CleanupPolicyCondition::tag_prefixes].
     pub fn set_tag_prefixes<T, V>(mut self, v: T) -> Self
     where
@@ -3351,6 +3333,24 @@ impl CleanupPolicyCondition {
     {
         use std::iter::Iterator;
         self.package_name_prefixes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [older_than][crate::model::CleanupPolicyCondition::older_than].
+    pub fn set_older_than<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.older_than = v.into();
+        self
+    }
+
+    /// Sets the value of [newer_than][crate::model::CleanupPolicyCondition::newer_than].
+    pub fn set_newer_than<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.newer_than = v.into();
         self
     }
 }
@@ -3530,12 +3530,6 @@ impl CleanupPolicyMostRecentVersions {
         std::default::Default::default()
     }
 
-    /// Sets the value of [keep_count][crate::model::CleanupPolicyMostRecentVersions::keep_count].
-    pub fn set_keep_count<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
-        self.keep_count = v.into();
-        self
-    }
-
     /// Sets the value of [package_name_prefixes][crate::model::CleanupPolicyMostRecentVersions::package_name_prefixes].
     pub fn set_package_name_prefixes<T, V>(mut self, v: T) -> Self
     where
@@ -3544,6 +3538,12 @@ impl CleanupPolicyMostRecentVersions {
     {
         use std::iter::Iterator;
         self.package_name_prefixes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [keep_count][crate::model::CleanupPolicyMostRecentVersions::keep_count].
+    pub fn set_keep_count<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
+        self.keep_count = v.into();
         self
     }
 }
@@ -3623,21 +3623,6 @@ impl CleanupPolicy {
         })
     }
 
-    /// The value of [condition_type][crate::model::CleanupPolicy::condition_type]
-    /// if it holds a `MostRecentVersions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn most_recent_versions(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CleanupPolicyMostRecentVersions>> {
-        #[allow(unreachable_patterns)]
-        self.condition_type.as_ref().and_then(|v| match v {
-            crate::model::cleanup_policy::ConditionType::MostRecentVersions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [condition_type][crate::model::CleanupPolicy::condition_type]
     /// to hold a `Condition`.
     ///
@@ -3653,6 +3638,21 @@ impl CleanupPolicy {
             crate::model::cleanup_policy::ConditionType::Condition(v.into()),
         );
         self
+    }
+
+    /// The value of [condition_type][crate::model::CleanupPolicy::condition_type]
+    /// if it holds a `MostRecentVersions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn most_recent_versions(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CleanupPolicyMostRecentVersions>> {
+        #[allow(unreachable_patterns)]
+        self.condition_type.as_ref().and_then(|v| match v {
+            crate::model::cleanup_policy::ConditionType::MostRecentVersions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [condition_type][crate::model::CleanupPolicy::condition_type]
@@ -3957,105 +3957,6 @@ impl RemoteRepositoryConfig {
         })
     }
 
-    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// if it holds a `MavenRepository`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn maven_repository(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::remote_repository_config::MavenRepository>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.remote_source.as_ref().and_then(|v| match v {
-            crate::model::remote_repository_config::RemoteSource::MavenRepository(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// if it holds a `NpmRepository`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn npm_repository(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::remote_repository_config::NpmRepository>>
-    {
-        #[allow(unreachable_patterns)]
-        self.remote_source.as_ref().and_then(|v| match v {
-            crate::model::remote_repository_config::RemoteSource::NpmRepository(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// if it holds a `PythonRepository`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn python_repository(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::remote_repository_config::PythonRepository>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.remote_source.as_ref().and_then(|v| match v {
-            crate::model::remote_repository_config::RemoteSource::PythonRepository(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// if it holds a `AptRepository`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn apt_repository(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::remote_repository_config::AptRepository>>
-    {
-        #[allow(unreachable_patterns)]
-        self.remote_source.as_ref().and_then(|v| match v {
-            crate::model::remote_repository_config::RemoteSource::AptRepository(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// if it holds a `YumRepository`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn yum_repository(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::remote_repository_config::YumRepository>>
-    {
-        #[allow(unreachable_patterns)]
-        self.remote_source.as_ref().and_then(|v| match v {
-            crate::model::remote_repository_config::RemoteSource::YumRepository(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// if it holds a `CommonRepository`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn common_repository(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::remote_repository_config::CommonRemoteRepository>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.remote_source.as_ref().and_then(|v| match v {
-            crate::model::remote_repository_config::RemoteSource::CommonRepository(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// to hold a `DockerRepository`.
     ///
@@ -4073,6 +3974,23 @@ impl RemoteRepositoryConfig {
             crate::model::remote_repository_config::RemoteSource::DockerRepository(v.into()),
         );
         self
+    }
+
+    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
+    /// if it holds a `MavenRepository`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn maven_repository(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::remote_repository_config::MavenRepository>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.remote_source.as_ref().and_then(|v| match v {
+            crate::model::remote_repository_config::RemoteSource::MavenRepository(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
@@ -4094,6 +4012,22 @@ impl RemoteRepositoryConfig {
         self
     }
 
+    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
+    /// if it holds a `NpmRepository`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn npm_repository(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::remote_repository_config::NpmRepository>>
+    {
+        #[allow(unreachable_patterns)]
+        self.remote_source.as_ref().and_then(|v| match v {
+            crate::model::remote_repository_config::RemoteSource::NpmRepository(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// to hold a `NpmRepository`.
     ///
@@ -4109,6 +4043,23 @@ impl RemoteRepositoryConfig {
             crate::model::remote_repository_config::RemoteSource::NpmRepository(v.into()),
         );
         self
+    }
+
+    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
+    /// if it holds a `PythonRepository`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn python_repository(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::remote_repository_config::PythonRepository>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.remote_source.as_ref().and_then(|v| match v {
+            crate::model::remote_repository_config::RemoteSource::PythonRepository(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
@@ -4130,6 +4081,22 @@ impl RemoteRepositoryConfig {
         self
     }
 
+    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
+    /// if it holds a `AptRepository`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn apt_repository(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::remote_repository_config::AptRepository>>
+    {
+        #[allow(unreachable_patterns)]
+        self.remote_source.as_ref().and_then(|v| match v {
+            crate::model::remote_repository_config::RemoteSource::AptRepository(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// to hold a `AptRepository`.
     ///
@@ -4147,6 +4114,22 @@ impl RemoteRepositoryConfig {
         self
     }
 
+    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
+    /// if it holds a `YumRepository`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn yum_repository(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::remote_repository_config::YumRepository>>
+    {
+        #[allow(unreachable_patterns)]
+        self.remote_source.as_ref().and_then(|v| match v {
+            crate::model::remote_repository_config::RemoteSource::YumRepository(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// to hold a `YumRepository`.
     ///
@@ -4162,6 +4145,23 @@ impl RemoteRepositoryConfig {
             crate::model::remote_repository_config::RemoteSource::YumRepository(v.into()),
         );
         self
+    }
+
+    /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
+    /// if it holds a `CommonRepository`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn common_repository(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::remote_repository_config::CommonRemoteRepository>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.remote_source.as_ref().and_then(|v| match v {
+            crate::model::remote_repository_config::RemoteSource::CommonRepository(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
@@ -4383,23 +4383,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// The value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
-        /// if it holds a `CustomRepository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::remote_repository_config::docker_repository::CustomRepository,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.upstream.as_ref().and_then(|v| match v {
-                crate::model::remote_repository_config::docker_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
         /// to hold a `PublicRepository`.
         ///
@@ -4419,6 +4402,23 @@ pub mod remote_repository_config {
                 )
             );
             self
+        }
+
+        /// The value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
+        /// if it holds a `CustomRepository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::remote_repository_config::docker_repository::CustomRepository,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.upstream.as_ref().and_then(|v| match v {
+                crate::model::remote_repository_config::docker_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
@@ -4689,23 +4689,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// The value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
-        /// if it holds a `CustomRepository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::remote_repository_config::maven_repository::CustomRepository,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.upstream.as_ref().and_then(|v| match v {
-                crate::model::remote_repository_config::maven_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
         /// to hold a `PublicRepository`.
         ///
@@ -4725,6 +4708,23 @@ pub mod remote_repository_config {
                 )
             );
             self
+        }
+
+        /// The value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
+        /// if it holds a `CustomRepository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::remote_repository_config::maven_repository::CustomRepository,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.upstream.as_ref().and_then(|v| match v {
+                crate::model::remote_repository_config::maven_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
@@ -4995,23 +4995,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// The value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
-        /// if it holds a `CustomRepository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::remote_repository_config::npm_repository::CustomRepository,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.upstream.as_ref().and_then(|v| match v {
-                crate::model::remote_repository_config::npm_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
         /// to hold a `PublicRepository`.
         ///
@@ -5031,6 +5014,23 @@ pub mod remote_repository_config {
                 ),
             );
             self
+        }
+
+        /// The value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
+        /// if it holds a `CustomRepository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::remote_repository_config::npm_repository::CustomRepository,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.upstream.as_ref().and_then(|v| match v {
+                crate::model::remote_repository_config::npm_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
@@ -5301,23 +5301,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// The value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
-        /// if it holds a `CustomRepository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::remote_repository_config::python_repository::CustomRepository,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.upstream.as_ref().and_then(|v| match v {
-                crate::model::remote_repository_config::python_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
         /// to hold a `PublicRepository`.
         ///
@@ -5337,6 +5320,23 @@ pub mod remote_repository_config {
                 )
             );
             self
+        }
+
+        /// The value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
+        /// if it holds a `CustomRepository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::remote_repository_config::python_repository::CustomRepository,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.upstream.as_ref().and_then(|v| match v {
+                crate::model::remote_repository_config::python_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
@@ -5608,23 +5608,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// The value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
-        /// if it holds a `CustomRepository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::remote_repository_config::apt_repository::CustomRepository,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.upstream.as_ref().and_then(|v| match v {
-                crate::model::remote_repository_config::apt_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
         /// to hold a `PublicRepository`.
         ///
@@ -5646,6 +5629,23 @@ pub mod remote_repository_config {
                 ),
             );
             self
+        }
+
+        /// The value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
+        /// if it holds a `CustomRepository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::remote_repository_config::apt_repository::CustomRepository,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.upstream.as_ref().and_then(|v| match v {
+                crate::model::remote_repository_config::apt_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
@@ -5987,23 +5987,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// The value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
-        /// if it holds a `CustomRepository`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn custom_repository(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::remote_repository_config::yum_repository::CustomRepository,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.upstream.as_ref().and_then(|v| match v {
-                crate::model::remote_repository_config::yum_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
         /// to hold a `PublicRepository`.
         ///
@@ -6025,6 +6008,23 @@ pub mod remote_repository_config {
                 ),
             );
             self
+        }
+
+        /// The value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
+        /// if it holds a `CustomRepository`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn custom_repository(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::remote_repository_config::yum_repository::CustomRepository,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.upstream.as_ref().and_then(|v| match v {
+                crate::model::remote_repository_config::yum_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
@@ -6517,6 +6517,18 @@ impl Repository {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Repository::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::Repository::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -6544,6 +6556,18 @@ impl Repository {
     /// Sets the value of [mode][crate::model::Repository::mode].
     pub fn set_mode<T: std::convert::Into<crate::model::repository::Mode>>(mut self, v: T) -> Self {
         self.mode = v.into();
+        self
+    }
+
+    /// Sets the value of [cleanup_policies][crate::model::Repository::cleanup_policies].
+    pub fn set_cleanup_policies<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::CleanupPolicy>,
+    {
+        use std::iter::Iterator;
+        self.cleanup_policies = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -6596,30 +6620,6 @@ impl Repository {
         self
     }
 
-    /// Sets the value of [labels][crate::model::Repository::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [cleanup_policies][crate::model::Repository::cleanup_policies].
-    pub fn set_cleanup_policies<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::CleanupPolicy>,
-    {
-        use std::iter::Iterator;
-        self.cleanup_policies = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [format_config][crate::model::Repository::format_config].
     ///
     /// Note that all the setters affecting `format_config` are mutually
@@ -6648,20 +6648,6 @@ impl Repository {
         })
     }
 
-    /// The value of [format_config][crate::model::Repository::format_config]
-    /// if it holds a `DockerConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn docker_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::repository::DockerRepositoryConfig>>
-    {
-        #[allow(unreachable_patterns)]
-        self.format_config.as_ref().and_then(|v| match v {
-            crate::model::repository::FormatConfig::DockerConfig(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [format_config][crate::model::Repository::format_config]
     /// to hold a `MavenConfig`.
     ///
@@ -6677,6 +6663,20 @@ impl Repository {
             crate::model::repository::FormatConfig::MavenConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [format_config][crate::model::Repository::format_config]
+    /// if it holds a `DockerConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn docker_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::repository::DockerRepositoryConfig>>
+    {
+        #[allow(unreachable_patterns)]
+        self.format_config.as_ref().and_then(|v| match v {
+            crate::model::repository::FormatConfig::DockerConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [format_config][crate::model::Repository::format_config]
@@ -6725,21 +6725,6 @@ impl Repository {
         })
     }
 
-    /// The value of [mode_config][crate::model::Repository::mode_config]
-    /// if it holds a `RemoteRepositoryConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn remote_repository_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RemoteRepositoryConfig>> {
-        #[allow(unreachable_patterns)]
-        self.mode_config.as_ref().and_then(|v| match v {
-            crate::model::repository::ModeConfig::RemoteRepositoryConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode_config][crate::model::Repository::mode_config]
     /// to hold a `VirtualRepositoryConfig`.
     ///
@@ -6755,6 +6740,21 @@ impl Repository {
             crate::model::repository::ModeConfig::VirtualRepositoryConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [mode_config][crate::model::Repository::mode_config]
+    /// if it holds a `RemoteRepositoryConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn remote_repository_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RemoteRepositoryConfig>> {
+        #[allow(unreachable_patterns)]
+        self.mode_config.as_ref().and_then(|v| match v {
+            crate::model::repository::ModeConfig::RemoteRepositoryConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode_config][crate::model::Repository::mode_config]
@@ -7843,12 +7843,6 @@ impl ListRepositoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [repositories][crate::model::ListRepositoriesResponse::repositories].
     pub fn set_repositories<T, V>(mut self, v: T) -> Self
     where
@@ -7857,6 +7851,12 @@ impl ListRepositoriesResponse {
     {
         use std::iter::Iterator;
         self.repositories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8472,12 +8472,6 @@ impl ListRulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rules][crate::model::ListRulesResponse::rules].
     pub fn set_rules<T, V>(mut self, v: T) -> Self
     where
@@ -8486,6 +8480,12 @@ impl ListRulesResponse {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9184,12 +9184,6 @@ impl ListTagsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTagsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tags][crate::model::ListTagsResponse::tags].
     pub fn set_tags<T, V>(mut self, v: T) -> Self
     where
@@ -9198,6 +9192,12 @@ impl ListTagsResponse {
     {
         use std::iter::Iterator;
         self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTagsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9477,15 +9477,6 @@ impl Version {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::Version::metadata].
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [related_tags][crate::model::Version::related_tags].
     pub fn set_related_tags<T, V>(mut self, v: T) -> Self
     where
@@ -9494,6 +9485,15 @@ impl Version {
     {
         use std::iter::Iterator;
         self.related_tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::Version::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Struct>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 
@@ -9665,12 +9665,6 @@ impl ListVersionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [versions][crate::model::ListVersionsResponse::versions].
     pub fn set_versions<T, V>(mut self, v: T) -> Self
     where
@@ -9679,6 +9673,12 @@ impl ListVersionsResponse {
     {
         use std::iter::Iterator;
         self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListVersionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -9822,12 +9822,6 @@ impl BatchDeleteVersionsRequest {
         self
     }
 
-    /// Sets the value of [validate_only][crate::model::BatchDeleteVersionsRequest::validate_only].
-    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.validate_only = v.into();
-        self
-    }
-
     /// Sets the value of [names][crate::model::BatchDeleteVersionsRequest::names].
     pub fn set_names<T, V>(mut self, v: T) -> Self
     where
@@ -9836,6 +9830,12 @@ impl BatchDeleteVersionsRequest {
     {
         use std::iter::Iterator;
         self.names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [validate_only][crate::model::BatchDeleteVersionsRequest::validate_only].
+    pub fn set_validate_only<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.validate_only = v.into();
         self
     }
 }
@@ -10433,12 +10433,6 @@ impl ImportYumArtifactsGcsSource {
         std::default::Default::default()
     }
 
-    /// Sets the value of [use_wildcards][crate::model::ImportYumArtifactsGcsSource::use_wildcards].
-    pub fn set_use_wildcards<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.use_wildcards = v.into();
-        self
-    }
-
     /// Sets the value of [uris][crate::model::ImportYumArtifactsGcsSource::uris].
     pub fn set_uris<T, V>(mut self, v: T) -> Self
     where
@@ -10447,6 +10441,12 @@ impl ImportYumArtifactsGcsSource {
     {
         use std::iter::Iterator;
         self.uris = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [use_wildcards][crate::model::ImportYumArtifactsGcsSource::use_wildcards].
+    pub fn set_use_wildcards<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.use_wildcards = v.into();
         self
     }
 }

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -537,28 +537,6 @@ impl RepoSource {
         })
     }
 
-    /// The value of [revision][crate::model::RepoSource::revision]
-    /// if it holds a `TagName`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tag_name(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.revision.as_ref().and_then(|v| match v {
-            crate::model::repo_source::Revision::TagName(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [revision][crate::model::RepoSource::revision]
-    /// if it holds a `CommitSha`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn commit_sha(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.revision.as_ref().and_then(|v| match v {
-            crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [revision][crate::model::RepoSource::revision]
     /// to hold a `BranchName`.
     ///
@@ -570,6 +548,17 @@ impl RepoSource {
         self
     }
 
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `TagName`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tag_name(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::TagName(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [revision][crate::model::RepoSource::revision]
     /// to hold a `TagName`.
     ///
@@ -579,6 +568,17 @@ impl RepoSource {
         self.revision =
             std::option::Option::Some(crate::model::repo_source::Revision::TagName(v.into()));
         self
+    }
+
+    /// The value of [revision][crate::model::RepoSource::revision]
+    /// if it holds a `CommitSha`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn commit_sha(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.revision.as_ref().and_then(|v| match v {
+            crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [revision][crate::model::RepoSource::revision]
@@ -729,41 +729,6 @@ impl Source {
         })
     }
 
-    /// The value of [source][crate::model::Source::source]
-    /// if it holds a `RepoSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn repo_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::RepoSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::source::Source::RepoSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::Source::source]
-    /// if it holds a `GitSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn git_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GitSource>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::source::Source::GitSource(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::Source::source]
-    /// if it holds a `StorageSourceManifest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn storage_source_manifest(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StorageSourceManifest>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::source::Source::StorageSourceManifest(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::Source::source]
     /// to hold a `StorageSource`.
     ///
@@ -780,6 +745,17 @@ impl Source {
         self
     }
 
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `RepoSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn repo_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::RepoSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::RepoSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::Source::source]
     /// to hold a `RepoSource`.
     ///
@@ -793,6 +769,17 @@ impl Source {
         self
     }
 
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `GitSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn git_source(&self) -> std::option::Option<&std::boxed::Box<crate::model::GitSource>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::GitSource(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::Source::source]
     /// to hold a `GitSource`.
     ///
@@ -804,6 +791,19 @@ impl Source {
     ) -> Self {
         self.source = std::option::Option::Some(crate::model::source::Source::GitSource(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::Source::source]
+    /// if it holds a `StorageSourceManifest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn storage_source_manifest(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StorageSourceManifest>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::source::Source::StorageSourceManifest(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::Source::source]
@@ -1299,6 +1299,28 @@ impl BuildStep {
         self
     }
 
+    /// Sets the value of [env][crate::model::BuildStep::env].
+    pub fn set_env<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.env = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [args][crate::model::BuildStep::args].
+    pub fn set_args<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.args = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [dir][crate::model::BuildStep::dir].
     pub fn set_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.dir = v.into();
@@ -1311,9 +1333,42 @@ impl BuildStep {
         self
     }
 
+    /// Sets the value of [wait_for][crate::model::BuildStep::wait_for].
+    pub fn set_wait_for<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.wait_for = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [entrypoint][crate::model::BuildStep::entrypoint].
     pub fn set_entrypoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.entrypoint = v.into();
+        self
+    }
+
+    /// Sets the value of [secret_env][crate::model::BuildStep::secret_env].
+    pub fn set_secret_env<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.secret_env = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [volumes][crate::model::BuildStep::volumes].
+    pub fn set_volumes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Volume>,
+    {
+        use std::iter::Iterator;
+        self.volumes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1362,6 +1417,17 @@ impl BuildStep {
         self
     }
 
+    /// Sets the value of [allow_exit_codes][crate::model::BuildStep::allow_exit_codes].
+    pub fn set_allow_exit_codes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<i32>,
+    {
+        use std::iter::Iterator;
+        self.allow_exit_codes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [script][crate::model::BuildStep::script].
     pub fn set_script<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.script = v.into();
@@ -1374,72 +1440,6 @@ impl BuildStep {
         v: T,
     ) -> Self {
         self.automap_substitutions = v.into();
-        self
-    }
-
-    /// Sets the value of [env][crate::model::BuildStep::env].
-    pub fn set_env<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.env = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [args][crate::model::BuildStep::args].
-    pub fn set_args<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.args = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [wait_for][crate::model::BuildStep::wait_for].
-    pub fn set_wait_for<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.wait_for = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [secret_env][crate::model::BuildStep::secret_env].
-    pub fn set_secret_env<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.secret_env = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [volumes][crate::model::BuildStep::volumes].
-    pub fn set_volumes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Volume>,
-    {
-        use std::iter::Iterator;
-        self.volumes = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [allow_exit_codes][crate::model::BuildStep::allow_exit_codes].
-    pub fn set_allow_exit_codes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<i32>,
-    {
-        use std::iter::Iterator;
-        self.allow_exit_codes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1566,32 +1566,6 @@ impl Results {
         std::default::Default::default()
     }
 
-    /// Sets the value of [artifact_manifest][crate::model::Results::artifact_manifest].
-    pub fn set_artifact_manifest<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.artifact_manifest = v.into();
-        self
-    }
-
-    /// Sets the value of [num_artifacts][crate::model::Results::num_artifacts].
-    pub fn set_num_artifacts<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.num_artifacts = v.into();
-        self
-    }
-
-    /// Sets the value of [artifact_timing][crate::model::Results::artifact_timing].
-    pub fn set_artifact_timing<
-        T: std::convert::Into<std::option::Option<crate::model::TimeSpan>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.artifact_timing = v.into();
-        self
-    }
-
     /// Sets the value of [images][crate::model::Results::images].
     pub fn set_images<T, V>(mut self, v: T) -> Self
     where
@@ -1614,6 +1588,21 @@ impl Results {
         self
     }
 
+    /// Sets the value of [artifact_manifest][crate::model::Results::artifact_manifest].
+    pub fn set_artifact_manifest<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.artifact_manifest = v.into();
+        self
+    }
+
+    /// Sets the value of [num_artifacts][crate::model::Results::num_artifacts].
+    pub fn set_num_artifacts<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.num_artifacts = v.into();
+        self
+    }
+
     /// Sets the value of [build_step_outputs][crate::model::Results::build_step_outputs].
     pub fn set_build_step_outputs<T, V>(mut self, v: T) -> Self
     where
@@ -1622,6 +1611,17 @@ impl Results {
     {
         use std::iter::Iterator;
         self.build_step_outputs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [artifact_timing][crate::model::Results::artifact_timing].
+    pub fn set_artifact_timing<
+        T: std::convert::Into<std::option::Option<crate::model::TimeSpan>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.artifact_timing = v.into();
         self
     }
 
@@ -1969,6 +1969,17 @@ impl Build {
         self
     }
 
+    /// Sets the value of [steps][crate::model::Build::steps].
+    pub fn set_steps<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BuildStep>,
+    {
+        use std::iter::Iterator;
+        self.steps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [results][crate::model::Build::results].
     pub fn set_results<T: std::convert::Into<std::option::Option<crate::model::Results>>>(
         mut self,
@@ -2011,6 +2022,17 @@ impl Build {
         v: T,
     ) -> Self {
         self.timeout = v.into();
+        self
+    }
+
+    /// Sets the value of [images][crate::model::Build::images].
+    pub fn set_images<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.images = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2073,6 +2095,52 @@ impl Build {
         self
     }
 
+    /// Sets the value of [substitutions][crate::model::Build::substitutions].
+    pub fn set_substitutions<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.substitutions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::Build::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [secrets][crate::model::Build::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>,
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [timing][crate::model::Build::timing].
+    pub fn set_timing<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::TimeSpan>,
+    {
+        use std::iter::Iterator;
+        self.timing = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [approval][crate::model::Build::approval].
     pub fn set_approval<T: std::convert::Into<std::option::Option<crate::model::BuildApproval>>>(
         mut self,
@@ -2099,6 +2167,17 @@ impl Build {
         self
     }
 
+    /// Sets the value of [warnings][crate::model::Build::warnings].
+    pub fn set_warnings<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::build::Warning>,
+    {
+        use std::iter::Iterator;
+        self.warnings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [git_config][crate::model::Build::git_config].
     pub fn set_git_config<T: std::convert::Into<std::option::Option<crate::model::GitConfig>>>(
         mut self,
@@ -2119,61 +2198,6 @@ impl Build {
         self
     }
 
-    /// Sets the value of [steps][crate::model::Build::steps].
-    pub fn set_steps<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BuildStep>,
-    {
-        use std::iter::Iterator;
-        self.steps = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [images][crate::model::Build::images].
-    pub fn set_images<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.images = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::Build::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [secrets][crate::model::Build::secrets].
-    pub fn set_secrets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Secret>,
-    {
-        use std::iter::Iterator;
-        self.secrets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [warnings][crate::model::Build::warnings].
-    pub fn set_warnings<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::build::Warning>,
-    {
-        use std::iter::Iterator;
-        self.warnings = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [dependencies][crate::model::Build::dependencies].
     pub fn set_dependencies<T, V>(mut self, v: T) -> Self
     where
@@ -2182,30 +2206,6 @@ impl Build {
     {
         use std::iter::Iterator;
         self.dependencies = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [substitutions][crate::model::Build::substitutions].
-    pub fn set_substitutions<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.substitutions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [timing][crate::model::Build::timing].
-    pub fn set_timing<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::TimeSpan>,
-    {
-        use std::iter::Iterator;
-        self.timing = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2854,6 +2854,16 @@ impl Dependency {
         })
     }
 
+    /// Sets the value of [dep][crate::model::Dependency::dep]
+    /// to hold a `Empty`.
+    ///
+    /// Note that all the setters affecting `dep` are
+    /// mutually exclusive.
+    pub fn set_empty<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.dep = std::option::Option::Some(crate::model::dependency::Dep::Empty(v.into()));
+        self
+    }
+
     /// The value of [dep][crate::model::Dependency::dep]
     /// if it holds a `GitSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -2865,16 +2875,6 @@ impl Dependency {
             crate::model::dependency::Dep::GitSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dep][crate::model::Dependency::dep]
-    /// to hold a `Empty`.
-    ///
-    /// Note that all the setters affecting `dep` are
-    /// mutually exclusive.
-    pub fn set_empty<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.dep = std::option::Option::Some(crate::model::dependency::Dep::Empty(v.into()));
-        self
     }
 
     /// Sets the value of [dep][crate::model::Dependency::dep]
@@ -3032,6 +3032,18 @@ pub mod dependency {
             })
         }
 
+        /// Sets the value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
+        /// to hold a `Url`.
+        ///
+        /// Note that all the setters affecting `repotype` are
+        /// mutually exclusive.
+        pub fn set_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.repotype = std::option::Option::Some(
+                crate::model::dependency::git_source_repository::Repotype::Url(v.into()),
+            );
+            self
+        }
+
         /// The value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
         /// if it holds a `DeveloperConnect`, `None` if the field is not set or
         /// holds a different branch.
@@ -3043,18 +3055,6 @@ pub mod dependency {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
-        /// to hold a `Url`.
-        ///
-        /// Note that all the setters affecting `repotype` are
-        /// mutually exclusive.
-        pub fn set_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.repotype = std::option::Option::Some(
-                crate::model::dependency::git_source_repository::Repotype::Url(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
@@ -3275,17 +3275,6 @@ impl Artifacts {
         std::default::Default::default()
     }
 
-    /// Sets the value of [objects][crate::model::Artifacts::objects].
-    pub fn set_objects<
-        T: std::convert::Into<std::option::Option<crate::model::artifacts::ArtifactObjects>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.objects = v.into();
-        self
-    }
-
     /// Sets the value of [images][crate::model::Artifacts::images].
     pub fn set_images<T, V>(mut self, v: T) -> Self
     where
@@ -3294,6 +3283,17 @@ impl Artifacts {
     {
         use std::iter::Iterator;
         self.images = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [objects][crate::model::Artifacts::objects].
+    pub fn set_objects<
+        T: std::convert::Into<std::option::Option<crate::model::artifacts::ArtifactObjects>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.objects = v.into();
         self
     }
 
@@ -3392,15 +3392,6 @@ pub mod artifacts {
             self
         }
 
-        /// Sets the value of [timing][crate::model::artifacts::ArtifactObjects::timing].
-        pub fn set_timing<T: std::convert::Into<std::option::Option<crate::model::TimeSpan>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.timing = v.into();
-            self
-        }
-
         /// Sets the value of [paths][crate::model::artifacts::ArtifactObjects::paths].
         pub fn set_paths<T, V>(mut self, v: T) -> Self
         where
@@ -3409,6 +3400,15 @@ pub mod artifacts {
         {
             use std::iter::Iterator;
             self.paths = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [timing][crate::model::artifacts::ArtifactObjects::timing].
+        pub fn set_timing<T: std::convert::Into<std::option::Option<crate::model::TimeSpan>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.timing = v.into();
             self
         }
     }
@@ -4557,12 +4557,6 @@ impl ListBuildsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBuildsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [builds][crate::model::ListBuildsResponse::builds].
     pub fn set_builds<T, V>(mut self, v: T) -> Self
     where
@@ -4571,6 +4565,12 @@ impl ListBuildsResponse {
     {
         use std::iter::Iterator;
         self.builds = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBuildsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5843,6 +5843,17 @@ impl BuildTrigger {
         self
     }
 
+    /// Sets the value of [tags][crate::model::BuildTrigger::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [trigger_template][crate::model::BuildTrigger::trigger_template].
     pub fn set_trigger_template<
         T: std::convert::Into<std::option::Option<crate::model::RepoSource>>,
@@ -5902,6 +5913,40 @@ impl BuildTrigger {
         self
     }
 
+    /// Sets the value of [substitutions][crate::model::BuildTrigger::substitutions].
+    pub fn set_substitutions<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.substitutions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [ignored_files][crate::model::BuildTrigger::ignored_files].
+    pub fn set_ignored_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.ignored_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [included_files][crate::model::BuildTrigger::included_files].
+    pub fn set_included_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.included_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [filter][crate::model::BuildTrigger::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
@@ -5936,51 +5981,6 @@ impl BuildTrigger {
         self
     }
 
-    /// Sets the value of [tags][crate::model::BuildTrigger::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [ignored_files][crate::model::BuildTrigger::ignored_files].
-    pub fn set_ignored_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.ignored_files = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [included_files][crate::model::BuildTrigger::included_files].
-    pub fn set_included_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.included_files = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [substitutions][crate::model::BuildTrigger::substitutions].
-    pub fn set_substitutions<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.substitutions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [build_template][crate::model::BuildTrigger::build_template].
     ///
     /// Note that all the setters affecting `build_template` are mutually
@@ -6008,43 +6008,6 @@ impl BuildTrigger {
         })
     }
 
-    /// The value of [build_template][crate::model::BuildTrigger::build_template]
-    /// if it holds a `Build`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn build(&self) -> std::option::Option<&std::boxed::Box<crate::model::Build>> {
-        #[allow(unreachable_patterns)]
-        self.build_template.as_ref().and_then(|v| match v {
-            crate::model::build_trigger::BuildTemplate::Build(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [build_template][crate::model::BuildTrigger::build_template]
-    /// if it holds a `Filename`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn filename(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.build_template.as_ref().and_then(|v| match v {
-            crate::model::build_trigger::BuildTemplate::Filename(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [build_template][crate::model::BuildTrigger::build_template]
-    /// if it holds a `GitFileSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn git_file_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GitFileSource>> {
-        #[allow(unreachable_patterns)]
-        self.build_template.as_ref().and_then(|v| match v {
-            crate::model::build_trigger::BuildTemplate::GitFileSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
     /// to hold a `Autodetect`.
     ///
@@ -6055,6 +6018,17 @@ impl BuildTrigger {
             crate::model::build_trigger::BuildTemplate::Autodetect(v.into()),
         );
         self
+    }
+
+    /// The value of [build_template][crate::model::BuildTrigger::build_template]
+    /// if it holds a `Build`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn build(&self) -> std::option::Option<&std::boxed::Box<crate::model::Build>> {
+        #[allow(unreachable_patterns)]
+        self.build_template.as_ref().and_then(|v| match v {
+            crate::model::build_trigger::BuildTemplate::Build(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
@@ -6071,6 +6045,17 @@ impl BuildTrigger {
         self
     }
 
+    /// The value of [build_template][crate::model::BuildTrigger::build_template]
+    /// if it holds a `Filename`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn filename(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.build_template.as_ref().and_then(|v| match v {
+            crate::model::build_trigger::BuildTemplate::Filename(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
     /// to hold a `Filename`.
     ///
@@ -6081,6 +6066,21 @@ impl BuildTrigger {
             crate::model::build_trigger::BuildTemplate::Filename(v.into()),
         );
         self
+    }
+
+    /// The value of [build_template][crate::model::BuildTrigger::build_template]
+    /// if it holds a `GitFileSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn git_file_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitFileSource>> {
+        #[allow(unreachable_patterns)]
+        self.build_template.as_ref().and_then(|v| match v {
+            crate::model::build_trigger::BuildTemplate::GitFileSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
@@ -6211,17 +6211,6 @@ impl RepositoryEventConfig {
         })
     }
 
-    /// The value of [filter][crate::model::RepositoryEventConfig::filter]
-    /// if it holds a `Push`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn push(&self) -> std::option::Option<&std::boxed::Box<crate::model::PushFilter>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::repository_event_config::Filter::Push(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::RepositoryEventConfig::filter]
     /// to hold a `PullRequest`.
     ///
@@ -6237,6 +6226,17 @@ impl RepositoryEventConfig {
             crate::model::repository_event_config::Filter::PullRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::RepositoryEventConfig::filter]
+    /// if it holds a `Push`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn push(&self) -> std::option::Option<&std::boxed::Box<crate::model::PushFilter>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::repository_event_config::Filter::Push(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::RepositoryEventConfig::filter]
@@ -6503,17 +6503,6 @@ impl GitHubEventsConfig {
         })
     }
 
-    /// The value of [event][crate::model::GitHubEventsConfig::event]
-    /// if it holds a `Push`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn push(&self) -> std::option::Option<&std::boxed::Box<crate::model::PushFilter>> {
-        #[allow(unreachable_patterns)]
-        self.event.as_ref().and_then(|v| match v {
-            crate::model::git_hub_events_config::Event::Push(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [event][crate::model::GitHubEventsConfig::event]
     /// to hold a `PullRequest`.
     ///
@@ -6529,6 +6518,17 @@ impl GitHubEventsConfig {
             crate::model::git_hub_events_config::Event::PullRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [event][crate::model::GitHubEventsConfig::event]
+    /// if it holds a `Push`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn push(&self) -> std::option::Option<&std::boxed::Box<crate::model::PushFilter>> {
+        #[allow(unreachable_patterns)]
+        self.event.as_ref().and_then(|v| match v {
+            crate::model::git_hub_events_config::Event::Push(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [event][crate::model::GitHubEventsConfig::event]
@@ -7346,17 +7346,6 @@ impl PushFilter {
         })
     }
 
-    /// The value of [git_ref][crate::model::PushFilter::git_ref]
-    /// if it holds a `Tag`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tag(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.git_ref.as_ref().and_then(|v| match v {
-            crate::model::push_filter::GitRef::Tag(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [git_ref][crate::model::PushFilter::git_ref]
     /// to hold a `Branch`.
     ///
@@ -7366,6 +7355,17 @@ impl PushFilter {
         self.git_ref =
             std::option::Option::Some(crate::model::push_filter::GitRef::Branch(v.into()));
         self
+    }
+
+    /// The value of [git_ref][crate::model::PushFilter::git_ref]
+    /// if it holds a `Tag`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tag(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.git_ref.as_ref().and_then(|v| match v {
+            crate::model::push_filter::GitRef::Tag(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [git_ref][crate::model::PushFilter::git_ref]
@@ -7604,12 +7604,6 @@ impl ListBuildTriggersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBuildTriggersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [triggers][crate::model::ListBuildTriggersResponse::triggers].
     pub fn set_triggers<T, V>(mut self, v: T) -> Self
     where
@@ -7618,6 +7612,12 @@ impl ListBuildTriggersResponse {
     {
         use std::iter::Iterator;
         self.triggers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBuildTriggersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -7878,6 +7878,17 @@ impl BuildOptions {
         std::default::Default::default()
     }
 
+    /// Sets the value of [source_provenance_hash][crate::model::BuildOptions::source_provenance_hash].
+    pub fn set_source_provenance_hash<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::hash::HashType>,
+    {
+        use std::iter::Iterator;
+        self.source_provenance_hash = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [requested_verify_option][crate::model::BuildOptions::requested_verify_option].
     pub fn set_requested_verify_option<
         T: std::convert::Into<crate::model::build_options::VerifyOption>,
@@ -7965,34 +7976,6 @@ impl BuildOptions {
         self
     }
 
-    /// Sets the value of [default_logs_bucket_behavior][crate::model::BuildOptions::default_logs_bucket_behavior].
-    pub fn set_default_logs_bucket_behavior<
-        T: std::convert::Into<crate::model::build_options::DefaultLogsBucketBehavior>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.default_logs_bucket_behavior = v.into();
-        self
-    }
-
-    /// Sets the value of [enable_structured_logging][crate::model::BuildOptions::enable_structured_logging].
-    pub fn set_enable_structured_logging<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.enable_structured_logging = v.into();
-        self
-    }
-
-    /// Sets the value of [source_provenance_hash][crate::model::BuildOptions::source_provenance_hash].
-    pub fn set_source_provenance_hash<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::hash::HashType>,
-    {
-        use std::iter::Iterator;
-        self.source_provenance_hash = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [env][crate::model::BuildOptions::env].
     pub fn set_env<T, V>(mut self, v: T) -> Self
     where
@@ -8023,6 +8006,23 @@ impl BuildOptions {
     {
         use std::iter::Iterator;
         self.volumes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [default_logs_bucket_behavior][crate::model::BuildOptions::default_logs_bucket_behavior].
+    pub fn set_default_logs_bucket_behavior<
+        T: std::convert::Into<crate::model::build_options::DefaultLogsBucketBehavior>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.default_logs_bucket_behavior = v.into();
+        self
+    }
+
+    /// Sets the value of [enable_structured_logging][crate::model::BuildOptions::enable_structured_logging].
+    pub fn set_enable_structured_logging<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.enable_structured_logging = v.into();
         self
     }
 }
@@ -9330,6 +9330,18 @@ impl WorkerPool {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::WorkerPool::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::WorkerPool::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -9369,18 +9381,6 @@ impl WorkerPool {
     /// Sets the value of [etag][crate::model::WorkerPool::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::WorkerPool::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -10344,12 +10344,6 @@ impl ListWorkerPoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListWorkerPoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [worker_pools][crate::model::ListWorkerPoolsResponse::worker_pools].
     pub fn set_worker_pools<T, V>(mut self, v: T) -> Self
     where
@@ -10358,6 +10352,12 @@ impl ListWorkerPoolsResponse {
     {
         use std::iter::Iterator;
         self.worker_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListWorkerPoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -347,12 +347,6 @@ impl Connection {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Connection::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::Connection::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -362,6 +356,12 @@ impl Connection {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Connection::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 
@@ -394,66 +394,6 @@ impl Connection {
         })
     }
 
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn github_enterprise_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GitHubEnterpriseConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `GitlabConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gitlab_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::GitlabConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `BitbucketDataCenterConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bitbucket_data_center_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BitbucketDataCenterConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::BitbucketDataCenterConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [connection_config][crate::model::Connection::connection_config]
-    /// if it holds a `BitbucketCloudConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bitbucket_cloud_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BitbucketCloudConfig>> {
-        #[allow(unreachable_patterns)]
-        self.connection_config.as_ref().and_then(|v| match v {
-            crate::model::connection::ConnectionConfig::BitbucketCloudConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
     /// to hold a `GithubConfig`.
     ///
@@ -467,6 +407,21 @@ impl Connection {
             crate::model::connection::ConnectionConfig::GithubConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn github_enterprise_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitHubEnterpriseConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
@@ -486,6 +441,21 @@ impl Connection {
         self
     }
 
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `GitlabConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gitlab_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GitLabConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::GitlabConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
     /// to hold a `GitlabConfig`.
     ///
@@ -499,6 +469,21 @@ impl Connection {
             crate::model::connection::ConnectionConfig::GitlabConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `BitbucketDataCenterConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bitbucket_data_center_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BitbucketDataCenterConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::BitbucketDataCenterConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
@@ -516,6 +501,21 @@ impl Connection {
             crate::model::connection::ConnectionConfig::BitbucketDataCenterConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [connection_config][crate::model::Connection::connection_config]
+    /// if it holds a `BitbucketCloudConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bitbucket_cloud_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BitbucketCloudConfig>> {
+        #[allow(unreachable_patterns)]
+        self.connection_config.as_ref().and_then(|v| match v {
+            crate::model::connection::ConnectionConfig::BitbucketCloudConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [connection_config][crate::model::Connection::connection_config]
@@ -853,12 +853,6 @@ impl FetchLinkableRepositoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::FetchLinkableRepositoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [repositories][crate::model::FetchLinkableRepositoriesResponse::repositories].
     pub fn set_repositories<T, V>(mut self, v: T) -> Self
     where
@@ -867,6 +861,12 @@ impl FetchLinkableRepositoriesResponse {
     {
         use std::iter::Iterator;
         self.repositories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::FetchLinkableRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1513,18 +1513,6 @@ impl Repository {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Repository::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [webhook_id][crate::model::Repository::webhook_id].
-    pub fn set_webhook_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.webhook_id = v.into();
-        self
-    }
-
     /// Sets the value of [annotations][crate::model::Repository::annotations].
     pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
     where
@@ -1534,6 +1522,18 @@ impl Repository {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Repository::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [webhook_id][crate::model::Repository::webhook_id].
+    pub fn set_webhook_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.webhook_id = v.into();
         self
     }
 }
@@ -1807,12 +1807,6 @@ impl ListConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connections][crate::model::ListConnectionsResponse::connections].
     pub fn set_connections<T, V>(mut self, v: T) -> Self
     where
@@ -1821,6 +1815,12 @@ impl ListConnectionsResponse {
     {
         use std::iter::Iterator;
         self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2243,12 +2243,6 @@ impl ListRepositoriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [repositories][crate::model::ListRepositoriesResponse::repositories].
     pub fn set_repositories<T, V>(mut self, v: T) -> Self
     where
@@ -2257,6 +2251,12 @@ impl ListRepositoriesResponse {
     {
         use std::iter::Iterator;
         self.repositories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRepositoriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/devtools/cloudprofiler/v2/src/model.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/model.rs
@@ -283,15 +283,6 @@ impl Profile {
         self
     }
 
-    /// Sets the value of [start_time][crate::model::Profile::start_time].
-    pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_time = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Profile::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -301,6 +292,15 @@ impl Profile {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [start_time][crate::model::Profile::start_time].
+    pub fn set_start_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.start_time = v.into();
         self
     }
 }
@@ -478,6 +478,17 @@ impl ListProfilesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [profiles][crate::model::ListProfilesResponse::profiles].
+    pub fn set_profiles<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Profile>,
+    {
+        use std::iter::Iterator;
+        self.profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListProfilesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -487,17 +498,6 @@ impl ListProfilesResponse {
     /// Sets the value of [skipped_profiles][crate::model::ListProfilesResponse::skipped_profiles].
     pub fn set_skipped_profiles<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.skipped_profiles = v.into();
-        self
-    }
-
-    /// Sets the value of [profiles][crate::model::ListProfilesResponse::profiles].
-    pub fn set_profiles<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Profile>,
-    {
-        use std::iter::Iterator;
-        self.profiles = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -309,12 +309,6 @@ pub mod span {
             std::default::Default::default()
         }
 
-        /// Sets the value of [dropped_attributes_count][crate::model::span::Attributes::dropped_attributes_count].
-        pub fn set_dropped_attributes_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.dropped_attributes_count = v.into();
-            self
-        }
-
         /// Sets the value of [attribute_map][crate::model::span::Attributes::attribute_map].
         pub fn set_attribute_map<T, K, V>(mut self, v: T) -> Self
         where
@@ -324,6 +318,12 @@ pub mod span {
         {
             use std::iter::Iterator;
             self.attribute_map = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [dropped_attributes_count][crate::model::span::Attributes::dropped_attributes_count].
+        pub fn set_dropped_attributes_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.dropped_attributes_count = v.into();
             self
         }
     }
@@ -397,22 +397,6 @@ pub mod span {
             })
         }
 
-        /// The value of [value][crate::model::span::TimeEvent::value]
-        /// if it holds a `MessageEvent`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn message_event(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::span::time_event::MessageEvent>>
-        {
-            #[allow(unreachable_patterns)]
-            self.value.as_ref().and_then(|v| match v {
-                crate::model::span::time_event::Value::MessageEvent(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [value][crate::model::span::TimeEvent::value]
         /// to hold a `Annotation`.
         ///
@@ -428,6 +412,22 @@ pub mod span {
                 crate::model::span::time_event::Value::Annotation(v.into()),
             );
             self
+        }
+
+        /// The value of [value][crate::model::span::TimeEvent::value]
+        /// if it holds a `MessageEvent`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn message_event(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::span::time_event::MessageEvent>>
+        {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::span::time_event::Value::MessageEvent(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [value][crate::model::span::TimeEvent::value]
@@ -772,6 +772,17 @@ pub mod span {
             std::default::Default::default()
         }
 
+        /// Sets the value of [time_event][crate::model::span::TimeEvents::time_event].
+        pub fn set_time_event<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::span::TimeEvent>,
+        {
+            use std::iter::Iterator;
+            self.time_event = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [dropped_annotations_count][crate::model::span::TimeEvents::dropped_annotations_count].
         pub fn set_dropped_annotations_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
             self.dropped_annotations_count = v.into();
@@ -784,17 +795,6 @@ pub mod span {
             v: T,
         ) -> Self {
             self.dropped_message_events_count = v.into();
-            self
-        }
-
-        /// Sets the value of [time_event][crate::model::span::TimeEvents::time_event].
-        pub fn set_time_event<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::span::TimeEvent>,
-        {
-            use std::iter::Iterator;
-            self.time_event = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1046,12 +1046,6 @@ pub mod span {
             std::default::Default::default()
         }
 
-        /// Sets the value of [dropped_links_count][crate::model::span::Links::dropped_links_count].
-        pub fn set_dropped_links_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.dropped_links_count = v.into();
-            self
-        }
-
         /// Sets the value of [link][crate::model::span::Links::link].
         pub fn set_link<T, V>(mut self, v: T) -> Self
         where
@@ -1060,6 +1054,12 @@ pub mod span {
         {
             use std::iter::Iterator;
             self.link = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [dropped_links_count][crate::model::span::Links::dropped_links_count].
+        pub fn set_dropped_links_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.dropped_links_count = v.into();
             self
         }
     }
@@ -1280,28 +1280,6 @@ impl AttributeValue {
         })
     }
 
-    /// The value of [value][crate::model::AttributeValue::value]
-    /// if it holds a `IntValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int_value(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::attribute_value::Value::IntValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::AttributeValue::value]
-    /// if it holds a `BoolValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bool_value(&self) -> std::option::Option<&bool> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::attribute_value::Value::BoolValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::AttributeValue::value]
     /// to hold a `StringValue`.
     ///
@@ -1318,6 +1296,17 @@ impl AttributeValue {
         self
     }
 
+    /// The value of [value][crate::model::AttributeValue::value]
+    /// if it holds a `IntValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_value::Value::IntValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::AttributeValue::value]
     /// to hold a `IntValue`.
     ///
@@ -1327,6 +1316,17 @@ impl AttributeValue {
         self.value =
             std::option::Option::Some(crate::model::attribute_value::Value::IntValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::AttributeValue::value]
+    /// if it holds a `BoolValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bool_value(&self) -> std::option::Option<&bool> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::attribute_value::Value::BoolValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::AttributeValue::value]
@@ -1575,12 +1575,6 @@ pub mod stack_trace {
             std::default::Default::default()
         }
 
-        /// Sets the value of [dropped_frames_count][crate::model::stack_trace::StackFrames::dropped_frames_count].
-        pub fn set_dropped_frames_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.dropped_frames_count = v.into();
-            self
-        }
-
         /// Sets the value of [frame][crate::model::stack_trace::StackFrames::frame].
         pub fn set_frame<T, V>(mut self, v: T) -> Self
         where
@@ -1589,6 +1583,12 @@ pub mod stack_trace {
         {
             use std::iter::Iterator;
             self.frame = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [dropped_frames_count][crate::model::stack_trace::StackFrames::dropped_frames_count].
+        pub fn set_dropped_frames_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.dropped_frames_count = v.into();
             self
         }
     }

--- a/src/generated/firestore/admin/v1/src/builder.rs
+++ b/src/generated/firestore/admin/v1/src/builder.rs
@@ -642,21 +642,6 @@ pub mod firestore_admin {
             self
         }
 
-        /// Sets the value of [output_uri_prefix][crate::model::ExportDocumentsRequest::output_uri_prefix].
-        pub fn set_output_uri_prefix<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.output_uri_prefix = v.into();
-            self
-        }
-
-        /// Sets the value of [snapshot_time][crate::model::ExportDocumentsRequest::snapshot_time].
-        pub fn set_snapshot_time<T: Into<std::option::Option<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request.snapshot_time = v.into();
-            self
-        }
-
         /// Sets the value of [collection_ids][crate::model::ExportDocumentsRequest::collection_ids].
         pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
         where
@@ -668,6 +653,12 @@ pub mod firestore_admin {
             self
         }
 
+        /// Sets the value of [output_uri_prefix][crate::model::ExportDocumentsRequest::output_uri_prefix].
+        pub fn set_output_uri_prefix<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.output_uri_prefix = v.into();
+            self
+        }
+
         /// Sets the value of [namespace_ids][crate::model::ExportDocumentsRequest::namespace_ids].
         pub fn set_namespace_ids<T, V>(mut self, v: T) -> Self
         where
@@ -676,6 +667,15 @@ pub mod firestore_admin {
         {
             use std::iter::Iterator;
             self.0.request.namespace_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [snapshot_time][crate::model::ExportDocumentsRequest::snapshot_time].
+        pub fn set_snapshot_time<T: Into<std::option::Option<wkt::Timestamp>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.snapshot_time = v.into();
             self
         }
     }
@@ -761,12 +761,6 @@ pub mod firestore_admin {
             self
         }
 
-        /// Sets the value of [input_uri_prefix][crate::model::ImportDocumentsRequest::input_uri_prefix].
-        pub fn set_input_uri_prefix<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.input_uri_prefix = v.into();
-            self
-        }
-
         /// Sets the value of [collection_ids][crate::model::ImportDocumentsRequest::collection_ids].
         pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
         where
@@ -775,6 +769,12 @@ pub mod firestore_admin {
         {
             use std::iter::Iterator;
             self.0.request.collection_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [input_uri_prefix][crate::model::ImportDocumentsRequest::input_uri_prefix].
+        pub fn set_input_uri_prefix<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.input_uri_prefix = v.into();
             self
         }
 

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -923,40 +923,6 @@ pub mod database {
             })
         }
 
-        /// The value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
-        /// if it holds a `UseSourceEncryption`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn use_source_encryption(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::database::encryption_config::SourceEncryptionOptions>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.encryption_type.as_ref().and_then(|v| match v {
-                crate::model::database::encryption_config::EncryptionType::UseSourceEncryption(
-                    v,
-                ) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
-        /// if it holds a `CustomerManagedEncryption`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn customer_managed_encryption(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::database::encryption_config::CustomerManagedEncryptionOptions,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.encryption_type.as_ref().and_then(|v| match v {
-                crate::model::database::encryption_config::EncryptionType::CustomerManagedEncryption(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
         /// to hold a `GoogleDefaultEncryption`.
         ///
@@ -980,6 +946,23 @@ pub mod database {
             self
         }
 
+        /// The value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
+        /// if it holds a `UseSourceEncryption`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn use_source_encryption(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::database::encryption_config::SourceEncryptionOptions>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.encryption_type.as_ref().and_then(|v| match v {
+                crate::model::database::encryption_config::EncryptionType::UseSourceEncryption(
+                    v,
+                ) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
         /// to hold a `UseSourceEncryption`.
         ///
@@ -1001,6 +984,23 @@ pub mod database {
                 ),
             );
             self
+        }
+
+        /// The value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
+        /// if it holds a `CustomerManagedEncryption`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn customer_managed_encryption(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::database::encryption_config::CustomerManagedEncryptionOptions,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.encryption_type.as_ref().and_then(|v| match v {
+                crate::model::database::encryption_config::EncryptionType::CustomerManagedEncryption(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
@@ -2139,6 +2139,17 @@ pub mod field {
             std::default::Default::default()
         }
 
+        /// Sets the value of [indexes][crate::model::field::IndexConfig::indexes].
+        pub fn set_indexes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::Index>,
+        {
+            use std::iter::Iterator;
+            self.indexes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [uses_ancestor_config][crate::model::field::IndexConfig::uses_ancestor_config].
         pub fn set_uses_ancestor_config<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.uses_ancestor_config = v.into();
@@ -2157,17 +2168,6 @@ pub mod field {
         /// Sets the value of [reverting][crate::model::field::IndexConfig::reverting].
         pub fn set_reverting<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
             self.reverting = v.into();
-            self
-        }
-
-        /// Sets the value of [indexes][crate::model::field::IndexConfig::indexes].
-        pub fn set_indexes<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::Index>,
-        {
-            use std::iter::Iterator;
-            self.indexes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -3466,12 +3466,6 @@ impl ListIndexesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListIndexesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [indexes][crate::model::ListIndexesResponse::indexes].
     pub fn set_indexes<T, V>(mut self, v: T) -> Self
     where
@@ -3480,6 +3474,12 @@ impl ListIndexesResponse {
     {
         use std::iter::Iterator;
         self.indexes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListIndexesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3769,12 +3769,6 @@ impl ListFieldsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFieldsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::model::ListFieldsResponse::fields].
     pub fn set_fields<T, V>(mut self, v: T) -> Self
     where
@@ -3783,6 +3777,12 @@ impl ListFieldsResponse {
     {
         use std::iter::Iterator;
         self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFieldsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3873,24 +3873,6 @@ impl ExportDocumentsRequest {
         self
     }
 
-    /// Sets the value of [output_uri_prefix][crate::model::ExportDocumentsRequest::output_uri_prefix].
-    pub fn set_output_uri_prefix<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_uri_prefix = v.into();
-        self
-    }
-
-    /// Sets the value of [snapshot_time][crate::model::ExportDocumentsRequest::snapshot_time].
-    pub fn set_snapshot_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.snapshot_time = v.into();
-        self
-    }
-
     /// Sets the value of [collection_ids][crate::model::ExportDocumentsRequest::collection_ids].
     pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
     where
@@ -3902,6 +3884,15 @@ impl ExportDocumentsRequest {
         self
     }
 
+    /// Sets the value of [output_uri_prefix][crate::model::ExportDocumentsRequest::output_uri_prefix].
+    pub fn set_output_uri_prefix<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_uri_prefix = v.into();
+        self
+    }
+
     /// Sets the value of [namespace_ids][crate::model::ExportDocumentsRequest::namespace_ids].
     pub fn set_namespace_ids<T, V>(mut self, v: T) -> Self
     where
@@ -3910,6 +3901,15 @@ impl ExportDocumentsRequest {
     {
         use std::iter::Iterator;
         self.namespace_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [snapshot_time][crate::model::ExportDocumentsRequest::snapshot_time].
+    pub fn set_snapshot_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.snapshot_time = v.into();
         self
     }
 }
@@ -3973,15 +3973,6 @@ impl ImportDocumentsRequest {
         self
     }
 
-    /// Sets the value of [input_uri_prefix][crate::model::ImportDocumentsRequest::input_uri_prefix].
-    pub fn set_input_uri_prefix<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_uri_prefix = v.into();
-        self
-    }
-
     /// Sets the value of [collection_ids][crate::model::ImportDocumentsRequest::collection_ids].
     pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
     where
@@ -3990,6 +3981,15 @@ impl ImportDocumentsRequest {
     {
         use std::iter::Iterator;
         self.collection_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [input_uri_prefix][crate::model::ImportDocumentsRequest::input_uri_prefix].
+    pub fn set_input_uri_prefix<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.input_uri_prefix = v.into();
         self
     }
 
@@ -4505,6 +4505,17 @@ impl Index {
         self
     }
 
+    /// Sets the value of [fields][crate::model::Index::fields].
+    pub fn set_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::index::IndexField>,
+    {
+        use std::iter::Iterator;
+        self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::Index::state].
     pub fn set_state<T: std::convert::Into<crate::model::index::State>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -4529,17 +4540,6 @@ impl Index {
     /// Sets the value of [shard_count][crate::model::Index::shard_count].
     pub fn set_shard_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.shard_count = v.into();
-        self
-    }
-
-    /// Sets the value of [fields][crate::model::Index::fields].
-    pub fn set_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::index::IndexField>,
-    {
-        use std::iter::Iterator;
-        self.fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4615,37 +4615,6 @@ pub mod index {
             })
         }
 
-        /// The value of [value_mode][crate::model::index::IndexField::value_mode]
-        /// if it holds a `ArrayConfig`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn array_config(
-            &self,
-        ) -> std::option::Option<&crate::model::index::index_field::ArrayConfig> {
-            #[allow(unreachable_patterns)]
-            self.value_mode.as_ref().and_then(|v| match v {
-                crate::model::index::index_field::ValueMode::ArrayConfig(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [value_mode][crate::model::index::IndexField::value_mode]
-        /// if it holds a `VectorConfig`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn vector_config(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::index::index_field::VectorConfig>>
-        {
-            #[allow(unreachable_patterns)]
-            self.value_mode.as_ref().and_then(|v| match v {
-                crate::model::index::index_field::ValueMode::VectorConfig(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [value_mode][crate::model::index::IndexField::value_mode]
         /// to hold a `Order`.
         ///
@@ -4659,6 +4628,21 @@ pub mod index {
                 crate::model::index::index_field::ValueMode::Order(v.into()),
             );
             self
+        }
+
+        /// The value of [value_mode][crate::model::index::IndexField::value_mode]
+        /// if it holds a `ArrayConfig`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn array_config(
+            &self,
+        ) -> std::option::Option<&crate::model::index::index_field::ArrayConfig> {
+            #[allow(unreachable_patterns)]
+            self.value_mode.as_ref().and_then(|v| match v {
+                crate::model::index::index_field::ValueMode::ArrayConfig(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [value_mode][crate::model::index::IndexField::value_mode]
@@ -4676,6 +4660,22 @@ pub mod index {
                 crate::model::index::index_field::ValueMode::ArrayConfig(v.into()),
             );
             self
+        }
+
+        /// The value of [value_mode][crate::model::index::IndexField::value_mode]
+        /// if it holds a `VectorConfig`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn vector_config(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::index::index_field::VectorConfig>>
+        {
+            #[allow(unreachable_patterns)]
+            self.value_mode.as_ref().and_then(|v| match v {
+                crate::model::index::index_field::ValueMode::VectorConfig(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [value_mode][crate::model::index::IndexField::value_mode]
@@ -5911,6 +5911,17 @@ impl FieldOperationMetadata {
         self
     }
 
+    /// Sets the value of [index_config_deltas][crate::model::FieldOperationMetadata::index_config_deltas].
+    pub fn set_index_config_deltas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::field_operation_metadata::IndexConfigDelta>,
+    {
+        use std::iter::Iterator;
+        self.index_config_deltas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [state][crate::model::FieldOperationMetadata::state].
     pub fn set_state<T: std::convert::Into<crate::model::OperationState>>(mut self, v: T) -> Self {
         self.state = v.into();
@@ -5949,17 +5960,6 @@ impl FieldOperationMetadata {
         v: T,
     ) -> Self {
         self.ttl_config_delta = v.into();
-        self
-    }
-
-    /// Sets the value of [index_config_deltas][crate::model::FieldOperationMetadata::index_config_deltas].
-    pub fn set_index_config_deltas<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::field_operation_metadata::IndexConfigDelta>,
-    {
-        use std::iter::Iterator;
-        self.index_config_deltas = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6454,24 +6454,6 @@ impl ExportDocumentsMetadata {
         self
     }
 
-    /// Sets the value of [output_uri_prefix][crate::model::ExportDocumentsMetadata::output_uri_prefix].
-    pub fn set_output_uri_prefix<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_uri_prefix = v.into();
-        self
-    }
-
-    /// Sets the value of [snapshot_time][crate::model::ExportDocumentsMetadata::snapshot_time].
-    pub fn set_snapshot_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.snapshot_time = v.into();
-        self
-    }
-
     /// Sets the value of [collection_ids][crate::model::ExportDocumentsMetadata::collection_ids].
     pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
     where
@@ -6483,6 +6465,15 @@ impl ExportDocumentsMetadata {
         self
     }
 
+    /// Sets the value of [output_uri_prefix][crate::model::ExportDocumentsMetadata::output_uri_prefix].
+    pub fn set_output_uri_prefix<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.output_uri_prefix = v.into();
+        self
+    }
+
     /// Sets the value of [namespace_ids][crate::model::ExportDocumentsMetadata::namespace_ids].
     pub fn set_namespace_ids<T, V>(mut self, v: T) -> Self
     where
@@ -6491,6 +6482,15 @@ impl ExportDocumentsMetadata {
     {
         use std::iter::Iterator;
         self.namespace_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [snapshot_time][crate::model::ExportDocumentsMetadata::snapshot_time].
+    pub fn set_snapshot_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.snapshot_time = v.into();
         self
     }
 }
@@ -6602,15 +6602,6 @@ impl ImportDocumentsMetadata {
         self
     }
 
-    /// Sets the value of [input_uri_prefix][crate::model::ImportDocumentsMetadata::input_uri_prefix].
-    pub fn set_input_uri_prefix<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_uri_prefix = v.into();
-        self
-    }
-
     /// Sets the value of [collection_ids][crate::model::ImportDocumentsMetadata::collection_ids].
     pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
     where
@@ -6619,6 +6610,15 @@ impl ImportDocumentsMetadata {
     {
         use std::iter::Iterator;
         self.collection_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [input_uri_prefix][crate::model::ImportDocumentsMetadata::input_uri_prefix].
+    pub fn set_input_uri_prefix<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.input_uri_prefix = v.into();
         self
     }
 
@@ -6744,15 +6744,6 @@ impl BulkDeleteDocumentsMetadata {
         self
     }
 
-    /// Sets the value of [snapshot_time][crate::model::BulkDeleteDocumentsMetadata::snapshot_time].
-    pub fn set_snapshot_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.snapshot_time = v.into();
-        self
-    }
-
     /// Sets the value of [collection_ids][crate::model::BulkDeleteDocumentsMetadata::collection_ids].
     pub fn set_collection_ids<T, V>(mut self, v: T) -> Self
     where
@@ -6772,6 +6763,15 @@ impl BulkDeleteDocumentsMetadata {
     {
         use std::iter::Iterator;
         self.namespace_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [snapshot_time][crate::model::BulkDeleteDocumentsMetadata::snapshot_time].
+    pub fn set_snapshot_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.snapshot_time = v.into();
         self
     }
 }
@@ -7082,21 +7082,6 @@ impl BackupSchedule {
         })
     }
 
-    /// The value of [recurrence][crate::model::BackupSchedule::recurrence]
-    /// if it holds a `WeeklyRecurrence`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn weekly_recurrence(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::WeeklyRecurrence>> {
-        #[allow(unreachable_patterns)]
-        self.recurrence.as_ref().and_then(|v| match v {
-            crate::model::backup_schedule::Recurrence::WeeklyRecurrence(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [recurrence][crate::model::BackupSchedule::recurrence]
     /// to hold a `DailyRecurrence`.
     ///
@@ -7112,6 +7097,21 @@ impl BackupSchedule {
             crate::model::backup_schedule::Recurrence::DailyRecurrence(v.into()),
         );
         self
+    }
+
+    /// The value of [recurrence][crate::model::BackupSchedule::recurrence]
+    /// if it holds a `WeeklyRecurrence`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn weekly_recurrence(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::WeeklyRecurrence>> {
+        #[allow(unreachable_patterns)]
+        self.recurrence.as_ref().and_then(|v| match v {
+            crate::model::backup_schedule::Recurrence::WeeklyRecurrence(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [recurrence][crate::model::BackupSchedule::recurrence]

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -791,6 +791,17 @@ impl ComplianceNote {
         self
     }
 
+    /// Sets the value of [version][crate::model::ComplianceNote::version].
+    pub fn set_version<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ComplianceVersion>,
+    {
+        use std::iter::Iterator;
+        self.version = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [rationale][crate::model::ComplianceNote::rationale].
     pub fn set_rationale<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.rationale = v.into();
@@ -806,17 +817,6 @@ impl ComplianceNote {
     /// Sets the value of [scan_instructions][crate::model::ComplianceNote::scan_instructions].
     pub fn set_scan_instructions<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.scan_instructions = v.into();
-        self
-    }
-
-    /// Sets the value of [version][crate::model::ComplianceNote::version].
-    pub fn set_version<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ComplianceVersion>,
-    {
-        use std::iter::Iterator;
-        self.version = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1057,6 +1057,17 @@ impl ComplianceOccurrence {
         std::default::Default::default()
     }
 
+    /// Sets the value of [non_compliant_files][crate::model::ComplianceOccurrence::non_compliant_files].
+    pub fn set_non_compliant_files<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NonCompliantFile>,
+    {
+        use std::iter::Iterator;
+        self.non_compliant_files = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [non_compliance_reason][crate::model::ComplianceOccurrence::non_compliance_reason].
     pub fn set_non_compliance_reason<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -1074,17 +1085,6 @@ impl ComplianceOccurrence {
         v: T,
     ) -> Self {
         self.version = v.into();
-        self
-    }
-
-    /// Sets the value of [non_compliant_files][crate::model::ComplianceOccurrence::non_compliant_files].
-    pub fn set_non_compliant_files<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NonCompliantFile>,
-    {
-        use std::iter::Iterator;
-        self.non_compliant_files = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3308,15 +3308,6 @@ impl DeploymentOccurrence {
         self
     }
 
-    /// Sets the value of [platform][crate::model::DeploymentOccurrence::platform].
-    pub fn set_platform<T: std::convert::Into<crate::model::deployment_occurrence::Platform>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.platform = v.into();
-        self
-    }
-
     /// Sets the value of [resource_uri][crate::model::DeploymentOccurrence::resource_uri].
     pub fn set_resource_uri<T, V>(mut self, v: T) -> Self
     where
@@ -3325,6 +3316,15 @@ impl DeploymentOccurrence {
     {
         use std::iter::Iterator;
         self.resource_uri = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [platform][crate::model::DeploymentOccurrence::platform].
+    pub fn set_platform<T: std::convert::Into<crate::model::deployment_occurrence::Platform>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.platform = v.into();
         self
     }
 }
@@ -3609,6 +3609,17 @@ impl DiscoveryOccurrence {
         self
     }
 
+    /// Sets the value of [analysis_error][crate::model::DiscoveryOccurrence::analysis_error].
+    pub fn set_analysis_error<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<rpc::model::Status>,
+    {
+        use std::iter::Iterator;
+        self.analysis_error = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [analysis_status_error][crate::model::DiscoveryOccurrence::analysis_status_error].
     pub fn set_analysis_status_error<
         T: std::convert::Into<std::option::Option<rpc::model::Status>>,
@@ -3665,17 +3676,6 @@ impl DiscoveryOccurrence {
         v: T,
     ) -> Self {
         self.vulnerability_attestation = v.into();
-        self
-    }
-
-    /// Sets the value of [analysis_error][crate::model::DiscoveryOccurrence::analysis_error].
-    pub fn set_analysis_error<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<rpc::model::Status>,
-    {
-        use std::iter::Iterator;
-        self.analysis_error = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4732,132 +4732,6 @@ impl Occurrence {
         })
     }
 
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Build`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn build(&self) -> std::option::Option<&std::boxed::Box<crate::model::BuildOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Build(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Image`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn image(&self) -> std::option::Option<&std::boxed::Box<crate::model::ImageOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Image(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Package`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn package(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PackageOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Package(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Deployment`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deployment(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeploymentOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Deployment(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Discovery`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn discovery(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DiscoveryOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Discovery(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Attestation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn attestation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AttestationOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Attestation(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Upgrade`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn upgrade(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UpgradeOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Upgrade(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `Compliance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn compliance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ComplianceOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::Compliance(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `DsseAttestation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dsse_attestation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DSSEAttestationOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::DsseAttestation(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [details][crate::model::Occurrence::details]
-    /// if it holds a `SbomReference`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sbom_reference(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SBOMReferenceOccurrence>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::occurrence::Details::SbomReference(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [details][crate::model::Occurrence::details]
     /// to hold a `Vulnerability`.
     ///
@@ -4874,6 +4748,17 @@ impl Occurrence {
         self
     }
 
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Build`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn build(&self) -> std::option::Option<&std::boxed::Box<crate::model::BuildOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Build(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Occurrence::details]
     /// to hold a `Build`.
     ///
@@ -4886,6 +4771,17 @@ impl Occurrence {
         self.details =
             std::option::Option::Some(crate::model::occurrence::Details::Build(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Image`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn image(&self) -> std::option::Option<&std::boxed::Box<crate::model::ImageOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Image(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Occurrence::details]
@@ -4902,6 +4798,19 @@ impl Occurrence {
         self
     }
 
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Package`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn package(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PackageOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Package(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Occurrence::details]
     /// to hold a `Package`.
     ///
@@ -4914,6 +4823,19 @@ impl Occurrence {
         self.details =
             std::option::Option::Some(crate::model::occurrence::Details::Package(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Deployment`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deployment(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeploymentOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Deployment(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Occurrence::details]
@@ -4932,6 +4854,19 @@ impl Occurrence {
         self
     }
 
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Discovery`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn discovery(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DiscoveryOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Discovery(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Occurrence::details]
     /// to hold a `Discovery`.
     ///
@@ -4946,6 +4881,19 @@ impl Occurrence {
         self.details =
             std::option::Option::Some(crate::model::occurrence::Details::Discovery(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Attestation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn attestation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AttestationOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Attestation(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Occurrence::details]
@@ -4964,6 +4912,19 @@ impl Occurrence {
         self
     }
 
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Upgrade`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn upgrade(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UpgradeOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Upgrade(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Occurrence::details]
     /// to hold a `Upgrade`.
     ///
@@ -4976,6 +4937,19 @@ impl Occurrence {
         self.details =
             std::option::Option::Some(crate::model::occurrence::Details::Upgrade(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `Compliance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn compliance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ComplianceOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::Compliance(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Occurrence::details]
@@ -4994,6 +4968,19 @@ impl Occurrence {
         self
     }
 
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `DsseAttestation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dsse_attestation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DSSEAttestationOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::DsseAttestation(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [details][crate::model::Occurrence::details]
     /// to hold a `DsseAttestation`.
     ///
@@ -5008,6 +4995,19 @@ impl Occurrence {
         self.details =
             std::option::Option::Some(crate::model::occurrence::Details::DsseAttestation(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::Occurrence::details]
+    /// if it holds a `SbomReference`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sbom_reference(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SBOMReferenceOccurrence>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::occurrence::Details::SbomReference(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::Occurrence::details]
@@ -5158,6 +5158,17 @@ impl Note {
         self
     }
 
+    /// Sets the value of [related_url][crate::model::Note::related_url].
+    pub fn set_related_url<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RelatedUrl>,
+    {
+        use std::iter::Iterator;
+        self.related_url = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [expiration_time][crate::model::Note::expiration_time].
     pub fn set_expiration_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -5182,17 +5193,6 @@ impl Note {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [related_url][crate::model::Note::related_url].
-    pub fn set_related_url<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RelatedUrl>,
-    {
-        use std::iter::Iterator;
-        self.related_url = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -5232,139 +5232,6 @@ impl Note {
         })
     }
 
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Build`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn build(&self) -> std::option::Option<&std::boxed::Box<crate::model::BuildNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Build(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Image`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn image(&self) -> std::option::Option<&std::boxed::Box<crate::model::ImageNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Image(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Package`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn package(&self) -> std::option::Option<&std::boxed::Box<crate::model::PackageNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Package(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Deployment`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deployment(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeploymentNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Deployment(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Discovery`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn discovery(&self) -> std::option::Option<&std::boxed::Box<crate::model::DiscoveryNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Discovery(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Attestation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn attestation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AttestationNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Attestation(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Upgrade`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn upgrade(&self) -> std::option::Option<&std::boxed::Box<crate::model::UpgradeNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Upgrade(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `Compliance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn compliance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ComplianceNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::Compliance(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `DsseAttestation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dsse_attestation(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DSSEAttestationNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::DsseAttestation(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `VulnerabilityAssessment`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vulnerability_assessment(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VulnerabilityAssessmentNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::VulnerabilityAssessment(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Note::r#type]
-    /// if it holds a `SbomReference`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn sbom_reference(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SBOMReferenceNote>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::note::Type::SbomReference(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `Vulnerability`.
     ///
@@ -5380,6 +5247,17 @@ impl Note {
         self
     }
 
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Build`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn build(&self) -> std::option::Option<&std::boxed::Box<crate::model::BuildNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Build(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `Build`.
     ///
@@ -5391,6 +5269,17 @@ impl Note {
     ) -> Self {
         self.r#type = std::option::Option::Some(crate::model::note::Type::Build(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Image`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn image(&self) -> std::option::Option<&std::boxed::Box<crate::model::ImageNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Image(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Note::r#type]
@@ -5406,6 +5295,17 @@ impl Note {
         self
     }
 
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Package`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn package(&self) -> std::option::Option<&std::boxed::Box<crate::model::PackageNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Package(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `Package`.
     ///
@@ -5417,6 +5317,19 @@ impl Note {
     ) -> Self {
         self.r#type = std::option::Option::Some(crate::model::note::Type::Package(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Deployment`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deployment(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeploymentNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Deployment(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Note::r#type]
@@ -5432,6 +5345,17 @@ impl Note {
         self
     }
 
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Discovery`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn discovery(&self) -> std::option::Option<&std::boxed::Box<crate::model::DiscoveryNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Discovery(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `Discovery`.
     ///
@@ -5443,6 +5367,19 @@ impl Note {
     ) -> Self {
         self.r#type = std::option::Option::Some(crate::model::note::Type::Discovery(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Attestation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn attestation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AttestationNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Attestation(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Note::r#type]
@@ -5460,6 +5397,17 @@ impl Note {
         self
     }
 
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Upgrade`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn upgrade(&self) -> std::option::Option<&std::boxed::Box<crate::model::UpgradeNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Upgrade(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `Upgrade`.
     ///
@@ -5473,6 +5421,19 @@ impl Note {
         self
     }
 
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `Compliance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn compliance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ComplianceNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::Compliance(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `Compliance`.
     ///
@@ -5484,6 +5445,19 @@ impl Note {
     ) -> Self {
         self.r#type = std::option::Option::Some(crate::model::note::Type::Compliance(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `DsseAttestation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dsse_attestation(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DSSEAttestationNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::DsseAttestation(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Note::r#type]
@@ -5502,6 +5476,19 @@ impl Note {
         self
     }
 
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `VulnerabilityAssessment`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vulnerability_assessment(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VulnerabilityAssessmentNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::VulnerabilityAssessment(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Note::r#type]
     /// to hold a `VulnerabilityAssessment`.
     ///
@@ -5516,6 +5503,19 @@ impl Note {
         self.r#type =
             std::option::Option::Some(crate::model::note::Type::VulnerabilityAssessment(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Note::r#type]
+    /// if it holds a `SbomReference`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn sbom_reference(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SBOMReferenceNote>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::note::Type::SbomReference(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Note::r#type]
@@ -5699,12 +5699,6 @@ impl ListOccurrencesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOccurrencesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [occurrences][crate::model::ListOccurrencesResponse::occurrences].
     pub fn set_occurrences<T, V>(mut self, v: T) -> Self
     where
@@ -5713,6 +5707,12 @@ impl ListOccurrencesResponse {
     {
         use std::iter::Iterator;
         self.occurrences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOccurrencesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6030,12 +6030,6 @@ impl ListNotesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNotesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [notes][crate::model::ListNotesResponse::notes].
     pub fn set_notes<T, V>(mut self, v: T) -> Self
     where
@@ -6044,6 +6038,12 @@ impl ListNotesResponse {
     {
         use std::iter::Iterator;
         self.notes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNotesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6302,12 +6302,6 @@ impl ListNoteOccurrencesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNoteOccurrencesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [occurrences][crate::model::ListNoteOccurrencesResponse::occurrences].
     pub fn set_occurrences<T, V>(mut self, v: T) -> Self
     where
@@ -6316,6 +6310,12 @@ impl ListNoteOccurrencesResponse {
     {
         use std::iter::Iterator;
         self.occurrences = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNoteOccurrencesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6591,12 +6591,6 @@ impl Fingerprint {
         self
     }
 
-    /// Sets the value of [v2_name][crate::model::Fingerprint::v2_name].
-    pub fn set_v2_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.v2_name = v.into();
-        self
-    }
-
     /// Sets the value of [v2_blob][crate::model::Fingerprint::v2_blob].
     pub fn set_v2_blob<T, V>(mut self, v: T) -> Self
     where
@@ -6605,6 +6599,12 @@ impl Fingerprint {
     {
         use std::iter::Iterator;
         self.v2_blob = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [v2_name][crate::model::Fingerprint::v2_name].
+    pub fn set_v2_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.v2_name = v.into();
         self
     }
 }
@@ -6721,15 +6721,6 @@ impl ImageOccurrence {
         self
     }
 
-    /// Sets the value of [base_resource_url][crate::model::ImageOccurrence::base_resource_url].
-    pub fn set_base_resource_url<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.base_resource_url = v.into();
-        self
-    }
-
     /// Sets the value of [layer_info][crate::model::ImageOccurrence::layer_info].
     pub fn set_layer_info<T, V>(mut self, v: T) -> Self
     where
@@ -6738,6 +6729,15 @@ impl ImageOccurrence {
     {
         use std::iter::Iterator;
         self.layer_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [base_resource_url][crate::model::ImageOccurrence::base_resource_url].
+    pub fn set_base_resource_url<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.base_resource_url = v.into();
         self
     }
 }
@@ -7147,12 +7147,6 @@ impl InTotoStatement {
         self
     }
 
-    /// Sets the value of [predicate_type][crate::model::InTotoStatement::predicate_type].
-    pub fn set_predicate_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.predicate_type = v.into();
-        self
-    }
-
     /// Sets the value of [subject][crate::model::InTotoStatement::subject].
     pub fn set_subject<T, V>(mut self, v: T) -> Self
     where
@@ -7161,6 +7155,12 @@ impl InTotoStatement {
     {
         use std::iter::Iterator;
         self.subject = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [predicate_type][crate::model::InTotoStatement::predicate_type].
+    pub fn set_predicate_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.predicate_type = v.into();
         self
     }
 
@@ -7193,36 +7193,6 @@ impl InTotoStatement {
         })
     }
 
-    /// The value of [predicate][crate::model::InTotoStatement::predicate]
-    /// if it holds a `SlsaProvenance`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn slsa_provenance(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SlsaProvenance>> {
-        #[allow(unreachable_patterns)]
-        self.predicate.as_ref().and_then(|v| match v {
-            crate::model::in_toto_statement::Predicate::SlsaProvenance(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [predicate][crate::model::InTotoStatement::predicate]
-    /// if it holds a `SlsaProvenanceZeroTwo`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn slsa_provenance_zero_two(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SlsaProvenanceZeroTwo>> {
-        #[allow(unreachable_patterns)]
-        self.predicate.as_ref().and_then(|v| match v {
-            crate::model::in_toto_statement::Predicate::SlsaProvenanceZeroTwo(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [predicate][crate::model::InTotoStatement::predicate]
     /// to hold a `Provenance`.
     ///
@@ -7240,6 +7210,21 @@ impl InTotoStatement {
         self
     }
 
+    /// The value of [predicate][crate::model::InTotoStatement::predicate]
+    /// if it holds a `SlsaProvenance`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn slsa_provenance(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SlsaProvenance>> {
+        #[allow(unreachable_patterns)]
+        self.predicate.as_ref().and_then(|v| match v {
+            crate::model::in_toto_statement::Predicate::SlsaProvenance(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [predicate][crate::model::InTotoStatement::predicate]
     /// to hold a `SlsaProvenance`.
     ///
@@ -7255,6 +7240,21 @@ impl InTotoStatement {
             crate::model::in_toto_statement::Predicate::SlsaProvenance(v.into()),
         );
         self
+    }
+
+    /// The value of [predicate][crate::model::InTotoStatement::predicate]
+    /// if it holds a `SlsaProvenanceZeroTwo`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn slsa_provenance_zero_two(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SlsaProvenanceZeroTwo>> {
+        #[allow(unreachable_patterns)]
+        self.predicate.as_ref().and_then(|v| match v {
+            crate::model::in_toto_statement::Predicate::SlsaProvenanceZeroTwo(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [predicate][crate::model::InTotoStatement::predicate]
@@ -7380,6 +7380,17 @@ impl InTotoSlsaProvenanceV1 {
         self
     }
 
+    /// Sets the value of [subject][crate::model::InTotoSlsaProvenanceV1::subject].
+    pub fn set_subject<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Subject>,
+    {
+        use std::iter::Iterator;
+        self.subject = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [predicate_type][crate::model::InTotoSlsaProvenanceV1::predicate_type].
     pub fn set_predicate_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.predicate_type = v.into();
@@ -7396,17 +7407,6 @@ impl InTotoSlsaProvenanceV1 {
         v: T,
     ) -> Self {
         self.predicate = v.into();
-        self
-    }
-
-    /// Sets the value of [subject][crate::model::InTotoSlsaProvenanceV1::subject].
-    pub fn set_subject<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Subject>,
-    {
-        use std::iter::Iterator;
-        self.subject = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -7596,6 +7596,18 @@ pub mod in_toto_slsa_provenance_v_1 {
             self
         }
 
+        /// Sets the value of [digest][crate::model::in_toto_slsa_provenance_v_1::ResourceDescriptor::digest].
+        pub fn set_digest<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.digest = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [content][crate::model::in_toto_slsa_provenance_v_1::ResourceDescriptor::content].
         pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
             self.content = v.into();
@@ -7614,18 +7626,6 @@ pub mod in_toto_slsa_provenance_v_1 {
         /// Sets the value of [media_type][crate::model::in_toto_slsa_provenance_v_1::ResourceDescriptor::media_type].
         pub fn set_media_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.media_type = v.into();
-            self
-        }
-
-        /// Sets the value of [digest][crate::model::in_toto_slsa_provenance_v_1::ResourceDescriptor::digest].
-        pub fn set_digest<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.digest = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -7749,17 +7749,6 @@ pub mod in_toto_slsa_provenance_v_1 {
             self
         }
 
-        /// Sets the value of [builder_dependencies][crate::model::in_toto_slsa_provenance_v_1::ProvenanceBuilder::builder_dependencies].
-        pub fn set_builder_dependencies<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::in_toto_slsa_provenance_v_1::ResourceDescriptor>,
-        {
-            use std::iter::Iterator;
-            self.builder_dependencies = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
         /// Sets the value of [version][crate::model::in_toto_slsa_provenance_v_1::ProvenanceBuilder::version].
         pub fn set_version<T, K, V>(mut self, v: T) -> Self
         where
@@ -7769,6 +7758,17 @@ pub mod in_toto_slsa_provenance_v_1 {
         {
             use std::iter::Iterator;
             self.version = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [builder_dependencies][crate::model::in_toto_slsa_provenance_v_1::ProvenanceBuilder::builder_dependencies].
+        pub fn set_builder_dependencies<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::in_toto_slsa_provenance_v_1::ResourceDescriptor>,
+        {
+            use std::iter::Iterator;
+            self.builder_dependencies = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -8055,6 +8055,17 @@ impl PackageNote {
         self
     }
 
+    /// Sets the value of [distribution][crate::model::PackageNote::distribution].
+    pub fn set_distribution<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Distribution>,
+    {
+        use std::iter::Iterator;
+        self.distribution = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [package_type][crate::model::PackageNote::package_type].
     pub fn set_package_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.package_type = v.into();
@@ -8109,17 +8120,6 @@ impl PackageNote {
         v: T,
     ) -> Self {
         self.license = v.into();
-        self
-    }
-
-    /// Sets the value of [distribution][crate::model::PackageNote::distribution].
-    pub fn set_distribution<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Distribution>,
-    {
-        use std::iter::Iterator;
-        self.distribution = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -8194,6 +8194,17 @@ impl PackageOccurrence {
         self
     }
 
+    /// Sets the value of [location][crate::model::PackageOccurrence::location].
+    pub fn set_location<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Location>,
+    {
+        use std::iter::Iterator;
+        self.location = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [package_type][crate::model::PackageOccurrence::package_type].
     pub fn set_package_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.package_type = v.into();
@@ -8230,17 +8241,6 @@ impl PackageOccurrence {
         v: T,
     ) -> Self {
         self.version = v.into();
-        self
-    }
-
-    /// Sets the value of [location][crate::model::PackageOccurrence::location].
-    pub fn set_location<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Location>,
-    {
-        use std::iter::Iterator;
-        self.location = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8571,6 +8571,28 @@ impl BuildProvenance {
         self
     }
 
+    /// Sets the value of [commands][crate::model::BuildProvenance::commands].
+    pub fn set_commands<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Command>,
+    {
+        use std::iter::Iterator;
+        self.commands = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [built_artifacts][crate::model::BuildProvenance::built_artifacts].
+    pub fn set_built_artifacts<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Artifact>,
+    {
+        use std::iter::Iterator;
+        self.built_artifacts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::BuildProvenance::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -8627,34 +8649,6 @@ impl BuildProvenance {
         self
     }
 
-    /// Sets the value of [builder_version][crate::model::BuildProvenance::builder_version].
-    pub fn set_builder_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.builder_version = v.into();
-        self
-    }
-
-    /// Sets the value of [commands][crate::model::BuildProvenance::commands].
-    pub fn set_commands<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Command>,
-    {
-        use std::iter::Iterator;
-        self.commands = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [built_artifacts][crate::model::BuildProvenance::built_artifacts].
-    pub fn set_built_artifacts<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Artifact>,
-    {
-        use std::iter::Iterator;
-        self.built_artifacts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [build_options][crate::model::BuildProvenance::build_options].
     pub fn set_build_options<T, K, V>(mut self, v: T) -> Self
     where
@@ -8664,6 +8658,12 @@ impl BuildProvenance {
     {
         use std::iter::Iterator;
         self.build_options = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [builder_version][crate::model::BuildProvenance::builder_version].
+    pub fn set_builder_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.builder_version = v.into();
         self
     }
 }
@@ -8725,6 +8725,18 @@ impl Source {
         self
     }
 
+    /// Sets the value of [file_hashes][crate::model::Source::file_hashes].
+    pub fn set_file_hashes<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<crate::model::FileHashes>,
+    {
+        use std::iter::Iterator;
+        self.file_hashes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [context][crate::model::Source::context].
     pub fn set_context<T: std::convert::Into<std::option::Option<crate::model::SourceContext>>>(
         mut self,
@@ -8742,18 +8754,6 @@ impl Source {
     {
         use std::iter::Iterator;
         self.additional_contexts = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [file_hashes][crate::model::Source::file_hashes].
-    pub fn set_file_hashes<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<crate::model::FileHashes>,
-    {
-        use std::iter::Iterator;
-        self.file_hashes = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -8894,18 +8894,6 @@ impl Command {
         self
     }
 
-    /// Sets the value of [dir][crate::model::Command::dir].
-    pub fn set_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.dir = v.into();
-        self
-    }
-
-    /// Sets the value of [id][crate::model::Command::id].
-    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id = v.into();
-        self
-    }
-
     /// Sets the value of [env][crate::model::Command::env].
     pub fn set_env<T, V>(mut self, v: T) -> Self
     where
@@ -8925,6 +8913,18 @@ impl Command {
     {
         use std::iter::Iterator;
         self.args = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [dir][crate::model::Command::dir].
+    pub fn set_dir<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.dir = v.into();
+        self
+    }
+
+    /// Sets the value of [id][crate::model::Command::id].
+    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.id = v.into();
         self
     }
 
@@ -9072,30 +9072,6 @@ impl SourceContext {
         })
     }
 
-    /// The value of [context][crate::model::SourceContext::context]
-    /// if it holds a `Gerrit`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gerrit(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::GerritSourceContext>> {
-        #[allow(unreachable_patterns)]
-        self.context.as_ref().and_then(|v| match v {
-            crate::model::source_context::Context::Gerrit(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [context][crate::model::SourceContext::context]
-    /// if it holds a `Git`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn git(&self) -> std::option::Option<&std::boxed::Box<crate::model::GitSourceContext>> {
-        #[allow(unreachable_patterns)]
-        self.context.as_ref().and_then(|v| match v {
-            crate::model::source_context::Context::Git(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [context][crate::model::SourceContext::context]
     /// to hold a `CloudRepo`.
     ///
@@ -9112,6 +9088,19 @@ impl SourceContext {
         self
     }
 
+    /// The value of [context][crate::model::SourceContext::context]
+    /// if it holds a `Gerrit`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gerrit(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::GerritSourceContext>> {
+        #[allow(unreachable_patterns)]
+        self.context.as_ref().and_then(|v| match v {
+            crate::model::source_context::Context::Gerrit(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [context][crate::model::SourceContext::context]
     /// to hold a `Gerrit`.
     ///
@@ -9124,6 +9113,17 @@ impl SourceContext {
         self.context =
             std::option::Option::Some(crate::model::source_context::Context::Gerrit(v.into()));
         self
+    }
+
+    /// The value of [context][crate::model::SourceContext::context]
+    /// if it holds a `Git`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn git(&self) -> std::option::Option<&std::boxed::Box<crate::model::GitSourceContext>> {
+        #[allow(unreachable_patterns)]
+        self.context.as_ref().and_then(|v| match v {
+            crate::model::source_context::Context::Git(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [context][crate::model::SourceContext::context]
@@ -9417,6 +9417,18 @@ impl CloudRepoSourceContext {
         })
     }
 
+    /// Sets the value of [revision][crate::model::CloudRepoSourceContext::revision]
+    /// to hold a `RevisionId`.
+    ///
+    /// Note that all the setters affecting `revision` are
+    /// mutually exclusive.
+    pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.revision = std::option::Option::Some(
+            crate::model::cloud_repo_source_context::Revision::RevisionId(v.into()),
+        );
+        self
+    }
+
     /// The value of [revision][crate::model::CloudRepoSourceContext::revision]
     /// if it holds a `AliasContext`, `None` if the field is not set or
     /// holds a different branch.
@@ -9430,18 +9442,6 @@ impl CloudRepoSourceContext {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [revision][crate::model::CloudRepoSourceContext::revision]
-    /// to hold a `RevisionId`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision = std::option::Option::Some(
-            crate::model::cloud_repo_source_context::Revision::RevisionId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [revision][crate::model::CloudRepoSourceContext::revision]
@@ -9553,6 +9553,18 @@ impl GerritSourceContext {
         })
     }
 
+    /// Sets the value of [revision][crate::model::GerritSourceContext::revision]
+    /// to hold a `RevisionId`.
+    ///
+    /// Note that all the setters affecting `revision` are
+    /// mutually exclusive.
+    pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.revision = std::option::Option::Some(
+            crate::model::gerrit_source_context::Revision::RevisionId(v.into()),
+        );
+        self
+    }
+
     /// The value of [revision][crate::model::GerritSourceContext::revision]
     /// if it holds a `AliasContext`, `None` if the field is not set or
     /// holds a different branch.
@@ -9566,18 +9578,6 @@ impl GerritSourceContext {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [revision][crate::model::GerritSourceContext::revision]
-    /// to hold a `RevisionId`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision = std::option::Option::Some(
-            crate::model::gerrit_source_context::Revision::RevisionId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [revision][crate::model::GerritSourceContext::revision]
@@ -9708,17 +9708,6 @@ impl RepoId {
         })
     }
 
-    /// The value of [id][crate::model::RepoId::id]
-    /// if it holds a `Uid`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn uid(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.id.as_ref().and_then(|v| match v {
-            crate::model::repo_id::Id::Uid(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [id][crate::model::RepoId::id]
     /// to hold a `ProjectRepoId`.
     ///
@@ -9732,6 +9721,17 @@ impl RepoId {
     ) -> Self {
         self.id = std::option::Option::Some(crate::model::repo_id::Id::ProjectRepoId(v.into()));
         self
+    }
+
+    /// The value of [id][crate::model::RepoId::id]
+    /// if it holds a `Uid`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn uid(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.id.as_ref().and_then(|v| match v {
+            crate::model::repo_id::Id::Uid(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [id][crate::model::RepoId::id]
@@ -9971,17 +9971,6 @@ impl SbomReferenceIntotoPayload {
         self
     }
 
-    /// Sets the value of [predicate][crate::model::SbomReferenceIntotoPayload::predicate].
-    pub fn set_predicate<
-        T: std::convert::Into<std::option::Option<crate::model::SbomReferenceIntotoPredicate>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.predicate = v.into();
-        self
-    }
-
     /// Sets the value of [subject][crate::model::SbomReferenceIntotoPayload::subject].
     pub fn set_subject<T, V>(mut self, v: T) -> Self
     where
@@ -9990,6 +9979,17 @@ impl SbomReferenceIntotoPayload {
     {
         use std::iter::Iterator;
         self.subject = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [predicate][crate::model::SbomReferenceIntotoPayload::predicate].
+    pub fn set_predicate<
+        T: std::convert::Into<std::option::Option<crate::model::SbomReferenceIntotoPredicate>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.predicate = v.into();
         self
     }
 }
@@ -10763,12 +10763,6 @@ pub mod slsa_provenance_zero_two {
             self
         }
 
-        /// Sets the value of [entry_point][crate::model::slsa_provenance_zero_two::SlsaConfigSource::entry_point].
-        pub fn set_entry_point<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.entry_point = v.into();
-            self
-        }
-
         /// Sets the value of [digest][crate::model::slsa_provenance_zero_two::SlsaConfigSource::digest].
         pub fn set_digest<T, K, V>(mut self, v: T) -> Self
         where
@@ -10778,6 +10772,12 @@ pub mod slsa_provenance_zero_two {
         {
             use std::iter::Iterator;
             self.digest = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [entry_point][crate::model::slsa_provenance_zero_two::SlsaConfigSource::entry_point].
+        pub fn set_entry_point<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.entry_point = v.into();
             self
         }
     }
@@ -10973,17 +10973,6 @@ impl UpgradeNote {
         self
     }
 
-    /// Sets the value of [windows_update][crate::model::UpgradeNote::windows_update].
-    pub fn set_windows_update<
-        T: std::convert::Into<std::option::Option<crate::model::WindowsUpdate>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.windows_update = v.into();
-        self
-    }
-
     /// Sets the value of [distributions][crate::model::UpgradeNote::distributions].
     pub fn set_distributions<T, V>(mut self, v: T) -> Self
     where
@@ -10992,6 +10981,17 @@ impl UpgradeNote {
     {
         use std::iter::Iterator;
         self.distributions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [windows_update][crate::model::UpgradeNote::windows_update].
+    pub fn set_windows_update<
+        T: std::convert::Into<std::option::Option<crate::model::WindowsUpdate>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.windows_update = v.into();
         self
     }
 }
@@ -11145,23 +11145,6 @@ impl WindowsUpdate {
         self
     }
 
-    /// Sets the value of [support_url][crate::model::WindowsUpdate::support_url].
-    pub fn set_support_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.support_url = v.into();
-        self
-    }
-
-    /// Sets the value of [last_published_timestamp][crate::model::WindowsUpdate::last_published_timestamp].
-    pub fn set_last_published_timestamp<
-        T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.last_published_timestamp = v.into();
-        self
-    }
-
     /// Sets the value of [categories][crate::model::WindowsUpdate::categories].
     pub fn set_categories<T, V>(mut self, v: T) -> Self
     where
@@ -11181,6 +11164,23 @@ impl WindowsUpdate {
     {
         use std::iter::Iterator;
         self.kb_article_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [support_url][crate::model::WindowsUpdate::support_url].
+    pub fn set_support_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.support_url = v.into();
+        self
+    }
+
+    /// Sets the value of [last_published_timestamp][crate::model::WindowsUpdate::last_published_timestamp].
+    pub fn set_last_published_timestamp<
+        T: std::convert::Into<std::option::Option<wkt::Timestamp>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.last_published_timestamp = v.into();
         self
     }
 }
@@ -11764,6 +11764,17 @@ pub mod vulnerability_assessment_note {
             self
         }
 
+        /// Sets the value of [related_uris][crate::model::vulnerability_assessment_note::Assessment::related_uris].
+        pub fn set_related_uris<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::RelatedUrl>,
+        {
+            use std::iter::Iterator;
+            self.related_uris = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [state][crate::model::vulnerability_assessment_note::Assessment::state].
         pub fn set_state<
             T: std::convert::Into<crate::model::vulnerability_assessment_note::assessment::State>,
@@ -11772,6 +11783,17 @@ pub mod vulnerability_assessment_note {
             v: T,
         ) -> Self {
             self.state = v.into();
+            self
+        }
+
+        /// Sets the value of [impacts][crate::model::vulnerability_assessment_note::Assessment::impacts].
+        pub fn set_impacts<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.impacts = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -11787,28 +11809,6 @@ pub mod vulnerability_assessment_note {
             v: T,
         ) -> Self {
             self.justification = v.into();
-            self
-        }
-
-        /// Sets the value of [related_uris][crate::model::vulnerability_assessment_note::Assessment::related_uris].
-        pub fn set_related_uris<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::RelatedUrl>,
-        {
-            use std::iter::Iterator;
-            self.related_uris = v.into_iter().map(|i| i.into()).collect();
-            self
-        }
-
-        /// Sets the value of [impacts][crate::model::vulnerability_assessment_note::Assessment::impacts].
-        pub fn set_impacts<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.impacts = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -12507,12 +12507,34 @@ impl VulnerabilityNote {
         self
     }
 
+    /// Sets the value of [details][crate::model::VulnerabilityNote::details].
+    pub fn set_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::vulnerability_note::Detail>,
+    {
+        use std::iter::Iterator;
+        self.details = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [cvss_v3][crate::model::VulnerabilityNote::cvss_v3].
     pub fn set_cvss_v3<T: std::convert::Into<std::option::Option<crate::model::CVSSv3>>>(
         mut self,
         v: T,
     ) -> Self {
         self.cvss_v3 = v.into();
+        self
+    }
+
+    /// Sets the value of [windows_details][crate::model::VulnerabilityNote::windows_details].
+    pub fn set_windows_details<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::vulnerability_note::WindowsDetail>,
+    {
+        use std::iter::Iterator;
+        self.windows_details = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -12540,28 +12562,6 @@ impl VulnerabilityNote {
         v: T,
     ) -> Self {
         self.cvss_v2 = v.into();
-        self
-    }
-
-    /// Sets the value of [details][crate::model::VulnerabilityNote::details].
-    pub fn set_details<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::vulnerability_note::Detail>,
-    {
-        use std::iter::Iterator;
-        self.details = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [windows_details][crate::model::VulnerabilityNote::windows_details].
-    pub fn set_windows_details<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::vulnerability_note::WindowsDetail>,
-    {
-        use std::iter::Iterator;
-        self.windows_details = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13030,6 +13030,17 @@ impl VulnerabilityOccurrence {
         self
     }
 
+    /// Sets the value of [package_issue][crate::model::VulnerabilityOccurrence::package_issue].
+    pub fn set_package_issue<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::vulnerability_occurrence::PackageIssue>,
+    {
+        use std::iter::Iterator;
+        self.package_issue = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [short_description][crate::model::VulnerabilityOccurrence::short_description].
     pub fn set_short_description<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -13045,6 +13056,17 @@ impl VulnerabilityOccurrence {
         v: T,
     ) -> Self {
         self.long_description = v.into();
+        self
+    }
+
+    /// Sets the value of [related_urls][crate::model::VulnerabilityOccurrence::related_urls].
+    pub fn set_related_urls<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RelatedUrl>,
+    {
+        use std::iter::Iterator;
+        self.related_urls = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -13097,28 +13119,6 @@ impl VulnerabilityOccurrence {
     /// Sets the value of [extra_details][crate::model::VulnerabilityOccurrence::extra_details].
     pub fn set_extra_details<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.extra_details = v.into();
-        self
-    }
-
-    /// Sets the value of [package_issue][crate::model::VulnerabilityOccurrence::package_issue].
-    pub fn set_package_issue<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::vulnerability_occurrence::PackageIssue>,
-    {
-        use std::iter::Iterator;
-        self.package_issue = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [related_urls][crate::model::VulnerabilityOccurrence::related_urls].
-    pub fn set_related_urls<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RelatedUrl>,
-    {
-        use std::iter::Iterator;
-        self.related_urls = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13374,6 +13374,17 @@ pub mod vulnerability_occurrence {
             self
         }
 
+        /// Sets the value of [related_uris][crate::model::vulnerability_occurrence::VexAssessment::related_uris].
+        pub fn set_related_uris<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::RelatedUrl>,
+        {
+            use std::iter::Iterator;
+            self.related_uris = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [note_name][crate::model::vulnerability_occurrence::VexAssessment::note_name].
         pub fn set_note_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.note_name = v.into();
@@ -13388,32 +13399,6 @@ pub mod vulnerability_occurrence {
             v: T,
         ) -> Self {
             self.state = v.into();
-            self
-        }
-
-        /// Sets the value of [justification][crate::model::vulnerability_occurrence::VexAssessment::justification].
-        pub fn set_justification<
-            T: std::convert::Into<
-                    std::option::Option<
-                        crate::model::vulnerability_assessment_note::assessment::Justification,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.justification = v.into();
-            self
-        }
-
-        /// Sets the value of [related_uris][crate::model::vulnerability_occurrence::VexAssessment::related_uris].
-        pub fn set_related_uris<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::RelatedUrl>,
-        {
-            use std::iter::Iterator;
-            self.related_uris = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -13438,6 +13423,21 @@ pub mod vulnerability_occurrence {
         {
             use std::iter::Iterator;
             self.remediations = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [justification][crate::model::vulnerability_occurrence::VexAssessment::justification].
+        pub fn set_justification<
+            T: std::convert::Into<
+                    std::option::Option<
+                        crate::model::vulnerability_assessment_note::assessment::Justification,
+                    >,
+                >,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.justification = v.into();
             self
         }
     }

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -438,12 +438,6 @@ impl ListServiceAccountsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceAccountsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [accounts][crate::model::ListServiceAccountsResponse::accounts].
     pub fn set_accounts<T, V>(mut self, v: T) -> Self
     where
@@ -452,6 +446,12 @@ impl ListServiceAccountsResponse {
     {
         use std::iter::Iterator;
         self.accounts = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceAccountsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1742,6 +1742,17 @@ impl Role {
         self
     }
 
+    /// Sets the value of [included_permissions][crate::model::Role::included_permissions].
+    pub fn set_included_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.included_permissions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [stage][crate::model::Role::stage].
     pub fn set_stage<T: std::convert::Into<crate::model::role::RoleLaunchStage>>(
         mut self,
@@ -1760,17 +1771,6 @@ impl Role {
     /// Sets the value of [deleted][crate::model::Role::deleted].
     pub fn set_deleted<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.deleted = v.into();
-        self
-    }
-
-    /// Sets the value of [included_permissions][crate::model::Role::included_permissions].
-    pub fn set_included_permissions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.included_permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2037,12 +2037,6 @@ impl QueryGrantableRolesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::QueryGrantableRolesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [roles][crate::model::QueryGrantableRolesResponse::roles].
     pub fn set_roles<T, V>(mut self, v: T) -> Self
     where
@@ -2051,6 +2045,12 @@ impl QueryGrantableRolesResponse {
     {
         use std::iter::Iterator;
         self.roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::QueryGrantableRolesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2205,12 +2205,6 @@ impl ListRolesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRolesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [roles][crate::model::ListRolesResponse::roles].
     pub fn set_roles<T, V>(mut self, v: T) -> Self
     where
@@ -2219,6 +2213,12 @@ impl ListRolesResponse {
     {
         use std::iter::Iterator;
         self.roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRolesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3081,12 +3081,6 @@ impl QueryTestablePermissionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::QueryTestablePermissionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [permissions][crate::model::QueryTestablePermissionsResponse::permissions].
     pub fn set_permissions<T, V>(mut self, v: T) -> Self
     where
@@ -3095,6 +3089,12 @@ impl QueryTestablePermissionsResponse {
     {
         use std::iter::Iterator;
         self.permissions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::QueryTestablePermissionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/iam/credentials/v1/src/builder.rs
+++ b/src/generated/iam/credentials/v1/src/builder.rs
@@ -110,12 +110,6 @@ pub mod iam_credentials {
             self
         }
 
-        /// Sets the value of [lifetime][crate::model::GenerateAccessTokenRequest::lifetime].
-        pub fn set_lifetime<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
-            self.0.request.lifetime = v.into();
-            self
-        }
-
         /// Sets the value of [delegates][crate::model::GenerateAccessTokenRequest::delegates].
         pub fn set_delegates<T, V>(mut self, v: T) -> Self
         where
@@ -137,6 +131,12 @@ pub mod iam_credentials {
         {
             use std::iter::Iterator;
             self.0.request.scope = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [lifetime][crate::model::GenerateAccessTokenRequest::lifetime].
+        pub fn set_lifetime<T: Into<std::option::Option<wkt::Duration>>>(mut self, v: T) -> Self {
+            self.0.request.lifetime = v.into();
             self
         }
     }
@@ -187,6 +187,17 @@ pub mod iam_credentials {
             self
         }
 
+        /// Sets the value of [delegates][crate::model::GenerateIdTokenRequest::delegates].
+        pub fn set_delegates<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [audience][crate::model::GenerateIdTokenRequest::audience].
         ///
         /// This is a **required** field for requests.
@@ -198,17 +209,6 @@ pub mod iam_credentials {
         /// Sets the value of [include_email][crate::model::GenerateIdTokenRequest::include_email].
         pub fn set_include_email<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.include_email = v.into();
-            self
-        }
-
-        /// Sets the value of [delegates][crate::model::GenerateIdTokenRequest::delegates].
-        pub fn set_delegates<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -259,14 +259,6 @@ pub mod iam_credentials {
             self
         }
 
-        /// Sets the value of [payload][crate::model::SignBlobRequest::payload].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_payload<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request.payload = v.into();
-            self
-        }
-
         /// Sets the value of [delegates][crate::model::SignBlobRequest::delegates].
         pub fn set_delegates<T, V>(mut self, v: T) -> Self
         where
@@ -275,6 +267,14 @@ pub mod iam_credentials {
         {
             use std::iter::Iterator;
             self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [payload][crate::model::SignBlobRequest::payload].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_payload<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.payload = v.into();
             self
         }
     }
@@ -325,14 +325,6 @@ pub mod iam_credentials {
             self
         }
 
-        /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_payload<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.payload = v.into();
-            self
-        }
-
         /// Sets the value of [delegates][crate::model::SignJwtRequest::delegates].
         pub fn set_delegates<T, V>(mut self, v: T) -> Self
         where
@@ -341,6 +333,14 @@ pub mod iam_credentials {
         {
             use std::iter::Iterator;
             self.0.request.delegates = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_payload<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.payload = v.into();
             self
         }
     }

--- a/src/generated/iam/credentials/v1/src/model.rs
+++ b/src/generated/iam/credentials/v1/src/model.rs
@@ -84,15 +84,6 @@ impl GenerateAccessTokenRequest {
         self
     }
 
-    /// Sets the value of [lifetime][crate::model::GenerateAccessTokenRequest::lifetime].
-    pub fn set_lifetime<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.lifetime = v.into();
-        self
-    }
-
     /// Sets the value of [delegates][crate::model::GenerateAccessTokenRequest::delegates].
     pub fn set_delegates<T, V>(mut self, v: T) -> Self
     where
@@ -112,6 +103,15 @@ impl GenerateAccessTokenRequest {
     {
         use std::iter::Iterator;
         self.scope = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [lifetime][crate::model::GenerateAccessTokenRequest::lifetime].
+    pub fn set_lifetime<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.lifetime = v.into();
         self
     }
 }
@@ -212,12 +212,6 @@ impl SignBlobRequest {
         self
     }
 
-    /// Sets the value of [payload][crate::model::SignBlobRequest::payload].
-    pub fn set_payload<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.payload = v.into();
-        self
-    }
-
     /// Sets the value of [delegates][crate::model::SignBlobRequest::delegates].
     pub fn set_delegates<T, V>(mut self, v: T) -> Self
     where
@@ -226,6 +220,12 @@ impl SignBlobRequest {
     {
         use std::iter::Iterator;
         self.delegates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [payload][crate::model::SignBlobRequest::payload].
+    pub fn set_payload<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.payload = v.into();
         self
     }
 }
@@ -322,12 +322,6 @@ impl SignJwtRequest {
         self
     }
 
-    /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
-    pub fn set_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.payload = v.into();
-        self
-    }
-
     /// Sets the value of [delegates][crate::model::SignJwtRequest::delegates].
     pub fn set_delegates<T, V>(mut self, v: T) -> Self
     where
@@ -336,6 +330,12 @@ impl SignJwtRequest {
     {
         use std::iter::Iterator;
         self.delegates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [payload][crate::model::SignJwtRequest::payload].
+    pub fn set_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.payload = v.into();
         self
     }
 }
@@ -437,6 +437,17 @@ impl GenerateIdTokenRequest {
         self
     }
 
+    /// Sets the value of [delegates][crate::model::GenerateIdTokenRequest::delegates].
+    pub fn set_delegates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.delegates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [audience][crate::model::GenerateIdTokenRequest::audience].
     pub fn set_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.audience = v.into();
@@ -446,17 +457,6 @@ impl GenerateIdTokenRequest {
     /// Sets the value of [include_email][crate::model::GenerateIdTokenRequest::include_email].
     pub fn set_include_email<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.include_email = v.into();
-        self
-    }
-
-    /// Sets the value of [delegates][crate::model::GenerateIdTokenRequest::delegates].
-    pub fn set_delegates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.delegates = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/iam/v1/src/model.rs
+++ b/src/generated/iam/v1/src/model.rs
@@ -437,12 +437,6 @@ impl Policy {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Policy::etag].
-    pub fn set_etag<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [bindings][crate::model::Policy::bindings].
     pub fn set_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -462,6 +456,12 @@ impl Policy {
     {
         use std::iter::Iterator;
         self.audit_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Policy::etag].
+    pub fn set_etag<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -557,15 +557,6 @@ impl Binding {
         self
     }
 
-    /// Sets the value of [condition][crate::model::Binding::condition].
-    pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition = v.into();
-        self
-    }
-
     /// Sets the value of [members][crate::model::Binding::members].
     pub fn set_members<T, V>(mut self, v: T) -> Self
     where
@@ -574,6 +565,15 @@ impl Binding {
     {
         use std::iter::Iterator;
         self.members = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [condition][crate::model::Binding::condition].
+    pub fn set_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.condition = v.into();
         self
     }
 }

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -134,15 +134,6 @@ impl DenyRule {
         std::default::Default::default()
     }
 
-    /// Sets the value of [denial_condition][crate::model::DenyRule::denial_condition].
-    pub fn set_denial_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.denial_condition = v.into();
-        self
-    }
-
     /// Sets the value of [denied_principals][crate::model::DenyRule::denied_principals].
     pub fn set_denied_principals<T, V>(mut self, v: T) -> Self
     where
@@ -184,6 +175,15 @@ impl DenyRule {
     {
         use std::iter::Iterator;
         self.exception_permissions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [denial_condition][crate::model::DenyRule::denial_condition].
+    pub fn set_denial_condition<T: std::convert::Into<std::option::Option<gtype::model::Expr>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.denial_condition = v.into();
         self
     }
 }
@@ -297,6 +297,18 @@ impl Policy {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::Policy::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::Policy::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
@@ -330,15 +342,6 @@ impl Policy {
         self
     }
 
-    /// Sets the value of [managing_authority][crate::model::Policy::managing_authority].
-    pub fn set_managing_authority<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.managing_authority = v.into();
-        self
-    }
-
     /// Sets the value of [rules][crate::model::Policy::rules].
     pub fn set_rules<T, V>(mut self, v: T) -> Self
     where
@@ -350,15 +353,12 @@ impl Policy {
         self
     }
 
-    /// Sets the value of [annotations][crate::model::Policy::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [managing_authority][crate::model::Policy::managing_authority].
+    pub fn set_managing_authority<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.managing_authority = v.into();
         self
     }
 }
@@ -547,12 +547,6 @@ impl ListPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policies][crate::model::ListPoliciesResponse::policies].
     pub fn set_policies<T, V>(mut self, v: T) -> Self
     where
@@ -561,6 +555,12 @@ impl ListPoliciesResponse {
     {
         use std::iter::Iterator;
         self.policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -279,6 +279,18 @@ impl PolicyBinding {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::PolicyBinding::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [target][crate::model::PolicyBinding::target].
     pub fn set_target<
         T: std::convert::Into<std::option::Option<crate::model::policy_binding::Target>>,
@@ -335,18 +347,6 @@ impl PolicyBinding {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::PolicyBinding::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -957,12 +957,6 @@ impl ListPolicyBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPolicyBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policy_bindings][crate::model::ListPolicyBindingsResponse::policy_bindings].
     pub fn set_policy_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -971,6 +965,12 @@ impl ListPolicyBindingsResponse {
     {
         use std::iter::Iterator;
         self.policy_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPolicyBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1109,12 +1109,6 @@ impl SearchTargetPolicyBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchTargetPolicyBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policy_bindings][crate::model::SearchTargetPolicyBindingsResponse::policy_bindings].
     pub fn set_policy_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -1123,6 +1117,12 @@ impl SearchTargetPolicyBindingsResponse {
     {
         use std::iter::Iterator;
         self.policy_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchTargetPolicyBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1489,12 +1489,6 @@ impl ListPrincipalAccessBoundaryPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListPrincipalAccessBoundaryPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [principal_access_boundary_policies][crate::model::ListPrincipalAccessBoundaryPoliciesResponse::principal_access_boundary_policies].
     pub fn set_principal_access_boundary_policies<T, V>(mut self, v: T) -> Self
     where
@@ -1503,6 +1497,12 @@ impl ListPrincipalAccessBoundaryPoliciesResponse {
     {
         use std::iter::Iterator;
         self.principal_access_boundary_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListPrincipalAccessBoundaryPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1615,12 +1615,6 @@ impl SearchPrincipalAccessBoundaryPolicyBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchPrincipalAccessBoundaryPolicyBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [policy_bindings][crate::model::SearchPrincipalAccessBoundaryPolicyBindingsResponse::policy_bindings].
     pub fn set_policy_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -1629,6 +1623,12 @@ impl SearchPrincipalAccessBoundaryPolicyBindingsResponse {
     {
         use std::iter::Iterator;
         self.policy_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchPrincipalAccessBoundaryPolicyBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1736,6 +1736,18 @@ impl PrincipalAccessBoundaryPolicy {
         self
     }
 
+    /// Sets the value of [annotations][crate::model::PrincipalAccessBoundaryPolicy::annotations].
+    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::PrincipalAccessBoundaryPolicy::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1762,18 +1774,6 @@ impl PrincipalAccessBoundaryPolicy {
         v: T,
     ) -> Self {
         self.details = v.into();
-        self
-    }
-
-    /// Sets the value of [annotations][crate::model::PrincipalAccessBoundaryPolicy::annotations].
-    pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1812,15 +1812,6 @@ impl PrincipalAccessBoundaryPolicyDetails {
         std::default::Default::default()
     }
 
-    /// Sets the value of [enforcement_version][crate::model::PrincipalAccessBoundaryPolicyDetails::enforcement_version].
-    pub fn set_enforcement_version<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enforcement_version = v.into();
-        self
-    }
-
     /// Sets the value of [rules][crate::model::PrincipalAccessBoundaryPolicyDetails::rules].
     pub fn set_rules<T, V>(mut self, v: T) -> Self
     where
@@ -1829,6 +1820,15 @@ impl PrincipalAccessBoundaryPolicyDetails {
     {
         use std::iter::Iterator;
         self.rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enforcement_version][crate::model::PrincipalAccessBoundaryPolicyDetails::enforcement_version].
+    pub fn set_enforcement_version<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.enforcement_version = v.into();
         self
     }
 }
@@ -1884,17 +1884,6 @@ impl PrincipalAccessBoundaryPolicyRule {
         self
     }
 
-    /// Sets the value of [effect][crate::model::PrincipalAccessBoundaryPolicyRule::effect].
-    pub fn set_effect<
-        T: std::convert::Into<crate::model::principal_access_boundary_policy_rule::Effect>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.effect = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::PrincipalAccessBoundaryPolicyRule::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -1903,6 +1892,17 @@ impl PrincipalAccessBoundaryPolicyRule {
     {
         use std::iter::Iterator;
         self.resources = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [effect][crate::model::PrincipalAccessBoundaryPolicyRule::effect].
+    pub fn set_effect<
+        T: std::convert::Into<crate::model::principal_access_boundary_policy_rule::Effect>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.effect = v.into();
         self
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/builder.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builder.rs
@@ -284,6 +284,17 @@ pub mod access_context_manager {
             self
         }
 
+        /// Sets the value of [scopes][crate::model::AccessPolicy::scopes].
+        pub fn set_scopes<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.scopes = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [create_time][crate::model::AccessPolicy::create_time].
         pub fn set_create_time<T: Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
@@ -305,17 +316,6 @@ pub mod access_context_manager {
         /// Sets the value of [etag][crate::model::AccessPolicy::etag].
         pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.etag = v.into();
-            self
-        }
-
-        /// Sets the value of [scopes][crate::model::AccessPolicy::scopes].
-        pub fn set_scopes<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.scopes = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -1044,12 +1044,6 @@ pub mod access_context_manager {
             self
         }
 
-        /// Sets the value of [etag][crate::model::ReplaceAccessLevelsRequest::etag].
-        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.etag = v.into();
-            self
-        }
-
         /// Sets the value of [access_levels][crate::model::ReplaceAccessLevelsRequest::access_levels].
         ///
         /// This is a **required** field for requests.
@@ -1060,6 +1054,12 @@ pub mod access_context_manager {
         {
             use std::iter::Iterator;
             self.0.request.access_levels = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [etag][crate::model::ReplaceAccessLevelsRequest::etag].
+        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.etag = v.into();
             self
         }
     }
@@ -1589,12 +1589,6 @@ pub mod access_context_manager {
             self
         }
 
-        /// Sets the value of [etag][crate::model::ReplaceServicePerimetersRequest::etag].
-        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.etag = v.into();
-            self
-        }
-
         /// Sets the value of [service_perimeters][crate::model::ReplaceServicePerimetersRequest::service_perimeters].
         ///
         /// This is a **required** field for requests.
@@ -1605,6 +1599,12 @@ pub mod access_context_manager {
         {
             use std::iter::Iterator;
             self.0.request.service_perimeters = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [etag][crate::model::ReplaceServicePerimetersRequest::etag].
+        pub fn set_etag<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.etag = v.into();
             self
         }
     }

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -116,12 +116,6 @@ impl ListAccessPoliciesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAccessPoliciesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [access_policies][crate::model::ListAccessPoliciesResponse::access_policies].
     pub fn set_access_policies<T, V>(mut self, v: T) -> Self
     where
@@ -130,6 +124,12 @@ impl ListAccessPoliciesResponse {
     {
         use std::iter::Iterator;
         self.access_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAccessPoliciesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -369,12 +369,6 @@ impl ListAccessLevelsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAccessLevelsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [access_levels][crate::model::ListAccessLevelsResponse::access_levels].
     pub fn set_access_levels<T, V>(mut self, v: T) -> Self
     where
@@ -383,6 +377,12 @@ impl ListAccessLevelsResponse {
     {
         use std::iter::Iterator;
         self.access_levels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAccessLevelsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -655,12 +655,6 @@ impl ReplaceAccessLevelsRequest {
         self
     }
 
-    /// Sets the value of [etag][crate::model::ReplaceAccessLevelsRequest::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [access_levels][crate::model::ReplaceAccessLevelsRequest::access_levels].
     pub fn set_access_levels<T, V>(mut self, v: T) -> Self
     where
@@ -669,6 +663,12 @@ impl ReplaceAccessLevelsRequest {
     {
         use std::iter::Iterator;
         self.access_levels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::ReplaceAccessLevelsRequest::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -803,12 +803,6 @@ impl ListServicePerimetersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicePerimetersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_perimeters][crate::model::ListServicePerimetersResponse::service_perimeters].
     pub fn set_service_perimeters<T, V>(mut self, v: T) -> Self
     where
@@ -817,6 +811,12 @@ impl ListServicePerimetersResponse {
     {
         use std::iter::Iterator;
         self.service_perimeters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicePerimetersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1067,12 +1067,6 @@ impl ReplaceServicePerimetersRequest {
         self
     }
 
-    /// Sets the value of [etag][crate::model::ReplaceServicePerimetersRequest::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [service_perimeters][crate::model::ReplaceServicePerimetersRequest::service_perimeters].
     pub fn set_service_perimeters<T, V>(mut self, v: T) -> Self
     where
@@ -1081,6 +1075,12 @@ impl ReplaceServicePerimetersRequest {
     {
         use std::iter::Iterator;
         self.service_perimeters = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::ReplaceServicePerimetersRequest::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -1311,12 +1311,6 @@ impl ListGcpUserAccessBindingsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGcpUserAccessBindingsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [gcp_user_access_bindings][crate::model::ListGcpUserAccessBindingsResponse::gcp_user_access_bindings].
     pub fn set_gcp_user_access_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -1325,6 +1319,12 @@ impl ListGcpUserAccessBindingsResponse {
     {
         use std::iter::Iterator;
         self.gcp_user_access_bindings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGcpUserAccessBindingsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1672,17 +1672,6 @@ impl AccessLevel {
         })
     }
 
-    /// The value of [level][crate::model::AccessLevel::level]
-    /// if it holds a `Custom`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom(&self) -> std::option::Option<&std::boxed::Box<crate::model::CustomLevel>> {
-        #[allow(unreachable_patterns)]
-        self.level.as_ref().and_then(|v| match v {
-            crate::model::access_level::Level::Custom(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [level][crate::model::AccessLevel::level]
     /// to hold a `Basic`.
     ///
@@ -1694,6 +1683,17 @@ impl AccessLevel {
     ) -> Self {
         self.level = std::option::Option::Some(crate::model::access_level::Level::Basic(v.into()));
         self
+    }
+
+    /// The value of [level][crate::model::AccessLevel::level]
+    /// if it holds a `Custom`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom(&self) -> std::option::Option<&std::boxed::Box<crate::model::CustomLevel>> {
+        #[allow(unreachable_patterns)]
+        self.level.as_ref().and_then(|v| match v {
+            crate::model::access_level::Level::Custom(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [level][crate::model::AccessLevel::level]
@@ -1759,17 +1759,6 @@ impl BasicLevel {
         std::default::Default::default()
     }
 
-    /// Sets the value of [combining_function][crate::model::BasicLevel::combining_function].
-    pub fn set_combining_function<
-        T: std::convert::Into<crate::model::basic_level::ConditionCombiningFunction>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.combining_function = v.into();
-        self
-    }
-
     /// Sets the value of [conditions][crate::model::BasicLevel::conditions].
     pub fn set_conditions<T, V>(mut self, v: T) -> Self
     where
@@ -1778,6 +1767,17 @@ impl BasicLevel {
     {
         use std::iter::Iterator;
         self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [combining_function][crate::model::BasicLevel::combining_function].
+    pub fn set_combining_function<
+        T: std::convert::Into<crate::model::basic_level::ConditionCombiningFunction>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.combining_function = v.into();
         self
     }
 }
@@ -1982,23 +1982,6 @@ impl Condition {
         std::default::Default::default()
     }
 
-    /// Sets the value of [device_policy][crate::model::Condition::device_policy].
-    pub fn set_device_policy<
-        T: std::convert::Into<std::option::Option<crate::model::DevicePolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.device_policy = v.into();
-        self
-    }
-
-    /// Sets the value of [negate][crate::model::Condition::negate].
-    pub fn set_negate<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.negate = v.into();
-        self
-    }
-
     /// Sets the value of [ip_subnetworks][crate::model::Condition::ip_subnetworks].
     pub fn set_ip_subnetworks<T, V>(mut self, v: T) -> Self
     where
@@ -2010,6 +1993,17 @@ impl Condition {
         self
     }
 
+    /// Sets the value of [device_policy][crate::model::Condition::device_policy].
+    pub fn set_device_policy<
+        T: std::convert::Into<std::option::Option<crate::model::DevicePolicy>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.device_policy = v.into();
+        self
+    }
+
     /// Sets the value of [required_access_levels][crate::model::Condition::required_access_levels].
     pub fn set_required_access_levels<T, V>(mut self, v: T) -> Self
     where
@@ -2018,6 +2012,12 @@ impl Condition {
     {
         use std::iter::Iterator;
         self.required_access_levels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [negate][crate::model::Condition::negate].
+    pub fn set_negate<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.negate = v.into();
         self
     }
 
@@ -2144,18 +2144,6 @@ impl DevicePolicy {
         self
     }
 
-    /// Sets the value of [require_admin_approval][crate::model::DevicePolicy::require_admin_approval].
-    pub fn set_require_admin_approval<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.require_admin_approval = v.into();
-        self
-    }
-
-    /// Sets the value of [require_corp_owned][crate::model::DevicePolicy::require_corp_owned].
-    pub fn set_require_corp_owned<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.require_corp_owned = v.into();
-        self
-    }
-
     /// Sets the value of [allowed_encryption_statuses][crate::model::DevicePolicy::allowed_encryption_statuses].
     pub fn set_allowed_encryption_statuses<T, V>(mut self, v: T) -> Self
     where
@@ -2186,6 +2174,18 @@ impl DevicePolicy {
     {
         use std::iter::Iterator;
         self.allowed_device_management_levels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [require_admin_approval][crate::model::DevicePolicy::require_admin_approval].
+    pub fn set_require_admin_approval<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.require_admin_approval = v.into();
+        self
+    }
+
+    /// Sets the value of [require_corp_owned][crate::model::DevicePolicy::require_corp_owned].
+    pub fn set_require_corp_owned<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.require_corp_owned = v.into();
         self
     }
 }
@@ -2340,6 +2340,17 @@ impl AccessPolicy {
         self
     }
 
+    /// Sets the value of [scopes][crate::model::AccessPolicy::scopes].
+    pub fn set_scopes<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.scopes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::AccessPolicy::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2361,17 +2372,6 @@ impl AccessPolicy {
     /// Sets the value of [etag][crate::model::AccessPolicy::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
-        self
-    }
-
-    /// Sets the value of [scopes][crate::model::AccessPolicy::scopes].
-    pub fn set_scopes<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.scopes = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2828,19 +2828,6 @@ impl ServicePerimeterConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [vpc_accessible_services][crate::model::ServicePerimeterConfig::vpc_accessible_services].
-    pub fn set_vpc_accessible_services<
-        T: std::convert::Into<
-                std::option::Option<crate::model::service_perimeter_config::VpcAccessibleServices>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vpc_accessible_services = v.into();
-        self
-    }
-
     /// Sets the value of [resources][crate::model::ServicePerimeterConfig::resources].
     pub fn set_resources<T, V>(mut self, v: T) -> Self
     where
@@ -2871,6 +2858,19 @@ impl ServicePerimeterConfig {
     {
         use std::iter::Iterator;
         self.restricted_services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [vpc_accessible_services][crate::model::ServicePerimeterConfig::vpc_accessible_services].
+    pub fn set_vpc_accessible_services<
+        T: std::convert::Into<
+                std::option::Option<crate::model::service_perimeter_config::VpcAccessibleServices>,
+            >,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.vpc_accessible_services = v.into();
         self
     }
 
@@ -3012,6 +3012,18 @@ pub mod service_perimeter_config {
             })
         }
 
+        /// Sets the value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
+        /// to hold a `Method`.
+        ///
+        /// Note that all the setters affecting `kind` are
+        /// mutually exclusive.
+        pub fn set_method<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.kind = std::option::Option::Some(
+                crate::model::service_perimeter_config::method_selector::Kind::Method(v.into()),
+            );
+            self
+        }
+
         /// The value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
         /// if it holds a `Permission`, `None` if the field is not set or
         /// holds a different branch.
@@ -3023,18 +3035,6 @@ pub mod service_perimeter_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
-        /// to hold a `Method`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_method<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::service_perimeter_config::method_selector::Kind::Method(v.into()),
-            );
-            self
         }
 
         /// Sets the value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
@@ -3195,19 +3195,6 @@ pub mod service_perimeter_config {
             })
         }
 
-        /// The value of [source][crate::model::service_perimeter_config::IngressSource::source]
-        /// if it holds a `Resource`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn resource(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::service_perimeter_config::ingress_source::Source::Resource(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [source][crate::model::service_perimeter_config::IngressSource::source]
         /// to hold a `AccessLevel`.
         ///
@@ -3223,6 +3210,19 @@ pub mod service_perimeter_config {
                 ),
             );
             self
+        }
+
+        /// The value of [source][crate::model::service_perimeter_config::IngressSource::source]
+        /// if it holds a `Resource`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn resource(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::service_perimeter_config::ingress_source::Source::Resource(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source][crate::model::service_perimeter_config::IngressSource::source]
@@ -3322,17 +3322,6 @@ pub mod service_perimeter_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [identity_type][crate::model::service_perimeter_config::IngressFrom::identity_type].
-        pub fn set_identity_type<
-            T: std::convert::Into<crate::model::service_perimeter_config::IdentityType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.identity_type = v.into();
-            self
-        }
-
         /// Sets the value of [sources][crate::model::service_perimeter_config::IngressFrom::sources].
         pub fn set_sources<T, V>(mut self, v: T) -> Self
         where
@@ -3352,6 +3341,17 @@ pub mod service_perimeter_config {
         {
             use std::iter::Iterator;
             self.identities = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [identity_type][crate::model::service_perimeter_config::IngressFrom::identity_type].
+        pub fn set_identity_type<
+            T: std::convert::Into<crate::model::service_perimeter_config::IdentityType>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.identity_type = v.into();
             self
         }
     }
@@ -3552,17 +3552,6 @@ pub mod service_perimeter_config {
             std::default::Default::default()
         }
 
-        /// Sets the value of [identity_type][crate::model::service_perimeter_config::EgressFrom::identity_type].
-        pub fn set_identity_type<
-            T: std::convert::Into<crate::model::service_perimeter_config::IdentityType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.identity_type = v.into();
-            self
-        }
-
         /// Sets the value of [identities][crate::model::service_perimeter_config::EgressFrom::identities].
         pub fn set_identities<T, V>(mut self, v: T) -> Self
         where
@@ -3571,6 +3560,17 @@ pub mod service_perimeter_config {
         {
             use std::iter::Iterator;
             self.identities = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [identity_type][crate::model::service_perimeter_config::EgressFrom::identity_type].
+        pub fn set_identity_type<
+            T: std::convert::Into<crate::model::service_perimeter_config::IdentityType>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.identity_type = v.into();
             self
         }
     }

--- a/src/generated/logging/v2/src/builder.rs
+++ b/src/generated/logging/v2/src/builder.rs
@@ -161,15 +161,14 @@ pub mod logging_service_v_2 {
             self
         }
 
-        /// Sets the value of [partial_success][crate::model::WriteLogEntriesRequest::partial_success].
-        pub fn set_partial_success<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.partial_success = v.into();
-            self
-        }
-
-        /// Sets the value of [dry_run][crate::model::WriteLogEntriesRequest::dry_run].
-        pub fn set_dry_run<T: Into<bool>>(mut self, v: T) -> Self {
-            self.0.request.dry_run = v.into();
+        /// Sets the value of [labels][crate::model::WriteLogEntriesRequest::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -186,14 +185,15 @@ pub mod logging_service_v_2 {
             self
         }
 
-        /// Sets the value of [labels][crate::model::WriteLogEntriesRequest::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            self.0.request.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        /// Sets the value of [partial_success][crate::model::WriteLogEntriesRequest::partial_success].
+        pub fn set_partial_success<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.partial_success = v.into();
+            self
+        }
+
+        /// Sets the value of [dry_run][crate::model::WriteLogEntriesRequest::dry_run].
+        pub fn set_dry_run<T: Into<bool>>(mut self, v: T) -> Self {
+            self.0.request.dry_run = v.into();
             self
         }
     }
@@ -251,6 +251,19 @@ pub mod logging_service_v_2 {
             gax::paginator::internal::new_paginator(token, execute)
         }
 
+        /// Sets the value of [resource_names][crate::model::ListLogEntriesRequest::resource_names].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_resource_names<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.resource_names = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [filter][crate::model::ListLogEntriesRequest::filter].
         pub fn set_filter<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.filter = v.into();
@@ -272,19 +285,6 @@ pub mod logging_service_v_2 {
         /// Sets the value of [page_token][crate::model::ListLogEntriesRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
-            self
-        }
-
-        /// Sets the value of [resource_names][crate::model::ListLogEntriesRequest::resource_names].
-        ///
-        /// This is a **required** field for requests.
-        pub fn set_resource_names<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.resource_names = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -408,6 +408,17 @@ pub mod logging_service_v_2 {
             self
         }
 
+        /// Sets the value of [resource_names][crate::model::ListLogsRequest::resource_names].
+        pub fn set_resource_names<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.resource_names = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [page_size][crate::model::ListLogsRequest::page_size].
         pub fn set_page_size<T: Into<i32>>(mut self, v: T) -> Self {
             self.0.request.page_size = v.into();
@@ -417,17 +428,6 @@ pub mod logging_service_v_2 {
         /// Sets the value of [page_token][crate::model::ListLogsRequest::page_token].
         pub fn set_page_token<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.page_token = v.into();
-            self
-        }
-
-        /// Sets the value of [resource_names][crate::model::ListLogsRequest::resource_names].
-        pub fn set_resource_names<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.resource_names = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -280,6 +280,18 @@ impl LogEntry {
         self
     }
 
+    /// Sets the value of [labels][crate::model::LogEntry::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [operation][crate::model::LogEntry::operation].
     pub fn set_operation<
         T: std::convert::Into<std::option::Option<crate::model::LogEntryOperation>>,
@@ -329,18 +341,6 @@ impl LogEntry {
         self
     }
 
-    /// Sets the value of [labels][crate::model::LogEntry::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [payload][crate::model::LogEntry::payload].
     ///
     /// Note that all the setters affecting `payload` are mutually
@@ -366,28 +366,6 @@ impl LogEntry {
         })
     }
 
-    /// The value of [payload][crate::model::LogEntry::payload]
-    /// if it holds a `TextPayload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text_payload(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.payload.as_ref().and_then(|v| match v {
-            crate::model::log_entry::Payload::TextPayload(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [payload][crate::model::LogEntry::payload]
-    /// if it holds a `JsonPayload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn json_payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
-        #[allow(unreachable_patterns)]
-        self.payload.as_ref().and_then(|v| match v {
-            crate::model::log_entry::Payload::JsonPayload(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [payload][crate::model::LogEntry::payload]
     /// to hold a `ProtoPayload`.
     ///
@@ -402,6 +380,17 @@ impl LogEntry {
         self
     }
 
+    /// The value of [payload][crate::model::LogEntry::payload]
+    /// if it holds a `TextPayload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text_payload(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.payload.as_ref().and_then(|v| match v {
+            crate::model::log_entry::Payload::TextPayload(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [payload][crate::model::LogEntry::payload]
     /// to hold a `TextPayload`.
     ///
@@ -411,6 +400,17 @@ impl LogEntry {
         self.payload =
             std::option::Option::Some(crate::model::log_entry::Payload::TextPayload(v.into()));
         self
+    }
+
+    /// The value of [payload][crate::model::LogEntry::payload]
+    /// if it holds a `JsonPayload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn json_payload(&self) -> std::option::Option<&std::boxed::Box<wkt::Struct>> {
+        #[allow(unreachable_patterns)]
+        self.payload.as_ref().and_then(|v| match v {
+            crate::model::log_entry::Payload::JsonPayload(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [payload][crate::model::LogEntry::payload]
@@ -815,15 +815,15 @@ impl WriteLogEntriesRequest {
         self
     }
 
-    /// Sets the value of [partial_success][crate::model::WriteLogEntriesRequest::partial_success].
-    pub fn set_partial_success<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.partial_success = v.into();
-        self
-    }
-
-    /// Sets the value of [dry_run][crate::model::WriteLogEntriesRequest::dry_run].
-    pub fn set_dry_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.dry_run = v.into();
+    /// Sets the value of [labels][crate::model::WriteLogEntriesRequest::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -838,15 +838,15 @@ impl WriteLogEntriesRequest {
         self
     }
 
-    /// Sets the value of [labels][crate::model::WriteLogEntriesRequest::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+    /// Sets the value of [partial_success][crate::model::WriteLogEntriesRequest::partial_success].
+    pub fn set_partial_success<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.partial_success = v.into();
+        self
+    }
+
+    /// Sets the value of [dry_run][crate::model::WriteLogEntriesRequest::dry_run].
+    pub fn set_dry_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.dry_run = v.into();
         self
     }
 }
@@ -988,6 +988,17 @@ impl ListLogEntriesRequest {
         std::default::Default::default()
     }
 
+    /// Sets the value of [resource_names][crate::model::ListLogEntriesRequest::resource_names].
+    pub fn set_resource_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [filter][crate::model::ListLogEntriesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
@@ -1009,17 +1020,6 @@ impl ListLogEntriesRequest {
     /// Sets the value of [page_token][crate::model::ListLogEntriesRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_names][crate::model::ListLogEntriesRequest::resource_names].
-    pub fn set_resource_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1064,12 +1064,6 @@ impl ListLogEntriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLogEntriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [entries][crate::model::ListLogEntriesResponse::entries].
     pub fn set_entries<T, V>(mut self, v: T) -> Self
     where
@@ -1078,6 +1072,12 @@ impl ListLogEntriesResponse {
     {
         use std::iter::Iterator;
         self.entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLogEntriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1174,12 +1174,6 @@ impl ListMonitoredResourceDescriptorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMonitoredResourceDescriptorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resource_descriptors][crate::model::ListMonitoredResourceDescriptorsResponse::resource_descriptors].
     pub fn set_resource_descriptors<T, V>(mut self, v: T) -> Self
     where
@@ -1188,6 +1182,12 @@ impl ListMonitoredResourceDescriptorsResponse {
     {
         use std::iter::Iterator;
         self.resource_descriptors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMonitoredResourceDescriptorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1273,6 +1273,17 @@ impl ListLogsRequest {
         self
     }
 
+    /// Sets the value of [resource_names][crate::model::ListLogsRequest::resource_names].
+    pub fn set_resource_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [page_size][crate::model::ListLogsRequest::page_size].
     pub fn set_page_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.page_size = v.into();
@@ -1282,17 +1293,6 @@ impl ListLogsRequest {
     /// Sets the value of [page_token][crate::model::ListLogsRequest::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_names][crate::model::ListLogsRequest::resource_names].
-    pub fn set_resource_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1330,12 +1330,6 @@ impl ListLogsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLogsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [log_names][crate::model::ListLogsResponse::log_names].
     pub fn set_log_names<T, V>(mut self, v: T) -> Self
     where
@@ -1344,6 +1338,12 @@ impl ListLogsResponse {
     {
         use std::iter::Iterator;
         self.log_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLogsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1400,6 +1400,17 @@ impl TailLogEntriesRequest {
         std::default::Default::default()
     }
 
+    /// Sets the value of [resource_names][crate::model::TailLogEntriesRequest::resource_names].
+    pub fn set_resource_names<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_names = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [filter][crate::model::TailLogEntriesRequest::filter].
     pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.filter = v.into();
@@ -1412,17 +1423,6 @@ impl TailLogEntriesRequest {
         v: T,
     ) -> Self {
         self.buffer_window = v.into();
-        self
-    }
-
-    /// Sets the value of [resource_names][crate::model::TailLogEntriesRequest::resource_names].
-    pub fn set_resource_names<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_names = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -1899,17 +1899,6 @@ impl LogBucket {
         self
     }
 
-    /// Sets the value of [cmek_settings][crate::model::LogBucket::cmek_settings].
-    pub fn set_cmek_settings<
-        T: std::convert::Into<std::option::Option<crate::model::CmekSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cmek_settings = v.into();
-        self
-    }
-
     /// Sets the value of [restricted_fields][crate::model::LogBucket::restricted_fields].
     pub fn set_restricted_fields<T, V>(mut self, v: T) -> Self
     where
@@ -1929,6 +1918,17 @@ impl LogBucket {
     {
         use std::iter::Iterator;
         self.index_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [cmek_settings][crate::model::LogBucket::cmek_settings].
+    pub fn set_cmek_settings<
+        T: std::convert::Into<std::option::Option<crate::model::CmekSettings>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.cmek_settings = v.into();
         self
     }
 }
@@ -2202,6 +2202,17 @@ impl LogSink {
         self
     }
 
+    /// Sets the value of [exclusions][crate::model::LogSink::exclusions].
+    pub fn set_exclusions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::LogExclusion>,
+    {
+        use std::iter::Iterator;
+        self.exclusions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [output_version_format][crate::model::LogSink::output_version_format].
     #[deprecated]
     pub fn set_output_version_format<
@@ -2241,17 +2252,6 @@ impl LogSink {
         v: T,
     ) -> Self {
         self.update_time = v.into();
-        self
-    }
-
-    /// Sets the value of [exclusions][crate::model::LogSink::exclusions].
-    pub fn set_exclusions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::LogExclusion>,
-    {
-        use std::iter::Iterator;
-        self.exclusions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2741,12 +2741,6 @@ impl ListBucketsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBucketsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [buckets][crate::model::ListBucketsResponse::buckets].
     pub fn set_buckets<T, V>(mut self, v: T) -> Self
     where
@@ -2755,6 +2749,12 @@ impl ListBucketsResponse {
     {
         use std::iter::Iterator;
         self.buckets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBucketsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3138,12 +3138,6 @@ impl ListViewsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListViewsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [views][crate::model::ListViewsResponse::views].
     pub fn set_views<T, V>(mut self, v: T) -> Self
     where
@@ -3152,6 +3146,12 @@ impl ListViewsResponse {
     {
         use std::iter::Iterator;
         self.views = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListViewsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3483,12 +3483,6 @@ impl ListSinksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSinksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sinks][crate::model::ListSinksResponse::sinks].
     pub fn set_sinks<T, V>(mut self, v: T) -> Self
     where
@@ -3497,6 +3491,12 @@ impl ListSinksResponse {
     {
         use std::iter::Iterator;
         self.sinks = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSinksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3982,12 +3982,6 @@ impl ListLinksResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLinksResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [links][crate::model::ListLinksResponse::links].
     pub fn set_links<T, V>(mut self, v: T) -> Self
     where
@@ -3996,6 +3990,12 @@ impl ListLinksResponse {
     {
         use std::iter::Iterator;
         self.links = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLinksResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -4259,12 +4259,6 @@ impl ListExclusionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListExclusionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [exclusions][crate::model::ListExclusionsResponse::exclusions].
     pub fn set_exclusions<T, V>(mut self, v: T) -> Self
     where
@@ -4273,6 +4267,12 @@ impl ListExclusionsResponse {
     {
         use std::iter::Iterator;
         self.exclusions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListExclusionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5351,21 +5351,6 @@ impl BucketMetadata {
         })
     }
 
-    /// The value of [request][crate::model::BucketMetadata::request]
-    /// if it holds a `UpdateBucketRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn update_bucket_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateBucketRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::bucket_metadata::Request::UpdateBucketRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [request][crate::model::BucketMetadata::request]
     /// to hold a `CreateBucketRequest`.
     ///
@@ -5381,6 +5366,21 @@ impl BucketMetadata {
             crate::model::bucket_metadata::Request::CreateBucketRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::BucketMetadata::request]
+    /// if it holds a `UpdateBucketRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn update_bucket_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UpdateBucketRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::bucket_metadata::Request::UpdateBucketRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::BucketMetadata::request]
@@ -5505,21 +5505,6 @@ impl LinkMetadata {
         })
     }
 
-    /// The value of [request][crate::model::LinkMetadata::request]
-    /// if it holds a `DeleteLinkRequest`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delete_link_request(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteLinkRequest>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::link_metadata::Request::DeleteLinkRequest(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [request][crate::model::LinkMetadata::request]
     /// to hold a `CreateLinkRequest`.
     ///
@@ -5535,6 +5520,21 @@ impl LinkMetadata {
             crate::model::link_metadata::Request::CreateLinkRequest(v.into()),
         );
         self
+    }
+
+    /// The value of [request][crate::model::LinkMetadata::request]
+    /// if it holds a `DeleteLinkRequest`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delete_link_request(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DeleteLinkRequest>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::link_metadata::Request::DeleteLinkRequest(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::LinkMetadata::request]
@@ -5815,6 +5815,18 @@ impl LogMetric {
         self
     }
 
+    /// Sets the value of [label_extractors][crate::model::LogMetric::label_extractors].
+    pub fn set_label_extractors<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.label_extractors = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [bucket_options][crate::model::LogMetric::bucket_options].
     pub fn set_bucket_options<
         T: std::convert::Into<std::option::Option<api::model::distribution::BucketOptions>>,
@@ -5851,18 +5863,6 @@ impl LogMetric {
         v: T,
     ) -> Self {
         self.version = v.into();
-        self
-    }
-
-    /// Sets the value of [label_extractors][crate::model::LogMetric::label_extractors].
-    pub fn set_label_extractors<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.label_extractors = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -6090,12 +6090,6 @@ impl ListLogMetricsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLogMetricsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [metrics][crate::model::ListLogMetricsResponse::metrics].
     pub fn set_metrics<T, V>(mut self, v: T) -> Self
     where
@@ -6104,6 +6098,12 @@ impl ListLogMetricsResponse {
     {
         use std::iter::Iterator;
         self.metrics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLogMetricsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -119,17 +119,6 @@ impl Operation {
         })
     }
 
-    /// The value of [result][crate::model::Operation::result]
-    /// if it holds a `Response`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn response(&self) -> std::option::Option<&std::boxed::Box<wkt::Any>> {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::operation::Result::Response(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::Operation::result]
     /// to hold a `Error`.
     ///
@@ -141,6 +130,17 @@ impl Operation {
     ) -> Self {
         self.result = std::option::Option::Some(crate::model::operation::Result::Error(v.into()));
         self
+    }
+
+    /// The value of [result][crate::model::Operation::result]
+    /// if it holds a `Response`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn response(&self) -> std::option::Option<&std::boxed::Box<wkt::Any>> {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::operation::Result::Response(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::Operation::result]
@@ -314,12 +314,6 @@ impl ListOperationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListOperationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [operations][crate::model::ListOperationsResponse::operations].
     pub fn set_operations<T, V>(mut self, v: T) -> Self
     where
@@ -328,6 +322,12 @@ impl ListOperationsResponse {
     {
         use std::iter::Iterator;
         self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -1529,43 +1529,6 @@ impl Dashboard {
         })
     }
 
-    /// The value of [layout][crate::model::Dashboard::layout]
-    /// if it holds a `MosaicLayout`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mosaic_layout(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MosaicLayout>> {
-        #[allow(unreachable_patterns)]
-        self.layout.as_ref().and_then(|v| match v {
-            crate::model::dashboard::Layout::MosaicLayout(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [layout][crate::model::Dashboard::layout]
-    /// if it holds a `RowLayout`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn row_layout(&self) -> std::option::Option<&std::boxed::Box<crate::model::RowLayout>> {
-        #[allow(unreachable_patterns)]
-        self.layout.as_ref().and_then(|v| match v {
-            crate::model::dashboard::Layout::RowLayout(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [layout][crate::model::Dashboard::layout]
-    /// if it holds a `ColumnLayout`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn column_layout(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnLayout>> {
-        #[allow(unreachable_patterns)]
-        self.layout.as_ref().and_then(|v| match v {
-            crate::model::dashboard::Layout::ColumnLayout(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [layout][crate::model::Dashboard::layout]
     /// to hold a `GridLayout`.
     ///
@@ -1578,6 +1541,19 @@ impl Dashboard {
         self.layout =
             std::option::Option::Some(crate::model::dashboard::Layout::GridLayout(v.into()));
         self
+    }
+
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `MosaicLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mosaic_layout(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MosaicLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::MosaicLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [layout][crate::model::Dashboard::layout]
@@ -1594,6 +1570,17 @@ impl Dashboard {
         self
     }
 
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `RowLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn row_layout(&self) -> std::option::Option<&std::boxed::Box<crate::model::RowLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::RowLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [layout][crate::model::Dashboard::layout]
     /// to hold a `RowLayout`.
     ///
@@ -1606,6 +1593,19 @@ impl Dashboard {
         self.layout =
             std::option::Option::Some(crate::model::dashboard::Layout::RowLayout(v.into()));
         self
+    }
+
+    /// The value of [layout][crate::model::Dashboard::layout]
+    /// if it holds a `ColumnLayout`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn column_layout(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnLayout>> {
+        #[allow(unreachable_patterns)]
+        self.layout.as_ref().and_then(|v| match v {
+            crate::model::dashboard::Layout::ColumnLayout(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [layout][crate::model::Dashboard::layout]
@@ -2071,12 +2071,6 @@ impl ListDashboardsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDashboardsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [dashboards][crate::model::ListDashboardsResponse::dashboards].
     pub fn set_dashboards<T, V>(mut self, v: T) -> Self
     where
@@ -2085,6 +2079,12 @@ impl ListDashboardsResponse {
     {
         use std::iter::Iterator;
         self.dashboards = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDashboardsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2873,47 +2873,6 @@ impl TimeSeriesQuery {
         })
     }
 
-    /// The value of [source][crate::model::TimeSeriesQuery::source]
-    /// if it holds a `TimeSeriesFilterRatio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_series_filter_ratio(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesFilterRatio>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::time_series_query::Source::TimeSeriesFilterRatio(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::TimeSeriesQuery::source]
-    /// if it holds a `TimeSeriesQueryLanguage`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_series_query_language(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::time_series_query::Source::TimeSeriesQueryLanguage(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::TimeSeriesQuery::source]
-    /// if it holds a `PrometheusQuery`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn prometheus_query(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::time_series_query::Source::PrometheusQuery(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
     /// to hold a `TimeSeriesFilter`.
     ///
@@ -2929,6 +2888,21 @@ impl TimeSeriesQuery {
             crate::model::time_series_query::Source::TimeSeriesFilter(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `TimeSeriesFilterRatio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_series_filter_ratio(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesFilterRatio>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::TimeSeriesFilterRatio(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
@@ -2948,6 +2922,19 @@ impl TimeSeriesQuery {
         self
     }
 
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `TimeSeriesQueryLanguage`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_series_query_language(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::TimeSeriesQueryLanguage(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
     /// to hold a `TimeSeriesQueryLanguage`.
     ///
@@ -2961,6 +2948,19 @@ impl TimeSeriesQuery {
             crate::model::time_series_query::Source::TimeSeriesQueryLanguage(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::TimeSeriesQuery::source]
+    /// if it holds a `PrometheusQuery`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn prometheus_query(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::time_series_query::Source::PrometheusQuery(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
@@ -3101,22 +3101,6 @@ impl TimeSeriesFilter {
         })
     }
 
-    /// The value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
-    /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
-    /// holds a different branch.
-    #[deprecated]
-    pub fn statistical_time_series_filter(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
-        #[allow(unreachable_patterns)]
-        self.output_filter.as_ref().and_then(|v| match v {
-            crate::model::time_series_filter::OutputFilter::StatisticalTimeSeriesFilter(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
     /// to hold a `PickTimeSeriesFilter`.
     ///
@@ -3132,6 +3116,22 @@ impl TimeSeriesFilter {
             crate::model::time_series_filter::OutputFilter::PickTimeSeriesFilter(v.into()),
         );
         self
+    }
+
+    /// The value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
+    /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    #[deprecated]
+    pub fn statistical_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.output_filter.as_ref().and_then(|v| match v {
+            crate::model::time_series_filter::OutputFilter::StatisticalTimeSeriesFilter(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
@@ -3276,22 +3276,6 @@ impl TimeSeriesFilterRatio {
         })
     }
 
-    /// The value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
-    /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
-    /// holds a different branch.
-    #[deprecated]
-    pub fn statistical_time_series_filter(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
-        #[allow(unreachable_patterns)]
-        self.output_filter.as_ref().and_then(|v| match v {
-            crate::model::time_series_filter_ratio::OutputFilter::StatisticalTimeSeriesFilter(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
     /// to hold a `PickTimeSeriesFilter`.
     ///
@@ -3307,6 +3291,22 @@ impl TimeSeriesFilterRatio {
             crate::model::time_series_filter_ratio::OutputFilter::PickTimeSeriesFilter(v.into()),
         );
         self
+    }
+
+    /// The value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
+    /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
+    /// holds a different branch.
+    #[deprecated]
+    pub fn statistical_time_series_filter(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>> {
+        #[allow(unreachable_patterns)]
+        self.output_filter.as_ref().and_then(|v| match v {
+            crate::model::time_series_filter_ratio::OutputFilter::StatisticalTimeSeriesFilter(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
@@ -3922,6 +3922,17 @@ impl PieChart {
         std::default::Default::default()
     }
 
+    /// Sets the value of [data_sets][crate::model::PieChart::data_sets].
+    pub fn set_data_sets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::pie_chart::PieChartDataSet>,
+    {
+        use std::iter::Iterator;
+        self.data_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [chart_type][crate::model::PieChart::chart_type].
     pub fn set_chart_type<T: std::convert::Into<crate::model::pie_chart::PieChartType>>(
         mut self,
@@ -3934,17 +3945,6 @@ impl PieChart {
     /// Sets the value of [show_labels][crate::model::PieChart::show_labels].
     pub fn set_show_labels<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.show_labels = v.into();
-        self
-    }
-
-    /// Sets the value of [data_sets][crate::model::PieChart::data_sets].
-    pub fn set_data_sets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::pie_chart::PieChartDataSet>,
-    {
-        use std::iter::Iterator;
-        self.data_sets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4284,30 +4284,6 @@ impl Scorecard {
         })
     }
 
-    /// The value of [data_view][crate::model::Scorecard::data_view]
-    /// if it holds a `SparkChartView`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn spark_chart_view(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::scorecard::SparkChartView>> {
-        #[allow(unreachable_patterns)]
-        self.data_view.as_ref().and_then(|v| match v {
-            crate::model::scorecard::DataView::SparkChartView(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_view][crate::model::Scorecard::data_view]
-    /// if it holds a `BlankView`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn blank_view(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
-        #[allow(unreachable_patterns)]
-        self.data_view.as_ref().and_then(|v| match v {
-            crate::model::scorecard::DataView::BlankView(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_view][crate::model::Scorecard::data_view]
     /// to hold a `GaugeView`.
     ///
@@ -4324,6 +4300,19 @@ impl Scorecard {
         self
     }
 
+    /// The value of [data_view][crate::model::Scorecard::data_view]
+    /// if it holds a `SparkChartView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn spark_chart_view(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::scorecard::SparkChartView>> {
+        #[allow(unreachable_patterns)]
+        self.data_view.as_ref().and_then(|v| match v {
+            crate::model::scorecard::DataView::SparkChartView(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_view][crate::model::Scorecard::data_view]
     /// to hold a `SparkChartView`.
     ///
@@ -4338,6 +4327,17 @@ impl Scorecard {
         self.data_view =
             std::option::Option::Some(crate::model::scorecard::DataView::SparkChartView(v.into()));
         self
+    }
+
+    /// The value of [data_view][crate::model::Scorecard::data_view]
+    /// if it holds a `BlankView`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn blank_view(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.data_view.as_ref().and_then(|v| match v {
+            crate::model::scorecard::DataView::BlankView(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_view][crate::model::Scorecard::data_view]
@@ -4577,17 +4577,6 @@ impl TimeSeriesTable {
         std::default::Default::default()
     }
 
-    /// Sets the value of [metric_visualization][crate::model::TimeSeriesTable::metric_visualization].
-    pub fn set_metric_visualization<
-        T: std::convert::Into<crate::model::time_series_table::MetricVisualization>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metric_visualization = v.into();
-        self
-    }
-
     /// Sets the value of [data_sets][crate::model::TimeSeriesTable::data_sets].
     pub fn set_data_sets<T, V>(mut self, v: T) -> Self
     where
@@ -4596,6 +4585,17 @@ impl TimeSeriesTable {
     {
         use std::iter::Iterator;
         self.data_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [metric_visualization][crate::model::TimeSeriesTable::metric_visualization].
+    pub fn set_metric_visualization<
+        T: std::convert::Into<crate::model::time_series_table::MetricVisualization>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metric_visualization = v.into();
         self
     }
 
@@ -6110,150 +6110,6 @@ impl Widget {
         })
     }
 
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `Scorecard`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn scorecard(&self) -> std::option::Option<&std::boxed::Box<crate::model::Scorecard>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::Scorecard(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `Text`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn text(&self) -> std::option::Option<&std::boxed::Box<crate::model::Text>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::Text(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `Blank`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn blank(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::Blank(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `AlertChart`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn alert_chart(&self) -> std::option::Option<&std::boxed::Box<crate::model::AlertChart>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::AlertChart(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `TimeSeriesTable`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_series_table(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesTable>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::TimeSeriesTable(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `CollapsibleGroup`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn collapsible_group(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CollapsibleGroup>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::CollapsibleGroup(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `LogsPanel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn logs_panel(&self) -> std::option::Option<&std::boxed::Box<crate::model::LogsPanel>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::LogsPanel(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `IncidentList`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn incident_list(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IncidentList>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::IncidentList(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `PieChart`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pie_chart(&self) -> std::option::Option<&std::boxed::Box<crate::model::PieChart>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::PieChart(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `ErrorReportingPanel`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn error_reporting_panel(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ErrorReportingPanel>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::ErrorReportingPanel(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `SectionHeader`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn section_header(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SectionHeader>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::SectionHeader(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [content][crate::model::Widget::content]
-    /// if it holds a `SingleViewGroup`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn single_view_group(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SingleViewGroup>> {
-        #[allow(unreachable_patterns)]
-        self.content.as_ref().and_then(|v| match v {
-            crate::model::widget::Content::SingleViewGroup(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `XyChart`.
     ///
@@ -6265,6 +6121,17 @@ impl Widget {
     ) -> Self {
         self.content = std::option::Option::Some(crate::model::widget::Content::XyChart(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `Scorecard`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn scorecard(&self) -> std::option::Option<&std::boxed::Box<crate::model::Scorecard>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::Scorecard(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Widget::content]
@@ -6281,6 +6148,17 @@ impl Widget {
         self
     }
 
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `Text`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn text(&self) -> std::option::Option<&std::boxed::Box<crate::model::Text>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::Text(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `Text`.
     ///
@@ -6294,6 +6172,17 @@ impl Widget {
         self
     }
 
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `Blank`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn blank(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::Blank(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `Blank`.
     ///
@@ -6302,6 +6191,17 @@ impl Widget {
     pub fn set_blank<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(mut self, v: T) -> Self {
         self.content = std::option::Option::Some(crate::model::widget::Content::Blank(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `AlertChart`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn alert_chart(&self) -> std::option::Option<&std::boxed::Box<crate::model::AlertChart>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::AlertChart(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Widget::content]
@@ -6316,6 +6216,19 @@ impl Widget {
         self.content =
             std::option::Option::Some(crate::model::widget::Content::AlertChart(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `TimeSeriesTable`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_series_table(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimeSeriesTable>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::TimeSeriesTable(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Widget::content]
@@ -6334,6 +6247,19 @@ impl Widget {
         self
     }
 
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `CollapsibleGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn collapsible_group(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CollapsibleGroup>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::CollapsibleGroup(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `CollapsibleGroup`.
     ///
@@ -6350,6 +6276,17 @@ impl Widget {
         self
     }
 
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `LogsPanel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn logs_panel(&self) -> std::option::Option<&std::boxed::Box<crate::model::LogsPanel>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::LogsPanel(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `LogsPanel`.
     ///
@@ -6362,6 +6299,19 @@ impl Widget {
         self.content =
             std::option::Option::Some(crate::model::widget::Content::LogsPanel(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `IncidentList`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn incident_list(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IncidentList>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::IncidentList(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Widget::content]
@@ -6378,6 +6328,17 @@ impl Widget {
         self
     }
 
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `PieChart`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pie_chart(&self) -> std::option::Option<&std::boxed::Box<crate::model::PieChart>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::PieChart(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `PieChart`.
     ///
@@ -6389,6 +6350,19 @@ impl Widget {
     ) -> Self {
         self.content = std::option::Option::Some(crate::model::widget::Content::PieChart(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `ErrorReportingPanel`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn error_reporting_panel(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ErrorReportingPanel>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::ErrorReportingPanel(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Widget::content]
@@ -6407,6 +6381,19 @@ impl Widget {
         self
     }
 
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `SectionHeader`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn section_header(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SectionHeader>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::SectionHeader(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [content][crate::model::Widget::content]
     /// to hold a `SectionHeader`.
     ///
@@ -6421,6 +6408,19 @@ impl Widget {
         self.content =
             std::option::Option::Some(crate::model::widget::Content::SectionHeader(v.into()));
         self
+    }
+
+    /// The value of [content][crate::model::Widget::content]
+    /// if it holds a `SingleViewGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn single_view_group(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SingleViewGroup>> {
+        #[allow(unreachable_patterns)]
+        self.content.as_ref().and_then(|v| match v {
+            crate::model::widget::Content::SingleViewGroup(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [content][crate::model::Widget::content]
@@ -6534,12 +6534,34 @@ impl XyChart {
         std::default::Default::default()
     }
 
+    /// Sets the value of [data_sets][crate::model::XyChart::data_sets].
+    pub fn set_data_sets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::xy_chart::DataSet>,
+    {
+        use std::iter::Iterator;
+        self.data_sets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [timeshift_duration][crate::model::XyChart::timeshift_duration].
     pub fn set_timeshift_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
         mut self,
         v: T,
     ) -> Self {
         self.timeshift_duration = v.into();
+        self
+    }
+
+    /// Sets the value of [thresholds][crate::model::XyChart::thresholds].
+    pub fn set_thresholds<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Threshold>,
+    {
+        use std::iter::Iterator;
+        self.thresholds = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -6578,28 +6600,6 @@ impl XyChart {
         v: T,
     ) -> Self {
         self.chart_options = v.into();
-        self
-    }
-
-    /// Sets the value of [data_sets][crate::model::XyChart::data_sets].
-    pub fn set_data_sets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::xy_chart::DataSet>,
-    {
-        use std::iter::Iterator;
-        self.data_sets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [thresholds][crate::model::XyChart::thresholds].
-    pub fn set_thresholds<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Threshold>,
-    {
-        use std::iter::Iterator;
-        self.thresholds = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -196,6 +196,29 @@ impl AlertPolicy {
         self
     }
 
+    /// Sets the value of [user_labels][crate::model::AlertPolicy::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [conditions][crate::model::AlertPolicy::conditions].
+    pub fn set_conditions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::alert_policy::Condition>,
+    {
+        use std::iter::Iterator;
+        self.conditions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [combiner][crate::model::AlertPolicy::combiner].
     pub fn set_combiner<
         T: std::convert::Into<crate::model::alert_policy::ConditionCombinerType>,
@@ -222,6 +245,17 @@ impl AlertPolicy {
         v: T,
     ) -> Self {
         self.validity = v.into();
+        self
+    }
+
+    /// Sets the value of [notification_channels][crate::model::AlertPolicy::notification_channels].
+    pub fn set_notification_channels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.notification_channels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -264,40 +298,6 @@ impl AlertPolicy {
         v: T,
     ) -> Self {
         self.severity = v.into();
-        self
-    }
-
-    /// Sets the value of [conditions][crate::model::AlertPolicy::conditions].
-    pub fn set_conditions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::alert_policy::Condition>,
-    {
-        use std::iter::Iterator;
-        self.conditions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [notification_channels][crate::model::AlertPolicy::notification_channels].
-    pub fn set_notification_channels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.notification_channels = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [user_labels][crate::model::AlertPolicy::user_labels].
-    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -564,90 +564,6 @@ pub mod alert_policy {
             })
         }
 
-        /// The value of [condition][crate::model::alert_policy::Condition::condition]
-        /// if it holds a `ConditionAbsent`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn condition_absent(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::alert_policy::condition::MetricAbsence>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.condition.as_ref().and_then(|v| match v {
-                crate::model::alert_policy::condition::Condition::ConditionAbsent(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [condition][crate::model::alert_policy::Condition::condition]
-        /// if it holds a `ConditionMatchedLog`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn condition_matched_log(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::alert_policy::condition::LogMatch>>
-        {
-            #[allow(unreachable_patterns)]
-            self.condition.as_ref().and_then(|v| match v {
-                crate::model::alert_policy::condition::Condition::ConditionMatchedLog(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [condition][crate::model::alert_policy::Condition::condition]
-        /// if it holds a `ConditionMonitoringQueryLanguage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn condition_monitoring_query_language(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::alert_policy::condition::MonitoringQueryLanguageCondition,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.condition.as_ref().and_then(|v| match v {
-                crate::model::alert_policy::condition::Condition::ConditionMonitoringQueryLanguage(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [condition][crate::model::alert_policy::Condition::condition]
-        /// if it holds a `ConditionPrometheusQueryLanguage`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn condition_prometheus_query_language(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<
-                crate::model::alert_policy::condition::PrometheusQueryLanguageCondition,
-            >,
-        > {
-            #[allow(unreachable_patterns)]
-            self.condition.as_ref().and_then(|v| match v {
-                crate::model::alert_policy::condition::Condition::ConditionPrometheusQueryLanguage(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// The value of [condition][crate::model::alert_policy::Condition::condition]
-        /// if it holds a `ConditionSql`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn condition_sql(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::alert_policy::condition::SqlCondition>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.condition.as_ref().and_then(|v| match v {
-                crate::model::alert_policy::condition::Condition::ConditionSql(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
         /// to hold a `ConditionThreshold`.
         ///
@@ -665,6 +581,23 @@ pub mod alert_policy {
                 crate::model::alert_policy::condition::Condition::ConditionThreshold(v.into()),
             );
             self
+        }
+
+        /// The value of [condition][crate::model::alert_policy::Condition::condition]
+        /// if it holds a `ConditionAbsent`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn condition_absent(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::alert_policy::condition::MetricAbsence>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.condition.as_ref().and_then(|v| match v {
+                crate::model::alert_policy::condition::Condition::ConditionAbsent(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
@@ -686,6 +619,22 @@ pub mod alert_policy {
             self
         }
 
+        /// The value of [condition][crate::model::alert_policy::Condition::condition]
+        /// if it holds a `ConditionMatchedLog`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn condition_matched_log(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::alert_policy::condition::LogMatch>>
+        {
+            #[allow(unreachable_patterns)]
+            self.condition.as_ref().and_then(|v| match v {
+                crate::model::alert_policy::condition::Condition::ConditionMatchedLog(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
         /// to hold a `ConditionMatchedLog`.
         ///
@@ -701,6 +650,23 @@ pub mod alert_policy {
                 crate::model::alert_policy::condition::Condition::ConditionMatchedLog(v.into()),
             );
             self
+        }
+
+        /// The value of [condition][crate::model::alert_policy::Condition::condition]
+        /// if it holds a `ConditionMonitoringQueryLanguage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn condition_monitoring_query_language(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::alert_policy::condition::MonitoringQueryLanguageCondition,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.condition.as_ref().and_then(|v| match v {
+                crate::model::alert_policy::condition::Condition::ConditionMonitoringQueryLanguage(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
@@ -726,6 +692,23 @@ pub mod alert_policy {
             self
         }
 
+        /// The value of [condition][crate::model::alert_policy::Condition::condition]
+        /// if it holds a `ConditionPrometheusQueryLanguage`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn condition_prometheus_query_language(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<
+                crate::model::alert_policy::condition::PrometheusQueryLanguageCondition,
+            >,
+        > {
+            #[allow(unreachable_patterns)]
+            self.condition.as_ref().and_then(|v| match v {
+                crate::model::alert_policy::condition::Condition::ConditionPrometheusQueryLanguage(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
+        }
+
         /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
         /// to hold a `ConditionPrometheusQueryLanguage`.
         ///
@@ -747,6 +730,23 @@ pub mod alert_policy {
                 ),
             );
             self
+        }
+
+        /// The value of [condition][crate::model::alert_policy::Condition::condition]
+        /// if it holds a `ConditionSql`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn condition_sql(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::alert_policy::condition::SqlCondition>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.condition.as_ref().and_then(|v| match v {
+                crate::model::alert_policy::condition::Condition::ConditionSql(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
@@ -829,6 +829,18 @@ pub mod alert_policy {
                 })
             }
 
+            /// Sets the value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
+            /// to hold a `Count`.
+            ///
+            /// Note that all the setters affecting `r#type` are
+            /// mutually exclusive.
+            pub fn set_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+                self.r#type = std::option::Option::Some(
+                    crate::model::alert_policy::condition::trigger::Type::Count(v.into()),
+                );
+                self
+            }
+
             /// The value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
             /// if it holds a `Percent`, `None` if the field is not set or
             /// holds a different branch.
@@ -840,18 +852,6 @@ pub mod alert_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
-            /// to hold a `Count`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::alert_policy::condition::trigger::Type::Count(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
@@ -1017,12 +1017,34 @@ pub mod alert_policy {
                 self
             }
 
+            /// Sets the value of [aggregations][crate::model::alert_policy::condition::MetricThreshold::aggregations].
+            pub fn set_aggregations<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::Aggregation>,
+            {
+                use std::iter::Iterator;
+                self.aggregations = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [denominator_filter][crate::model::alert_policy::condition::MetricThreshold::denominator_filter].
             pub fn set_denominator_filter<T: std::convert::Into<std::string::String>>(
                 mut self,
                 v: T,
             ) -> Self {
                 self.denominator_filter = v.into();
+                self
+            }
+
+            /// Sets the value of [denominator_aggregations][crate::model::alert_policy::condition::MetricThreshold::denominator_aggregations].
+            pub fn set_denominator_aggregations<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::Aggregation>,
+            {
+                use std::iter::Iterator;
+                self.denominator_aggregations = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -1077,28 +1099,6 @@ pub mod alert_policy {
                 v: T,
             ) -> Self {
                 self.evaluation_missing_data = v.into();
-                self
-            }
-
-            /// Sets the value of [aggregations][crate::model::alert_policy::condition::MetricThreshold::aggregations].
-            pub fn set_aggregations<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::Aggregation>,
-            {
-                use std::iter::Iterator;
-                self.aggregations = v.into_iter().map(|i| i.into()).collect();
-                self
-            }
-
-            /// Sets the value of [denominator_aggregations][crate::model::alert_policy::condition::MetricThreshold::denominator_aggregations].
-            pub fn set_denominator_aggregations<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::Aggregation>,
-            {
-                use std::iter::Iterator;
-                self.denominator_aggregations = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -1228,6 +1228,17 @@ pub mod alert_policy {
                 self
             }
 
+            /// Sets the value of [aggregations][crate::model::alert_policy::condition::MetricAbsence::aggregations].
+            pub fn set_aggregations<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::Aggregation>,
+            {
+                use std::iter::Iterator;
+                self.aggregations = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [duration][crate::model::alert_policy::condition::MetricAbsence::duration].
             pub fn set_duration<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
                 mut self,
@@ -1247,17 +1258,6 @@ pub mod alert_policy {
                 v: T,
             ) -> Self {
                 self.trigger = v.into();
-                self
-            }
-
-            /// Sets the value of [aggregations][crate::model::alert_policy::condition::MetricAbsence::aggregations].
-            pub fn set_aggregations<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::Aggregation>,
-            {
-                use std::iter::Iterator;
-                self.aggregations = v.into_iter().map(|i| i.into()).collect();
                 self
             }
         }
@@ -1574,6 +1574,18 @@ pub mod alert_policy {
                 self
             }
 
+            /// Sets the value of [labels][crate::model::alert_policy::condition::PrometheusQueryLanguageCondition::labels].
+            pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = (K, V)>,
+                K: std::convert::Into<std::string::String>,
+                V: std::convert::Into<std::string::String>,
+            {
+                use std::iter::Iterator;
+                self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+                self
+            }
+
             /// Sets the value of [rule_group][crate::model::alert_policy::condition::PrometheusQueryLanguageCondition::rule_group].
             pub fn set_rule_group<T: std::convert::Into<std::string::String>>(
                 mut self,
@@ -1598,18 +1610,6 @@ pub mod alert_policy {
                 v: T,
             ) -> Self {
                 self.disable_metric_validation = v.into();
-                self
-            }
-
-            /// Sets the value of [labels][crate::model::alert_policy::condition::PrometheusQueryLanguageCondition::labels].
-            pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = (K, V)>,
-                K: std::convert::Into<std::string::String>,
-                V: std::convert::Into<std::string::String>,
-            {
-                use std::iter::Iterator;
-                self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
                 self
             }
         }
@@ -1708,40 +1708,6 @@ pub mod alert_policy {
                 })
             }
 
-            /// The value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
-            /// if it holds a `Hourly`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn hourly(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::alert_policy::condition::sql_condition::Hourly>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.schedule.as_ref().and_then(|v| match v {
-                    crate::model::alert_policy::condition::sql_condition::Schedule::Hourly(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
-            /// if it holds a `Daily`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn daily(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::alert_policy::condition::sql_condition::Daily>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.schedule.as_ref().and_then(|v| match v {
-                    crate::model::alert_policy::condition::sql_condition::Schedule::Daily(v) => {
-                        std::option::Option::Some(v)
-                    }
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
             /// to hold a `Minutes`.
             ///
@@ -1765,6 +1731,23 @@ pub mod alert_policy {
                 self
             }
 
+            /// The value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
+            /// if it holds a `Hourly`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn hourly(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::alert_policy::condition::sql_condition::Hourly>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.schedule.as_ref().and_then(|v| match v {
+                    crate::model::alert_policy::condition::sql_condition::Schedule::Hourly(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
             /// to hold a `Hourly`.
             ///
@@ -1786,6 +1769,23 @@ pub mod alert_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
+            /// if it holds a `Daily`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn daily(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::alert_policy::condition::sql_condition::Daily>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.schedule.as_ref().and_then(|v| match v {
+                    crate::model::alert_policy::condition::sql_condition::Schedule::Daily(v) => {
+                        std::option::Option::Some(v)
+                    }
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
@@ -1844,23 +1844,6 @@ pub mod alert_policy {
                 })
             }
 
-            /// The value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
-            /// if it holds a `BooleanTest`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn boolean_test(
-                &self,
-            ) -> std::option::Option<
-                &std::boxed::Box<crate::model::alert_policy::condition::sql_condition::BooleanTest>,
-            > {
-                #[allow(unreachable_patterns)]
-                self.evaluate.as_ref().and_then(|v| match v {
-                    crate::model::alert_policy::condition::sql_condition::Evaluate::BooleanTest(
-                        v,
-                    ) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
             /// to hold a `RowCountTest`.
             ///
@@ -1882,6 +1865,23 @@ pub mod alert_policy {
                     ),
                 );
                 self
+            }
+
+            /// The value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
+            /// if it holds a `BooleanTest`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn boolean_test(
+                &self,
+            ) -> std::option::Option<
+                &std::boxed::Box<crate::model::alert_policy::condition::sql_condition::BooleanTest>,
+            > {
+                #[allow(unreachable_patterns)]
+                self.evaluate.as_ref().and_then(|v| match v {
+                    crate::model::alert_policy::condition::sql_condition::Evaluate::BooleanTest(
+                        v,
+                    ) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
@@ -2414,15 +2414,6 @@ pub mod alert_policy {
             self
         }
 
-        /// Sets the value of [auto_close][crate::model::alert_policy::AlertStrategy::auto_close].
-        pub fn set_auto_close<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.auto_close = v.into();
-            self
-        }
-
         /// Sets the value of [notification_prompts][crate::model::alert_policy::AlertStrategy::notification_prompts].
         pub fn set_notification_prompts<T, V>(mut self, v: T) -> Self
         where
@@ -2431,6 +2422,15 @@ pub mod alert_policy {
         {
             use std::iter::Iterator;
             self.notification_prompts = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [auto_close][crate::model::alert_policy::AlertStrategy::auto_close].
+        pub fn set_auto_close<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.auto_close = v.into();
             self
         }
 
@@ -2528,17 +2528,6 @@ pub mod alert_policy {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [renotify_interval][crate::model::alert_policy::alert_strategy::NotificationChannelStrategy::renotify_interval].
-            pub fn set_renotify_interval<
-                T: std::convert::Into<std::option::Option<wkt::Duration>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.renotify_interval = v.into();
-                self
-            }
-
             /// Sets the value of [notification_channel_names][crate::model::alert_policy::alert_strategy::NotificationChannelStrategy::notification_channel_names].
             pub fn set_notification_channel_names<T, V>(mut self, v: T) -> Self
             where
@@ -2547,6 +2536,17 @@ pub mod alert_policy {
             {
                 use std::iter::Iterator;
                 self.notification_channel_names = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [renotify_interval][crate::model::alert_policy::alert_strategy::NotificationChannelStrategy::renotify_interval].
+            pub fn set_renotify_interval<
+                T: std::convert::Into<std::option::Option<wkt::Duration>>,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.renotify_interval = v.into();
                 self
             }
         }
@@ -3213,6 +3213,17 @@ impl ListAlertPoliciesResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [alert_policies][crate::model::ListAlertPoliciesResponse::alert_policies].
+    pub fn set_alert_policies<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::AlertPolicy>,
+    {
+        use std::iter::Iterator;
+        self.alert_policies = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListAlertPoliciesResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -3222,17 +3233,6 @@ impl ListAlertPoliciesResponse {
     /// Sets the value of [total_size][crate::model::ListAlertPoliciesResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [alert_policies][crate::model::ListAlertPoliciesResponse::alert_policies].
-    pub fn set_alert_policies<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::AlertPolicy>,
-    {
-        use std::iter::Iterator;
-        self.alert_policies = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3414,52 +3414,6 @@ impl TypedValue {
         })
     }
 
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `Int64Value`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int64_value(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::Int64Value(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `DoubleValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn double_value(&self) -> std::option::Option<&f64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::DoubleValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `StringValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::StringValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::TypedValue::value]
-    /// if it holds a `DistributionValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn distribution_value(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<api::model::Distribution>> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::typed_value::Value::DistributionValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::TypedValue::value]
     /// to hold a `BoolValue`.
     ///
@@ -3469,6 +3423,17 @@ impl TypedValue {
         self.value =
             std::option::Option::Some(crate::model::typed_value::Value::BoolValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `Int64Value`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int64_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::Int64Value(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::TypedValue::value]
@@ -3482,6 +3447,17 @@ impl TypedValue {
         self
     }
 
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `DoubleValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn double_value(&self) -> std::option::Option<&f64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::DoubleValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::TypedValue::value]
     /// to hold a `DoubleValue`.
     ///
@@ -3493,6 +3469,17 @@ impl TypedValue {
         self
     }
 
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::TypedValue::value]
     /// to hold a `StringValue`.
     ///
@@ -3502,6 +3489,19 @@ impl TypedValue {
         self.value =
             std::option::Option::Some(crate::model::typed_value::Value::StringValue(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::TypedValue::value]
+    /// if it holds a `DistributionValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn distribution_value(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<api::model::Distribution>> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::typed_value::Value::DistributionValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::TypedValue::value]
@@ -4661,32 +4661,6 @@ impl ListGroupsRequest {
         })
     }
 
-    /// The value of [filter][crate::model::ListGroupsRequest::filter]
-    /// if it holds a `AncestorsOfGroup`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ancestors_of_group(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::list_groups_request::Filter::AncestorsOfGroup(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::ListGroupsRequest::filter]
-    /// if it holds a `DescendantsOfGroup`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn descendants_of_group(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::list_groups_request::Filter::DescendantsOfGroup(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
     /// to hold a `ChildrenOfGroup`.
     ///
@@ -4702,6 +4676,19 @@ impl ListGroupsRequest {
         self
     }
 
+    /// The value of [filter][crate::model::ListGroupsRequest::filter]
+    /// if it holds a `AncestorsOfGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ancestors_of_group(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::list_groups_request::Filter::AncestorsOfGroup(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
     /// to hold a `AncestorsOfGroup`.
     ///
@@ -4715,6 +4702,19 @@ impl ListGroupsRequest {
             crate::model::list_groups_request::Filter::AncestorsOfGroup(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::ListGroupsRequest::filter]
+    /// if it holds a `DescendantsOfGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn descendants_of_group(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::list_groups_request::Filter::DescendantsOfGroup(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
@@ -4809,12 +4809,6 @@ impl ListGroupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [group][crate::model::ListGroupsResponse::group].
     pub fn set_group<T, V>(mut self, v: T) -> Self
     where
@@ -4823,6 +4817,12 @@ impl ListGroupsResponse {
     {
         use std::iter::Iterator;
         self.group = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListGroupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5163,6 +5163,17 @@ impl ListGroupMembersResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [members][crate::model::ListGroupMembersResponse::members].
+    pub fn set_members<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<api::model::MonitoredResource>,
+    {
+        use std::iter::Iterator;
+        self.members = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListGroupMembersResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -5172,17 +5183,6 @@ impl ListGroupMembersResponse {
     /// Sets the value of [total_size][crate::model::ListGroupMembersResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [members][crate::model::ListGroupMembersResponse::members].
-    pub fn set_members<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<api::model::MonitoredResource>,
-    {
-        use std::iter::Iterator;
-        self.members = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5394,6 +5394,17 @@ impl TimeSeries {
         self
     }
 
+    /// Sets the value of [points][crate::model::TimeSeries::points].
+    pub fn set_points<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Point>,
+    {
+        use std::iter::Iterator;
+        self.points = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [unit][crate::model::TimeSeries::unit].
     pub fn set_unit<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.unit = v.into();
@@ -5403,17 +5414,6 @@ impl TimeSeries {
     /// Sets the value of [description][crate::model::TimeSeries::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
-        self
-    }
-
-    /// Sets the value of [points][crate::model::TimeSeries::points].
-    pub fn set_points<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Point>,
-    {
-        use std::iter::Iterator;
-        self.points = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5637,17 +5637,6 @@ pub mod time_series_data {
             std::default::Default::default()
         }
 
-        /// Sets the value of [time_interval][crate::model::time_series_data::PointData::time_interval].
-        pub fn set_time_interval<
-            T: std::convert::Into<std::option::Option<crate::model::TimeInterval>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.time_interval = v.into();
-            self
-        }
-
         /// Sets the value of [values][crate::model::time_series_data::PointData::values].
         pub fn set_values<T, V>(mut self, v: T) -> Self
         where
@@ -5656,6 +5645,17 @@ pub mod time_series_data {
         {
             use std::iter::Iterator;
             self.values = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [time_interval][crate::model::time_series_data::PointData::time_interval].
+        pub fn set_time_interval<
+            T: std::convert::Into<std::option::Option<crate::model::TimeInterval>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.time_interval = v.into();
             self
         }
     }
@@ -5711,28 +5711,6 @@ impl LabelValue {
         })
     }
 
-    /// The value of [value][crate::model::LabelValue::value]
-    /// if it holds a `Int64Value`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn int64_value(&self) -> std::option::Option<&i64> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::label_value::Value::Int64Value(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [value][crate::model::LabelValue::value]
-    /// if it holds a `StringValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.value.as_ref().and_then(|v| match v {
-            crate::model::label_value::Value::StringValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [value][crate::model::LabelValue::value]
     /// to hold a `BoolValue`.
     ///
@@ -5744,6 +5722,17 @@ impl LabelValue {
         self
     }
 
+    /// The value of [value][crate::model::LabelValue::value]
+    /// if it holds a `Int64Value`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn int64_value(&self) -> std::option::Option<&i64> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::label_value::Value::Int64Value(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [value][crate::model::LabelValue::value]
     /// to hold a `Int64Value`.
     ///
@@ -5753,6 +5742,17 @@ impl LabelValue {
         self.value =
             std::option::Option::Some(crate::model::label_value::Value::Int64Value(v.into()));
         self
+    }
+
+    /// The value of [value][crate::model::LabelValue::value]
+    /// if it holds a `StringValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn string_value(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.value.as_ref().and_then(|v| match v {
+            crate::model::label_value::Value::StringValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [value][crate::model::LabelValue::value]
@@ -6110,12 +6110,6 @@ impl ListMonitoredResourceDescriptorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMonitoredResourceDescriptorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [resource_descriptors][crate::model::ListMonitoredResourceDescriptorsResponse::resource_descriptors].
     pub fn set_resource_descriptors<T, V>(mut self, v: T) -> Self
     where
@@ -6124,6 +6118,12 @@ impl ListMonitoredResourceDescriptorsResponse {
     {
         use std::iter::Iterator;
         self.resource_descriptors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMonitoredResourceDescriptorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6315,12 +6315,6 @@ impl ListMetricDescriptorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListMetricDescriptorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [metric_descriptors][crate::model::ListMetricDescriptorsResponse::metric_descriptors].
     pub fn set_metric_descriptors<T, V>(mut self, v: T) -> Self
     where
@@ -6329,6 +6323,12 @@ impl ListMetricDescriptorsResponse {
     {
         use std::iter::Iterator;
         self.metric_descriptors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListMetricDescriptorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6817,18 +6817,6 @@ impl ListTimeSeriesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTimeSeriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
-    /// Sets the value of [unit][crate::model::ListTimeSeriesResponse::unit].
-    pub fn set_unit<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.unit = v.into();
-        self
-    }
-
     /// Sets the value of [time_series][crate::model::ListTimeSeriesResponse::time_series].
     pub fn set_time_series<T, V>(mut self, v: T) -> Self
     where
@@ -6840,6 +6828,12 @@ impl ListTimeSeriesResponse {
         self
     }
 
+    /// Sets the value of [next_page_token][crate::model::ListTimeSeriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
+        self
+    }
+
     /// Sets the value of [execution_errors][crate::model::ListTimeSeriesResponse::execution_errors].
     pub fn set_execution_errors<T, V>(mut self, v: T) -> Self
     where
@@ -6848,6 +6842,12 @@ impl ListTimeSeriesResponse {
     {
         use std::iter::Iterator;
         self.execution_errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [unit][crate::model::ListTimeSeriesResponse::unit].
+    pub fn set_unit<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.unit = v.into();
         self
     }
 }
@@ -7215,12 +7215,6 @@ impl QueryTimeSeriesResponse {
         self
     }
 
-    /// Sets the value of [next_page_token][crate::model::QueryTimeSeriesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [time_series_data][crate::model::QueryTimeSeriesResponse::time_series_data].
     pub fn set_time_series_data<T, V>(mut self, v: T) -> Self
     where
@@ -7229,6 +7223,12 @@ impl QueryTimeSeriesResponse {
     {
         use std::iter::Iterator;
         self.time_series_data = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::QueryTimeSeriesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -7288,12 +7288,6 @@ impl QueryErrorList {
         std::default::Default::default()
     }
 
-    /// Sets the value of [error_summary][crate::model::QueryErrorList::error_summary].
-    pub fn set_error_summary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.error_summary = v.into();
-        self
-    }
-
     /// Sets the value of [errors][crate::model::QueryErrorList::errors].
     pub fn set_errors<T, V>(mut self, v: T) -> Self
     where
@@ -7302,6 +7296,12 @@ impl QueryErrorList {
     {
         use std::iter::Iterator;
         self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [error_summary][crate::model::QueryErrorList::error_summary].
+    pub fn set_error_summary<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.error_summary = v.into();
         self
     }
 }
@@ -7443,15 +7443,6 @@ impl NotificationChannelDescriptor {
         self
     }
 
-    /// Sets the value of [launch_stage][crate::model::NotificationChannelDescriptor::launch_stage].
-    pub fn set_launch_stage<T: std::convert::Into<api::model::LaunchStage>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.launch_stage = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::NotificationChannelDescriptor::labels].
     pub fn set_labels<T, V>(mut self, v: T) -> Self
     where
@@ -7472,6 +7463,15 @@ impl NotificationChannelDescriptor {
     {
         use std::iter::Iterator;
         self.supported_tiers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [launch_stage][crate::model::NotificationChannelDescriptor::launch_stage].
+    pub fn set_launch_stage<T: std::convert::Into<api::model::LaunchStage>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.launch_stage = v.into();
         self
     }
 }
@@ -7622,6 +7622,30 @@ impl NotificationChannel {
         self
     }
 
+    /// Sets the value of [labels][crate::model::NotificationChannel::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [user_labels][crate::model::NotificationChannel::user_labels].
+    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [verification_status][crate::model::NotificationChannel::verification_status].
     pub fn set_verification_status<
         T: std::convert::Into<crate::model::notification_channel::VerificationStatus>,
@@ -7661,30 +7685,6 @@ impl NotificationChannel {
     {
         use std::iter::Iterator;
         self.mutation_records = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::NotificationChannel::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
-    /// Sets the value of [user_labels][crate::model::NotificationChannel::user_labels].
-    pub fn set_user_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.user_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -7945,12 +7945,6 @@ impl ListNotificationChannelDescriptorsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListNotificationChannelDescriptorsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [channel_descriptors][crate::model::ListNotificationChannelDescriptorsResponse::channel_descriptors].
     pub fn set_channel_descriptors<T, V>(mut self, v: T) -> Self
     where
@@ -7959,6 +7953,12 @@ impl ListNotificationChannelDescriptorsResponse {
     {
         use std::iter::Iterator;
         self.channel_descriptors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListNotificationChannelDescriptorsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -8208,6 +8208,17 @@ impl ListNotificationChannelsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [notification_channels][crate::model::ListNotificationChannelsResponse::notification_channels].
+    pub fn set_notification_channels<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::NotificationChannel>,
+    {
+        use std::iter::Iterator;
+        self.notification_channels = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListNotificationChannelsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -8217,17 +8228,6 @@ impl ListNotificationChannelsResponse {
     /// Sets the value of [total_size][crate::model::ListNotificationChannelsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [notification_channels][crate::model::ListNotificationChannelsResponse::notification_channels].
-    pub fn set_notification_channels<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::NotificationChannel>,
-    {
-        use std::iter::Iterator;
-        self.notification_channels = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -8701,125 +8701,6 @@ impl Service {
         })
     }
 
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `AppEngine`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn app_engine(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::AppEngine>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::AppEngine(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `CloudEndpoints`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_endpoints(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::CloudEndpoints>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::CloudEndpoints(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `ClusterIstio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cluster_istio(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::ClusterIstio>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::ClusterIstio(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `MeshIstio`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn mesh_istio(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::MeshIstio>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::MeshIstio(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `IstioCanonicalService`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn istio_canonical_service(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::IstioCanonicalService>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::IstioCanonicalService(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `CloudRun`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_run(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::CloudRun>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::CloudRun(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `GkeNamespace`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gke_namespace(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::GkeNamespace>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::GkeNamespace(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `GkeWorkload`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gke_workload(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::GkeWorkload>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::GkeWorkload(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [identifier][crate::model::Service::identifier]
-    /// if it holds a `GkeService`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn gke_service(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::service::GkeService>> {
-        #[allow(unreachable_patterns)]
-        self.identifier.as_ref().and_then(|v| match v {
-            crate::model::service::Identifier::GkeService(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [identifier][crate::model::Service::identifier]
     /// to hold a `Custom`.
     ///
@@ -8832,6 +8713,19 @@ impl Service {
         self.identifier =
             std::option::Option::Some(crate::model::service::Identifier::Custom(v.into()));
         self
+    }
+
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `AppEngine`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn app_engine(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::AppEngine>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::AppEngine(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [identifier][crate::model::Service::identifier]
@@ -8850,6 +8744,19 @@ impl Service {
         self
     }
 
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `CloudEndpoints`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_endpoints(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::CloudEndpoints>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::CloudEndpoints(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [identifier][crate::model::Service::identifier]
     /// to hold a `CloudEndpoints`.
     ///
@@ -8864,6 +8771,19 @@ impl Service {
         self.identifier =
             std::option::Option::Some(crate::model::service::Identifier::CloudEndpoints(v.into()));
         self
+    }
+
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `ClusterIstio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cluster_istio(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::ClusterIstio>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::ClusterIstio(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [identifier][crate::model::Service::identifier]
@@ -8882,6 +8802,19 @@ impl Service {
         self
     }
 
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `MeshIstio`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn mesh_istio(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::MeshIstio>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::MeshIstio(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [identifier][crate::model::Service::identifier]
     /// to hold a `MeshIstio`.
     ///
@@ -8896,6 +8829,21 @@ impl Service {
         self.identifier =
             std::option::Option::Some(crate::model::service::Identifier::MeshIstio(v.into()));
         self
+    }
+
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `IstioCanonicalService`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn istio_canonical_service(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::IstioCanonicalService>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::IstioCanonicalService(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [identifier][crate::model::Service::identifier]
@@ -8915,6 +8863,19 @@ impl Service {
         self
     }
 
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `CloudRun`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_run(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::CloudRun>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::CloudRun(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [identifier][crate::model::Service::identifier]
     /// to hold a `CloudRun`.
     ///
@@ -8929,6 +8890,19 @@ impl Service {
         self.identifier =
             std::option::Option::Some(crate::model::service::Identifier::CloudRun(v.into()));
         self
+    }
+
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `GkeNamespace`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gke_namespace(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::GkeNamespace>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::GkeNamespace(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [identifier][crate::model::Service::identifier]
@@ -8947,6 +8921,19 @@ impl Service {
         self
     }
 
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `GkeWorkload`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gke_workload(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::GkeWorkload>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::GkeWorkload(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [identifier][crate::model::Service::identifier]
     /// to hold a `GkeWorkload`.
     ///
@@ -8961,6 +8948,19 @@ impl Service {
         self.identifier =
             std::option::Option::Some(crate::model::service::Identifier::GkeWorkload(v.into()));
         self
+    }
+
+    /// The value of [identifier][crate::model::Service::identifier]
+    /// if it holds a `GkeService`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn gke_service(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::service::GkeService>> {
+        #[allow(unreachable_patterns)]
+        self.identifier.as_ref().and_then(|v| match v {
+            crate::model::service::Identifier::GkeService(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [identifier][crate::model::Service::identifier]
@@ -9847,19 +9847,6 @@ impl ServiceLevelObjective {
         })
     }
 
-    /// The value of [period][crate::model::ServiceLevelObjective::period]
-    /// if it holds a `CalendarPeriod`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn calendar_period(&self) -> std::option::Option<&gtype::model::CalendarPeriod> {
-        #[allow(unreachable_patterns)]
-        self.period.as_ref().and_then(|v| match v {
-            crate::model::service_level_objective::Period::CalendarPeriod(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [period][crate::model::ServiceLevelObjective::period]
     /// to hold a `RollingPeriod`.
     ///
@@ -9873,6 +9860,19 @@ impl ServiceLevelObjective {
             crate::model::service_level_objective::Period::RollingPeriod(v.into()),
         );
         self
+    }
+
+    /// The value of [period][crate::model::ServiceLevelObjective::period]
+    /// if it holds a `CalendarPeriod`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn calendar_period(&self) -> std::option::Option<&gtype::model::CalendarPeriod> {
+        #[allow(unreachable_patterns)]
+        self.period.as_ref().and_then(|v| match v {
+            crate::model::service_level_objective::Period::CalendarPeriod(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [period][crate::model::ServiceLevelObjective::period]
@@ -10116,36 +10116,6 @@ impl ServiceLevelIndicator {
         })
     }
 
-    /// The value of [r#type][crate::model::ServiceLevelIndicator::r#type]
-    /// if it holds a `RequestBased`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn request_based(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RequestBasedSli>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::service_level_indicator::Type::RequestBased(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::ServiceLevelIndicator::r#type]
-    /// if it holds a `WindowsBased`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn windows_based(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::WindowsBasedSli>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::service_level_indicator::Type::WindowsBased(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::ServiceLevelIndicator::r#type]
     /// to hold a `BasicSli`.
     ///
@@ -10159,6 +10129,21 @@ impl ServiceLevelIndicator {
             crate::model::service_level_indicator::Type::BasicSli(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::ServiceLevelIndicator::r#type]
+    /// if it holds a `RequestBased`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn request_based(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RequestBasedSli>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::service_level_indicator::Type::RequestBased(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::ServiceLevelIndicator::r#type]
@@ -10176,6 +10161,21 @@ impl ServiceLevelIndicator {
             crate::model::service_level_indicator::Type::RequestBased(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::ServiceLevelIndicator::r#type]
+    /// if it holds a `WindowsBased`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn windows_based(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::WindowsBasedSli>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::service_level_indicator::Type::WindowsBased(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::ServiceLevelIndicator::r#type]
@@ -10331,19 +10331,6 @@ impl BasicSli {
         })
     }
 
-    /// The value of [sli_criteria][crate::model::BasicSli::sli_criteria]
-    /// if it holds a `Latency`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn latency(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::basic_sli::LatencyCriteria>> {
-        #[allow(unreachable_patterns)]
-        self.sli_criteria.as_ref().and_then(|v| match v {
-            crate::model::basic_sli::SliCriteria::Latency(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [sli_criteria][crate::model::BasicSli::sli_criteria]
     /// to hold a `Availability`.
     ///
@@ -10358,6 +10345,19 @@ impl BasicSli {
         self.sli_criteria =
             std::option::Option::Some(crate::model::basic_sli::SliCriteria::Availability(v.into()));
         self
+    }
+
+    /// The value of [sli_criteria][crate::model::BasicSli::sli_criteria]
+    /// if it holds a `Latency`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn latency(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::basic_sli::LatencyCriteria>> {
+        #[allow(unreachable_patterns)]
+        self.sli_criteria.as_ref().and_then(|v| match v {
+            crate::model::basic_sli::SliCriteria::Latency(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [sli_criteria][crate::model::BasicSli::sli_criteria]
@@ -10551,21 +10551,6 @@ impl RequestBasedSli {
         })
     }
 
-    /// The value of [method][crate::model::RequestBasedSli::method]
-    /// if it holds a `DistributionCut`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn distribution_cut(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DistributionCut>> {
-        #[allow(unreachable_patterns)]
-        self.method.as_ref().and_then(|v| match v {
-            crate::model::request_based_sli::Method::DistributionCut(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [method][crate::model::RequestBasedSli::method]
     /// to hold a `GoodTotalRatio`.
     ///
@@ -10581,6 +10566,21 @@ impl RequestBasedSli {
             crate::model::request_based_sli::Method::GoodTotalRatio(v.into()),
         );
         self
+    }
+
+    /// The value of [method][crate::model::RequestBasedSli::method]
+    /// if it holds a `DistributionCut`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn distribution_cut(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DistributionCut>> {
+        #[allow(unreachable_patterns)]
+        self.method.as_ref().and_then(|v| match v {
+            crate::model::request_based_sli::Method::DistributionCut(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [method][crate::model::RequestBasedSli::method]
@@ -10821,6 +10821,21 @@ impl WindowsBasedSli {
         })
     }
 
+    /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
+    /// to hold a `GoodBadMetricFilter`.
+    ///
+    /// Note that all the setters affecting `window_criterion` are
+    /// mutually exclusive.
+    pub fn set_good_bad_metric_filter<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.window_criterion = std::option::Option::Some(
+            crate::model::windows_based_sli::WindowCriterion::GoodBadMetricFilter(v.into()),
+        );
+        self
+    }
+
     /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
     /// if it holds a `GoodTotalRatioThreshold`, `None` if the field is not set or
     /// holds a different branch.
@@ -10835,51 +10850,6 @@ impl WindowsBasedSli {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// if it holds a `MetricMeanInRange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn metric_mean_in_range(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::windows_based_sli::MetricRange>> {
-        #[allow(unreachable_patterns)]
-        self.window_criterion.as_ref().and_then(|v| match v {
-            crate::model::windows_based_sli::WindowCriterion::MetricMeanInRange(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// if it holds a `MetricSumInRange`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn metric_sum_in_range(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::windows_based_sli::MetricRange>> {
-        #[allow(unreachable_patterns)]
-        self.window_criterion.as_ref().and_then(|v| match v {
-            crate::model::windows_based_sli::WindowCriterion::MetricSumInRange(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// to hold a `GoodBadMetricFilter`.
-    ///
-    /// Note that all the setters affecting `window_criterion` are
-    /// mutually exclusive.
-    pub fn set_good_bad_metric_filter<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.window_criterion = std::option::Option::Some(
-            crate::model::windows_based_sli::WindowCriterion::GoodBadMetricFilter(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
@@ -10899,6 +10869,21 @@ impl WindowsBasedSli {
         self
     }
 
+    /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
+    /// if it holds a `MetricMeanInRange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn metric_mean_in_range(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::windows_based_sli::MetricRange>> {
+        #[allow(unreachable_patterns)]
+        self.window_criterion.as_ref().and_then(|v| match v {
+            crate::model::windows_based_sli::WindowCriterion::MetricMeanInRange(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
     /// to hold a `MetricMeanInRange`.
     ///
@@ -10914,6 +10899,21 @@ impl WindowsBasedSli {
             crate::model::windows_based_sli::WindowCriterion::MetricMeanInRange(v.into()),
         );
         self
+    }
+
+    /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
+    /// if it holds a `MetricSumInRange`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn metric_sum_in_range(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::windows_based_sli::MetricRange>> {
+        #[allow(unreachable_patterns)]
+        self.window_criterion.as_ref().and_then(|v| match v {
+            crate::model::windows_based_sli::WindowCriterion::MetricSumInRange(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
@@ -11010,19 +11010,6 @@ pub mod windows_based_sli {
             })
         }
 
-        /// The value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
-        /// if it holds a `BasicSliPerformance`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn basic_sli_performance(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::BasicSli>> {
-            #[allow(unreachable_patterns)]
-            self.r#type.as_ref().and_then(|v| match v {
-                crate::model::windows_based_sli::performance_threshold::Type::BasicSliPerformance(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
         /// to hold a `Performance`.
         ///
@@ -11038,6 +11025,19 @@ pub mod windows_based_sli {
                 crate::model::windows_based_sli::performance_threshold::Type::Performance(v.into()),
             );
             self
+        }
+
+        /// The value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
+        /// if it holds a `BasicSliPerformance`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn basic_sli_performance(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::BasicSli>> {
+            #[allow(unreachable_patterns)]
+            self.r#type.as_ref().and_then(|v| match v {
+                crate::model::windows_based_sli::performance_threshold::Type::BasicSliPerformance(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
@@ -11368,12 +11368,6 @@ impl ListServicesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [services][crate::model::ListServicesResponse::services].
     pub fn set_services<T, V>(mut self, v: T) -> Self
     where
@@ -11382,6 +11376,12 @@ impl ListServicesResponse {
     {
         use std::iter::Iterator;
         self.services = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServicesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11722,12 +11722,6 @@ impl ListServiceLevelObjectivesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListServiceLevelObjectivesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [service_level_objectives][crate::model::ListServiceLevelObjectivesResponse::service_level_objectives].
     pub fn set_service_level_objectives<T, V>(mut self, v: T) -> Self
     where
@@ -11736,6 +11730,12 @@ impl ListServiceLevelObjectivesResponse {
     {
         use std::iter::Iterator;
         self.service_level_objectives = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListServiceLevelObjectivesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -11988,12 +11988,6 @@ pub mod snooze {
             std::default::Default::default()
         }
 
-        /// Sets the value of [filter][crate::model::snooze::Criteria::filter].
-        pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.filter = v.into();
-            self
-        }
-
         /// Sets the value of [policies][crate::model::snooze::Criteria::policies].
         pub fn set_policies<T, V>(mut self, v: T) -> Self
         where
@@ -12002,6 +11996,12 @@ pub mod snooze {
         {
             use std::iter::Iterator;
             self.policies = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [filter][crate::model::snooze::Criteria::filter].
+        pub fn set_filter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.filter = v.into();
             self
         }
     }
@@ -12176,12 +12176,6 @@ impl ListSnoozesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSnoozesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [snoozes][crate::model::ListSnoozesResponse::snoozes].
     pub fn set_snoozes<T, V>(mut self, v: T) -> Self
     where
@@ -12190,6 +12184,12 @@ impl ListSnoozesResponse {
     {
         use std::iter::Iterator;
         self.snoozes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSnoozesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -12910,24 +12910,6 @@ impl UptimeCheckConfig {
         self
     }
 
-    /// Sets the value of [checker_type][crate::model::UptimeCheckConfig::checker_type].
-    pub fn set_checker_type<
-        T: std::convert::Into<crate::model::uptime_check_config::CheckerType>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.checker_type = v.into();
-        self
-    }
-
-    /// Sets the value of [is_internal][crate::model::UptimeCheckConfig::is_internal].
-    #[deprecated]
-    pub fn set_is_internal<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.is_internal = v.into();
-        self
-    }
-
     /// Sets the value of [content_matchers][crate::model::UptimeCheckConfig::content_matchers].
     pub fn set_content_matchers<T, V>(mut self, v: T) -> Self
     where
@@ -12939,6 +12921,17 @@ impl UptimeCheckConfig {
         self
     }
 
+    /// Sets the value of [checker_type][crate::model::UptimeCheckConfig::checker_type].
+    pub fn set_checker_type<
+        T: std::convert::Into<crate::model::uptime_check_config::CheckerType>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.checker_type = v.into();
+        self
+    }
+
     /// Sets the value of [selected_regions][crate::model::UptimeCheckConfig::selected_regions].
     pub fn set_selected_regions<T, V>(mut self, v: T) -> Self
     where
@@ -12947,6 +12940,13 @@ impl UptimeCheckConfig {
     {
         use std::iter::Iterator;
         self.selected_regions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [is_internal][crate::model::UptimeCheckConfig::is_internal].
+    #[deprecated]
+    pub fn set_is_internal<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.is_internal = v.into();
         self
     }
 
@@ -13003,37 +13003,6 @@ impl UptimeCheckConfig {
         })
     }
 
-    /// The value of [resource][crate::model::UptimeCheckConfig::resource]
-    /// if it holds a `ResourceGroup`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn resource_group(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::uptime_check_config::ResourceGroup>>
-    {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::uptime_check_config::Resource::ResourceGroup(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [resource][crate::model::UptimeCheckConfig::resource]
-    /// if it holds a `SyntheticMonitor`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn synthetic_monitor(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SyntheticMonitorTarget>> {
-        #[allow(unreachable_patterns)]
-        self.resource.as_ref().and_then(|v| match v {
-            crate::model::uptime_check_config::Resource::SyntheticMonitor(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [resource][crate::model::UptimeCheckConfig::resource]
     /// to hold a `MonitoredResource`.
     ///
@@ -13051,6 +13020,22 @@ impl UptimeCheckConfig {
         self
     }
 
+    /// The value of [resource][crate::model::UptimeCheckConfig::resource]
+    /// if it holds a `ResourceGroup`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn resource_group(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::uptime_check_config::ResourceGroup>>
+    {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::uptime_check_config::Resource::ResourceGroup(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [resource][crate::model::UptimeCheckConfig::resource]
     /// to hold a `ResourceGroup`.
     ///
@@ -13066,6 +13051,21 @@ impl UptimeCheckConfig {
             crate::model::uptime_check_config::Resource::ResourceGroup(v.into()),
         );
         self
+    }
+
+    /// The value of [resource][crate::model::UptimeCheckConfig::resource]
+    /// if it holds a `SyntheticMonitor`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn synthetic_monitor(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SyntheticMonitorTarget>> {
+        #[allow(unreachable_patterns)]
+        self.resource.as_ref().and_then(|v| match v {
+            crate::model::uptime_check_config::Resource::SyntheticMonitor(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [resource][crate::model::UptimeCheckConfig::resource]
@@ -13116,21 +13116,6 @@ impl UptimeCheckConfig {
         })
     }
 
-    /// The value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
-    /// if it holds a `TcpCheck`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tcp_check(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::uptime_check_config::TcpCheck>> {
-        #[allow(unreachable_patterns)]
-        self.check_request_type.as_ref().and_then(|v| match v {
-            crate::model::uptime_check_config::CheckRequestType::TcpCheck(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
     /// to hold a `HttpCheck`.
     ///
@@ -13146,6 +13131,21 @@ impl UptimeCheckConfig {
             crate::model::uptime_check_config::CheckRequestType::HttpCheck(v.into()),
         );
         self
+    }
+
+    /// The value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
+    /// if it holds a `TcpCheck`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tcp_check(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::uptime_check_config::TcpCheck>> {
+        #[allow(unreachable_patterns)]
+        self.check_request_type.as_ref().and_then(|v| match v {
+            crate::model::uptime_check_config::CheckRequestType::TcpCheck(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
@@ -13432,6 +13432,18 @@ pub mod uptime_check_config {
             self
         }
 
+        /// Sets the value of [headers][crate::model::uptime_check_config::HttpCheck::headers].
+        pub fn set_headers<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [content_type][crate::model::uptime_check_config::HttpCheck::content_type].
         pub fn set_content_type<
             T: std::convert::Into<crate::model::uptime_check_config::http_check::ContentType>,
@@ -13464,17 +13476,6 @@ pub mod uptime_check_config {
             self
         }
 
-        /// Sets the value of [ping_config][crate::model::uptime_check_config::HttpCheck::ping_config].
-        pub fn set_ping_config<
-            T: std::convert::Into<std::option::Option<crate::model::uptime_check_config::PingConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ping_config = v.into();
-            self
-        }
-
         /// Sets the value of [accepted_response_status_codes][crate::model::uptime_check_config::HttpCheck::accepted_response_status_codes].
         pub fn set_accepted_response_status_codes<T, V>(mut self, v: T) -> Self
         where
@@ -13488,15 +13489,14 @@ pub mod uptime_check_config {
             self
         }
 
-        /// Sets the value of [headers][crate::model::uptime_check_config::HttpCheck::headers].
-        pub fn set_headers<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        /// Sets the value of [ping_config][crate::model::uptime_check_config::HttpCheck::ping_config].
+        pub fn set_ping_config<
+            T: std::convert::Into<std::option::Option<crate::model::uptime_check_config::PingConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.ping_config = v.into();
             self
         }
 
@@ -13662,6 +13662,20 @@ pub mod uptime_check_config {
                 })
             }
 
+            /// Sets the value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
+            /// to hold a `StatusValue`.
+            ///
+            /// Note that all the setters affecting `status_code` are
+            /// mutually exclusive.
+            pub fn set_status_value<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+                self.status_code = std::option::Option::Some(
+                    crate::model::uptime_check_config::http_check::response_status_code::StatusCode::StatusValue(
+                        v.into()
+                    )
+                );
+                self
+            }
+
             /// The value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
             /// if it holds a `StatusClass`, `None` if the field is not set or
             /// holds a different branch.
@@ -13675,20 +13689,6 @@ pub mod uptime_check_config {
                     crate::model::uptime_check_config::http_check::response_status_code::StatusCode::StatusClass(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
-            /// to hold a `StatusValue`.
-            ///
-            /// Note that all the setters affecting `status_code` are
-            /// mutually exclusive.
-            pub fn set_status_value<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.status_code = std::option::Option::Some(
-                    crate::model::uptime_check_config::http_check::response_status_code::StatusCode::StatusValue(
-                        v.into()
-                    )
-                );
-                self
             }
 
             /// Sets the value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
@@ -15260,6 +15260,17 @@ impl ListUptimeCheckConfigsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [uptime_check_configs][crate::model::ListUptimeCheckConfigsResponse::uptime_check_configs].
+    pub fn set_uptime_check_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::UptimeCheckConfig>,
+    {
+        use std::iter::Iterator;
+        self.uptime_check_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListUptimeCheckConfigsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.next_page_token = v.into();
@@ -15269,17 +15280,6 @@ impl ListUptimeCheckConfigsResponse {
     /// Sets the value of [total_size][crate::model::ListUptimeCheckConfigsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [uptime_check_configs][crate::model::ListUptimeCheckConfigsResponse::uptime_check_configs].
-    pub fn set_uptime_check_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::UptimeCheckConfig>,
-    {
-        use std::iter::Iterator;
-        self.uptime_check_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -15570,12 +15570,6 @@ impl ListUptimeCheckIpsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUptimeCheckIpsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [uptime_check_ips][crate::model::ListUptimeCheckIpsResponse::uptime_check_ips].
     pub fn set_uptime_check_ips<T, V>(mut self, v: T) -> Self
     where
@@ -15584,6 +15578,12 @@ impl ListUptimeCheckIpsResponse {
     {
         use std::iter::Iterator;
         self.uptime_check_ips = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUptimeCheckIpsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/openapi-validation/src/builder.rs
+++ b/src/generated/openapi-validation/src/builder.rs
@@ -2464,6 +2464,17 @@ pub mod secret_manager_service {
                 .map(gax::response::Response::into_body)
         }
 
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
         ///
         /// This is a **required** field for requests.
@@ -2485,17 +2496,6 @@ pub mod secret_manager_service {
         /// This is a **required** field for requests.
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
-            self
-        }
-
-        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
-        pub fn set_permissions<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -2546,6 +2546,17 @@ pub mod secret_manager_service {
                 .map(gax::response::Response::into_body)
         }
 
+        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+        pub fn set_permissions<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
         ///
         /// This is a **required** field for requests.
@@ -2567,17 +2578,6 @@ pub mod secret_manager_service {
         /// This is a **required** field for requests.
         pub fn set_location<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.location = v.into();
-            self
-        }
-
-        /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
-        pub fn set_permissions<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.permissions = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/openapi-validation/src/model.rs
+++ b/src/generated/openapi-validation/src/model.rs
@@ -53,15 +53,6 @@ impl ListLocationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [locations][crate::model::ListLocationsResponse::locations].
     pub fn set_locations<T, V>(mut self, v: T) -> Self
     where
@@ -70,6 +61,15 @@ impl ListLocationsResponse {
     {
         use std::iter::Iterator;
         self.locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListLocationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -163,15 +163,6 @@ impl Location {
         self
     }
 
-    /// Sets the value of [metadata][crate::model::Location::metadata].
-    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = v.into();
-        self
-    }
-
     /// Sets the value of [labels][crate::model::Location::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
@@ -181,6 +172,15 @@ impl Location {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [metadata][crate::model::Location::metadata].
+    pub fn set_metadata<T: std::convert::Into<std::option::Option<wkt::Any>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.metadata = v.into();
         self
     }
 }
@@ -221,6 +221,17 @@ impl ListSecretsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
+    pub fn set_secrets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Secret>,
+    {
+        use std::iter::Iterator;
+        self.secrets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListSecretsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
@@ -233,17 +244,6 @@ impl ListSecretsResponse {
     /// Sets the value of [total_size][crate::model::ListSecretsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [secrets][crate::model::ListSecretsResponse::secrets].
-    pub fn set_secrets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Secret>,
-    {
-        use std::iter::Iterator;
-        self.secrets = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -415,6 +415,29 @@ impl Secret {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Secret::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [topics][crate::model::Secret::topics].
+    pub fn set_topics<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Topic>,
+    {
+        use std::iter::Iterator;
+        self.topics = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [expire_time][crate::model::Secret::expire_time].
     pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -451,49 +474,6 @@ impl Secret {
         self
     }
 
-    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
-    pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.version_destroy_ttl = v.into();
-        self
-    }
-
-    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
-    pub fn set_customer_managed_encryption<
-        T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.customer_managed_encryption = v.into();
-        self
-    }
-
-    /// Sets the value of [topics][crate::model::Secret::topics].
-    pub fn set_topics<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Topic>,
-    {
-        use std::iter::Iterator;
-        self.topics = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Secret::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
-
     /// Sets the value of [version_aliases][crate::model::Secret::version_aliases].
     pub fn set_version_aliases<T, K, V>(mut self, v: T) -> Self
     where
@@ -515,6 +495,26 @@ impl Secret {
     {
         use std::iter::Iterator;
         self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [version_destroy_ttl][crate::model::Secret::version_destroy_ttl].
+    pub fn set_version_destroy_ttl<T: std::convert::Into<std::option::Option<wkt::Duration>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.version_destroy_ttl = v.into();
+        self
+    }
+
+    /// Sets the value of [customer_managed_encryption][crate::model::Secret::customer_managed_encryption].
+    pub fn set_customer_managed_encryption<
+        T: std::convert::Into<std::option::Option<crate::model::CustomerManagedEncryption>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.customer_managed_encryption = v.into();
         self
     }
 }
@@ -1435,6 +1435,17 @@ impl ListSecretVersionsResponse {
         std::default::Default::default()
     }
 
+    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
+    pub fn set_versions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::SecretVersion>,
+    {
+        use std::iter::Iterator;
+        self.versions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [next_page_token][crate::model::ListSecretVersionsResponse::next_page_token].
     pub fn set_next_page_token<T: std::convert::Into<std::option::Option<std::string::String>>>(
         mut self,
@@ -1447,17 +1458,6 @@ impl ListSecretVersionsResponse {
     /// Sets the value of [total_size][crate::model::ListSecretVersionsResponse::total_size].
     pub fn set_total_size<T: std::convert::Into<std::option::Option<i32>>>(mut self, v: T) -> Self {
         self.total_size = v.into();
-        self
-    }
-
-    /// Sets the value of [versions][crate::model::ListSecretVersionsResponse::versions].
-    pub fn set_versions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::SecretVersion>,
-    {
-        use std::iter::Iterator;
-        self.versions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2004,15 +2004,6 @@ impl Policy {
         self
     }
 
-    /// Sets the value of [etag][crate::model::Policy::etag].
-    pub fn set_etag<T: std::convert::Into<std::option::Option<::bytes::Bytes>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [bindings][crate::model::Policy::bindings].
     pub fn set_bindings<T, V>(mut self, v: T) -> Self
     where
@@ -2032,6 +2023,15 @@ impl Policy {
     {
         use std::iter::Iterator;
         self.audit_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::Policy::etag].
+    pub fn set_etag<T: std::convert::Into<std::option::Option<::bytes::Bytes>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.etag = v.into();
         self
     }
 }
@@ -2172,15 +2172,6 @@ impl Binding {
         self
     }
 
-    /// Sets the value of [condition][crate::model::Binding::condition].
-    pub fn set_condition<T: std::convert::Into<std::option::Option<crate::model::Expr>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition = v.into();
-        self
-    }
-
     /// Sets the value of [members][crate::model::Binding::members].
     pub fn set_members<T, V>(mut self, v: T) -> Self
     where
@@ -2189,6 +2180,15 @@ impl Binding {
     {
         use std::iter::Iterator;
         self.members = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [condition][crate::model::Binding::condition].
+    pub fn set_condition<T: std::convert::Into<std::option::Option<crate::model::Expr>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.condition = v.into();
         self
     }
 }
@@ -2532,6 +2532,17 @@ impl TestIamPermissionsRequest {
         std::default::Default::default()
     }
 
+    /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
+    pub fn set_permissions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.permissions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [project][crate::model::TestIamPermissionsRequest::project].
     pub fn set_project<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.project = v.into();
@@ -2547,17 +2558,6 @@ impl TestIamPermissionsRequest {
     /// Sets the value of [location][crate::model::TestIamPermissionsRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
-        self
-    }
-
-    /// Sets the value of [permissions][crate::model::TestIamPermissionsRequest::permissions].
-    pub fn set_permissions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.permissions = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }

--- a/src/generated/privacy/dlp/v2/src/builder.rs
+++ b/src/generated/privacy/dlp/v2/src/builder.rs
@@ -195,6 +195,17 @@ pub mod dlp_service {
             self
         }
 
+        /// Sets the value of [image_redaction_configs][crate::model::RedactImageRequest::image_redaction_configs].
+        pub fn set_image_redaction_configs<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::redact_image_request::ImageRedactionConfig>,
+        {
+            use std::iter::Iterator;
+            self.0.request.image_redaction_configs = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [include_findings][crate::model::RedactImageRequest::include_findings].
         pub fn set_include_findings<T: Into<bool>>(mut self, v: T) -> Self {
             self.0.request.include_findings = v.into();
@@ -207,17 +218,6 @@ pub mod dlp_service {
             v: T,
         ) -> Self {
             self.0.request.byte_item = v.into();
-            self
-        }
-
-        /// Sets the value of [image_redaction_configs][crate::model::RedactImageRequest::image_redaction_configs].
-        pub fn set_image_redaction_configs<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::redact_image_request::ImageRedactionConfig>,
-        {
-            use std::iter::Iterator;
-            self.0.request.image_redaction_configs = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -195,45 +195,6 @@ impl ExclusionRule {
         })
     }
 
-    /// The value of [r#type][crate::model::ExclusionRule::r#type]
-    /// if it holds a `Regex`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn regex(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Regex>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::exclusion_rule::Type::Regex(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::ExclusionRule::r#type]
-    /// if it holds a `ExcludeInfoTypes`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn exclude_info_types(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExcludeInfoTypes>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::exclusion_rule::Type::ExcludeInfoTypes(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::ExclusionRule::r#type]
-    /// if it holds a `ExcludeByHotword`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn exclude_by_hotword(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExcludeByHotword>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::exclusion_rule::Type::ExcludeByHotword(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
     /// to hold a `Dictionary`.
     ///
@@ -248,6 +209,19 @@ impl ExclusionRule {
         self.r#type =
             std::option::Option::Some(crate::model::exclusion_rule::Type::Dictionary(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::ExclusionRule::r#type]
+    /// if it holds a `Regex`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn regex(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Regex>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::exclusion_rule::Type::Regex(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
@@ -266,6 +240,19 @@ impl ExclusionRule {
         self
     }
 
+    /// The value of [r#type][crate::model::ExclusionRule::r#type]
+    /// if it holds a `ExcludeInfoTypes`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn exclude_info_types(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExcludeInfoTypes>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::exclusion_rule::Type::ExcludeInfoTypes(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
     /// to hold a `ExcludeInfoTypes`.
     ///
@@ -281,6 +268,19 @@ impl ExclusionRule {
             crate::model::exclusion_rule::Type::ExcludeInfoTypes(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::ExclusionRule::r#type]
+    /// if it holds a `ExcludeByHotword`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn exclude_by_hotword(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExcludeByHotword>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::exclusion_rule::Type::ExcludeByHotword(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
@@ -378,19 +378,6 @@ impl InspectionRule {
         })
     }
 
-    /// The value of [r#type][crate::model::InspectionRule::r#type]
-    /// if it holds a `ExclusionRule`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn exclusion_rule(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ExclusionRule>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::inspection_rule::Type::ExclusionRule(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::InspectionRule::r#type]
     /// to hold a `HotwordRule`.
     ///
@@ -407,6 +394,19 @@ impl InspectionRule {
         self.r#type =
             std::option::Option::Some(crate::model::inspection_rule::Type::HotwordRule(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::InspectionRule::r#type]
+    /// if it holds a `ExclusionRule`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn exclusion_rule(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ExclusionRule>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::inspection_rule::Type::ExclusionRule(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::InspectionRule::r#type]
@@ -601,12 +601,34 @@ impl InspectConfig {
         std::default::Default::default()
     }
 
+    /// Sets the value of [info_types][crate::model::InspectConfig::info_types].
+    pub fn set_info_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InfoType>,
+    {
+        use std::iter::Iterator;
+        self.info_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [min_likelihood][crate::model::InspectConfig::min_likelihood].
     pub fn set_min_likelihood<T: std::convert::Into<crate::model::Likelihood>>(
         mut self,
         v: T,
     ) -> Self {
         self.min_likelihood = v.into();
+        self
+    }
+
+    /// Sets the value of [min_likelihood_per_info_type][crate::model::InspectConfig::min_likelihood_per_info_type].
+    pub fn set_min_likelihood_per_info_type<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::inspect_config::InfoTypeLikelihood>,
+    {
+        use std::iter::Iterator;
+        self.min_likelihood_per_info_type = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -630,28 +652,6 @@ impl InspectConfig {
     /// Sets the value of [exclude_info_types][crate::model::InspectConfig::exclude_info_types].
     pub fn set_exclude_info_types<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.exclude_info_types = v.into();
-        self
-    }
-
-    /// Sets the value of [info_types][crate::model::InspectConfig::info_types].
-    pub fn set_info_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InfoType>,
-    {
-        use std::iter::Iterator;
-        self.info_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [min_likelihood_per_info_type][crate::model::InspectConfig::min_likelihood_per_info_type].
-    pub fn set_min_likelihood_per_info_type<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::inspect_config::InfoTypeLikelihood>,
-    {
-        use std::iter::Iterator;
-        self.min_likelihood_per_info_type = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1240,30 +1240,6 @@ impl ContentItem {
         })
     }
 
-    /// The value of [data_item][crate::model::ContentItem::data_item]
-    /// if it holds a `Table`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn table(&self) -> std::option::Option<&std::boxed::Box<crate::model::Table>> {
-        #[allow(unreachable_patterns)]
-        self.data_item.as_ref().and_then(|v| match v {
-            crate::model::content_item::DataItem::Table(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_item][crate::model::ContentItem::data_item]
-    /// if it holds a `ByteItem`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn byte_item(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ByteContentItem>> {
-        #[allow(unreachable_patterns)]
-        self.data_item.as_ref().and_then(|v| match v {
-            crate::model::content_item::DataItem::ByteItem(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_item][crate::model::ContentItem::data_item]
     /// to hold a `Value`.
     ///
@@ -1273,6 +1249,17 @@ impl ContentItem {
         self.data_item =
             std::option::Option::Some(crate::model::content_item::DataItem::Value(v.into()));
         self
+    }
+
+    /// The value of [data_item][crate::model::ContentItem::data_item]
+    /// if it holds a `Table`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn table(&self) -> std::option::Option<&std::boxed::Box<crate::model::Table>> {
+        #[allow(unreachable_patterns)]
+        self.data_item.as_ref().and_then(|v| match v {
+            crate::model::content_item::DataItem::Table(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_item][crate::model::ContentItem::data_item]
@@ -1287,6 +1274,19 @@ impl ContentItem {
         self.data_item =
             std::option::Option::Some(crate::model::content_item::DataItem::Table(v.into()));
         self
+    }
+
+    /// The value of [data_item][crate::model::ContentItem::data_item]
+    /// if it holds a `ByteItem`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn byte_item(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ByteContentItem>> {
+        #[allow(unreachable_patterns)]
+        self.data_item.as_ref().and_then(|v| match v {
+            crate::model::content_item::DataItem::ByteItem(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_item][crate::model::ContentItem::data_item]
@@ -1456,12 +1456,6 @@ impl InspectResult {
         std::default::Default::default()
     }
 
-    /// Sets the value of [findings_truncated][crate::model::InspectResult::findings_truncated].
-    pub fn set_findings_truncated<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.findings_truncated = v.into();
-        self
-    }
-
     /// Sets the value of [findings][crate::model::InspectResult::findings].
     pub fn set_findings<T, V>(mut self, v: T) -> Self
     where
@@ -1470,6 +1464,12 @@ impl InspectResult {
     {
         use std::iter::Iterator;
         self.findings = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [findings_truncated][crate::model::InspectResult::findings_truncated].
+    pub fn set_findings_truncated<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.findings_truncated = v.into();
         self
     }
 }
@@ -1634,6 +1634,18 @@ impl Finding {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Finding::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [job_create_time][crate::model::Finding::job_create_time].
     pub fn set_job_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -1652,18 +1664,6 @@ impl Finding {
     /// Sets the value of [finding_id][crate::model::Finding::finding_id].
     pub fn set_finding_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.finding_id = v.into();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Finding::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1730,15 +1730,6 @@ impl Location {
         self
     }
 
-    /// Sets the value of [container][crate::model::Location::container].
-    pub fn set_container<T: std::convert::Into<std::option::Option<crate::model::Container>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.container = v.into();
-        self
-    }
-
     /// Sets the value of [content_locations][crate::model::Location::content_locations].
     pub fn set_content_locations<T, V>(mut self, v: T) -> Self
     where
@@ -1747,6 +1738,15 @@ impl Location {
     {
         use std::iter::Iterator;
         self.content_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [container][crate::model::Location::container].
+    pub fn set_container<T: std::convert::Into<std::option::Option<crate::model::Container>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.container = v.into();
         self
     }
 }
@@ -1855,51 +1855,6 @@ impl ContentLocation {
         })
     }
 
-    /// The value of [location][crate::model::ContentLocation::location]
-    /// if it holds a `ImageLocation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn image_location(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ImageLocation>> {
-        #[allow(unreachable_patterns)]
-        self.location.as_ref().and_then(|v| match v {
-            crate::model::content_location::Location::ImageLocation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [location][crate::model::ContentLocation::location]
-    /// if it holds a `DocumentLocation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn document_location(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentLocation>> {
-        #[allow(unreachable_patterns)]
-        self.location.as_ref().and_then(|v| match v {
-            crate::model::content_location::Location::DocumentLocation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [location][crate::model::ContentLocation::location]
-    /// if it holds a `MetadataLocation`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn metadata_location(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::MetadataLocation>> {
-        #[allow(unreachable_patterns)]
-        self.location.as_ref().and_then(|v| match v {
-            crate::model::content_location::Location::MetadataLocation(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [location][crate::model::ContentLocation::location]
     /// to hold a `RecordLocation`.
     ///
@@ -1915,6 +1870,21 @@ impl ContentLocation {
             crate::model::content_location::Location::RecordLocation(v.into()),
         );
         self
+    }
+
+    /// The value of [location][crate::model::ContentLocation::location]
+    /// if it holds a `ImageLocation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn image_location(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ImageLocation>> {
+        #[allow(unreachable_patterns)]
+        self.location.as_ref().and_then(|v| match v {
+            crate::model::content_location::Location::ImageLocation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [location][crate::model::ContentLocation::location]
@@ -1934,6 +1904,21 @@ impl ContentLocation {
         self
     }
 
+    /// The value of [location][crate::model::ContentLocation::location]
+    /// if it holds a `DocumentLocation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn document_location(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DocumentLocation>> {
+        #[allow(unreachable_patterns)]
+        self.location.as_ref().and_then(|v| match v {
+            crate::model::content_location::Location::DocumentLocation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [location][crate::model::ContentLocation::location]
     /// to hold a `DocumentLocation`.
     ///
@@ -1949,6 +1934,21 @@ impl ContentLocation {
             crate::model::content_location::Location::DocumentLocation(v.into()),
         );
         self
+    }
+
+    /// The value of [location][crate::model::ContentLocation::location]
+    /// if it holds a `MetadataLocation`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn metadata_location(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::MetadataLocation>> {
+        #[allow(unreachable_patterns)]
+        self.location.as_ref().and_then(|v| match v {
+            crate::model::content_location::Location::MetadataLocation(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [location][crate::model::ContentLocation::location]
@@ -2603,6 +2603,17 @@ impl RedactImageRequest {
         self
     }
 
+    /// Sets the value of [image_redaction_configs][crate::model::RedactImageRequest::image_redaction_configs].
+    pub fn set_image_redaction_configs<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::redact_image_request::ImageRedactionConfig>,
+    {
+        use std::iter::Iterator;
+        self.image_redaction_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [include_findings][crate::model::RedactImageRequest::include_findings].
     pub fn set_include_findings<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.include_findings = v.into();
@@ -2617,17 +2628,6 @@ impl RedactImageRequest {
         v: T,
     ) -> Self {
         self.byte_item = v.into();
-        self
-    }
-
-    /// Sets the value of [image_redaction_configs][crate::model::RedactImageRequest::image_redaction_configs].
-    pub fn set_image_redaction_configs<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::redact_image_request::ImageRedactionConfig>,
-    {
-        use std::iter::Iterator;
-        self.image_redaction_configs = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2710,17 +2710,6 @@ pub mod redact_image_request {
             })
         }
 
-        /// The value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
-        /// if it holds a `RedactAllText`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn redact_all_text(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.target.as_ref().and_then(|v| match v {
-                crate::model::redact_image_request::image_redaction_config::Target::RedactAllText(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
         /// to hold a `InfoType`.
         ///
@@ -2736,6 +2725,17 @@ pub mod redact_image_request {
                 ),
             );
             self
+        }
+
+        /// The value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
+        /// if it holds a `RedactAllText`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn redact_all_text(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.target.as_ref().and_then(|v| match v {
+                crate::model::redact_image_request::image_redaction_config::Target::RedactAllText(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
@@ -3913,6 +3913,17 @@ pub mod inspect_data_source_details {
             self
         }
 
+        /// Sets the value of [info_type_stats][crate::model::inspect_data_source_details::Result::info_type_stats].
+        pub fn set_info_type_stats<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::InfoTypeStats>,
+        {
+            use std::iter::Iterator;
+            self.info_type_stats = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [num_rows_processed][crate::model::inspect_data_source_details::Result::num_rows_processed].
         pub fn set_num_rows_processed<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.num_rows_processed = v.into();
@@ -3927,17 +3938,6 @@ pub mod inspect_data_source_details {
             v: T,
         ) -> Self {
             self.hybrid_stats = v.into();
-            self
-        }
-
-        /// Sets the value of [info_type_stats][crate::model::inspect_data_source_details::Result::info_type_stats].
-        pub fn set_info_type_stats<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::InfoTypeStats>,
-        {
-            use std::iter::Iterator;
-            self.info_type_stats = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -4001,36 +4001,6 @@ impl DataProfileBigQueryRowSchema {
         })
     }
 
-    /// The value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
-    /// if it holds a `ColumnProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn column_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnDataProfile>> {
-        #[allow(unreachable_patterns)]
-        self.data_profile.as_ref().and_then(|v| match v {
-            crate::model::data_profile_big_query_row_schema::DataProfile::ColumnProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
-    /// if it holds a `FileStoreProfile`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn file_store_profile(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FileStoreDataProfile>> {
-        #[allow(unreachable_patterns)]
-        self.data_profile.as_ref().and_then(|v| match v {
-            crate::model::data_profile_big_query_row_schema::DataProfile::FileStoreProfile(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
     /// to hold a `TableProfile`.
     ///
@@ -4048,6 +4018,21 @@ impl DataProfileBigQueryRowSchema {
         self
     }
 
+    /// The value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
+    /// if it holds a `ColumnProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn column_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ColumnDataProfile>> {
+        #[allow(unreachable_patterns)]
+        self.data_profile.as_ref().and_then(|v| match v {
+            crate::model::data_profile_big_query_row_schema::DataProfile::ColumnProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
     /// to hold a `ColumnProfile`.
     ///
@@ -4063,6 +4048,21 @@ impl DataProfileBigQueryRowSchema {
             crate::model::data_profile_big_query_row_schema::DataProfile::ColumnProfile(v.into()),
         );
         self
+    }
+
+    /// The value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
+    /// if it holds a `FileStoreProfile`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn file_store_profile(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FileStoreDataProfile>> {
+        #[allow(unreachable_patterns)]
+        self.data_profile.as_ref().and_then(|v| match v {
+            crate::model::data_profile_big_query_row_schema::DataProfile::FileStoreProfile(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
@@ -4523,6 +4523,17 @@ impl InfoTypeDescription {
         self
     }
 
+    /// Sets the value of [supported_by][crate::model::InfoTypeDescription::supported_by].
+    pub fn set_supported_by<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InfoTypeSupportedBy>,
+    {
+        use std::iter::Iterator;
+        self.supported_by = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [description][crate::model::InfoTypeDescription::description].
     pub fn set_description<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.description = v.into();
@@ -4532,28 +4543,6 @@ impl InfoTypeDescription {
     /// Sets the value of [example][crate::model::InfoTypeDescription::example].
     pub fn set_example<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.example = v.into();
-        self
-    }
-
-    /// Sets the value of [sensitivity_score][crate::model::InfoTypeDescription::sensitivity_score].
-    pub fn set_sensitivity_score<
-        T: std::convert::Into<std::option::Option<crate::model::SensitivityScore>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sensitivity_score = v.into();
-        self
-    }
-
-    /// Sets the value of [supported_by][crate::model::InfoTypeDescription::supported_by].
-    pub fn set_supported_by<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InfoTypeSupportedBy>,
-    {
-        use std::iter::Iterator;
-        self.supported_by = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -4576,6 +4565,17 @@ impl InfoTypeDescription {
     {
         use std::iter::Iterator;
         self.categories = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [sensitivity_score][crate::model::InfoTypeDescription::sensitivity_score].
+    pub fn set_sensitivity_score<
+        T: std::convert::Into<std::option::Option<crate::model::SensitivityScore>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.sensitivity_score = v.into();
         self
     }
 
@@ -4646,36 +4646,6 @@ impl InfoTypeCategory {
         })
     }
 
-    /// The value of [category][crate::model::InfoTypeCategory::category]
-    /// if it holds a `IndustryCategory`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn industry_category(
-        &self,
-    ) -> std::option::Option<&crate::model::info_type_category::IndustryCategory> {
-        #[allow(unreachable_patterns)]
-        self.category.as_ref().and_then(|v| match v {
-            crate::model::info_type_category::Category::IndustryCategory(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [category][crate::model::InfoTypeCategory::category]
-    /// if it holds a `TypeCategory`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn type_category(
-        &self,
-    ) -> std::option::Option<&crate::model::info_type_category::TypeCategory> {
-        #[allow(unreachable_patterns)]
-        self.category.as_ref().and_then(|v| match v {
-            crate::model::info_type_category::Category::TypeCategory(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [category][crate::model::InfoTypeCategory::category]
     /// to hold a `LocationCategory`.
     ///
@@ -4693,6 +4663,21 @@ impl InfoTypeCategory {
         self
     }
 
+    /// The value of [category][crate::model::InfoTypeCategory::category]
+    /// if it holds a `IndustryCategory`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn industry_category(
+        &self,
+    ) -> std::option::Option<&crate::model::info_type_category::IndustryCategory> {
+        #[allow(unreachable_patterns)]
+        self.category.as_ref().and_then(|v| match v {
+            crate::model::info_type_category::Category::IndustryCategory(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [category][crate::model::InfoTypeCategory::category]
     /// to hold a `IndustryCategory`.
     ///
@@ -4708,6 +4693,21 @@ impl InfoTypeCategory {
             crate::model::info_type_category::Category::IndustryCategory(v.into()),
         );
         self
+    }
+
+    /// The value of [category][crate::model::InfoTypeCategory::category]
+    /// if it holds a `TypeCategory`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn type_category(
+        &self,
+    ) -> std::option::Option<&crate::model::info_type_category::TypeCategory> {
+        #[allow(unreachable_patterns)]
+        self.category.as_ref().and_then(|v| match v {
+            crate::model::info_type_category::Category::TypeCategory(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [category][crate::model::InfoTypeCategory::category]
@@ -5827,28 +5827,6 @@ impl QuasiId {
         })
     }
 
-    /// The value of [tag][crate::model::QuasiId::tag]
-    /// if it holds a `CustomTag`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_tag(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.tag.as_ref().and_then(|v| match v {
-            crate::model::quasi_id::Tag::CustomTag(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [tag][crate::model::QuasiId::tag]
-    /// if it holds a `Inferred`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn inferred(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
-        #[allow(unreachable_patterns)]
-        self.tag.as_ref().and_then(|v| match v {
-            crate::model::quasi_id::Tag::Inferred(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [tag][crate::model::QuasiId::tag]
     /// to hold a `InfoType`.
     ///
@@ -5862,6 +5840,17 @@ impl QuasiId {
         self
     }
 
+    /// The value of [tag][crate::model::QuasiId::tag]
+    /// if it holds a `CustomTag`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_tag(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.tag.as_ref().and_then(|v| match v {
+            crate::model::quasi_id::Tag::CustomTag(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [tag][crate::model::QuasiId::tag]
     /// to hold a `CustomTag`.
     ///
@@ -5870,6 +5859,17 @@ impl QuasiId {
     pub fn set_custom_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.tag = std::option::Option::Some(crate::model::quasi_id::Tag::CustomTag(v.into()));
         self
+    }
+
+    /// The value of [tag][crate::model::QuasiId::tag]
+    /// if it holds a `Inferred`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn inferred(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+        #[allow(unreachable_patterns)]
+        self.tag.as_ref().and_then(|v| match v {
+            crate::model::quasi_id::Tag::Inferred(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [tag][crate::model::QuasiId::tag]
@@ -5963,17 +5963,6 @@ impl StatisticalTable {
         self
     }
 
-    /// Sets the value of [relative_frequency][crate::model::StatisticalTable::relative_frequency].
-    pub fn set_relative_frequency<
-        T: std::convert::Into<std::option::Option<crate::model::FieldId>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.relative_frequency = v.into();
-        self
-    }
-
     /// Sets the value of [quasi_ids][crate::model::StatisticalTable::quasi_ids].
     pub fn set_quasi_ids<T, V>(mut self, v: T) -> Self
     where
@@ -5982,6 +5971,17 @@ impl StatisticalTable {
     {
         use std::iter::Iterator;
         self.quasi_ids = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [relative_frequency][crate::model::StatisticalTable::relative_frequency].
+    pub fn set_relative_frequency<
+        T: std::convert::Into<std::option::Option<crate::model::FieldId>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.relative_frequency = v.into();
         self
     }
 }
@@ -6095,81 +6095,6 @@ impl PrivacyMetric {
         })
     }
 
-    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// if it holds a `CategoricalStatsConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn categorical_stats_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::CategoricalStatsConfig>>
-    {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::privacy_metric::Type::CategoricalStatsConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// if it holds a `KAnonymityConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn k_anonymity_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::KAnonymityConfig>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::privacy_metric::Type::KAnonymityConfig(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// if it holds a `LDiversityConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn l_diversity_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::LDiversityConfig>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::privacy_metric::Type::LDiversityConfig(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// if it holds a `KMapEstimationConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn k_map_estimation_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::KMapEstimationConfig>>
-    {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::privacy_metric::Type::KMapEstimationConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// if it holds a `DeltaPresenceEstimationConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delta_presence_estimation_config(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::privacy_metric::DeltaPresenceEstimationConfig>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::privacy_metric::Type::DeltaPresenceEstimationConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
     /// to hold a `NumericalStatsConfig`.
     ///
@@ -6185,6 +6110,22 @@ impl PrivacyMetric {
             crate::model::privacy_metric::Type::NumericalStatsConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
+    /// if it holds a `CategoricalStatsConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn categorical_stats_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::CategoricalStatsConfig>>
+    {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::privacy_metric::Type::CategoricalStatsConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
@@ -6204,6 +6145,19 @@ impl PrivacyMetric {
         self
     }
 
+    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
+    /// if it holds a `KAnonymityConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn k_anonymity_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::KAnonymityConfig>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::privacy_metric::Type::KAnonymityConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
     /// to hold a `KAnonymityConfig`.
     ///
@@ -6219,6 +6173,19 @@ impl PrivacyMetric {
             crate::model::privacy_metric::Type::KAnonymityConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
+    /// if it holds a `LDiversityConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn l_diversity_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::LDiversityConfig>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::privacy_metric::Type::LDiversityConfig(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
@@ -6238,6 +6205,22 @@ impl PrivacyMetric {
         self
     }
 
+    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
+    /// if it holds a `KMapEstimationConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn k_map_estimation_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::privacy_metric::KMapEstimationConfig>>
+    {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::privacy_metric::Type::KMapEstimationConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
     /// to hold a `KMapEstimationConfig`.
     ///
@@ -6253,6 +6236,23 @@ impl PrivacyMetric {
             crate::model::privacy_metric::Type::KMapEstimationConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::PrivacyMetric::r#type]
+    /// if it holds a `DeltaPresenceEstimationConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delta_presence_estimation_config(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::privacy_metric::DeltaPresenceEstimationConfig>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::privacy_metric::Type::DeltaPresenceEstimationConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
@@ -6398,15 +6398,6 @@ pub mod privacy_metric {
             std::default::Default::default()
         }
 
-        /// Sets the value of [entity_id][crate::model::privacy_metric::KAnonymityConfig::entity_id].
-        pub fn set_entity_id<T: std::convert::Into<std::option::Option<crate::model::EntityId>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.entity_id = v.into();
-            self
-        }
-
         /// Sets the value of [quasi_ids][crate::model::privacy_metric::KAnonymityConfig::quasi_ids].
         pub fn set_quasi_ids<T, V>(mut self, v: T) -> Self
         where
@@ -6415,6 +6406,15 @@ pub mod privacy_metric {
         {
             use std::iter::Iterator;
             self.quasi_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [entity_id][crate::model::privacy_metric::KAnonymityConfig::entity_id].
+        pub fn set_entity_id<T: std::convert::Into<std::option::Option<crate::model::EntityId>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.entity_id = v.into();
             self
         }
     }
@@ -6450,17 +6450,6 @@ pub mod privacy_metric {
             std::default::Default::default()
         }
 
-        /// Sets the value of [sensitive_attribute][crate::model::privacy_metric::LDiversityConfig::sensitive_attribute].
-        pub fn set_sensitive_attribute<
-            T: std::convert::Into<std::option::Option<crate::model::FieldId>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.sensitive_attribute = v.into();
-            self
-        }
-
         /// Sets the value of [quasi_ids][crate::model::privacy_metric::LDiversityConfig::quasi_ids].
         pub fn set_quasi_ids<T, V>(mut self, v: T) -> Self
         where
@@ -6469,6 +6458,17 @@ pub mod privacy_metric {
         {
             use std::iter::Iterator;
             self.quasi_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [sensitive_attribute][crate::model::privacy_metric::LDiversityConfig::sensitive_attribute].
+        pub fn set_sensitive_attribute<
+            T: std::convert::Into<std::option::Option<crate::model::FieldId>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.sensitive_attribute = v.into();
             self
         }
     }
@@ -6518,12 +6518,6 @@ pub mod privacy_metric {
             std::default::Default::default()
         }
 
-        /// Sets the value of [region_code][crate::model::privacy_metric::KMapEstimationConfig::region_code].
-        pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.region_code = v.into();
-            self
-        }
-
         /// Sets the value of [quasi_ids][crate::model::privacy_metric::KMapEstimationConfig::quasi_ids].
         pub fn set_quasi_ids<T, V>(mut self, v: T) -> Self
         where
@@ -6534,6 +6528,12 @@ pub mod privacy_metric {
         {
             use std::iter::Iterator;
             self.quasi_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [region_code][crate::model::privacy_metric::KMapEstimationConfig::region_code].
+        pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.region_code = v.into();
             self
         }
 
@@ -6621,28 +6621,6 @@ pub mod privacy_metric {
                 })
             }
 
-            /// The value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
-            /// if it holds a `CustomTag`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn custom_tag(&self) -> std::option::Option<&std::string::String> {
-                #[allow(unreachable_patterns)]
-                self.tag.as_ref().and_then(|v| match v {
-                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::CustomTag(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
-            /// The value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
-            /// if it holds a `Inferred`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn inferred(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
-                #[allow(unreachable_patterns)]
-                self.tag.as_ref().and_then(|v| match v {
-                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::Inferred(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
             /// to hold a `InfoType`.
             ///
@@ -6660,6 +6638,17 @@ pub mod privacy_metric {
                 self
             }
 
+            /// The value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
+            /// if it holds a `CustomTag`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn custom_tag(&self) -> std::option::Option<&std::string::String> {
+                #[allow(unreachable_patterns)]
+                self.tag.as_ref().and_then(|v| match v {
+                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::CustomTag(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
+            }
+
             /// Sets the value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
             /// to hold a `CustomTag`.
             ///
@@ -6675,6 +6664,17 @@ pub mod privacy_metric {
                     )
                 );
                 self
+            }
+
+            /// The value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
+            /// if it holds a `Inferred`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn inferred(&self) -> std::option::Option<&std::boxed::Box<wkt::Empty>> {
+                #[allow(unreachable_patterns)]
+                self.tag.as_ref().and_then(|v| match v {
+                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::Inferred(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
@@ -6775,17 +6775,6 @@ pub mod privacy_metric {
                 self
             }
 
-            /// Sets the value of [relative_frequency][crate::model::privacy_metric::k_map_estimation_config::AuxiliaryTable::relative_frequency].
-            pub fn set_relative_frequency<
-                T: std::convert::Into<std::option::Option<crate::model::FieldId>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.relative_frequency = v.into();
-                self
-            }
-
             /// Sets the value of [quasi_ids][crate::model::privacy_metric::k_map_estimation_config::AuxiliaryTable::quasi_ids].
             pub fn set_quasi_ids<T, V>(mut self, v: T) -> Self
             where
@@ -6794,6 +6783,17 @@ pub mod privacy_metric {
             {
                 use std::iter::Iterator;
                 self.quasi_ids = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [relative_frequency][crate::model::privacy_metric::k_map_estimation_config::AuxiliaryTable::relative_frequency].
+            pub fn set_relative_frequency<
+                T: std::convert::Into<std::option::Option<crate::model::FieldId>>,
+            >(
+                mut self,
+                v: T,
+            ) -> Self {
+                self.relative_frequency = v.into();
                 self
             }
         }
@@ -6897,12 +6897,6 @@ pub mod privacy_metric {
             std::default::Default::default()
         }
 
-        /// Sets the value of [region_code][crate::model::privacy_metric::DeltaPresenceEstimationConfig::region_code].
-        pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.region_code = v.into();
-            self
-        }
-
         /// Sets the value of [quasi_ids][crate::model::privacy_metric::DeltaPresenceEstimationConfig::quasi_ids].
         pub fn set_quasi_ids<T, V>(mut self, v: T) -> Self
         where
@@ -6911,6 +6905,12 @@ pub mod privacy_metric {
         {
             use std::iter::Iterator;
             self.quasi_ids = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [region_code][crate::model::privacy_metric::DeltaPresenceEstimationConfig::region_code].
+        pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.region_code = v.into();
             self
         }
 
@@ -7059,91 +7059,6 @@ impl AnalyzeDataSourceRiskDetails {
         })
     }
 
-    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// if it holds a `CategoricalStatsResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn categorical_stats_result(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::analyze_data_source_risk_details::CategoricalStatsResult>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::analyze_data_source_risk_details::Result::CategoricalStatsResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// if it holds a `KAnonymityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn k_anonymity_result(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::analyze_data_source_risk_details::KAnonymityResult>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::analyze_data_source_risk_details::Result::KAnonymityResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// if it holds a `LDiversityResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn l_diversity_result(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::analyze_data_source_risk_details::LDiversityResult>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::analyze_data_source_risk_details::Result::LDiversityResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// if it holds a `KMapEstimationResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn k_map_estimation_result(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::analyze_data_source_risk_details::KMapEstimationResult>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::analyze_data_source_risk_details::Result::KMapEstimationResult(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// if it holds a `DeltaPresenceEstimationResult`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn delta_presence_estimation_result(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<
-            crate::model::analyze_data_source_risk_details::DeltaPresenceEstimationResult,
-        >,
-    > {
-        #[allow(unreachable_patterns)]
-        self.result.as_ref().and_then(|v| match v {
-            crate::model::analyze_data_source_risk_details::Result::DeltaPresenceEstimationResult(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
     /// to hold a `NumericalStatsResult`.
     ///
@@ -7163,6 +7078,23 @@ impl AnalyzeDataSourceRiskDetails {
             crate::model::analyze_data_source_risk_details::Result::NumericalStatsResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
+    /// if it holds a `CategoricalStatsResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn categorical_stats_result(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::analyze_data_source_risk_details::CategoricalStatsResult>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::analyze_data_source_risk_details::Result::CategoricalStatsResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
@@ -7188,6 +7120,23 @@ impl AnalyzeDataSourceRiskDetails {
         self
     }
 
+    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
+    /// if it holds a `KAnonymityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn k_anonymity_result(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::analyze_data_source_risk_details::KAnonymityResult>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::analyze_data_source_risk_details::Result::KAnonymityResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
     /// to hold a `KAnonymityResult`.
     ///
@@ -7205,6 +7154,23 @@ impl AnalyzeDataSourceRiskDetails {
             crate::model::analyze_data_source_risk_details::Result::KAnonymityResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
+    /// if it holds a `LDiversityResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn l_diversity_result(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::analyze_data_source_risk_details::LDiversityResult>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::analyze_data_source_risk_details::Result::LDiversityResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
@@ -7226,6 +7192,23 @@ impl AnalyzeDataSourceRiskDetails {
         self
     }
 
+    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
+    /// if it holds a `KMapEstimationResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn k_map_estimation_result(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::analyze_data_source_risk_details::KMapEstimationResult>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::analyze_data_source_risk_details::Result::KMapEstimationResult(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
     /// to hold a `KMapEstimationResult`.
     ///
@@ -7245,6 +7228,23 @@ impl AnalyzeDataSourceRiskDetails {
             crate::model::analyze_data_source_risk_details::Result::KMapEstimationResult(v.into()),
         );
         self
+    }
+
+    /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
+    /// if it holds a `DeltaPresenceEstimationResult`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn delta_presence_estimation_result(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<
+            crate::model::analyze_data_source_risk_details::DeltaPresenceEstimationResult,
+        >,
+    > {
+        #[allow(unreachable_patterns)]
+        self.result.as_ref().and_then(|v| match v {
+            crate::model::analyze_data_source_risk_details::Result::DeltaPresenceEstimationResult(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
@@ -7453,12 +7453,6 @@ pub mod analyze_data_source_risk_details {
                 self
             }
 
-            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::categorical_stats_result::CategoricalStatsHistogramBucket::bucket_value_count].
-            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.bucket_value_count = v.into();
-                self
-            }
-
             /// Sets the value of [bucket_values][crate::model::analyze_data_source_risk_details::categorical_stats_result::CategoricalStatsHistogramBucket::bucket_values].
             pub fn set_bucket_values<T, V>(mut self, v: T) -> Self
             where
@@ -7467,6 +7461,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.bucket_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::categorical_stats_result::CategoricalStatsHistogramBucket::bucket_value_count].
+            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.bucket_value_count = v.into();
                 self
             }
         }
@@ -7548,12 +7548,6 @@ pub mod analyze_data_source_risk_details {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [equivalence_class_size][crate::model::analyze_data_source_risk_details::k_anonymity_result::KAnonymityEquivalenceClass::equivalence_class_size].
-            pub fn set_equivalence_class_size<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.equivalence_class_size = v.into();
-                self
-            }
-
             /// Sets the value of [quasi_ids_values][crate::model::analyze_data_source_risk_details::k_anonymity_result::KAnonymityEquivalenceClass::quasi_ids_values].
             pub fn set_quasi_ids_values<T, V>(mut self, v: T) -> Self
             where
@@ -7562,6 +7556,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.quasi_ids_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [equivalence_class_size][crate::model::analyze_data_source_risk_details::k_anonymity_result::KAnonymityEquivalenceClass::equivalence_class_size].
+            pub fn set_equivalence_class_size<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.equivalence_class_size = v.into();
                 self
             }
         }
@@ -7637,12 +7637,6 @@ pub mod analyze_data_source_risk_details {
                 self
             }
 
-            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::k_anonymity_result::KAnonymityHistogramBucket::bucket_value_count].
-            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.bucket_value_count = v.into();
-                self
-            }
-
             /// Sets the value of [bucket_values][crate::model::analyze_data_source_risk_details::k_anonymity_result::KAnonymityHistogramBucket::bucket_values].
             pub fn set_bucket_values<T, V>(mut self, v: T) -> Self
             where
@@ -7651,6 +7645,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.bucket_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::k_anonymity_result::KAnonymityHistogramBucket::bucket_value_count].
+            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.bucket_value_count = v.into();
                 self
             }
         }
@@ -7740,6 +7740,17 @@ pub mod analyze_data_source_risk_details {
                 std::default::Default::default()
             }
 
+            /// Sets the value of [quasi_ids_values][crate::model::analyze_data_source_risk_details::l_diversity_result::LDiversityEquivalenceClass::quasi_ids_values].
+            pub fn set_quasi_ids_values<T, V>(mut self, v: T) -> Self
+            where
+                T: std::iter::IntoIterator<Item = V>,
+                V: std::convert::Into<crate::model::Value>,
+            {
+                use std::iter::Iterator;
+                self.quasi_ids_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
             /// Sets the value of [equivalence_class_size][crate::model::analyze_data_source_risk_details::l_diversity_result::LDiversityEquivalenceClass::equivalence_class_size].
             pub fn set_equivalence_class_size<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
                 self.equivalence_class_size = v.into();
@@ -7752,17 +7763,6 @@ pub mod analyze_data_source_risk_details {
                 v: T,
             ) -> Self {
                 self.num_distinct_sensitive_values = v.into();
-                self
-            }
-
-            /// Sets the value of [quasi_ids_values][crate::model::analyze_data_source_risk_details::l_diversity_result::LDiversityEquivalenceClass::quasi_ids_values].
-            pub fn set_quasi_ids_values<T, V>(mut self, v: T) -> Self
-            where
-                T: std::iter::IntoIterator<Item = V>,
-                V: std::convert::Into<crate::model::Value>,
-            {
-                use std::iter::Iterator;
-                self.quasi_ids_values = v.into_iter().map(|i| i.into()).collect();
                 self
             }
 
@@ -7851,12 +7851,6 @@ pub mod analyze_data_source_risk_details {
                 self
             }
 
-            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::l_diversity_result::LDiversityHistogramBucket::bucket_value_count].
-            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.bucket_value_count = v.into();
-                self
-            }
-
             /// Sets the value of [bucket_values][crate::model::analyze_data_source_risk_details::l_diversity_result::LDiversityHistogramBucket::bucket_values].
             pub fn set_bucket_values<T, V>(mut self, v: T) -> Self
             where
@@ -7865,6 +7859,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.bucket_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::l_diversity_result::LDiversityHistogramBucket::bucket_value_count].
+            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.bucket_value_count = v.into();
                 self
             }
         }
@@ -7951,12 +7951,6 @@ pub mod analyze_data_source_risk_details {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [estimated_anonymity][crate::model::analyze_data_source_risk_details::k_map_estimation_result::KMapEstimationQuasiIdValues::estimated_anonymity].
-            pub fn set_estimated_anonymity<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.estimated_anonymity = v.into();
-                self
-            }
-
             /// Sets the value of [quasi_ids_values][crate::model::analyze_data_source_risk_details::k_map_estimation_result::KMapEstimationQuasiIdValues::quasi_ids_values].
             pub fn set_quasi_ids_values<T, V>(mut self, v: T) -> Self
             where
@@ -7965,6 +7959,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.quasi_ids_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [estimated_anonymity][crate::model::analyze_data_source_risk_details::k_map_estimation_result::KMapEstimationQuasiIdValues::estimated_anonymity].
+            pub fn set_estimated_anonymity<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.estimated_anonymity = v.into();
                 self
             }
         }
@@ -8041,12 +8041,6 @@ pub mod analyze_data_source_risk_details {
                 self
             }
 
-            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::k_map_estimation_result::KMapEstimationHistogramBucket::bucket_value_count].
-            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.bucket_value_count = v.into();
-                self
-            }
-
             /// Sets the value of [bucket_values][crate::model::analyze_data_source_risk_details::k_map_estimation_result::KMapEstimationHistogramBucket::bucket_values].
             pub fn set_bucket_values<T, V>(mut self, v: T) -> Self
             where
@@ -8055,6 +8049,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.bucket_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::k_map_estimation_result::KMapEstimationHistogramBucket::bucket_value_count].
+            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.bucket_value_count = v.into();
                 self
             }
         }
@@ -8147,12 +8147,6 @@ pub mod analyze_data_source_risk_details {
                 std::default::Default::default()
             }
 
-            /// Sets the value of [estimated_probability][crate::model::analyze_data_source_risk_details::delta_presence_estimation_result::DeltaPresenceEstimationQuasiIdValues::estimated_probability].
-            pub fn set_estimated_probability<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-                self.estimated_probability = v.into();
-                self
-            }
-
             /// Sets the value of [quasi_ids_values][crate::model::analyze_data_source_risk_details::delta_presence_estimation_result::DeltaPresenceEstimationQuasiIdValues::quasi_ids_values].
             pub fn set_quasi_ids_values<T, V>(mut self, v: T) -> Self
             where
@@ -8161,6 +8155,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.quasi_ids_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [estimated_probability][crate::model::analyze_data_source_risk_details::delta_presence_estimation_result::DeltaPresenceEstimationQuasiIdValues::estimated_probability].
+            pub fn set_estimated_probability<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+                self.estimated_probability = v.into();
                 self
             }
         }
@@ -8236,12 +8236,6 @@ pub mod analyze_data_source_risk_details {
                 self
             }
 
-            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::delta_presence_estimation_result::DeltaPresenceEstimationHistogramBucket::bucket_value_count].
-            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-                self.bucket_value_count = v.into();
-                self
-            }
-
             /// Sets the value of [bucket_values][crate::model::analyze_data_source_risk_details::delta_presence_estimation_result::DeltaPresenceEstimationHistogramBucket::bucket_values].
             pub fn set_bucket_values<T, V>(mut self, v: T) -> Self
             where
@@ -8250,6 +8244,12 @@ pub mod analyze_data_source_risk_details {
             {
                 use std::iter::Iterator;
                 self.bucket_values = v.into_iter().map(|i| i.into()).collect();
+                self
+            }
+
+            /// Sets the value of [bucket_value_count][crate::model::analyze_data_source_risk_details::delta_presence_estimation_result::DeltaPresenceEstimationHistogramBucket::bucket_value_count].
+            pub fn set_bucket_value_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+                self.bucket_value_count = v.into();
                 self
             }
         }
@@ -8425,6 +8425,16 @@ impl Value {
         })
     }
 
+    /// Sets the value of [r#type][crate::model::Value::r#type]
+    /// to hold a `IntegerValue`.
+    ///
+    /// Note that all the setters affecting `r#type` are
+    /// mutually exclusive.
+    pub fn set_integer_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.r#type = std::option::Option::Some(crate::model::value::Type::IntegerValue(v.into()));
+        self
+    }
+
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `FloatValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8434,6 +8444,16 @@ impl Value {
             crate::model::value::Type::FloatValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
+    }
+
+    /// Sets the value of [r#type][crate::model::Value::r#type]
+    /// to hold a `FloatValue`.
+    ///
+    /// Note that all the setters affecting `r#type` are
+    /// mutually exclusive.
+    pub fn set_float_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
+        self.r#type = std::option::Option::Some(crate::model::value::Type::FloatValue(v.into()));
+        self
     }
 
     /// The value of [r#type][crate::model::Value::r#type]
@@ -8447,6 +8467,16 @@ impl Value {
         })
     }
 
+    /// Sets the value of [r#type][crate::model::Value::r#type]
+    /// to hold a `StringValue`.
+    ///
+    /// Note that all the setters affecting `r#type` are
+    /// mutually exclusive.
+    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.r#type = std::option::Option::Some(crate::model::value::Type::StringValue(v.into()));
+        self
+    }
+
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `BooleanValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8458,6 +8488,16 @@ impl Value {
         })
     }
 
+    /// Sets the value of [r#type][crate::model::Value::r#type]
+    /// to hold a `BooleanValue`.
+    ///
+    /// Note that all the setters affecting `r#type` are
+    /// mutually exclusive.
+    pub fn set_boolean_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.r#type = std::option::Option::Some(crate::model::value::Type::BooleanValue(v.into()));
+        self
+    }
+
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `TimestampValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8467,79 +8507,6 @@ impl Value {
             crate::model::value::Type::TimestampValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// The value of [r#type][crate::model::Value::r#type]
-    /// if it holds a `TimeValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::TimeOfDay>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::value::Type::TimeValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Value::r#type]
-    /// if it holds a `DateValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn date_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::Date>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::value::Type::DateValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::Value::r#type]
-    /// if it holds a `DayOfWeekValue`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn day_of_week_value(&self) -> std::option::Option<&gtype::model::DayOfWeek> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::value::Type::DayOfWeekValue(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `IntegerValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_integer_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::IntegerValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `FloatValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_float_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::FloatValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::StringValue(v.into()));
-        self
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `BooleanValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_boolean_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::BooleanValue(v.into()));
-        self
     }
 
     /// Sets the value of [r#type][crate::model::Value::r#type]
@@ -8556,6 +8523,17 @@ impl Value {
         self
     }
 
+    /// The value of [r#type][crate::model::Value::r#type]
+    /// if it holds a `TimeValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::TimeOfDay>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::value::Type::TimeValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Value::r#type]
     /// to hold a `TimeValue`.
     ///
@@ -8569,6 +8547,17 @@ impl Value {
         self
     }
 
+    /// The value of [r#type][crate::model::Value::r#type]
+    /// if it holds a `DateValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn date_value(&self) -> std::option::Option<&std::boxed::Box<gtype::model::Date>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::value::Type::DateValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::Value::r#type]
     /// to hold a `DateValue`.
     ///
@@ -8580,6 +8569,17 @@ impl Value {
     ) -> Self {
         self.r#type = std::option::Option::Some(crate::model::value::Type::DateValue(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::Value::r#type]
+    /// if it holds a `DayOfWeekValue`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn day_of_week_value(&self) -> std::option::Option<&gtype::model::DayOfWeek> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::value::Type::DayOfWeekValue(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::Value::r#type]
@@ -8890,36 +8890,6 @@ impl DeidentifyConfig {
         })
     }
 
-    /// The value of [transformation][crate::model::DeidentifyConfig::transformation]
-    /// if it holds a `RecordTransformations`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn record_transformations(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RecordTransformations>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::deidentify_config::Transformation::RecordTransformations(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::DeidentifyConfig::transformation]
-    /// if it holds a `ImageTransformations`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn image_transformations(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ImageTransformations>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::deidentify_config::Transformation::ImageTransformations(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [transformation][crate::model::DeidentifyConfig::transformation]
     /// to hold a `InfoTypeTransformations`.
     ///
@@ -8937,6 +8907,21 @@ impl DeidentifyConfig {
         self
     }
 
+    /// The value of [transformation][crate::model::DeidentifyConfig::transformation]
+    /// if it holds a `RecordTransformations`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn record_transformations(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RecordTransformations>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::deidentify_config::Transformation::RecordTransformations(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::DeidentifyConfig::transformation]
     /// to hold a `RecordTransformations`.
     ///
@@ -8952,6 +8937,21 @@ impl DeidentifyConfig {
             crate::model::deidentify_config::Transformation::RecordTransformations(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::DeidentifyConfig::transformation]
+    /// if it holds a `ImageTransformations`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn image_transformations(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ImageTransformations>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::deidentify_config::Transformation::ImageTransformations(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::DeidentifyConfig::transformation]
@@ -9113,6 +9113,20 @@ pub mod image_transformations {
             })
         }
 
+        /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
+        /// to hold a `SelectedInfoTypes`.
+        ///
+        /// Note that all the setters affecting `target` are
+        /// mutually exclusive.
+        pub fn set_selected_info_types<T: std::convert::Into<std::boxed::Box<crate::model::image_transformations::image_transformation::SelectedInfoTypes>>>(mut self, v: T) -> Self{
+            self.target = std::option::Option::Some(
+                crate::model::image_transformations::image_transformation::Target::SelectedInfoTypes(
+                    v.into()
+                )
+            );
+            self
+        }
+
         /// The value of [target][crate::model::image_transformations::ImageTransformation::target]
         /// if it holds a `AllInfoTypes`, `None` if the field is not set or
         /// holds a different branch.
@@ -9130,37 +9144,6 @@ pub mod image_transformations {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// The value of [target][crate::model::image_transformations::ImageTransformation::target]
-        /// if it holds a `AllText`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn all_text(
-            &self,
-        ) -> std::option::Option<
-            &std::boxed::Box<crate::model::image_transformations::image_transformation::AllText>,
-        > {
-            #[allow(unreachable_patterns)]
-            self.target.as_ref().and_then(|v| match v {
-                crate::model::image_transformations::image_transformation::Target::AllText(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
-        /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
-        /// to hold a `SelectedInfoTypes`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_selected_info_types<T: std::convert::Into<std::boxed::Box<crate::model::image_transformations::image_transformation::SelectedInfoTypes>>>(mut self, v: T) -> Self{
-            self.target = std::option::Option::Some(
-                crate::model::image_transformations::image_transformation::Target::SelectedInfoTypes(
-                    v.into()
-                )
-            );
-            self
         }
 
         /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
@@ -9184,6 +9167,23 @@ pub mod image_transformations {
                 ),
             );
             self
+        }
+
+        /// The value of [target][crate::model::image_transformations::ImageTransformation::target]
+        /// if it holds a `AllText`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn all_text(
+            &self,
+        ) -> std::option::Option<
+            &std::boxed::Box<crate::model::image_transformations::image_transformation::AllText>,
+        > {
+            #[allow(unreachable_patterns)]
+            self.target.as_ref().and_then(|v| match v {
+                crate::model::image_transformations::image_transformation::Target::AllText(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
@@ -9388,23 +9388,6 @@ impl TransformationErrorHandling {
         })
     }
 
-    /// The value of [mode][crate::model::TransformationErrorHandling::mode]
-    /// if it holds a `LeaveUntransformed`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn leave_untransformed(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::transformation_error_handling::LeaveUntransformed>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.mode.as_ref().and_then(|v| match v {
-            crate::model::transformation_error_handling::Mode::LeaveUntransformed(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [mode][crate::model::TransformationErrorHandling::mode]
     /// to hold a `ThrowError`.
     ///
@@ -9422,6 +9405,23 @@ impl TransformationErrorHandling {
             crate::model::transformation_error_handling::Mode::ThrowError(v.into()),
         );
         self
+    }
+
+    /// The value of [mode][crate::model::TransformationErrorHandling::mode]
+    /// if it holds a `LeaveUntransformed`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn leave_untransformed(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::transformation_error_handling::LeaveUntransformed>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.mode.as_ref().and_then(|v| match v {
+            crate::model::transformation_error_handling::Mode::LeaveUntransformed(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [mode][crate::model::TransformationErrorHandling::mode]
@@ -9566,171 +9566,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `RedactConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn redact_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RedactConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::RedactConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `CharacterMaskConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn character_mask_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CharacterMaskConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::CharacterMaskConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `CryptoReplaceFfxFpeConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn crypto_replace_ffx_fpe_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CryptoReplaceFfxFpeConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::CryptoReplaceFfxFpeConfig(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `FixedSizeBucketingConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn fixed_size_bucketing_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::FixedSizeBucketingConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::FixedSizeBucketingConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `BucketingConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn bucketing_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BucketingConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::BucketingConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `ReplaceWithInfoTypeConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn replace_with_info_type_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplaceWithInfoTypeConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::ReplaceWithInfoTypeConfig(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `TimePartConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_part_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TimePartConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::TimePartConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `CryptoHashConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn crypto_hash_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CryptoHashConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::CryptoHashConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `DateShiftConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn date_shift_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DateShiftConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::DateShiftConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `CryptoDeterministicConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn crypto_deterministic_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CryptoDeterministicConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::CryptoDeterministicConfig(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// if it holds a `ReplaceDictionaryConfig`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn replace_dictionary_config(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplaceDictionaryConfig>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::primitive_transformation::Transformation::ReplaceDictionaryConfig(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// to hold a `ReplaceConfig`.
     ///
@@ -9748,6 +9583,21 @@ impl PrimitiveTransformation {
         self
     }
 
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `RedactConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn redact_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RedactConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::RedactConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// to hold a `RedactConfig`.
     ///
@@ -9761,6 +9611,21 @@ impl PrimitiveTransformation {
             crate::model::primitive_transformation::Transformation::RedactConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `CharacterMaskConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn character_mask_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CharacterMaskConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::CharacterMaskConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9778,6 +9643,21 @@ impl PrimitiveTransformation {
             crate::model::primitive_transformation::Transformation::CharacterMaskConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `CryptoReplaceFfxFpeConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn crypto_replace_ffx_fpe_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CryptoReplaceFfxFpeConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::CryptoReplaceFfxFpeConfig(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9799,6 +9679,21 @@ impl PrimitiveTransformation {
         self
     }
 
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `FixedSizeBucketingConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn fixed_size_bucketing_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::FixedSizeBucketingConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::FixedSizeBucketingConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// to hold a `FixedSizeBucketingConfig`.
     ///
@@ -9818,6 +9713,21 @@ impl PrimitiveTransformation {
         self
     }
 
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `BucketingConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn bucketing_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BucketingConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::BucketingConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// to hold a `BucketingConfig`.
     ///
@@ -9833,6 +9743,21 @@ impl PrimitiveTransformation {
             crate::model::primitive_transformation::Transformation::BucketingConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `ReplaceWithInfoTypeConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn replace_with_info_type_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplaceWithInfoTypeConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::ReplaceWithInfoTypeConfig(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9854,6 +9779,21 @@ impl PrimitiveTransformation {
         self
     }
 
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `TimePartConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_part_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TimePartConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::TimePartConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// to hold a `TimePartConfig`.
     ///
@@ -9869,6 +9809,21 @@ impl PrimitiveTransformation {
             crate::model::primitive_transformation::Transformation::TimePartConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `CryptoHashConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn crypto_hash_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CryptoHashConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::CryptoHashConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9888,6 +9843,21 @@ impl PrimitiveTransformation {
         self
     }
 
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `DateShiftConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn date_shift_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DateShiftConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::DateShiftConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// to hold a `DateShiftConfig`.
     ///
@@ -9903,6 +9873,21 @@ impl PrimitiveTransformation {
             crate::model::primitive_transformation::Transformation::DateShiftConfig(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `CryptoDeterministicConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn crypto_deterministic_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CryptoDeterministicConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::CryptoDeterministicConfig(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9922,6 +9907,21 @@ impl PrimitiveTransformation {
             ),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
+    /// if it holds a `ReplaceDictionaryConfig`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn replace_dictionary_config(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::ReplaceDictionaryConfig>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::primitive_transformation::Transformation::ReplaceDictionaryConfig(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -10564,21 +10564,6 @@ impl CharsToIgnore {
         })
     }
 
-    /// The value of [characters][crate::model::CharsToIgnore::characters]
-    /// if it holds a `CommonCharactersToIgnore`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn common_characters_to_ignore(
-        &self,
-    ) -> std::option::Option<&crate::model::chars_to_ignore::CommonCharsToIgnore> {
-        #[allow(unreachable_patterns)]
-        self.characters.as_ref().and_then(|v| match v {
-            crate::model::chars_to_ignore::Characters::CommonCharactersToIgnore(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [characters][crate::model::CharsToIgnore::characters]
     /// to hold a `CharactersToSkip`.
     ///
@@ -10592,6 +10577,21 @@ impl CharsToIgnore {
             crate::model::chars_to_ignore::Characters::CharactersToSkip(v.into()),
         );
         self
+    }
+
+    /// The value of [characters][crate::model::CharsToIgnore::characters]
+    /// if it holds a `CommonCharactersToIgnore`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn common_characters_to_ignore(
+        &self,
+    ) -> std::option::Option<&crate::model::chars_to_ignore::CommonCharsToIgnore> {
+        #[allow(unreachable_patterns)]
+        self.characters.as_ref().and_then(|v| match v {
+            crate::model::chars_to_ignore::Characters::CommonCharactersToIgnore(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [characters][crate::model::CharsToIgnore::characters]
@@ -11240,32 +11240,6 @@ impl CryptoReplaceFfxFpeConfig {
         })
     }
 
-    /// The value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
-    /// if it holds a `CustomAlphabet`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn custom_alphabet(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.alphabet.as_ref().and_then(|v| match v {
-            crate::model::crypto_replace_ffx_fpe_config::Alphabet::CustomAlphabet(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
-    /// if it holds a `Radix`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn radix(&self) -> std::option::Option<&i32> {
-        #[allow(unreachable_patterns)]
-        self.alphabet.as_ref().and_then(|v| match v {
-            crate::model::crypto_replace_ffx_fpe_config::Alphabet::Radix(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
     /// to hold a `CommonAlphabet`.
     ///
@@ -11283,6 +11257,19 @@ impl CryptoReplaceFfxFpeConfig {
         self
     }
 
+    /// The value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
+    /// if it holds a `CustomAlphabet`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn custom_alphabet(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.alphabet.as_ref().and_then(|v| match v {
+            crate::model::crypto_replace_ffx_fpe_config::Alphabet::CustomAlphabet(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
     /// to hold a `CustomAlphabet`.
     ///
@@ -11293,6 +11280,19 @@ impl CryptoReplaceFfxFpeConfig {
             crate::model::crypto_replace_ffx_fpe_config::Alphabet::CustomAlphabet(v.into()),
         );
         self
+    }
+
+    /// The value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
+    /// if it holds a `Radix`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn radix(&self) -> std::option::Option<&i32> {
+        #[allow(unreachable_patterns)]
+        self.alphabet.as_ref().and_then(|v| match v {
+            crate::model::crypto_replace_ffx_fpe_config::Alphabet::Radix(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
@@ -11546,32 +11546,6 @@ impl CryptoKey {
         })
     }
 
-    /// The value of [source][crate::model::CryptoKey::source]
-    /// if it holds a `Unwrapped`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn unwrapped(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::UnwrappedCryptoKey>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::crypto_key::Source::Unwrapped(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [source][crate::model::CryptoKey::source]
-    /// if it holds a `KmsWrapped`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn kms_wrapped(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::KmsWrappedCryptoKey>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::crypto_key::Source::KmsWrapped(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::CryptoKey::source]
     /// to hold a `Transient`.
     ///
@@ -11588,6 +11562,19 @@ impl CryptoKey {
         self
     }
 
+    /// The value of [source][crate::model::CryptoKey::source]
+    /// if it holds a `Unwrapped`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn unwrapped(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::UnwrappedCryptoKey>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::crypto_key::Source::Unwrapped(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [source][crate::model::CryptoKey::source]
     /// to hold a `Unwrapped`.
     ///
@@ -11602,6 +11589,19 @@ impl CryptoKey {
         self.source =
             std::option::Option::Some(crate::model::crypto_key::Source::Unwrapped(v.into()));
         self
+    }
+
+    /// The value of [source][crate::model::CryptoKey::source]
+    /// if it holds a `KmsWrapped`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn kms_wrapped(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::KmsWrappedCryptoKey>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::crypto_key::Source::KmsWrapped(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::CryptoKey::source]
@@ -11971,17 +11971,6 @@ pub mod info_type_transformations {
             std::default::Default::default()
         }
 
-        /// Sets the value of [primitive_transformation][crate::model::info_type_transformations::InfoTypeTransformation::primitive_transformation].
-        pub fn set_primitive_transformation<
-            T: std::convert::Into<std::option::Option<crate::model::PrimitiveTransformation>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.primitive_transformation = v.into();
-            self
-        }
-
         /// Sets the value of [info_types][crate::model::info_type_transformations::InfoTypeTransformation::info_types].
         pub fn set_info_types<T, V>(mut self, v: T) -> Self
         where
@@ -11990,6 +11979,17 @@ pub mod info_type_transformations {
         {
             use std::iter::Iterator;
             self.info_types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [primitive_transformation][crate::model::info_type_transformations::InfoTypeTransformation::primitive_transformation].
+        pub fn set_primitive_transformation<
+            T: std::convert::Into<std::option::Option<crate::model::PrimitiveTransformation>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.primitive_transformation = v.into();
             self
         }
     }
@@ -12039,17 +12039,6 @@ impl FieldTransformation {
         std::default::Default::default()
     }
 
-    /// Sets the value of [condition][crate::model::FieldTransformation::condition].
-    pub fn set_condition<
-        T: std::convert::Into<std::option::Option<crate::model::RecordCondition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::model::FieldTransformation::fields].
     pub fn set_fields<T, V>(mut self, v: T) -> Self
     where
@@ -12058,6 +12047,17 @@ impl FieldTransformation {
     {
         use std::iter::Iterator;
         self.fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [condition][crate::model::FieldTransformation::condition].
+    pub fn set_condition<
+        T: std::convert::Into<std::option::Option<crate::model::RecordCondition>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.condition = v.into();
         self
     }
 
@@ -12090,21 +12090,6 @@ impl FieldTransformation {
         })
     }
 
-    /// The value of [transformation][crate::model::FieldTransformation::transformation]
-    /// if it holds a `InfoTypeTransformations`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn info_type_transformations(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InfoTypeTransformations>> {
-        #[allow(unreachable_patterns)]
-        self.transformation.as_ref().and_then(|v| match v {
-            crate::model::field_transformation::Transformation::InfoTypeTransformations(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [transformation][crate::model::FieldTransformation::transformation]
     /// to hold a `PrimitiveTransformation`.
     ///
@@ -12120,6 +12105,21 @@ impl FieldTransformation {
             crate::model::field_transformation::Transformation::PrimitiveTransformation(v.into()),
         );
         self
+    }
+
+    /// The value of [transformation][crate::model::FieldTransformation::transformation]
+    /// if it holds a `InfoTypeTransformations`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn info_type_transformations(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InfoTypeTransformations>> {
+        #[allow(unreachable_patterns)]
+        self.transformation.as_ref().and_then(|v| match v {
+            crate::model::field_transformation::Transformation::InfoTypeTransformations(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [transformation][crate::model::FieldTransformation::transformation]
@@ -12774,23 +12774,6 @@ impl TransformationSummary {
         self
     }
 
-    /// Sets the value of [record_suppress][crate::model::TransformationSummary::record_suppress].
-    pub fn set_record_suppress<
-        T: std::convert::Into<std::option::Option<crate::model::RecordSuppression>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.record_suppress = v.into();
-        self
-    }
-
-    /// Sets the value of [transformed_bytes][crate::model::TransformationSummary::transformed_bytes].
-    pub fn set_transformed_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.transformed_bytes = v.into();
-        self
-    }
-
     /// Sets the value of [field_transformations][crate::model::TransformationSummary::field_transformations].
     pub fn set_field_transformations<T, V>(mut self, v: T) -> Self
     where
@@ -12802,6 +12785,17 @@ impl TransformationSummary {
         self
     }
 
+    /// Sets the value of [record_suppress][crate::model::TransformationSummary::record_suppress].
+    pub fn set_record_suppress<
+        T: std::convert::Into<std::option::Option<crate::model::RecordSuppression>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.record_suppress = v.into();
+        self
+    }
+
     /// Sets the value of [results][crate::model::TransformationSummary::results].
     pub fn set_results<T, V>(mut self, v: T) -> Self
     where
@@ -12810,6 +12804,12 @@ impl TransformationSummary {
     {
         use std::iter::Iterator;
         self.results = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [transformed_bytes][crate::model::TransformationSummary::transformed_bytes].
+    pub fn set_transformed_bytes<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.transformed_bytes = v.into();
         self
     }
 }
@@ -13166,6 +13166,17 @@ impl TransformationDetails {
         self
     }
 
+    /// Sets the value of [transformation][crate::model::TransformationDetails::transformation].
+    pub fn set_transformation<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::TransformationDescription>,
+    {
+        use std::iter::Iterator;
+        self.transformation = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [status_details][crate::model::TransformationDetails::status_details].
     pub fn set_status_details<
         T: std::convert::Into<std::option::Option<crate::model::TransformationResultStatus>>,
@@ -13191,17 +13202,6 @@ impl TransformationDetails {
         v: T,
     ) -> Self {
         self.transformation_location = v.into();
-        self
-    }
-
-    /// Sets the value of [transformation][crate::model::TransformationDetails::transformation].
-    pub fn set_transformation<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::TransformationDescription>,
-    {
-        use std::iter::Iterator;
-        self.transformation = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -13273,6 +13273,18 @@ impl TransformationLocation {
         })
     }
 
+    /// Sets the value of [location_type][crate::model::TransformationLocation::location_type]
+    /// to hold a `FindingId`.
+    ///
+    /// Note that all the setters affecting `location_type` are
+    /// mutually exclusive.
+    pub fn set_finding_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.location_type = std::option::Option::Some(
+            crate::model::transformation_location::LocationType::FindingId(v.into()),
+        );
+        self
+    }
+
     /// The value of [location_type][crate::model::TransformationLocation::location_type]
     /// if it holds a `RecordTransformation`, `None` if the field is not set or
     /// holds a different branch.
@@ -13286,18 +13298,6 @@ impl TransformationLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location_type][crate::model::TransformationLocation::location_type]
-    /// to hold a `FindingId`.
-    ///
-    /// Note that all the setters affecting `location_type` are
-    /// mutually exclusive.
-    pub fn set_finding_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.location_type = std::option::Option::Some(
-            crate::model::transformation_location::LocationType::FindingId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [location_type][crate::model::TransformationLocation::location_type]
@@ -13899,15 +13899,6 @@ impl Error {
         self
     }
 
-    /// Sets the value of [extra_info][crate::model::Error::extra_info].
-    pub fn set_extra_info<T: std::convert::Into<crate::model::error::ErrorExtraInfo>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.extra_info = v.into();
-        self
-    }
-
     /// Sets the value of [timestamps][crate::model::Error::timestamps].
     pub fn set_timestamps<T, V>(mut self, v: T) -> Self
     where
@@ -13916,6 +13907,15 @@ impl Error {
     {
         use std::iter::Iterator;
         self.timestamps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [extra_info][crate::model::Error::extra_info].
+    pub fn set_extra_info<T: std::convert::Into<crate::model::error::ErrorExtraInfo>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.extra_info = v.into();
         self
     }
 }
@@ -14150,6 +14150,28 @@ impl JobTrigger {
         self
     }
 
+    /// Sets the value of [triggers][crate::model::JobTrigger::triggers].
+    pub fn set_triggers<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::job_trigger::Trigger>,
+    {
+        use std::iter::Iterator;
+        self.triggers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [errors][crate::model::JobTrigger::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Error>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::JobTrigger::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -14183,28 +14205,6 @@ impl JobTrigger {
         v: T,
     ) -> Self {
         self.status = v.into();
-        self
-    }
-
-    /// Sets the value of [triggers][crate::model::JobTrigger::triggers].
-    pub fn set_triggers<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::job_trigger::Trigger>,
-    {
-        use std::iter::Iterator;
-        self.triggers = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::JobTrigger::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Error>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -14306,19 +14306,6 @@ pub mod job_trigger {
             })
         }
 
-        /// The value of [trigger][crate::model::job_trigger::Trigger::trigger]
-        /// if it holds a `Manual`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn manual(&self) -> std::option::Option<&std::boxed::Box<crate::model::Manual>> {
-            #[allow(unreachable_patterns)]
-            self.trigger.as_ref().and_then(|v| match v {
-                crate::model::job_trigger::trigger::Trigger::Manual(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [trigger][crate::model::job_trigger::Trigger::trigger]
         /// to hold a `Schedule`.
         ///
@@ -14332,6 +14319,19 @@ pub mod job_trigger {
                 crate::model::job_trigger::trigger::Trigger::Schedule(v.into()),
             );
             self
+        }
+
+        /// The value of [trigger][crate::model::job_trigger::Trigger::trigger]
+        /// if it holds a `Manual`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn manual(&self) -> std::option::Option<&std::boxed::Box<crate::model::Manual>> {
+            #[allow(unreachable_patterns)]
+            self.trigger.as_ref().and_then(|v| match v {
+                crate::model::job_trigger::trigger::Trigger::Manual(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [trigger][crate::model::job_trigger::Trigger::trigger]
@@ -14571,88 +14571,6 @@ impl Action {
         })
     }
 
-    /// The value of [action][crate::model::Action::action]
-    /// if it holds a `PubSub`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pub_sub(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::PublishToPubSub>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::action::Action::PubSub(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Action::action]
-    /// if it holds a `PublishSummaryToCscc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn publish_summary_to_cscc(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::PublishSummaryToCscc>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::action::Action::PublishSummaryToCscc(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Action::action]
-    /// if it holds a `PublishFindingsToCloudDataCatalog`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn publish_findings_to_cloud_data_catalog(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::action::PublishFindingsToCloudDataCatalog>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::action::Action::PublishFindingsToCloudDataCatalog(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Action::action]
-    /// if it holds a `Deidentify`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn deidentify(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::Deidentify>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::action::Action::Deidentify(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Action::action]
-    /// if it holds a `JobNotificationEmails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn job_notification_emails(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::JobNotificationEmails>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::action::Action::JobNotificationEmails(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::Action::action]
-    /// if it holds a `PublishToStackdriver`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn publish_to_stackdriver(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::action::PublishToStackdriver>> {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::action::Action::PublishToStackdriver(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [action][crate::model::Action::action]
     /// to hold a `SaveFindings`.
     ///
@@ -14667,6 +14585,19 @@ impl Action {
         self.action =
             std::option::Option::Some(crate::model::action::Action::SaveFindings(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Action::action]
+    /// if it holds a `PubSub`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pub_sub(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::PublishToPubSub>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::action::Action::PubSub(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Action::action]
@@ -14684,6 +14615,19 @@ impl Action {
         self
     }
 
+    /// The value of [action][crate::model::Action::action]
+    /// if it holds a `PublishSummaryToCscc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn publish_summary_to_cscc(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::PublishSummaryToCscc>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::action::Action::PublishSummaryToCscc(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Action::action]
     /// to hold a `PublishSummaryToCscc`.
     ///
@@ -14698,6 +14642,23 @@ impl Action {
         self.action =
             std::option::Option::Some(crate::model::action::Action::PublishSummaryToCscc(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Action::action]
+    /// if it holds a `PublishFindingsToCloudDataCatalog`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn publish_findings_to_cloud_data_catalog(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::action::PublishFindingsToCloudDataCatalog>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::action::Action::PublishFindingsToCloudDataCatalog(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Action::action]
@@ -14719,6 +14680,19 @@ impl Action {
         self
     }
 
+    /// The value of [action][crate::model::Action::action]
+    /// if it holds a `Deidentify`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn deidentify(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::Deidentify>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::action::Action::Deidentify(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::Action::action]
     /// to hold a `Deidentify`.
     ///
@@ -14732,6 +14706,19 @@ impl Action {
     ) -> Self {
         self.action = std::option::Option::Some(crate::model::action::Action::Deidentify(v.into()));
         self
+    }
+
+    /// The value of [action][crate::model::Action::action]
+    /// if it holds a `JobNotificationEmails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn job_notification_emails(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::JobNotificationEmails>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::action::Action::JobNotificationEmails(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Action::action]
@@ -14749,6 +14736,19 @@ impl Action {
             crate::model::action::Action::JobNotificationEmails(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::Action::action]
+    /// if it holds a `PublishToStackdriver`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn publish_to_stackdriver(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::action::PublishToStackdriver>> {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::action::Action::PublishToStackdriver(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::Action::action]
@@ -15563,12 +15563,6 @@ impl ListInspectTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInspectTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [inspect_templates][crate::model::ListInspectTemplatesResponse::inspect_templates].
     pub fn set_inspect_templates<T, V>(mut self, v: T) -> Self
     where
@@ -15577,6 +15571,12 @@ impl ListInspectTemplatesResponse {
     {
         use std::iter::Iterator;
         self.inspect_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInspectTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -16125,12 +16125,6 @@ impl ListDiscoveryConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDiscoveryConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [discovery_configs][crate::model::ListDiscoveryConfigsResponse::discovery_configs].
     pub fn set_discovery_configs<T, V>(mut self, v: T) -> Self
     where
@@ -16139,6 +16133,12 @@ impl ListDiscoveryConfigsResponse {
     {
         use std::iter::Iterator;
         self.discovery_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDiscoveryConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -16296,19 +16296,6 @@ impl CreateDlpJobRequest {
         })
     }
 
-    /// The value of [job][crate::model::CreateDlpJobRequest::job]
-    /// if it holds a `RiskJob`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn risk_job(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::RiskAnalysisJobConfig>> {
-        #[allow(unreachable_patterns)]
-        self.job.as_ref().and_then(|v| match v {
-            crate::model::create_dlp_job_request::Job::RiskJob(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [job][crate::model::CreateDlpJobRequest::job]
     /// to hold a `InspectJob`.
     ///
@@ -16324,6 +16311,19 @@ impl CreateDlpJobRequest {
             crate::model::create_dlp_job_request::Job::InspectJob(v.into()),
         );
         self
+    }
+
+    /// The value of [job][crate::model::CreateDlpJobRequest::job]
+    /// if it holds a `RiskJob`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn risk_job(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::RiskAnalysisJobConfig>> {
+        #[allow(unreachable_patterns)]
+        self.job.as_ref().and_then(|v| match v {
+            crate::model::create_dlp_job_request::Job::RiskJob(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [job][crate::model::CreateDlpJobRequest::job]
@@ -16539,12 +16539,6 @@ impl ListJobTriggersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListJobTriggersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [job_triggers][crate::model::ListJobTriggersResponse::job_triggers].
     pub fn set_job_triggers<T, V>(mut self, v: T) -> Self
     where
@@ -16553,6 +16547,12 @@ impl ListJobTriggersResponse {
     {
         use std::iter::Iterator;
         self.job_triggers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListJobTriggersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -16740,71 +16740,6 @@ impl DataProfileAction {
         })
     }
 
-    /// The value of [action][crate::model::DataProfileAction::action]
-    /// if it holds a `PubSubNotification`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn pub_sub_notification(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_action::PubSubNotification>>
-    {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::data_profile_action::Action::PubSubNotification(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::DataProfileAction::action]
-    /// if it holds a `PublishToChronicle`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn publish_to_chronicle(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_action::PublishToChronicle>>
-    {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::data_profile_action::Action::PublishToChronicle(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::DataProfileAction::action]
-    /// if it holds a `PublishToScc`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn publish_to_scc(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::data_profile_action::PublishToSecurityCommandCenter>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::data_profile_action::Action::PublishToScc(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [action][crate::model::DataProfileAction::action]
-    /// if it holds a `TagResources`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn tag_resources(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_action::TagResources>>
-    {
-        #[allow(unreachable_patterns)]
-        self.action.as_ref().and_then(|v| match v {
-            crate::model::data_profile_action::Action::TagResources(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [action][crate::model::DataProfileAction::action]
     /// to hold a `ExportData`.
     ///
@@ -16820,6 +16755,22 @@ impl DataProfileAction {
             crate::model::data_profile_action::Action::ExportData(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::DataProfileAction::action]
+    /// if it holds a `PubSubNotification`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn pub_sub_notification(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_action::PubSubNotification>>
+    {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::data_profile_action::Action::PubSubNotification(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::DataProfileAction::action]
@@ -16839,6 +16790,22 @@ impl DataProfileAction {
         self
     }
 
+    /// The value of [action][crate::model::DataProfileAction::action]
+    /// if it holds a `PublishToChronicle`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn publish_to_chronicle(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_action::PublishToChronicle>>
+    {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::data_profile_action::Action::PublishToChronicle(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [action][crate::model::DataProfileAction::action]
     /// to hold a `PublishToChronicle`.
     ///
@@ -16854,6 +16821,23 @@ impl DataProfileAction {
             crate::model::data_profile_action::Action::PublishToChronicle(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::DataProfileAction::action]
+    /// if it holds a `PublishToScc`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn publish_to_scc(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::data_profile_action::PublishToSecurityCommandCenter>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::data_profile_action::Action::PublishToScc(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::DataProfileAction::action]
@@ -16873,6 +16857,22 @@ impl DataProfileAction {
             crate::model::data_profile_action::Action::PublishToScc(v.into()),
         );
         self
+    }
+
+    /// The value of [action][crate::model::DataProfileAction::action]
+    /// if it holds a `TagResources`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn tag_resources(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::data_profile_action::TagResources>>
+    {
+        #[allow(unreachable_patterns)]
+        self.action.as_ref().and_then(|v| match v {
+            crate::model::data_profile_action::Action::TagResources(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [action][crate::model::DataProfileAction::action]
@@ -17310,12 +17310,6 @@ pub mod data_profile_action {
             std::default::Default::default()
         }
 
-        /// Sets the value of [lower_data_risk_to_low][crate::model::data_profile_action::TagResources::lower_data_risk_to_low].
-        pub fn set_lower_data_risk_to_low<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.lower_data_risk_to_low = v.into();
-            self
-        }
-
         /// Sets the value of [tag_conditions][crate::model::data_profile_action::TagResources::tag_conditions].
         pub fn set_tag_conditions<T, V>(mut self, v: T) -> Self
         where
@@ -17335,6 +17329,12 @@ pub mod data_profile_action {
         {
             use std::iter::Iterator;
             self.profile_generations_to_tag = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [lower_data_risk_to_low][crate::model::data_profile_action::TagResources::lower_data_risk_to_low].
+        pub fn set_lower_data_risk_to_low<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+            self.lower_data_risk_to_low = v.into();
             self
         }
     }
@@ -18327,6 +18327,18 @@ impl DataProfileLocation {
         })
     }
 
+    /// Sets the value of [location][crate::model::DataProfileLocation::location]
+    /// to hold a `OrganizationId`.
+    ///
+    /// Note that all the setters affecting `location` are
+    /// mutually exclusive.
+    pub fn set_organization_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.location = std::option::Option::Some(
+            crate::model::data_profile_location::Location::OrganizationId(v.into()),
+        );
+        self
+    }
+
     /// The value of [location][crate::model::DataProfileLocation::location]
     /// if it holds a `FolderId`, `None` if the field is not set or
     /// holds a different branch.
@@ -18338,18 +18350,6 @@ impl DataProfileLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::DataProfileLocation::location]
-    /// to hold a `OrganizationId`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_organization_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::data_profile_location::Location::OrganizationId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [location][crate::model::DataProfileLocation::location]
@@ -18517,6 +18517,50 @@ impl DiscoveryConfig {
         self
     }
 
+    /// Sets the value of [inspect_templates][crate::model::DiscoveryConfig::inspect_templates].
+    pub fn set_inspect_templates<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.inspect_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [actions][crate::model::DiscoveryConfig::actions].
+    pub fn set_actions<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DataProfileAction>,
+    {
+        use std::iter::Iterator;
+        self.actions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [targets][crate::model::DiscoveryConfig::targets].
+    pub fn set_targets<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::DiscoveryTarget>,
+    {
+        use std::iter::Iterator;
+        self.targets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [errors][crate::model::DiscoveryConfig::errors].
+    pub fn set_errors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Error>,
+    {
+        use std::iter::Iterator;
+        self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::DiscoveryConfig::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -18561,50 +18605,6 @@ impl DiscoveryConfig {
         v: T,
     ) -> Self {
         self.processing_location = v.into();
-        self
-    }
-
-    /// Sets the value of [inspect_templates][crate::model::DiscoveryConfig::inspect_templates].
-    pub fn set_inspect_templates<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.inspect_templates = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [actions][crate::model::DiscoveryConfig::actions].
-    pub fn set_actions<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DataProfileAction>,
-    {
-        use std::iter::Iterator;
-        self.actions = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [targets][crate::model::DiscoveryConfig::targets].
-    pub fn set_targets<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::DiscoveryTarget>,
-    {
-        use std::iter::Iterator;
-        self.targets = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [errors][crate::model::DiscoveryConfig::errors].
-    pub fn set_errors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Error>,
-    {
-        use std::iter::Iterator;
-        self.errors = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -18851,81 +18851,6 @@ impl DiscoveryTarget {
         })
     }
 
-    /// The value of [target][crate::model::DiscoveryTarget::target]
-    /// if it holds a `CloudSqlTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_sql_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlDiscoveryTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::discovery_target::Target::CloudSqlTarget(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [target][crate::model::DiscoveryTarget::target]
-    /// if it holds a `SecretsTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn secrets_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::SecretsDiscoveryTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::discovery_target::Target::SecretsTarget(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [target][crate::model::DiscoveryTarget::target]
-    /// if it holds a `CloudStorageTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_storage_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStorageDiscoveryTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::discovery_target::Target::CloudStorageTarget(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [target][crate::model::DiscoveryTarget::target]
-    /// if it holds a `OtherCloudTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn other_cloud_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OtherCloudDiscoveryTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::discovery_target::Target::OtherCloudTarget(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [target][crate::model::DiscoveryTarget::target]
-    /// if it holds a `VertexDatasetTarget`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertex_dataset_target(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexDatasetDiscoveryTarget>> {
-        #[allow(unreachable_patterns)]
-        self.target.as_ref().and_then(|v| match v {
-            crate::model::discovery_target::Target::VertexDatasetTarget(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [target][crate::model::DiscoveryTarget::target]
     /// to hold a `BigQueryTarget`.
     ///
@@ -18941,6 +18866,21 @@ impl DiscoveryTarget {
             crate::model::discovery_target::Target::BigQueryTarget(v.into()),
         );
         self
+    }
+
+    /// The value of [target][crate::model::DiscoveryTarget::target]
+    /// if it holds a `CloudSqlTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_sql_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlDiscoveryTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::discovery_target::Target::CloudSqlTarget(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::DiscoveryTarget::target]
@@ -18960,6 +18900,21 @@ impl DiscoveryTarget {
         self
     }
 
+    /// The value of [target][crate::model::DiscoveryTarget::target]
+    /// if it holds a `SecretsTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn secrets_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::SecretsDiscoveryTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::discovery_target::Target::SecretsTarget(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [target][crate::model::DiscoveryTarget::target]
     /// to hold a `SecretsTarget`.
     ///
@@ -18975,6 +18930,21 @@ impl DiscoveryTarget {
             crate::model::discovery_target::Target::SecretsTarget(v.into()),
         );
         self
+    }
+
+    /// The value of [target][crate::model::DiscoveryTarget::target]
+    /// if it holds a `CloudStorageTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_storage_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStorageDiscoveryTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::discovery_target::Target::CloudStorageTarget(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::DiscoveryTarget::target]
@@ -18994,6 +18964,21 @@ impl DiscoveryTarget {
         self
     }
 
+    /// The value of [target][crate::model::DiscoveryTarget::target]
+    /// if it holds a `OtherCloudTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn other_cloud_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OtherCloudDiscoveryTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::discovery_target::Target::OtherCloudTarget(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [target][crate::model::DiscoveryTarget::target]
     /// to hold a `OtherCloudTarget`.
     ///
@@ -19009,6 +18994,21 @@ impl DiscoveryTarget {
             crate::model::discovery_target::Target::OtherCloudTarget(v.into()),
         );
         self
+    }
+
+    /// The value of [target][crate::model::DiscoveryTarget::target]
+    /// if it holds a `VertexDatasetTarget`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertex_dataset_target(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexDatasetDiscoveryTarget>> {
+        #[allow(unreachable_patterns)]
+        self.target.as_ref().and_then(|v| match v {
+            crate::model::discovery_target::Target::VertexDatasetTarget(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [target][crate::model::DiscoveryTarget::target]
@@ -19157,19 +19157,6 @@ impl BigQueryDiscoveryTarget {
         })
     }
 
-    /// The value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
-    /// if it holds a `Disabled`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
-        #[allow(unreachable_patterns)]
-        self.frequency.as_ref().and_then(|v| match v {
-            crate::model::big_query_discovery_target::Frequency::Disabled(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
     /// to hold a `Cadence`.
     ///
@@ -19185,6 +19172,19 @@ impl BigQueryDiscoveryTarget {
             crate::model::big_query_discovery_target::Frequency::Cadence(v.into()),
         );
         self
+    }
+
+    /// The value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
+    /// if it holds a `Disabled`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
+        #[allow(unreachable_patterns)]
+        self.frequency.as_ref().and_then(|v| match v {
+            crate::model::big_query_discovery_target::Frequency::Disabled(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
@@ -19283,38 +19283,6 @@ impl DiscoveryBigQueryFilter {
         })
     }
 
-    /// The value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
-    /// if it holds a `OtherTables`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn other_tables(
-        &self,
-    ) -> std::option::Option<
-        &std::boxed::Box<crate::model::discovery_big_query_filter::AllOtherBigQueryTables>,
-    > {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_big_query_filter::Filter::OtherTables(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
-    /// if it holds a `TableReference`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn table_reference(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::TableReference>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_big_query_filter::Filter::TableReference(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
     /// to hold a `Tables`.
     ///
@@ -19330,6 +19298,23 @@ impl DiscoveryBigQueryFilter {
             crate::model::discovery_big_query_filter::Filter::Tables(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
+    /// if it holds a `OtherTables`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn other_tables(
+        &self,
+    ) -> std::option::Option<
+        &std::boxed::Box<crate::model::discovery_big_query_filter::AllOtherBigQueryTables>,
+    > {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_big_query_filter::Filter::OtherTables(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
@@ -19349,6 +19334,21 @@ impl DiscoveryBigQueryFilter {
             crate::model::discovery_big_query_filter::Filter::OtherTables(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
+    /// if it holds a `TableReference`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn table_reference(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::TableReference>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_big_query_filter::Filter::TableReference(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
@@ -19607,21 +19607,6 @@ impl DiscoveryBigQueryConditions {
         })
     }
 
-    /// The value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
-    /// if it holds a `TypeCollection`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn type_collection(
-        &self,
-    ) -> std::option::Option<&crate::model::BigQueryTableTypeCollection> {
-        #[allow(unreachable_patterns)]
-        self.included_types.as_ref().and_then(|v| match v {
-            crate::model::discovery_big_query_conditions::IncludedTypes::TypeCollection(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
     /// to hold a `Types`.
     ///
@@ -19635,6 +19620,21 @@ impl DiscoveryBigQueryConditions {
             crate::model::discovery_big_query_conditions::IncludedTypes::Types(v.into()),
         );
         self
+    }
+
+    /// The value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
+    /// if it holds a `TypeCollection`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn type_collection(
+        &self,
+    ) -> std::option::Option<&crate::model::BigQueryTableTypeCollection> {
+        #[allow(unreachable_patterns)]
+        self.included_types.as_ref().and_then(|v| match v {
+            crate::model::discovery_big_query_conditions::IncludedTypes::TypeCollection(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
@@ -19841,15 +19841,6 @@ impl DiscoveryTableModifiedCadence {
         std::default::Default::default()
     }
 
-    /// Sets the value of [frequency][crate::model::DiscoveryTableModifiedCadence::frequency].
-    pub fn set_frequency<T: std::convert::Into<crate::model::DataProfileUpdateFrequency>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.frequency = v.into();
-        self
-    }
-
     /// Sets the value of [types][crate::model::DiscoveryTableModifiedCadence::types].
     pub fn set_types<T, V>(mut self, v: T) -> Self
     where
@@ -19858,6 +19849,15 @@ impl DiscoveryTableModifiedCadence {
     {
         use std::iter::Iterator;
         self.types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [frequency][crate::model::DiscoveryTableModifiedCadence::frequency].
+    pub fn set_frequency<T: std::convert::Into<crate::model::DataProfileUpdateFrequency>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.frequency = v.into();
         self
     }
 }
@@ -19893,15 +19893,6 @@ impl DiscoverySchemaModifiedCadence {
         std::default::Default::default()
     }
 
-    /// Sets the value of [frequency][crate::model::DiscoverySchemaModifiedCadence::frequency].
-    pub fn set_frequency<T: std::convert::Into<crate::model::DataProfileUpdateFrequency>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.frequency = v.into();
-        self
-    }
-
     /// Sets the value of [types][crate::model::DiscoverySchemaModifiedCadence::types].
     pub fn set_types<T, V>(mut self, v: T) -> Self
     where
@@ -19910,6 +19901,15 @@ impl DiscoverySchemaModifiedCadence {
     {
         use std::iter::Iterator;
         self.types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [frequency][crate::model::DiscoverySchemaModifiedCadence::frequency].
+    pub fn set_frequency<T: std::convert::Into<crate::model::DataProfileUpdateFrequency>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.frequency = v.into();
         self
     }
 }
@@ -20037,19 +20037,6 @@ impl CloudSqlDiscoveryTarget {
         })
     }
 
-    /// The value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
-    /// if it holds a `Disabled`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
-        #[allow(unreachable_patterns)]
-        self.cadence.as_ref().and_then(|v| match v {
-            crate::model::cloud_sql_discovery_target::Cadence::Disabled(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
     /// to hold a `GenerationCadence`.
     ///
@@ -20065,6 +20052,19 @@ impl CloudSqlDiscoveryTarget {
             crate::model::cloud_sql_discovery_target::Cadence::GenerationCadence(v.into()),
         );
         self
+    }
+
+    /// The value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
+    /// if it holds a `Disabled`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
+        #[allow(unreachable_patterns)]
+        self.cadence.as_ref().and_then(|v| match v {
+            crate::model::cloud_sql_discovery_target::Cadence::Disabled(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
@@ -20161,36 +20161,6 @@ impl DiscoveryCloudSqlFilter {
         })
     }
 
-    /// The value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
-    /// if it holds a `Others`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn others(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherDatabaseResources>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_cloud_sql_filter::Filter::Others(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
-    /// if it holds a `DatabaseResourceReference`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn database_resource_reference(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::DatabaseResourceReference>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_cloud_sql_filter::Filter::DatabaseResourceReference(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
     /// to hold a `Collection`.
     ///
@@ -20208,6 +20178,21 @@ impl DiscoveryCloudSqlFilter {
         self
     }
 
+    /// The value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
+    /// if it holds a `Others`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn others(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherDatabaseResources>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_cloud_sql_filter::Filter::Others(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
     /// to hold a `Others`.
     ///
@@ -20223,6 +20208,21 @@ impl DiscoveryCloudSqlFilter {
             crate::model::discovery_cloud_sql_filter::Filter::Others(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
+    /// if it holds a `DatabaseResourceReference`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn database_resource_reference(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::DatabaseResourceReference>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_cloud_sql_filter::Filter::DatabaseResourceReference(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
@@ -21025,15 +21025,6 @@ pub mod discovery_cloud_sql_generation_cadence {
             std::default::Default::default()
         }
 
-        /// Sets the value of [frequency][crate::model::discovery_cloud_sql_generation_cadence::SchemaModifiedCadence::frequency].
-        pub fn set_frequency<T: std::convert::Into<crate::model::DataProfileUpdateFrequency>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.frequency = v.into();
-            self
-        }
-
         /// Sets the value of [types][crate::model::discovery_cloud_sql_generation_cadence::SchemaModifiedCadence::types].
         pub fn set_types<T, V>(mut self, v: T) -> Self
         where
@@ -21042,6 +21033,15 @@ pub mod discovery_cloud_sql_generation_cadence {
         {
             use std::iter::Iterator;
             self.types = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [frequency][crate::model::discovery_cloud_sql_generation_cadence::SchemaModifiedCadence::frequency].
+        pub fn set_frequency<T: std::convert::Into<crate::model::DataProfileUpdateFrequency>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.frequency = v.into();
             self
         }
     }
@@ -21311,19 +21311,6 @@ impl CloudStorageDiscoveryTarget {
         })
     }
 
-    /// The value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
-    /// if it holds a `Disabled`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
-        #[allow(unreachable_patterns)]
-        self.cadence.as_ref().and_then(|v| match v {
-            crate::model::cloud_storage_discovery_target::Cadence::Disabled(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
     /// to hold a `GenerationCadence`.
     ///
@@ -21339,6 +21326,19 @@ impl CloudStorageDiscoveryTarget {
             crate::model::cloud_storage_discovery_target::Cadence::GenerationCadence(v.into()),
         );
         self
+    }
+
+    /// The value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
+    /// if it holds a `Disabled`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
+        #[allow(unreachable_patterns)]
+        self.cadence.as_ref().and_then(|v| match v {
+            crate::model::cloud_storage_discovery_target::Cadence::Disabled(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
@@ -21437,34 +21437,6 @@ impl DiscoveryCloudStorageFilter {
         })
     }
 
-    /// The value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
-    /// if it holds a `CloudStorageResourceReference`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_storage_resource_reference(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStorageResourceReference>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_cloud_storage_filter::Filter::CloudStorageResourceReference(
-                v,
-            ) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
-    /// if it holds a `Others`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn others(&self) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherResources>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_cloud_storage_filter::Filter::Others(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
     /// to hold a `Collection`.
     ///
@@ -21480,6 +21452,21 @@ impl DiscoveryCloudStorageFilter {
             crate::model::discovery_cloud_storage_filter::Filter::Collection(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
+    /// if it holds a `CloudStorageResourceReference`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_storage_resource_reference(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStorageResourceReference>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_cloud_storage_filter::Filter::CloudStorageResourceReference(
+                v,
+            ) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
@@ -21499,6 +21486,19 @@ impl DiscoveryCloudStorageFilter {
             ),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
+    /// if it holds a `Others`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn others(&self) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherResources>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_cloud_storage_filter::Filter::Others(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
@@ -22550,19 +22550,6 @@ impl OtherCloudDiscoveryTarget {
         })
     }
 
-    /// The value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
-    /// if it holds a `Disabled`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
-        #[allow(unreachable_patterns)]
-        self.cadence.as_ref().and_then(|v| match v {
-            crate::model::other_cloud_discovery_target::Cadence::Disabled(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
     /// to hold a `GenerationCadence`.
     ///
@@ -22578,6 +22565,19 @@ impl OtherCloudDiscoveryTarget {
             crate::model::other_cloud_discovery_target::Cadence::GenerationCadence(v.into()),
         );
         self
+    }
+
+    /// The value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
+    /// if it holds a `Disabled`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
+        #[allow(unreachable_patterns)]
+        self.cadence.as_ref().and_then(|v| match v {
+            crate::model::other_cloud_discovery_target::Cadence::Disabled(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
@@ -22672,35 +22672,6 @@ impl DiscoveryOtherCloudFilter {
         })
     }
 
-    /// The value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
-    /// if it holds a `SingleResource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn single_resource(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::OtherCloudSingleResourceReference>>
-    {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_other_cloud_filter::Filter::SingleResource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
-    /// if it holds a `Others`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn others(&self) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherResources>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_other_cloud_filter::Filter::Others(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
     /// to hold a `Collection`.
     ///
@@ -22718,6 +22689,22 @@ impl DiscoveryOtherCloudFilter {
         self
     }
 
+    /// The value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
+    /// if it holds a `SingleResource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn single_resource(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::OtherCloudSingleResourceReference>>
+    {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_other_cloud_filter::Filter::SingleResource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
     /// to hold a `SingleResource`.
     ///
@@ -22733,6 +22720,19 @@ impl DiscoveryOtherCloudFilter {
             crate::model::discovery_other_cloud_filter::Filter::SingleResource(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
+    /// if it holds a `Others`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn others(&self) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherResources>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_other_cloud_filter::Filter::Others(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
@@ -23823,6 +23823,18 @@ impl DiscoveryStartingLocation {
         })
     }
 
+    /// Sets the value of [location][crate::model::DiscoveryStartingLocation::location]
+    /// to hold a `OrganizationId`.
+    ///
+    /// Note that all the setters affecting `location` are
+    /// mutually exclusive.
+    pub fn set_organization_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.location = std::option::Option::Some(
+            crate::model::discovery_starting_location::Location::OrganizationId(v.into()),
+        );
+        self
+    }
+
     /// The value of [location][crate::model::DiscoveryStartingLocation::location]
     /// if it holds a `FolderId`, `None` if the field is not set or
     /// holds a different branch.
@@ -23834,18 +23846,6 @@ impl DiscoveryStartingLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::DiscoveryStartingLocation::location]
-    /// to hold a `OrganizationId`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_organization_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::discovery_starting_location::Location::OrganizationId(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [location][crate::model::DiscoveryStartingLocation::location]
@@ -24006,17 +24006,6 @@ pub mod other_cloud_discovery_starting_location {
             })
         }
 
-        /// The value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
-        /// if it holds a `AllAssetInventoryAssets`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn all_asset_inventory_assets(&self) -> std::option::Option<&bool> {
-            #[allow(unreachable_patterns)]
-            self.scope.as_ref().and_then(|v| match v {
-                crate::model::other_cloud_discovery_starting_location::aws_discovery_starting_location::Scope::AllAssetInventoryAssets(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
         /// to hold a `AccountId`.
         ///
@@ -24029,6 +24018,17 @@ pub mod other_cloud_discovery_starting_location {
                 )
             );
             self
+        }
+
+        /// The value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
+        /// if it holds a `AllAssetInventoryAssets`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn all_asset_inventory_assets(&self) -> std::option::Option<&bool> {
+            #[allow(unreachable_patterns)]
+            self.scope.as_ref().and_then(|v| match v {
+                crate::model::other_cloud_discovery_starting_location::aws_discovery_starting_location::Scope::AllAssetInventoryAssets(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
@@ -24192,19 +24192,6 @@ impl VertexDatasetDiscoveryTarget {
         })
     }
 
-    /// The value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
-    /// if it holds a `Disabled`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
-        #[allow(unreachable_patterns)]
-        self.cadence.as_ref().and_then(|v| match v {
-            crate::model::vertex_dataset_discovery_target::Cadence::Disabled(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
     /// to hold a `GenerationCadence`.
     ///
@@ -24220,6 +24207,19 @@ impl VertexDatasetDiscoveryTarget {
             crate::model::vertex_dataset_discovery_target::Cadence::GenerationCadence(v.into()),
         );
         self
+    }
+
+    /// The value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
+    /// if it holds a `Disabled`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn disabled(&self) -> std::option::Option<&std::boxed::Box<crate::model::Disabled>> {
+        #[allow(unreachable_patterns)]
+        self.cadence.as_ref().and_then(|v| match v {
+            crate::model::vertex_dataset_discovery_target::Cadence::Disabled(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
@@ -24318,32 +24318,6 @@ impl DiscoveryVertexDatasetFilter {
         })
     }
 
-    /// The value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
-    /// if it holds a `VertexDatasetResourceReference`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn vertex_dataset_resource_reference(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexDatasetResourceReference>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_vertex_dataset_filter::Filter::VertexDatasetResourceReference(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
-    /// if it holds a `Others`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn others(&self) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherResources>> {
-        #[allow(unreachable_patterns)]
-        self.filter.as_ref().and_then(|v| match v {
-            crate::model::discovery_vertex_dataset_filter::Filter::Others(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
     /// to hold a `Collection`.
     ///
@@ -24359,6 +24333,19 @@ impl DiscoveryVertexDatasetFilter {
             crate::model::discovery_vertex_dataset_filter::Filter::Collection(v.into()),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
+    /// if it holds a `VertexDatasetResourceReference`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn vertex_dataset_resource_reference(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::VertexDatasetResourceReference>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_vertex_dataset_filter::Filter::VertexDatasetResourceReference(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
@@ -24378,6 +24365,19 @@ impl DiscoveryVertexDatasetFilter {
             ),
         );
         self
+    }
+
+    /// The value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
+    /// if it holds a `Others`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn others(&self) -> std::option::Option<&std::boxed::Box<crate::model::AllOtherResources>> {
+        #[allow(unreachable_patterns)]
+        self.filter.as_ref().and_then(|v| match v {
+            crate::model::discovery_vertex_dataset_filter::Filter::Others(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
@@ -24915,19 +24915,6 @@ impl DlpJob {
         })
     }
 
-    /// The value of [details][crate::model::DlpJob::details]
-    /// if it holds a `InspectDetails`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn inspect_details(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::InspectDataSourceDetails>> {
-        #[allow(unreachable_patterns)]
-        self.details.as_ref().and_then(|v| match v {
-            crate::model::dlp_job::Details::InspectDetails(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [details][crate::model::DlpJob::details]
     /// to hold a `RiskDetails`.
     ///
@@ -24942,6 +24929,19 @@ impl DlpJob {
         self.details =
             std::option::Option::Some(crate::model::dlp_job::Details::RiskDetails(v.into()));
         self
+    }
+
+    /// The value of [details][crate::model::DlpJob::details]
+    /// if it holds a `InspectDetails`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn inspect_details(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::InspectDataSourceDetails>> {
+        #[allow(unreachable_patterns)]
+        self.details.as_ref().and_then(|v| match v {
+            crate::model::dlp_job::Details::InspectDetails(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [details][crate::model::DlpJob::details]
@@ -25354,12 +25354,6 @@ impl ListDlpJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDlpJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [jobs][crate::model::ListDlpJobsResponse::jobs].
     pub fn set_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -25368,6 +25362,12 @@ impl ListDlpJobsResponse {
     {
         use std::iter::Iterator;
         self.jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDlpJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -25808,12 +25808,6 @@ impl ListDeidentifyTemplatesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDeidentifyTemplatesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [deidentify_templates][crate::model::ListDeidentifyTemplatesResponse::deidentify_templates].
     pub fn set_deidentify_templates<T, V>(mut self, v: T) -> Self
     where
@@ -25822,6 +25816,12 @@ impl ListDeidentifyTemplatesResponse {
     {
         use std::iter::Iterator;
         self.deidentify_templates = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDeidentifyTemplatesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -25954,21 +25954,6 @@ impl LargeCustomDictionaryConfig {
         })
     }
 
-    /// The value of [source][crate::model::LargeCustomDictionaryConfig::source]
-    /// if it holds a `BigQueryField`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn big_query_field(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryField>> {
-        #[allow(unreachable_patterns)]
-        self.source.as_ref().and_then(|v| match v {
-            crate::model::large_custom_dictionary_config::Source::BigQueryField(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [source][crate::model::LargeCustomDictionaryConfig::source]
     /// to hold a `CloudStorageFileSet`.
     ///
@@ -25984,6 +25969,21 @@ impl LargeCustomDictionaryConfig {
             crate::model::large_custom_dictionary_config::Source::CloudStorageFileSet(v.into()),
         );
         self
+    }
+
+    /// The value of [source][crate::model::LargeCustomDictionaryConfig::source]
+    /// if it holds a `BigQueryField`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn big_query_field(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryField>> {
+        #[allow(unreachable_patterns)]
+        self.source.as_ref().and_then(|v| match v {
+            crate::model::large_custom_dictionary_config::Source::BigQueryField(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [source][crate::model::LargeCustomDictionaryConfig::source]
@@ -26130,34 +26130,6 @@ impl StoredInfoTypeConfig {
         })
     }
 
-    /// The value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
-    /// if it holds a `Dictionary`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn dictionary(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Dictionary>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::stored_info_type_config::Type::Dictionary(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
-    /// if it holds a `Regex`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn regex(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Regex>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::stored_info_type_config::Type::Regex(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
     /// to hold a `LargeCustomDictionary`.
     ///
@@ -26175,6 +26147,21 @@ impl StoredInfoTypeConfig {
         self
     }
 
+    /// The value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
+    /// if it holds a `Dictionary`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn dictionary(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Dictionary>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::stored_info_type_config::Type::Dictionary(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
     /// to hold a `Dictionary`.
     ///
@@ -26190,6 +26177,19 @@ impl StoredInfoTypeConfig {
             crate::model::stored_info_type_config::Type::Dictionary(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
+    /// if it holds a `Regex`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn regex(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Regex>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::stored_info_type_config::Type::Regex(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
@@ -26399,17 +26399,6 @@ impl StoredInfoTypeVersion {
         self
     }
 
-    /// Sets the value of [stats][crate::model::StoredInfoTypeVersion::stats].
-    pub fn set_stats<
-        T: std::convert::Into<std::option::Option<crate::model::StoredInfoTypeStats>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.stats = v.into();
-        self
-    }
-
     /// Sets the value of [errors][crate::model::StoredInfoTypeVersion::errors].
     pub fn set_errors<T, V>(mut self, v: T) -> Self
     where
@@ -26418,6 +26407,17 @@ impl StoredInfoTypeVersion {
     {
         use std::iter::Iterator;
         self.errors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [stats][crate::model::StoredInfoTypeVersion::stats].
+    pub fn set_stats<
+        T: std::convert::Into<std::option::Option<crate::model::StoredInfoTypeStats>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.stats = v.into();
         self
     }
 }
@@ -26812,12 +26812,6 @@ impl ListStoredInfoTypesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListStoredInfoTypesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [stored_info_types][crate::model::ListStoredInfoTypesResponse::stored_info_types].
     pub fn set_stored_info_types<T, V>(mut self, v: T) -> Self
     where
@@ -26826,6 +26820,12 @@ impl ListStoredInfoTypesResponse {
     {
         use std::iter::Iterator;
         self.stored_info_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListStoredInfoTypesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -27300,12 +27300,6 @@ impl ListProjectDataProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListProjectDataProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [project_data_profiles][crate::model::ListProjectDataProfilesResponse::project_data_profiles].
     pub fn set_project_data_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -27314,6 +27308,12 @@ impl ListProjectDataProfilesResponse {
     {
         use std::iter::Iterator;
         self.project_data_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListProjectDataProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -27483,12 +27483,6 @@ impl ListTableDataProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTableDataProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [table_data_profiles][crate::model::ListTableDataProfilesResponse::table_data_profiles].
     pub fn set_table_data_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -27497,6 +27491,12 @@ impl ListTableDataProfilesResponse {
     {
         use std::iter::Iterator;
         self.table_data_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTableDataProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -27667,12 +27667,6 @@ impl ListColumnDataProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListColumnDataProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [column_data_profiles][crate::model::ListColumnDataProfilesResponse::column_data_profiles].
     pub fn set_column_data_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -27681,6 +27675,12 @@ impl ListColumnDataProfilesResponse {
     {
         use std::iter::Iterator;
         self.column_data_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListColumnDataProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -28369,6 +28369,28 @@ impl TableDataProfile {
         self
     }
 
+    /// Sets the value of [predicted_info_types][crate::model::TableDataProfile::predicted_info_types].
+    pub fn set_predicted_info_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::InfoTypeSummary>,
+    {
+        use std::iter::Iterator;
+        self.predicted_info_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [other_info_types][crate::model::TableDataProfile::other_info_types].
+    pub fn set_other_info_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::OtherInfoTypeSummary>,
+    {
+        use std::iter::Iterator;
+        self.other_info_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [config_snapshot][crate::model::TableDataProfile::config_snapshot].
     pub fn set_config_snapshot<
         T: std::convert::Into<std::option::Option<crate::model::DataProfileConfigSnapshot>>,
@@ -28451,6 +28473,18 @@ impl TableDataProfile {
         self
     }
 
+    /// Sets the value of [resource_labels][crate::model::TableDataProfile::resource_labels].
+    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [create_time][crate::model::TableDataProfile::create_time].
     pub fn set_create_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -28468,28 +28502,6 @@ impl TableDataProfile {
         v: T,
     ) -> Self {
         self.sample_findings_table = v.into();
-        self
-    }
-
-    /// Sets the value of [predicted_info_types][crate::model::TableDataProfile::predicted_info_types].
-    pub fn set_predicted_info_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::InfoTypeSummary>,
-    {
-        use std::iter::Iterator;
-        self.predicted_info_types = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [other_info_types][crate::model::TableDataProfile::other_info_types].
-    pub fn set_other_info_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::OtherInfoTypeSummary>,
-    {
-        use std::iter::Iterator;
-        self.other_info_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -28512,18 +28524,6 @@ impl TableDataProfile {
     {
         use std::iter::Iterator;
         self.related_resources = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [resource_labels][crate::model::TableDataProfile::resource_labels].
-    pub fn set_resource_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -29050,6 +29050,17 @@ impl ColumnDataProfile {
         self
     }
 
+    /// Sets the value of [other_matches][crate::model::ColumnDataProfile::other_matches].
+    pub fn set_other_matches<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::OtherInfoTypeSummary>,
+    {
+        use std::iter::Iterator;
+        self.other_matches = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [estimated_null_percentage][crate::model::ColumnDataProfile::estimated_null_percentage].
     pub fn set_estimated_null_percentage<
         T: std::convert::Into<crate::model::NullPercentageLevel>,
@@ -29097,17 +29108,6 @@ impl ColumnDataProfile {
         v: T,
     ) -> Self {
         self.policy_state = v.into();
-        self
-    }
-
-    /// Sets the value of [other_matches][crate::model::ColumnDataProfile::other_matches].
-    pub fn set_other_matches<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::OtherInfoTypeSummary>,
-    {
-        use std::iter::Iterator;
-        self.other_matches = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -29818,6 +29818,17 @@ impl FileStoreDataProfile {
         self
     }
 
+    /// Sets the value of [data_storage_locations][crate::model::FileStoreDataProfile::data_storage_locations].
+    pub fn set_data_storage_locations<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.data_storage_locations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [location_type][crate::model::FileStoreDataProfile::location_type].
     pub fn set_location_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location_type = v.into();
@@ -29927,34 +29938,6 @@ impl FileStoreDataProfile {
         self
     }
 
-    /// Sets the value of [sample_findings_table][crate::model::FileStoreDataProfile::sample_findings_table].
-    pub fn set_sample_findings_table<
-        T: std::convert::Into<std::option::Option<crate::model::BigQueryTable>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sample_findings_table = v.into();
-        self
-    }
-
-    /// Sets the value of [file_store_is_empty][crate::model::FileStoreDataProfile::file_store_is_empty].
-    pub fn set_file_store_is_empty<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.file_store_is_empty = v.into();
-        self
-    }
-
-    /// Sets the value of [data_storage_locations][crate::model::FileStoreDataProfile::data_storage_locations].
-    pub fn set_data_storage_locations<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.data_storage_locations = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [file_cluster_summaries][crate::model::FileStoreDataProfile::file_cluster_summaries].
     pub fn set_file_cluster_summaries<T, V>(mut self, v: T) -> Self
     where
@@ -29963,39 +29946,6 @@ impl FileStoreDataProfile {
     {
         use std::iter::Iterator;
         self.file_cluster_summaries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [file_store_info_type_summaries][crate::model::FileStoreDataProfile::file_store_info_type_summaries].
-    pub fn set_file_store_info_type_summaries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FileStoreInfoTypeSummary>,
-    {
-        use std::iter::Iterator;
-        self.file_store_info_type_summaries = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [tags][crate::model::FileStoreDataProfile::tags].
-    pub fn set_tags<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::Tag>,
-    {
-        use std::iter::Iterator;
-        self.tags = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [related_resources][crate::model::FileStoreDataProfile::related_resources].
-    pub fn set_related_resources<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::RelatedResource>,
-    {
-        use std::iter::Iterator;
-        self.related_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -30020,6 +29970,56 @@ impl FileStoreDataProfile {
     {
         use std::iter::Iterator;
         self.resource_labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [file_store_info_type_summaries][crate::model::FileStoreDataProfile::file_store_info_type_summaries].
+    pub fn set_file_store_info_type_summaries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FileStoreInfoTypeSummary>,
+    {
+        use std::iter::Iterator;
+        self.file_store_info_type_summaries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [sample_findings_table][crate::model::FileStoreDataProfile::sample_findings_table].
+    pub fn set_sample_findings_table<
+        T: std::convert::Into<std::option::Option<crate::model::BigQueryTable>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.sample_findings_table = v.into();
+        self
+    }
+
+    /// Sets the value of [file_store_is_empty][crate::model::FileStoreDataProfile::file_store_is_empty].
+    pub fn set_file_store_is_empty<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.file_store_is_empty = v.into();
+        self
+    }
+
+    /// Sets the value of [tags][crate::model::FileStoreDataProfile::tags].
+    pub fn set_tags<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::Tag>,
+    {
+        use std::iter::Iterator;
+        self.tags = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [related_resources][crate::model::FileStoreDataProfile::related_resources].
+    pub fn set_related_resources<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::RelatedResource>,
+    {
+        use std::iter::Iterator;
+        self.related_resources = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -30400,6 +30400,17 @@ impl FileClusterSummary {
         self
     }
 
+    /// Sets the value of [file_store_info_type_summaries][crate::model::FileClusterSummary::file_store_info_type_summaries].
+    pub fn set_file_store_info_type_summaries<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FileStoreInfoTypeSummary>,
+    {
+        use std::iter::Iterator;
+        self.file_store_info_type_summaries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [sensitivity_score][crate::model::FileClusterSummary::sensitivity_score].
     pub fn set_sensitivity_score<
         T: std::convert::Into<std::option::Option<crate::model::SensitivityScore>>,
@@ -30419,23 +30430,6 @@ impl FileClusterSummary {
         v: T,
     ) -> Self {
         self.data_risk_level = v.into();
-        self
-    }
-
-    /// Sets the value of [no_files_exist][crate::model::FileClusterSummary::no_files_exist].
-    pub fn set_no_files_exist<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.no_files_exist = v.into();
-        self
-    }
-
-    /// Sets the value of [file_store_info_type_summaries][crate::model::FileClusterSummary::file_store_info_type_summaries].
-    pub fn set_file_store_info_type_summaries<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FileStoreInfoTypeSummary>,
-    {
-        use std::iter::Iterator;
-        self.file_store_info_type_summaries = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -30469,6 +30463,12 @@ impl FileClusterSummary {
     {
         use std::iter::Iterator;
         self.file_extensions_seen = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [no_files_exist][crate::model::FileClusterSummary::no_files_exist].
+    pub fn set_no_files_exist<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.no_files_exist = v.into();
         self
     }
 }
@@ -30696,12 +30696,6 @@ impl ListFileStoreDataProfilesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListFileStoreDataProfilesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [file_store_data_profiles][crate::model::ListFileStoreDataProfilesResponse::file_store_data_profiles].
     pub fn set_file_store_data_profiles<T, V>(mut self, v: T) -> Self
     where
@@ -30710,6 +30704,12 @@ impl ListFileStoreDataProfilesResponse {
     {
         use std::iter::Iterator;
         self.file_store_data_profiles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListFileStoreDataProfilesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -30932,20 +30932,6 @@ pub mod data_profile_pub_sub_condition {
             })
         }
 
-        /// The value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
-        /// if it holds a `MinimumSensitivityScore`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn minimum_sensitivity_score(
-            &self,
-        ) -> std::option::Option<&crate::model::data_profile_pub_sub_condition::ProfileScoreBucket>
-        {
-            #[allow(unreachable_patterns)]
-            self.value.as_ref().and_then(|v| match v {
-                crate::model::data_profile_pub_sub_condition::pub_sub_condition::Value::MinimumSensitivityScore(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
         /// to hold a `MinimumRiskScore`.
         ///
@@ -30963,6 +30949,20 @@ pub mod data_profile_pub_sub_condition {
                 )
             );
             self
+        }
+
+        /// The value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
+        /// if it holds a `MinimumSensitivityScore`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn minimum_sensitivity_score(
+            &self,
+        ) -> std::option::Option<&crate::model::data_profile_pub_sub_condition::ProfileScoreBucket>
+        {
+            #[allow(unreachable_patterns)]
+            self.value.as_ref().and_then(|v| match v {
+                crate::model::data_profile_pub_sub_condition::pub_sub_condition::Value::MinimumSensitivityScore(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
@@ -31642,12 +31642,6 @@ impl ListConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connections][crate::model::ListConnectionsResponse::connections].
     pub fn set_connections<T, V>(mut self, v: T) -> Self
     where
@@ -31656,6 +31650,12 @@ impl ListConnectionsResponse {
     {
         use std::iter::Iterator;
         self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -31706,12 +31706,6 @@ impl SearchConnectionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchConnectionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [connections][crate::model::SearchConnectionsResponse::connections].
     pub fn set_connections<T, V>(mut self, v: T) -> Self
     where
@@ -31720,6 +31714,12 @@ impl SearchConnectionsResponse {
     {
         use std::iter::Iterator;
         self.connections = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchConnectionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -32124,21 +32124,6 @@ impl CloudSqlProperties {
         })
     }
 
-    /// The value of [credential][crate::model::CloudSqlProperties::credential]
-    /// if it holds a `CloudSqlIam`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_sql_iam(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlIamCredential>> {
-        #[allow(unreachable_patterns)]
-        self.credential.as_ref().and_then(|v| match v {
-            crate::model::cloud_sql_properties::Credential::CloudSqlIam(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [credential][crate::model::CloudSqlProperties::credential]
     /// to hold a `UsernamePassword`.
     ///
@@ -32154,6 +32139,21 @@ impl CloudSqlProperties {
             crate::model::cloud_sql_properties::Credential::UsernamePassword(v.into()),
         );
         self
+    }
+
+    /// The value of [credential][crate::model::CloudSqlProperties::credential]
+    /// if it holds a `CloudSqlIam`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_sql_iam(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudSqlIamCredential>> {
+        #[allow(unreachable_patterns)]
+        self.credential.as_ref().and_then(|v| match v {
+            crate::model::cloud_sql_properties::Credential::CloudSqlIam(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [credential][crate::model::CloudSqlProperties::credential]
@@ -33202,6 +33202,17 @@ impl CustomInfoType {
         self
     }
 
+    /// Sets the value of [detection_rules][crate::model::CustomInfoType::detection_rules].
+    pub fn set_detection_rules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::custom_info_type::DetectionRule>,
+    {
+        use std::iter::Iterator;
+        self.detection_rules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [exclusion_type][crate::model::CustomInfoType::exclusion_type].
     pub fn set_exclusion_type<
         T: std::convert::Into<crate::model::custom_info_type::ExclusionType>,
@@ -33221,17 +33232,6 @@ impl CustomInfoType {
         v: T,
     ) -> Self {
         self.sensitivity_score = v.into();
-        self
-    }
-
-    /// Sets the value of [detection_rules][crate::model::CustomInfoType::detection_rules].
-    pub fn set_detection_rules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::custom_info_type::DetectionRule>,
-    {
-        use std::iter::Iterator;
-        self.detection_rules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -33262,43 +33262,6 @@ impl CustomInfoType {
         })
     }
 
-    /// The value of [r#type][crate::model::CustomInfoType::r#type]
-    /// if it holds a `Regex`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn regex(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Regex>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::custom_info_type::Type::Regex(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::CustomInfoType::r#type]
-    /// if it holds a `SurrogateType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn surrogate_type(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::SurrogateType>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::custom_info_type::Type::SurrogateType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::CustomInfoType::r#type]
-    /// if it holds a `StoredType`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn stored_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::StoredType>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::custom_info_type::Type::StoredType(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
     /// to hold a `Dictionary`.
     ///
@@ -33313,6 +33276,19 @@ impl CustomInfoType {
         self.r#type =
             std::option::Option::Some(crate::model::custom_info_type::Type::Dictionary(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::CustomInfoType::r#type]
+    /// if it holds a `Regex`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn regex(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::Regex>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::custom_info_type::Type::Regex(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
@@ -33331,6 +33307,19 @@ impl CustomInfoType {
         self
     }
 
+    /// The value of [r#type][crate::model::CustomInfoType::r#type]
+    /// if it holds a `SurrogateType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn surrogate_type(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::custom_info_type::SurrogateType>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::custom_info_type::Type::SurrogateType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
     /// to hold a `SurrogateType`.
     ///
@@ -33346,6 +33335,17 @@ impl CustomInfoType {
             crate::model::custom_info_type::Type::SurrogateType(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::CustomInfoType::r#type]
+    /// if it holds a `StoredType`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn stored_type(&self) -> std::option::Option<&std::boxed::Box<crate::model::StoredType>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::custom_info_type::Type::StoredType(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
@@ -33448,21 +33448,6 @@ pub mod custom_info_type {
             })
         }
 
-        /// The value of [source][crate::model::custom_info_type::Dictionary::source]
-        /// if it holds a `CloudStoragePath`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn cloud_storage_path(
-            &self,
-        ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStoragePath>> {
-            #[allow(unreachable_patterns)]
-            self.source.as_ref().and_then(|v| match v {
-                crate::model::custom_info_type::dictionary::Source::CloudStoragePath(v) => {
-                    std::option::Option::Some(v)
-                }
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [source][crate::model::custom_info_type::Dictionary::source]
         /// to hold a `WordList`.
         ///
@@ -33480,6 +33465,21 @@ pub mod custom_info_type {
                 crate::model::custom_info_type::dictionary::Source::WordList(v.into()),
             );
             self
+        }
+
+        /// The value of [source][crate::model::custom_info_type::Dictionary::source]
+        /// if it holds a `CloudStoragePath`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn cloud_storage_path(
+            &self,
+        ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStoragePath>> {
+            #[allow(unreachable_patterns)]
+            self.source.as_ref().and_then(|v| match v {
+                crate::model::custom_info_type::dictionary::Source::CloudStoragePath(v) => {
+                    std::option::Option::Some(v)
+                }
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [source][crate::model::custom_info_type::Dictionary::source]
@@ -33818,17 +33818,6 @@ pub mod custom_info_type {
                 })
             }
 
-            /// The value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
-            /// if it holds a `RelativeLikelihood`, `None` if the field is not set or
-            /// holds a different branch.
-            pub fn relative_likelihood(&self) -> std::option::Option<&i32> {
-                #[allow(unreachable_patterns)]
-                self.adjustment.as_ref().and_then(|v| match v {
-                    crate::model::custom_info_type::detection_rule::likelihood_adjustment::Adjustment::RelativeLikelihood(v) => std::option::Option::Some(v),
-                    _ => std::option::Option::None,
-                })
-            }
-
             /// Sets the value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
             /// to hold a `FixedLikelihood`.
             ///
@@ -33844,6 +33833,17 @@ pub mod custom_info_type {
                     )
                 );
                 self
+            }
+
+            /// The value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
+            /// if it holds a `RelativeLikelihood`, `None` if the field is not set or
+            /// holds a different branch.
+            pub fn relative_likelihood(&self) -> std::option::Option<&i32> {
+                #[allow(unreachable_patterns)]
+                self.adjustment.as_ref().and_then(|v| match v {
+                    crate::model::custom_info_type::detection_rule::likelihood_adjustment::Adjustment::RelativeLikelihood(v) => std::option::Option::Some(v),
+                    _ => std::option::Option::None,
+                })
             }
 
             /// Sets the value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
@@ -34491,6 +34491,17 @@ impl CloudStorageOptions {
         self
     }
 
+    /// Sets the value of [file_types][crate::model::CloudStorageOptions::file_types].
+    pub fn set_file_types<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FileType>,
+    {
+        use std::iter::Iterator;
+        self.file_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [sample_method][crate::model::CloudStorageOptions::sample_method].
     pub fn set_sample_method<
         T: std::convert::Into<crate::model::cloud_storage_options::SampleMethod>,
@@ -34505,17 +34516,6 @@ impl CloudStorageOptions {
     /// Sets the value of [files_limit_percent][crate::model::CloudStorageOptions::files_limit_percent].
     pub fn set_files_limit_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
         self.files_limit_percent = v.into();
-        self
-    }
-
-    /// Sets the value of [file_types][crate::model::CloudStorageOptions::file_types].
-    pub fn set_file_types<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FileType>,
-    {
-        use std::iter::Iterator;
-        self.file_types = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -34867,6 +34867,17 @@ impl BigQueryOptions {
         self
     }
 
+    /// Sets the value of [identifying_fields][crate::model::BigQueryOptions::identifying_fields].
+    pub fn set_identifying_fields<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::FieldId>,
+    {
+        use std::iter::Iterator;
+        self.identifying_fields = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [rows_limit][crate::model::BigQueryOptions::rows_limit].
     pub fn set_rows_limit<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
         self.rows_limit = v.into();
@@ -34887,17 +34898,6 @@ impl BigQueryOptions {
         v: T,
     ) -> Self {
         self.sample_method = v.into();
-        self
-    }
-
-    /// Sets the value of [identifying_fields][crate::model::BigQueryOptions::identifying_fields].
-    pub fn set_identifying_fields<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::FieldId>,
-    {
-        use std::iter::Iterator;
-        self.identifying_fields = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -35133,47 +35133,6 @@ impl StorageConfig {
         })
     }
 
-    /// The value of [r#type][crate::model::StorageConfig::r#type]
-    /// if it holds a `CloudStorageOptions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn cloud_storage_options(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStorageOptions>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::storage_config::Type::CloudStorageOptions(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::StorageConfig::r#type]
-    /// if it holds a `BigQueryOptions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn big_query_options(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryOptions>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::storage_config::Type::BigQueryOptions(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [r#type][crate::model::StorageConfig::r#type]
-    /// if it holds a `HybridOptions`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn hybrid_options(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::HybridOptions>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::storage_config::Type::HybridOptions(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
     /// to hold a `DatastoreOptions`.
     ///
@@ -35189,6 +35148,21 @@ impl StorageConfig {
             crate::model::storage_config::Type::DatastoreOptions(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::StorageConfig::r#type]
+    /// if it holds a `CloudStorageOptions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn cloud_storage_options(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::CloudStorageOptions>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::storage_config::Type::CloudStorageOptions(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
@@ -35208,6 +35182,19 @@ impl StorageConfig {
         self
     }
 
+    /// The value of [r#type][crate::model::StorageConfig::r#type]
+    /// if it holds a `BigQueryOptions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn big_query_options(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryOptions>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::storage_config::Type::BigQueryOptions(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
     /// to hold a `BigQueryOptions`.
     ///
@@ -35223,6 +35210,19 @@ impl StorageConfig {
             crate::model::storage_config::Type::BigQueryOptions(v.into()),
         );
         self
+    }
+
+    /// The value of [r#type][crate::model::StorageConfig::r#type]
+    /// if it holds a `HybridOptions`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn hybrid_options(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HybridOptions>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::storage_config::Type::HybridOptions(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
@@ -35455,17 +35455,6 @@ impl HybridOptions {
         self
     }
 
-    /// Sets the value of [table_options][crate::model::HybridOptions::table_options].
-    pub fn set_table_options<
-        T: std::convert::Into<std::option::Option<crate::model::TableOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.table_options = v.into();
-        self
-    }
-
     /// Sets the value of [required_finding_label_keys][crate::model::HybridOptions::required_finding_label_keys].
     pub fn set_required_finding_label_keys<T, V>(mut self, v: T) -> Self
     where
@@ -35486,6 +35475,17 @@ impl HybridOptions {
     {
         use std::iter::Iterator;
         self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [table_options][crate::model::HybridOptions::table_options].
+    pub fn set_table_options<
+        T: std::convert::Into<std::option::Option<crate::model::TableOptions>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.table_options = v.into();
         self
     }
 }
@@ -35713,17 +35713,6 @@ pub mod key {
             })
         }
 
-        /// The value of [id_type][crate::model::key::PathElement::id_type]
-        /// if it holds a `Name`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn name(&self) -> std::option::Option<&std::string::String> {
-            #[allow(unreachable_patterns)]
-            self.id_type.as_ref().and_then(|v| match v {
-                crate::model::key::path_element::IdType::Name(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [id_type][crate::model::key::PathElement::id_type]
         /// to hold a `Id`.
         ///
@@ -35733,6 +35722,17 @@ pub mod key {
             self.id_type =
                 std::option::Option::Some(crate::model::key::path_element::IdType::Id(v.into()));
             self
+        }
+
+        /// The value of [id_type][crate::model::key::PathElement::id_type]
+        /// if it holds a `Name`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn name(&self) -> std::option::Option<&std::string::String> {
+            #[allow(unreachable_patterns)]
+            self.id_type.as_ref().and_then(|v| match v {
+                crate::model::key::path_element::IdType::Name(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [id_type][crate::model::key::PathElement::id_type]
@@ -35836,19 +35836,6 @@ impl RecordKey {
         })
     }
 
-    /// The value of [r#type][crate::model::RecordKey::r#type]
-    /// if it holds a `BigQueryKey`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn big_query_key(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryKey>> {
-        #[allow(unreachable_patterns)]
-        self.r#type.as_ref().and_then(|v| match v {
-            crate::model::record_key::Type::BigQueryKey(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [r#type][crate::model::RecordKey::r#type]
     /// to hold a `DatastoreKey`.
     ///
@@ -35861,6 +35848,19 @@ impl RecordKey {
         self.r#type =
             std::option::Option::Some(crate::model::record_key::Type::DatastoreKey(v.into()));
         self
+    }
+
+    /// The value of [r#type][crate::model::RecordKey::r#type]
+    /// if it holds a `BigQueryKey`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn big_query_key(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::BigQueryKey>> {
+        #[allow(unreachable_patterns)]
+        self.r#type.as_ref().and_then(|v| match v {
+            crate::model::record_key::Type::BigQueryKey(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [r#type][crate::model::RecordKey::r#type]

--- a/src/generated/rpc/context/src/model.rs
+++ b/src/generated/rpc/context/src/model.rs
@@ -250,18 +250,6 @@ pub mod attribute_context {
             self
         }
 
-        /// Sets the value of [principal][crate::model::attribute_context::Peer::principal].
-        pub fn set_principal<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.principal = v.into();
-            self
-        }
-
-        /// Sets the value of [region_code][crate::model::attribute_context::Peer::region_code].
-        pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.region_code = v.into();
-            self
-        }
-
         /// Sets the value of [labels][crate::model::attribute_context::Peer::labels].
         pub fn set_labels<T, K, V>(mut self, v: T) -> Self
         where
@@ -271,6 +259,18 @@ pub mod attribute_context {
         {
             use std::iter::Iterator;
             self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
+        /// Sets the value of [principal][crate::model::attribute_context::Peer::principal].
+        pub fn set_principal<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.principal = v.into();
+            self
+        }
+
+        /// Sets the value of [region_code][crate::model::attribute_context::Peer::region_code].
+        pub fn set_region_code<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.region_code = v.into();
             self
         }
     }
@@ -434,6 +434,17 @@ pub mod attribute_context {
             self
         }
 
+        /// Sets the value of [audiences][crate::model::attribute_context::Auth::audiences].
+        pub fn set_audiences<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.audiences = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [presenter][crate::model::attribute_context::Auth::presenter].
         pub fn set_presenter<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.presenter = v.into();
@@ -446,17 +457,6 @@ pub mod attribute_context {
             v: T,
         ) -> Self {
             self.claims = v.into();
-            self
-        }
-
-        /// Sets the value of [audiences][crate::model::attribute_context::Auth::audiences].
-        pub fn set_audiences<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.audiences = v.into_iter().map(|i| i.into()).collect();
             self
         }
 
@@ -567,6 +567,18 @@ pub mod attribute_context {
             self
         }
 
+        /// Sets the value of [headers][crate::model::attribute_context::Request::headers].
+        pub fn set_headers<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [path][crate::model::attribute_context::Request::path].
         pub fn set_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.path = v.into();
@@ -626,18 +638,6 @@ pub mod attribute_context {
             v: T,
         ) -> Self {
             self.auth = v.into();
-            self
-        }
-
-        /// Sets the value of [headers][crate::model::attribute_context::Request::headers].
-        pub fn set_headers<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -704,6 +704,18 @@ pub mod attribute_context {
             self
         }
 
+        /// Sets the value of [headers][crate::model::attribute_context::Response::headers].
+        pub fn set_headers<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [time][crate::model::attribute_context::Response::time].
         pub fn set_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
             mut self,
@@ -719,18 +731,6 @@ pub mod attribute_context {
             v: T,
         ) -> Self {
             self.backend_latency = v.into();
-            self
-        }
-
-        /// Sets the value of [headers][crate::model::attribute_context::Response::headers].
-        pub fn set_headers<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.headers = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -865,9 +865,33 @@ pub mod attribute_context {
             self
         }
 
+        /// Sets the value of [labels][crate::model::attribute_context::Resource::labels].
+        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [uid][crate::model::attribute_context::Resource::uid].
         pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.uid = v.into();
+            self
+        }
+
+        /// Sets the value of [annotations][crate::model::attribute_context::Resource::annotations].
+        pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
 
@@ -916,30 +940,6 @@ pub mod attribute_context {
         /// Sets the value of [location][crate::model::attribute_context::Resource::location].
         pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.location = v.into();
-            self
-        }
-
-        /// Sets the value of [labels][crate::model::attribute_context::Resource::labels].
-        pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-            self
-        }
-
-        /// Sets the value of [annotations][crate::model::attribute_context::Resource::annotations].
-        pub fn set_annotations<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.annotations = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }

--- a/src/generated/rpc/types/src/model.rs
+++ b/src/generated/rpc/types/src/model.rs
@@ -196,12 +196,6 @@ impl DebugInfo {
         std::default::Default::default()
     }
 
-    /// Sets the value of [detail][crate::model::DebugInfo::detail].
-    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.detail = v.into();
-        self
-    }
-
     /// Sets the value of [stack_entries][crate::model::DebugInfo::stack_entries].
     pub fn set_stack_entries<T, V>(mut self, v: T) -> Self
     where
@@ -210,6 +204,12 @@ impl DebugInfo {
     {
         use std::iter::Iterator;
         self.stack_entries = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [detail][crate::model::DebugInfo::detail].
+    pub fn set_detail<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.detail = v.into();
         self
     }
 }
@@ -410,6 +410,18 @@ pub mod quota_failure {
             self
         }
 
+        /// Sets the value of [quota_dimensions][crate::model::quota_failure::Violation::quota_dimensions].
+        pub fn set_quota_dimensions<T, K, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = (K, V)>,
+            K: std::convert::Into<std::string::String>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.quota_dimensions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            self
+        }
+
         /// Sets the value of [quota_value][crate::model::quota_failure::Violation::quota_value].
         pub fn set_quota_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
             self.quota_value = v.into();
@@ -422,18 +434,6 @@ pub mod quota_failure {
             v: T,
         ) -> Self {
             self.future_quota_value = v.into();
-            self
-        }
-
-        /// Sets the value of [quota_dimensions][crate::model::quota_failure::Violation::quota_dimensions].
-        pub fn set_quota_dimensions<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<std::string::String>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.quota_dimensions = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
             self
         }
     }
@@ -1004,12 +1004,6 @@ impl HttpRequest {
         self
     }
 
-    /// Sets the value of [body][crate::model::HttpRequest::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::HttpRequest::headers].
     pub fn set_headers<T, V>(mut self, v: T) -> Self
     where
@@ -1018,6 +1012,12 @@ impl HttpRequest {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::HttpRequest::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 }
@@ -1073,12 +1073,6 @@ impl HttpResponse {
         self
     }
 
-    /// Sets the value of [body][crate::model::HttpResponse::body].
-    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.body = v.into();
-        self
-    }
-
     /// Sets the value of [headers][crate::model::HttpResponse::headers].
     pub fn set_headers<T, V>(mut self, v: T) -> Self
     where
@@ -1087,6 +1081,12 @@ impl HttpResponse {
     {
         use std::iter::Iterator;
         self.headers = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [body][crate::model::HttpResponse::body].
+    pub fn set_body<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.body = v.into();
         self
     }
 }

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -1077,17 +1077,6 @@ impl EchoRequest {
         })
     }
 
-    /// The value of [response][crate::model::EchoRequest::response]
-    /// if it holds a `Error`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::echo_request::Response::Error(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response][crate::model::EchoRequest::response]
     /// to hold a `Content`.
     ///
@@ -1097,6 +1086,17 @@ impl EchoRequest {
         self.response =
             std::option::Option::Some(crate::model::echo_request::Response::Content(v.into()));
         self
+    }
+
+    /// The value of [response][crate::model::EchoRequest::response]
+    /// if it holds a `Error`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn error(&self) -> std::option::Option<&std::boxed::Box<rpc::model::Status>> {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::echo_request::Response::Error(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response][crate::model::EchoRequest::response]
@@ -1729,12 +1729,6 @@ impl PagedExpandResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::PagedExpandResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [responses][crate::model::PagedExpandResponse::responses].
     pub fn set_responses<T, V>(mut self, v: T) -> Self
     where
@@ -1743,6 +1737,12 @@ impl PagedExpandResponse {
     {
         use std::iter::Iterator;
         self.responses = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::PagedExpandResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1828,12 +1828,6 @@ impl PagedExpandLegacyMappedResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::PagedExpandLegacyMappedResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [alphabetized][crate::model::PagedExpandLegacyMappedResponse::alphabetized].
     pub fn set_alphabetized<T, K, V>(mut self, v: T) -> Self
     where
@@ -1843,6 +1837,12 @@ impl PagedExpandLegacyMappedResponse {
     {
         use std::iter::Iterator;
         self.alphabetized = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::PagedExpandLegacyMappedResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1897,17 +1897,6 @@ impl WaitRequest {
         })
     }
 
-    /// The value of [end][crate::model::WaitRequest::end]
-    /// if it holds a `Ttl`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
-        #[allow(unreachable_patterns)]
-        self.end.as_ref().and_then(|v| match v {
-            crate::model::wait_request::End::Ttl(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [end][crate::model::WaitRequest::end]
     /// to hold a `EndTime`.
     ///
@@ -1919,6 +1908,17 @@ impl WaitRequest {
     ) -> Self {
         self.end = std::option::Option::Some(crate::model::wait_request::End::EndTime(v.into()));
         self
+    }
+
+    /// The value of [end][crate::model::WaitRequest::end]
+    /// if it holds a `Ttl`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn ttl(&self) -> std::option::Option<&std::boxed::Box<wkt::Duration>> {
+        #[allow(unreachable_patterns)]
+        self.end.as_ref().and_then(|v| match v {
+            crate::model::wait_request::End::Ttl(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [end][crate::model::WaitRequest::end]
@@ -1956,17 +1956,6 @@ impl WaitRequest {
         })
     }
 
-    /// The value of [response][crate::model::WaitRequest::response]
-    /// if it holds a `Success`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn success(&self) -> std::option::Option<&std::boxed::Box<crate::model::WaitResponse>> {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::wait_request::Response::Success(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response][crate::model::WaitRequest::response]
     /// to hold a `Error`.
     ///
@@ -1979,6 +1968,17 @@ impl WaitRequest {
         self.response =
             std::option::Option::Some(crate::model::wait_request::Response::Error(v.into()));
         self
+    }
+
+    /// The value of [response][crate::model::WaitRequest::response]
+    /// if it holds a `Success`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn success(&self) -> std::option::Option<&std::boxed::Box<crate::model::WaitResponse>> {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::wait_request::Response::Success(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response][crate::model::WaitRequest::response]
@@ -2152,17 +2152,6 @@ impl BlockRequest {
         })
     }
 
-    /// The value of [response][crate::model::BlockRequest::response]
-    /// if it holds a `Success`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn success(&self) -> std::option::Option<&std::boxed::Box<crate::model::BlockResponse>> {
-        #[allow(unreachable_patterns)]
-        self.response.as_ref().and_then(|v| match v {
-            crate::model::block_request::Response::Success(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [response][crate::model::BlockRequest::response]
     /// to hold a `Error`.
     ///
@@ -2175,6 +2164,17 @@ impl BlockRequest {
         self.response =
             std::option::Option::Some(crate::model::block_request::Response::Error(v.into()));
         self
+    }
+
+    /// The value of [response][crate::model::BlockRequest::response]
+    /// if it holds a `Success`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn success(&self) -> std::option::Option<&std::boxed::Box<crate::model::BlockResponse>> {
+        #[allow(unreachable_patterns)]
+        self.response.as_ref().and_then(|v| match v {
+            crate::model::block_request::Response::Success(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [response][crate::model::BlockRequest::response]
@@ -2606,12 +2606,6 @@ impl ListUsersResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListUsersResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [users][crate::model::ListUsersResponse::users].
     pub fn set_users<T, V>(mut self, v: T) -> Self
     where
@@ -2620,6 +2614,12 @@ impl ListUsersResponse {
     {
         use std::iter::Iterator;
         self.users = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListUsersResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2947,12 +2947,6 @@ impl ListRoomsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListRoomsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [rooms][crate::model::ListRoomsResponse::rooms].
     pub fn set_rooms<T, V>(mut self, v: T) -> Self
     where
@@ -2961,6 +2955,12 @@ impl ListRoomsResponse {
     {
         use std::iter::Iterator;
         self.rooms = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListRoomsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3079,6 +3079,16 @@ impl Blurb {
         })
     }
 
+    /// Sets the value of [content][crate::model::Blurb::content]
+    /// to hold a `Text`.
+    ///
+    /// Note that all the setters affecting `content` are
+    /// mutually exclusive.
+    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.content = std::option::Option::Some(crate::model::blurb::Content::Text(v.into()));
+        self
+    }
+
     /// The value of [content][crate::model::Blurb::content]
     /// if it holds a `Image`, `None` if the field is not set or
     /// holds a different branch.
@@ -3088,16 +3098,6 @@ impl Blurb {
             crate::model::blurb::Content::Image(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Blurb::content]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.content = std::option::Option::Some(crate::model::blurb::Content::Text(v.into()));
-        self
     }
 
     /// Sets the value of [content][crate::model::Blurb::content]
@@ -3135,17 +3135,6 @@ impl Blurb {
         })
     }
 
-    /// The value of [legacy_id][crate::model::Blurb::legacy_id]
-    /// if it holds a `LegacyUserId`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn legacy_user_id(&self) -> std::option::Option<&std::string::String> {
-        #[allow(unreachable_patterns)]
-        self.legacy_id.as_ref().and_then(|v| match v {
-            crate::model::blurb::LegacyId::LegacyUserId(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [legacy_id][crate::model::Blurb::legacy_id]
     /// to hold a `LegacyRoomId`.
     ///
@@ -3155,6 +3144,17 @@ impl Blurb {
         self.legacy_id =
             std::option::Option::Some(crate::model::blurb::LegacyId::LegacyRoomId(v.into()));
         self
+    }
+
+    /// The value of [legacy_id][crate::model::Blurb::legacy_id]
+    /// if it holds a `LegacyUserId`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn legacy_user_id(&self) -> std::option::Option<&std::string::String> {
+        #[allow(unreachable_patterns)]
+        self.legacy_id.as_ref().and_then(|v| match v {
+            crate::model::blurb::LegacyId::LegacyUserId(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [legacy_id][crate::model::Blurb::legacy_id]
@@ -3455,12 +3455,6 @@ impl ListBlurbsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBlurbsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [blurbs][crate::model::ListBlurbsResponse::blurbs].
     pub fn set_blurbs<T, V>(mut self, v: T) -> Self
     where
@@ -3469,6 +3463,12 @@ impl ListBlurbsResponse {
     {
         use std::iter::Iterator;
         self.blurbs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBlurbsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3626,12 +3626,6 @@ impl SearchBlurbsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::SearchBlurbsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [blurbs][crate::model::SearchBlurbsResponse::blurbs].
     pub fn set_blurbs<T, V>(mut self, v: T) -> Self
     where
@@ -3640,6 +3634,12 @@ impl SearchBlurbsResponse {
     {
         use std::iter::Iterator;
         self.blurbs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::SearchBlurbsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3972,17 +3972,6 @@ impl ConnectRequest {
         })
     }
 
-    /// The value of [request][crate::model::ConnectRequest::request]
-    /// if it holds a `Blurb`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn blurb(&self) -> std::option::Option<&std::boxed::Box<crate::model::Blurb>> {
-        #[allow(unreachable_patterns)]
-        self.request.as_ref().and_then(|v| match v {
-            crate::model::connect_request::Request::Blurb(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [request][crate::model::ConnectRequest::request]
     /// to hold a `Config`.
     ///
@@ -3997,6 +3986,17 @@ impl ConnectRequest {
         self.request =
             std::option::Option::Some(crate::model::connect_request::Request::Config(v.into()));
         self
+    }
+
+    /// The value of [request][crate::model::ConnectRequest::request]
+    /// if it holds a `Blurb`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn blurb(&self) -> std::option::Option<&std::boxed::Box<crate::model::Blurb>> {
+        #[allow(unreachable_patterns)]
+        self.request.as_ref().and_then(|v| match v {
+            crate::model::connect_request::Request::Blurb(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [request][crate::model::ConnectRequest::request]
@@ -5225,12 +5225,6 @@ impl ListSessionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [sessions][crate::model::ListSessionsResponse::sessions].
     pub fn set_sessions<T, V>(mut self, v: T) -> Self
     where
@@ -5239,6 +5233,12 @@ impl ListSessionsResponse {
     {
         use std::iter::Iterator;
         self.sessions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListSessionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -6283,12 +6283,6 @@ impl ListTestsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTestsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [tests][crate::model::ListTestsResponse::tests].
     pub fn set_tests<T, V>(mut self, v: T) -> Self
     where
@@ -6297,6 +6291,12 @@ impl ListTestsResponse {
     {
         use std::iter::Iterator;
         self.tests = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTestsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -228,6 +228,17 @@ pub mod database_admin {
             self
         }
 
+        /// Sets the value of [extra_statements][crate::model::CreateDatabaseRequest::extra_statements].
+        pub fn set_extra_statements<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<std::string::String>,
+        {
+            use std::iter::Iterator;
+            self.0.request.extra_statements = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [encryption_config][crate::model::CreateDatabaseRequest::encryption_config].
         pub fn set_encryption_config<
             T: Into<std::option::Option<crate::model::EncryptionConfig>>,
@@ -251,17 +262,6 @@ pub mod database_admin {
         /// Sets the value of [proto_descriptors][crate::model::CreateDatabaseRequest::proto_descriptors].
         pub fn set_proto_descriptors<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
             self.0.request.proto_descriptors = v.into();
-            self
-        }
-
-        /// Sets the value of [extra_statements][crate::model::CreateDatabaseRequest::extra_statements].
-        pub fn set_extra_statements<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<std::string::String>,
-        {
-            use std::iter::Iterator;
-            self.0.request.extra_statements = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -499,18 +499,6 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of [operation_id][crate::model::UpdateDatabaseDdlRequest::operation_id].
-        pub fn set_operation_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.operation_id = v.into();
-            self
-        }
-
-        /// Sets the value of [proto_descriptors][crate::model::UpdateDatabaseDdlRequest::proto_descriptors].
-        pub fn set_proto_descriptors<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request.proto_descriptors = v.into();
-            self
-        }
-
         /// Sets the value of [statements][crate::model::UpdateDatabaseDdlRequest::statements].
         ///
         /// This is a **required** field for requests.
@@ -521,6 +509,18 @@ pub mod database_admin {
         {
             use std::iter::Iterator;
             self.0.request.statements = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [operation_id][crate::model::UpdateDatabaseDdlRequest::operation_id].
+        pub fn set_operation_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.operation_id = v.into();
+            self
+        }
+
+        /// Sets the value of [proto_descriptors][crate::model::UpdateDatabaseDdlRequest::proto_descriptors].
+        pub fn set_proto_descriptors<T: Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+            self.0.request.proto_descriptors = v.into();
             self
         }
     }
@@ -1695,12 +1695,6 @@ pub mod database_admin {
             self
         }
 
-        /// Sets the value of [initiator][crate::model::AddSplitPointsRequest::initiator].
-        pub fn set_initiator<T: Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request.initiator = v.into();
-            self
-        }
-
         /// Sets the value of [split_points][crate::model::AddSplitPointsRequest::split_points].
         ///
         /// This is a **required** field for requests.
@@ -1711,6 +1705,12 @@ pub mod database_admin {
         {
             use std::iter::Iterator;
             self.0.request.split_points = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [initiator][crate::model::AddSplitPointsRequest::initiator].
+        pub fn set_initiator<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.initiator = v.into();
             self
         }
     }

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -282,6 +282,17 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [referencing_databases][crate::model::Backup::referencing_databases].
+    pub fn set_referencing_databases<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.referencing_databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [encryption_info][crate::model::Backup::encryption_info].
     pub fn set_encryption_info<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionInfo>>,
@@ -290,6 +301,17 @@ impl Backup {
         v: T,
     ) -> Self {
         self.encryption_info = v.into();
+        self
+    }
+
+    /// Sets the value of [encryption_information][crate::model::Backup::encryption_information].
+    pub fn set_encryption_information<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EncryptionInfo>,
+    {
+        use std::iter::Iterator;
+        self.encryption_information = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -302,12 +324,34 @@ impl Backup {
         self
     }
 
+    /// Sets the value of [referencing_backups][crate::model::Backup::referencing_backups].
+    pub fn set_referencing_backups<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.referencing_backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [max_expire_time][crate::model::Backup::max_expire_time].
     pub fn set_max_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
         v: T,
     ) -> Self {
         self.max_expire_time = v.into();
+        self
+    }
+
+    /// Sets the value of [backup_schedules][crate::model::Backup::backup_schedules].
+    pub fn set_backup_schedules<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.backup_schedules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -326,50 +370,6 @@ impl Backup {
         v: T,
     ) -> Self {
         self.oldest_version_time = v.into();
-        self
-    }
-
-    /// Sets the value of [referencing_databases][crate::model::Backup::referencing_databases].
-    pub fn set_referencing_databases<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.referencing_databases = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [encryption_information][crate::model::Backup::encryption_information].
-    pub fn set_encryption_information<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EncryptionInfo>,
-    {
-        use std::iter::Iterator;
-        self.encryption_information = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [referencing_backups][crate::model::Backup::referencing_backups].
-    pub fn set_referencing_backups<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.referencing_backups = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [backup_schedules][crate::model::Backup::backup_schedules].
-    pub fn set_backup_schedules<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.backup_schedules = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -1182,12 +1182,6 @@ impl ListBackupsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backups][crate::model::ListBackupsResponse::backups].
     pub fn set_backups<T, V>(mut self, v: T) -> Self
     where
@@ -1196,6 +1190,12 @@ impl ListBackupsResponse {
     {
         use std::iter::Iterator;
         self.backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1408,12 +1408,6 @@ impl ListBackupOperationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupOperationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [operations][crate::model::ListBackupOperationsResponse::operations].
     pub fn set_operations<T, V>(mut self, v: T) -> Self
     where
@@ -1422,6 +1416,12 @@ impl ListBackupOperationsResponse {
     {
         use std::iter::Iterator;
         self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -2313,21 +2313,6 @@ impl BackupSchedule {
         })
     }
 
-    /// The value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
-    /// if it holds a `IncrementalBackupSpec`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn incremental_backup_spec(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::IncrementalBackupSpec>> {
-        #[allow(unreachable_patterns)]
-        self.backup_type_spec.as_ref().and_then(|v| match v {
-            crate::model::backup_schedule::BackupTypeSpec::IncrementalBackupSpec(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
     /// to hold a `FullBackupSpec`.
     ///
@@ -2343,6 +2328,21 @@ impl BackupSchedule {
             crate::model::backup_schedule::BackupTypeSpec::FullBackupSpec(v.into()),
         );
         self
+    }
+
+    /// The value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
+    /// if it holds a `IncrementalBackupSpec`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn incremental_backup_spec(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::IncrementalBackupSpec>> {
+        #[allow(unreachable_patterns)]
+        self.backup_type_spec.as_ref().and_then(|v| match v {
+            crate::model::backup_schedule::BackupTypeSpec::IncrementalBackupSpec(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
@@ -2696,12 +2696,6 @@ impl ListBackupSchedulesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBackupSchedulesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [backup_schedules][crate::model::ListBackupSchedulesResponse::backup_schedules].
     pub fn set_backup_schedules<T, V>(mut self, v: T) -> Self
     where
@@ -2710,6 +2704,12 @@ impl ListBackupSchedulesResponse {
     {
         use std::iter::Iterator;
         self.backup_schedules = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBackupSchedulesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3357,6 +3357,17 @@ impl Database {
         self
     }
 
+    /// Sets the value of [encryption_info][crate::model::Database::encryption_info].
+    pub fn set_encryption_info<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::EncryptionInfo>,
+    {
+        use std::iter::Iterator;
+        self.encryption_info = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [version_retention_period][crate::model::Database::version_retention_period].
     pub fn set_version_retention_period<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -3399,17 +3410,6 @@ impl Database {
     /// Sets the value of [reconciling][crate::model::Database::reconciling].
     pub fn set_reconciling<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.reconciling = v.into();
-        self
-    }
-
-    /// Sets the value of [encryption_info][crate::model::Database::encryption_info].
-    pub fn set_encryption_info<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::EncryptionInfo>,
-    {
-        use std::iter::Iterator;
-        self.encryption_info = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -3666,12 +3666,6 @@ impl ListDatabasesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatabasesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [databases][crate::model::ListDatabasesResponse::databases].
     pub fn set_databases<T, V>(mut self, v: T) -> Self
     where
@@ -3680,6 +3674,12 @@ impl ListDatabasesResponse {
     {
         use std::iter::Iterator;
         self.databases = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatabasesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3787,6 +3787,17 @@ impl CreateDatabaseRequest {
         self
     }
 
+    /// Sets the value of [extra_statements][crate::model::CreateDatabaseRequest::extra_statements].
+    pub fn set_extra_statements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.extra_statements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [encryption_config][crate::model::CreateDatabaseRequest::encryption_config].
     pub fn set_encryption_config<
         T: std::convert::Into<std::option::Option<crate::model::EncryptionConfig>>,
@@ -3810,17 +3821,6 @@ impl CreateDatabaseRequest {
     /// Sets the value of [proto_descriptors][crate::model::CreateDatabaseRequest::proto_descriptors].
     pub fn set_proto_descriptors<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.proto_descriptors = v.into();
-        self
-    }
-
-    /// Sets the value of [extra_statements][crate::model::CreateDatabaseRequest::extra_statements].
-    pub fn set_extra_statements<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.extra_statements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4128,6 +4128,17 @@ impl UpdateDatabaseDdlRequest {
         self
     }
 
+    /// Sets the value of [statements][crate::model::UpdateDatabaseDdlRequest::statements].
+    pub fn set_statements<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.statements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [operation_id][crate::model::UpdateDatabaseDdlRequest::operation_id].
     pub fn set_operation_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.operation_id = v.into();
@@ -4137,17 +4148,6 @@ impl UpdateDatabaseDdlRequest {
     /// Sets the value of [proto_descriptors][crate::model::UpdateDatabaseDdlRequest::proto_descriptors].
     pub fn set_proto_descriptors<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
         self.proto_descriptors = v.into();
-        self
-    }
-
-    /// Sets the value of [statements][crate::model::UpdateDatabaseDdlRequest::statements].
-    pub fn set_statements<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.statements = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -4289,12 +4289,6 @@ impl UpdateDatabaseDdlMetadata {
         self
     }
 
-    /// Sets the value of [throttled][crate::model::UpdateDatabaseDdlMetadata::throttled].
-    pub fn set_throttled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.throttled = v.into();
-        self
-    }
-
     /// Sets the value of [statements][crate::model::UpdateDatabaseDdlMetadata::statements].
     pub fn set_statements<T, V>(mut self, v: T) -> Self
     where
@@ -4314,6 +4308,12 @@ impl UpdateDatabaseDdlMetadata {
     {
         use std::iter::Iterator;
         self.commit_timestamps = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [throttled][crate::model::UpdateDatabaseDdlMetadata::throttled].
+    pub fn set_throttled<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
+        self.throttled = v.into();
         self
     }
 
@@ -4450,12 +4450,6 @@ impl GetDatabaseDdlResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [proto_descriptors][crate::model::GetDatabaseDdlResponse::proto_descriptors].
-    pub fn set_proto_descriptors<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.proto_descriptors = v.into();
-        self
-    }
-
     /// Sets the value of [statements][crate::model::GetDatabaseDdlResponse::statements].
     pub fn set_statements<T, V>(mut self, v: T) -> Self
     where
@@ -4464,6 +4458,12 @@ impl GetDatabaseDdlResponse {
     {
         use std::iter::Iterator;
         self.statements = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [proto_descriptors][crate::model::GetDatabaseDdlResponse::proto_descriptors].
+    pub fn set_proto_descriptors<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
+        self.proto_descriptors = v.into();
         self
     }
 }
@@ -4632,12 +4632,6 @@ impl ListDatabaseOperationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatabaseOperationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [operations][crate::model::ListDatabaseOperationsResponse::operations].
     pub fn set_operations<T, V>(mut self, v: T) -> Self
     where
@@ -4646,6 +4640,12 @@ impl ListDatabaseOperationsResponse {
     {
         use std::iter::Iterator;
         self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatabaseOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5410,12 +5410,6 @@ impl ListDatabaseRolesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListDatabaseRolesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [database_roles][crate::model::ListDatabaseRolesResponse::database_roles].
     pub fn set_database_roles<T, V>(mut self, v: T) -> Self
     where
@@ -5424,6 +5418,12 @@ impl ListDatabaseRolesResponse {
     {
         use std::iter::Iterator;
         self.database_roles = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListDatabaseRolesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -5490,12 +5490,6 @@ impl AddSplitPointsRequest {
         self
     }
 
-    /// Sets the value of [initiator][crate::model::AddSplitPointsRequest::initiator].
-    pub fn set_initiator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.initiator = v.into();
-        self
-    }
-
     /// Sets the value of [split_points][crate::model::AddSplitPointsRequest::split_points].
     pub fn set_split_points<T, V>(mut self, v: T) -> Self
     where
@@ -5504,6 +5498,12 @@ impl AddSplitPointsRequest {
     {
         use std::iter::Iterator;
         self.split_points = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [initiator][crate::model::AddSplitPointsRequest::initiator].
+    pub fn set_initiator<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.initiator = v.into();
         self
     }
 }
@@ -5586,15 +5586,6 @@ impl SplitPoints {
         self
     }
 
-    /// Sets the value of [expire_time][crate::model::SplitPoints::expire_time].
-    pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.expire_time = v.into();
-        self
-    }
-
     /// Sets the value of [keys][crate::model::SplitPoints::keys].
     pub fn set_keys<T, V>(mut self, v: T) -> Self
     where
@@ -5603,6 +5594,15 @@ impl SplitPoints {
     {
         use std::iter::Iterator;
         self.keys = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [expire_time][crate::model::SplitPoints::expire_time].
+    pub fn set_expire_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.expire_time = v.into();
         self
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -487,15 +487,60 @@ impl InstanceConfig {
         self
     }
 
+    /// Sets the value of [replicas][crate::model::InstanceConfig::replicas].
+    pub fn set_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaInfo>,
+    {
+        use std::iter::Iterator;
+        self.replicas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [optional_replicas][crate::model::InstanceConfig::optional_replicas].
+    pub fn set_optional_replicas<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaInfo>,
+    {
+        use std::iter::Iterator;
+        self.optional_replicas = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [base_config][crate::model::InstanceConfig::base_config].
     pub fn set_base_config<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.base_config = v.into();
         self
     }
 
+    /// Sets the value of [labels][crate::model::InstanceConfig::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [etag][crate::model::InstanceConfig::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [leader_options][crate::model::InstanceConfig::leader_options].
+    pub fn set_leader_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.leader_options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -540,51 +585,6 @@ impl InstanceConfig {
         v: T,
     ) -> Self {
         self.storage_limit_per_processing_unit = v.into();
-        self
-    }
-
-    /// Sets the value of [replicas][crate::model::InstanceConfig::replicas].
-    pub fn set_replicas<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ReplicaInfo>,
-    {
-        use std::iter::Iterator;
-        self.replicas = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [optional_replicas][crate::model::InstanceConfig::optional_replicas].
-    pub fn set_optional_replicas<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ReplicaInfo>,
-    {
-        use std::iter::Iterator;
-        self.optional_replicas = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [leader_options][crate::model::InstanceConfig::leader_options].
-    pub fn set_leader_options<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.leader_options = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::InstanceConfig::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -1239,6 +1239,18 @@ impl ReplicaComputeCapacity {
         })
     }
 
+    /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
+    /// to hold a `NodeCount`.
+    ///
+    /// Note that all the setters affecting `compute_capacity` are
+    /// mutually exclusive.
+    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.compute_capacity = std::option::Option::Some(
+            crate::model::replica_compute_capacity::ComputeCapacity::NodeCount(v.into()),
+        );
+        self
+    }
+
     /// The value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
     /// if it holds a `ProcessingUnits`, `None` if the field is not set or
     /// holds a different branch.
@@ -1250,18 +1262,6 @@ impl ReplicaComputeCapacity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
-    /// to hold a `NodeCount`.
-    ///
-    /// Note that all the setters affecting `compute_capacity` are
-    /// mutually exclusive.
-    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.compute_capacity = std::option::Option::Some(
-            crate::model::replica_compute_capacity::ComputeCapacity::NodeCount(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
@@ -1459,17 +1459,6 @@ pub mod autoscaling_config {
             })
         }
 
-        /// The value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
-        /// if it holds a `MinProcessingUnits`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn min_processing_units(&self) -> std::option::Option<&i32> {
-            #[allow(unreachable_patterns)]
-            self.min_limit.as_ref().and_then(|v| match v {
-                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinProcessingUnits(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
         /// to hold a `MinNodes`.
         ///
@@ -1480,6 +1469,17 @@ pub mod autoscaling_config {
                 crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinNodes(v.into()),
             );
             self
+        }
+
+        /// The value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
+        /// if it holds a `MinProcessingUnits`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn min_processing_units(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.min_limit.as_ref().and_then(|v| match v {
+                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinProcessingUnits(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
@@ -1527,17 +1527,6 @@ pub mod autoscaling_config {
             })
         }
 
-        /// The value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
-        /// if it holds a `MaxProcessingUnits`, `None` if the field is not set or
-        /// holds a different branch.
-        pub fn max_processing_units(&self) -> std::option::Option<&i32> {
-            #[allow(unreachable_patterns)]
-            self.max_limit.as_ref().and_then(|v| match v {
-                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxProcessingUnits(v) => std::option::Option::Some(v),
-                _ => std::option::Option::None,
-            })
-        }
-
         /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
         /// to hold a `MaxNodes`.
         ///
@@ -1548,6 +1537,17 @@ pub mod autoscaling_config {
                 crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxNodes(v.into()),
             );
             self
+        }
+
+        /// The value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
+        /// if it holds a `MaxProcessingUnits`, `None` if the field is not set or
+        /// holds a different branch.
+        pub fn max_processing_units(&self) -> std::option::Option<&i32> {
+            #[allow(unreachable_patterns)]
+            self.max_limit.as_ref().and_then(|v| match v {
+                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxProcessingUnits(v) => std::option::Option::Some(v),
+                _ => std::option::Option::None,
+            })
         }
 
         /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
@@ -1961,6 +1961,17 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [replica_compute_capacity][crate::model::Instance::replica_compute_capacity].
+    pub fn set_replica_compute_capacity<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ReplicaComputeCapacity>,
+    {
+        use std::iter::Iterator;
+        self.replica_compute_capacity = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [autoscaling_config][crate::model::Instance::autoscaling_config].
     pub fn set_autoscaling_config<
         T: std::convert::Into<std::option::Option<crate::model::AutoscalingConfig>>,
@@ -1978,12 +1989,35 @@ impl Instance {
         self
     }
 
+    /// Sets the value of [labels][crate::model::Instance::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [instance_type][crate::model::Instance::instance_type].
     pub fn set_instance_type<T: std::convert::Into<crate::model::instance::InstanceType>>(
         mut self,
         v: T,
     ) -> Self {
         self.instance_type = v.into();
+        self
+    }
+
+    /// Sets the value of [endpoint_uris][crate::model::Instance::endpoint_uris].
+    pub fn set_endpoint_uris<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.endpoint_uris = v.into_iter().map(|i| i.into()).collect();
         self
     }
 
@@ -2033,40 +2067,6 @@ impl Instance {
         v: T,
     ) -> Self {
         self.default_backup_schedule_type = v.into();
-        self
-    }
-
-    /// Sets the value of [replica_compute_capacity][crate::model::Instance::replica_compute_capacity].
-    pub fn set_replica_compute_capacity<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ReplicaComputeCapacity>,
-    {
-        use std::iter::Iterator;
-        self.replica_compute_capacity = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [endpoint_uris][crate::model::Instance::endpoint_uris].
-    pub fn set_endpoint_uris<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.endpoint_uris = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Instance::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -2733,12 +2733,6 @@ impl ListInstanceConfigsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstanceConfigsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instance_configs][crate::model::ListInstanceConfigsResponse::instance_configs].
     pub fn set_instance_configs<T, V>(mut self, v: T) -> Self
     where
@@ -2747,6 +2741,12 @@ impl ListInstanceConfigsResponse {
     {
         use std::iter::Iterator;
         self.instance_configs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstanceConfigsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3184,12 +3184,6 @@ impl ListInstanceConfigOperationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstanceConfigOperationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [operations][crate::model::ListInstanceConfigOperationsResponse::operations].
     pub fn set_operations<T, V>(mut self, v: T) -> Self
     where
@@ -3198,6 +3192,12 @@ impl ListInstanceConfigOperationsResponse {
     {
         use std::iter::Iterator;
         self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstanceConfigOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -3489,12 +3489,6 @@ impl ListInstancesResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instances][crate::model::ListInstancesResponse::instances].
     pub fn set_instances<T, V>(mut self, v: T) -> Self
     where
@@ -3503,6 +3497,12 @@ impl ListInstancesResponse {
     {
         use std::iter::Iterator;
         self.instances = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancesResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -4320,12 +4320,6 @@ impl InstancePartition {
         self
     }
 
-    /// Sets the value of [etag][crate::model::InstancePartition::etag].
-    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.etag = v.into();
-        self
-    }
-
     /// Sets the value of [referencing_databases][crate::model::InstancePartition::referencing_databases].
     pub fn set_referencing_databases<T, V>(mut self, v: T) -> Self
     where
@@ -4346,6 +4340,12 @@ impl InstancePartition {
     {
         use std::iter::Iterator;
         self.referencing_backups = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [etag][crate::model::InstancePartition::etag].
+    pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.etag = v.into();
         self
     }
 
@@ -4376,6 +4376,18 @@ impl InstancePartition {
         })
     }
 
+    /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
+    /// to hold a `NodeCount`.
+    ///
+    /// Note that all the setters affecting `compute_capacity` are
+    /// mutually exclusive.
+    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+        self.compute_capacity = std::option::Option::Some(
+            crate::model::instance_partition::ComputeCapacity::NodeCount(v.into()),
+        );
+        self
+    }
+
     /// The value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
     /// if it holds a `ProcessingUnits`, `None` if the field is not set or
     /// holds a different branch.
@@ -4387,18 +4399,6 @@ impl InstancePartition {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
-    /// to hold a `NodeCount`.
-    ///
-    /// Note that all the setters affecting `compute_capacity` are
-    /// mutually exclusive.
-    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.compute_capacity = std::option::Option::Some(
-            crate::model::instance_partition::ComputeCapacity::NodeCount(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
@@ -5107,12 +5107,6 @@ impl ListInstancePartitionsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancePartitionsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [instance_partitions][crate::model::ListInstancePartitionsResponse::instance_partitions].
     pub fn set_instance_partitions<T, V>(mut self, v: T) -> Self
     where
@@ -5121,6 +5115,12 @@ impl ListInstancePartitionsResponse {
     {
         use std::iter::Iterator;
         self.instance_partitions = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancePartitionsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 
@@ -5339,12 +5339,6 @@ impl ListInstancePartitionOperationsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListInstancePartitionOperationsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [operations][crate::model::ListInstancePartitionOperationsResponse::operations].
     pub fn set_operations<T, V>(mut self, v: T) -> Self
     where
@@ -5353,6 +5347,12 @@ impl ListInstancePartitionOperationsResponse {
     {
         use std::iter::Iterator;
         self.operations = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListInstancePartitionOperationsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -405,12 +405,6 @@ impl ListTransferJobsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListTransferJobsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [transfer_jobs][crate::model::ListTransferJobsResponse::transfer_jobs].
     pub fn set_transfer_jobs<T, V>(mut self, v: T) -> Self
     where
@@ -419,6 +413,12 @@ impl ListTransferJobsResponse {
     {
         use std::iter::Iterator;
         self.transfer_jobs = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListTransferJobsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -848,12 +848,6 @@ impl ListAgentPoolsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListAgentPoolsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [agent_pools][crate::model::ListAgentPoolsResponse::agent_pools].
     pub fn set_agent_pools<T, V>(mut self, v: T) -> Self
     where
@@ -862,6 +856,12 @@ impl ListAgentPoolsResponse {
     {
         use std::iter::Iterator;
         self.agent_pools = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListAgentPoolsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -1191,24 +1191,6 @@ impl ObjectConditions {
         self
     }
 
-    /// Sets the value of [last_modified_since][crate::model::ObjectConditions::last_modified_since].
-    pub fn set_last_modified_since<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.last_modified_since = v.into();
-        self
-    }
-
-    /// Sets the value of [last_modified_before][crate::model::ObjectConditions::last_modified_before].
-    pub fn set_last_modified_before<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.last_modified_before = v.into();
-        self
-    }
-
     /// Sets the value of [include_prefixes][crate::model::ObjectConditions::include_prefixes].
     pub fn set_include_prefixes<T, V>(mut self, v: T) -> Self
     where
@@ -1228,6 +1210,24 @@ impl ObjectConditions {
     {
         use std::iter::Iterator;
         self.exclude_prefixes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [last_modified_since][crate::model::ObjectConditions::last_modified_since].
+    pub fn set_last_modified_since<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.last_modified_since = v.into();
+        self
+    }
+
+    /// Sets the value of [last_modified_before][crate::model::ObjectConditions::last_modified_before].
+    pub fn set_last_modified_before<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.last_modified_before = v.into();
         self
     }
 }
@@ -3188,19 +3188,6 @@ impl TransferSpec {
         })
     }
 
-    /// The value of [data_sink][crate::model::TransferSpec::data_sink]
-    /// if it holds a `PosixDataSink`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn posix_data_sink(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PosixFilesystem>> {
-        #[allow(unreachable_patterns)]
-        self.data_sink.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSink::PosixDataSink(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_sink][crate::model::TransferSpec::data_sink]
     /// to hold a `GcsDataSink`.
     ///
@@ -3213,6 +3200,19 @@ impl TransferSpec {
         self.data_sink =
             std::option::Option::Some(crate::model::transfer_spec::DataSink::GcsDataSink(v.into()));
         self
+    }
+
+    /// The value of [data_sink][crate::model::TransferSpec::data_sink]
+    /// if it holds a `PosixDataSink`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn posix_data_sink(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PosixFilesystem>> {
+        #[allow(unreachable_patterns)]
+        self.data_sink.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSink::PosixDataSink(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_sink][crate::model::TransferSpec::data_sink]
@@ -3259,96 +3259,6 @@ impl TransferSpec {
         })
     }
 
-    /// The value of [data_source][crate::model::TransferSpec::data_source]
-    /// if it holds a `AwsS3DataSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws_s3_data_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsS3Data>> {
-        #[allow(unreachable_patterns)]
-        self.data_source.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSource::AwsS3DataSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_source][crate::model::TransferSpec::data_source]
-    /// if it holds a `HttpDataSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn http_data_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::HttpData>> {
-        #[allow(unreachable_patterns)]
-        self.data_source.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSource::HttpDataSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_source][crate::model::TransferSpec::data_source]
-    /// if it holds a `PosixDataSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn posix_data_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::PosixFilesystem>> {
-        #[allow(unreachable_patterns)]
-        self.data_source.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSource::PosixDataSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_source][crate::model::TransferSpec::data_source]
-    /// if it holds a `AzureBlobStorageDataSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn azure_blob_storage_data_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureBlobStorageData>> {
-        #[allow(unreachable_patterns)]
-        self.data_source.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSource::AzureBlobStorageDataSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_source][crate::model::TransferSpec::data_source]
-    /// if it holds a `AwsS3CompatibleDataSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn aws_s3_compatible_data_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsS3CompatibleData>> {
-        #[allow(unreachable_patterns)]
-        self.data_source.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSource::AwsS3CompatibleDataSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
-    /// The value of [data_source][crate::model::TransferSpec::data_source]
-    /// if it holds a `HdfsDataSource`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn hdfs_data_source(
-        &self,
-    ) -> std::option::Option<&std::boxed::Box<crate::model::HdfsData>> {
-        #[allow(unreachable_patterns)]
-        self.data_source.as_ref().and_then(|v| match v {
-            crate::model::transfer_spec::DataSource::HdfsDataSource(v) => {
-                std::option::Option::Some(v)
-            }
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
     /// to hold a `GcsDataSource`.
     ///
@@ -3362,6 +3272,21 @@ impl TransferSpec {
             crate::model::transfer_spec::DataSource::GcsDataSource(v.into()),
         );
         self
+    }
+
+    /// The value of [data_source][crate::model::TransferSpec::data_source]
+    /// if it holds a `AwsS3DataSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws_s3_data_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsS3Data>> {
+        #[allow(unreachable_patterns)]
+        self.data_source.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSource::AwsS3DataSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
@@ -3381,6 +3306,21 @@ impl TransferSpec {
         self
     }
 
+    /// The value of [data_source][crate::model::TransferSpec::data_source]
+    /// if it holds a `HttpDataSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn http_data_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HttpData>> {
+        #[allow(unreachable_patterns)]
+        self.data_source.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSource::HttpDataSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
     /// to hold a `HttpDataSource`.
     ///
@@ -3394,6 +3334,21 @@ impl TransferSpec {
             crate::model::transfer_spec::DataSource::HttpDataSource(v.into()),
         );
         self
+    }
+
+    /// The value of [data_source][crate::model::TransferSpec::data_source]
+    /// if it holds a `PosixDataSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn posix_data_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::PosixFilesystem>> {
+        #[allow(unreachable_patterns)]
+        self.data_source.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSource::PosixDataSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
@@ -3413,6 +3368,21 @@ impl TransferSpec {
         self
     }
 
+    /// The value of [data_source][crate::model::TransferSpec::data_source]
+    /// if it holds a `AzureBlobStorageDataSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn azure_blob_storage_data_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AzureBlobStorageData>> {
+        #[allow(unreachable_patterns)]
+        self.data_source.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSource::AzureBlobStorageDataSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
     /// to hold a `AzureBlobStorageDataSource`.
     ///
@@ -3430,6 +3400,21 @@ impl TransferSpec {
         self
     }
 
+    /// The value of [data_source][crate::model::TransferSpec::data_source]
+    /// if it holds a `AwsS3CompatibleDataSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn aws_s3_compatible_data_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::AwsS3CompatibleData>> {
+        #[allow(unreachable_patterns)]
+        self.data_source.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSource::AwsS3CompatibleDataSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
+    }
+
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
     /// to hold a `AwsS3CompatibleDataSource`.
     ///
@@ -3445,6 +3430,21 @@ impl TransferSpec {
             crate::model::transfer_spec::DataSource::AwsS3CompatibleDataSource(v.into()),
         );
         self
+    }
+
+    /// The value of [data_source][crate::model::TransferSpec::data_source]
+    /// if it holds a `HdfsDataSource`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn hdfs_data_source(
+        &self,
+    ) -> std::option::Option<&std::boxed::Box<crate::model::HdfsData>> {
+        #[allow(unreachable_patterns)]
+        self.data_source.as_ref().and_then(|v| match v {
+            crate::model::transfer_spec::DataSource::HdfsDataSource(v) => {
+                std::option::Option::Some(v)
+            }
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
@@ -6289,17 +6289,6 @@ impl NotificationConfig {
         self
     }
 
-    /// Sets the value of [payload_format][crate::model::NotificationConfig::payload_format].
-    pub fn set_payload_format<
-        T: std::convert::Into<crate::model::notification_config::PayloadFormat>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload_format = v.into();
-        self
-    }
-
     /// Sets the value of [event_types][crate::model::NotificationConfig::event_types].
     pub fn set_event_types<T, V>(mut self, v: T) -> Self
     where
@@ -6308,6 +6297,17 @@ impl NotificationConfig {
     {
         use std::iter::Iterator;
         self.event_types = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [payload_format][crate::model::NotificationConfig::payload_format].
+    pub fn set_payload_format<
+        T: std::convert::Into<crate::model::notification_config::PayloadFormat>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.payload_format = v.into();
         self
     }
 }
@@ -6655,15 +6655,6 @@ impl LoggingConfig {
         std::default::Default::default()
     }
 
-    /// Sets the value of [enable_onprem_gcs_transfer_logs][crate::model::LoggingConfig::enable_onprem_gcs_transfer_logs].
-    pub fn set_enable_onprem_gcs_transfer_logs<T: std::convert::Into<bool>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enable_onprem_gcs_transfer_logs = v.into();
-        self
-    }
-
     /// Sets the value of [log_actions][crate::model::LoggingConfig::log_actions].
     pub fn set_log_actions<T, V>(mut self, v: T) -> Self
     where
@@ -6683,6 +6674,15 @@ impl LoggingConfig {
     {
         use std::iter::Iterator;
         self.log_action_states = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [enable_onprem_gcs_transfer_logs][crate::model::LoggingConfig::enable_onprem_gcs_transfer_logs].
+    pub fn set_enable_onprem_gcs_transfer_logs<T: std::convert::Into<bool>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.enable_onprem_gcs_transfer_logs = v.into();
         self
     }
 }
@@ -7113,15 +7113,6 @@ impl TransferOperation {
         self
     }
 
-    /// Sets the value of [transfer_job_name][crate::model::TransferOperation::transfer_job_name].
-    pub fn set_transfer_job_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transfer_job_name = v.into();
-        self
-    }
-
     /// Sets the value of [error_breakdowns][crate::model::TransferOperation::error_breakdowns].
     pub fn set_error_breakdowns<T, V>(mut self, v: T) -> Self
     where
@@ -7130,6 +7121,15 @@ impl TransferOperation {
     {
         use std::iter::Iterator;
         self.error_breakdowns = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [transfer_job_name][crate::model::TransferOperation::transfer_job_name].
+    pub fn set_transfer_job_name<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.transfer_job_name = v.into();
         self
     }
 }

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -445,17 +445,6 @@ impl DateTime {
         })
     }
 
-    /// The value of [time_offset][crate::model::DateTime::time_offset]
-    /// if it holds a `TimeZone`, `None` if the field is not set or
-    /// holds a different branch.
-    pub fn time_zone(&self) -> std::option::Option<&std::boxed::Box<crate::model::TimeZone>> {
-        #[allow(unreachable_patterns)]
-        self.time_offset.as_ref().and_then(|v| match v {
-            crate::model::date_time::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
-            _ => std::option::Option::None,
-        })
-    }
-
     /// Sets the value of [time_offset][crate::model::DateTime::time_offset]
     /// to hold a `UtcOffset`.
     ///
@@ -468,6 +457,17 @@ impl DateTime {
         self.time_offset =
             std::option::Option::Some(crate::model::date_time::TimeOffset::UtcOffset(v.into()));
         self
+    }
+
+    /// The value of [time_offset][crate::model::DateTime::time_offset]
+    /// if it holds a `TimeZone`, `None` if the field is not set or
+    /// holds a different branch.
+    pub fn time_zone(&self) -> std::option::Option<&std::boxed::Box<crate::model::TimeZone>> {
+        #[allow(unreachable_patterns)]
+        self.time_offset.as_ref().and_then(|v| match v {
+            crate::model::date_time::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
+            _ => std::option::Option::None,
+        })
     }
 
     /// Sets the value of [time_offset][crate::model::DateTime::time_offset]
@@ -1108,6 +1108,17 @@ impl PhoneNumber {
         })
     }
 
+    /// Sets the value of [kind][crate::model::PhoneNumber::kind]
+    /// to hold a `E164Number`.
+    ///
+    /// Note that all the setters affecting `kind` are
+    /// mutually exclusive.
+    pub fn set_e164_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.kind =
+            std::option::Option::Some(crate::model::phone_number::Kind::E164Number(v.into()));
+        self
+    }
+
     /// The value of [kind][crate::model::PhoneNumber::kind]
     /// if it holds a `ShortCode`, `None` if the field is not set or
     /// holds a different branch.
@@ -1119,17 +1130,6 @@ impl PhoneNumber {
             crate::model::phone_number::Kind::ShortCode(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::PhoneNumber::kind]
-    /// to hold a `E164Number`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_e164_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kind =
-            std::option::Option::Some(crate::model::phone_number::Kind::E164Number(v.into()));
-        self
     }
 
     /// Sets the value of [kind][crate::model::PhoneNumber::kind]
@@ -1435,12 +1435,6 @@ impl PostalAddress {
         self
     }
 
-    /// Sets the value of [organization][crate::model::PostalAddress::organization].
-    pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.organization = v.into();
-        self
-    }
-
     /// Sets the value of [address_lines][crate::model::PostalAddress::address_lines].
     pub fn set_address_lines<T, V>(mut self, v: T) -> Self
     where
@@ -1460,6 +1454,12 @@ impl PostalAddress {
     {
         use std::iter::Iterator;
         self.recipients = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [organization][crate::model::PostalAddress::organization].
+    pub fn set_organization<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.organization = v.into();
         self
     }
 }

--- a/src/storage-control/src/generated/gapic/builder.rs
+++ b/src/storage-control/src/generated/gapic/builder.rs
@@ -706,6 +706,17 @@ pub mod storage {
             self
         }
 
+        /// Sets the value of [source_objects][crate::model::ComposeObjectRequest::source_objects].
+        pub fn set_source_objects<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<crate::model::compose_object_request::SourceObject>,
+        {
+            use std::iter::Iterator;
+            self.0.request.source_objects = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [destination_predefined_acl][crate::model::ComposeObjectRequest::destination_predefined_acl].
         pub fn set_destination_predefined_acl<T: Into<std::string::String>>(
             mut self,
@@ -753,17 +764,6 @@ pub mod storage {
             v: T,
         ) -> Self {
             self.0.request.object_checksums = v.into();
-            self
-        }
-
-        /// Sets the value of [source_objects][crate::model::ComposeObjectRequest::source_objects].
-        pub fn set_source_objects<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<crate::model::compose_object_request::SourceObject>,
-        {
-            use std::iter::Iterator;
-            self.0.request.source_objects = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }

--- a/src/storage-control/src/generated/gapic/model.rs
+++ b/src/storage-control/src/generated/gapic/model.rs
@@ -352,12 +352,6 @@ impl ListBucketsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListBucketsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [buckets][crate::model::ListBucketsResponse::buckets].
     pub fn set_buckets<T, V>(mut self, v: T) -> Self
     where
@@ -366,6 +360,12 @@ impl ListBucketsResponse {
     {
         use std::iter::Iterator;
         self.buckets = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListBucketsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }
@@ -614,6 +614,17 @@ impl ComposeObjectRequest {
         self
     }
 
+    /// Sets the value of [source_objects][crate::model::ComposeObjectRequest::source_objects].
+    pub fn set_source_objects<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::compose_object_request::SourceObject>,
+    {
+        use std::iter::Iterator;
+        self.source_objects = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [destination_predefined_acl][crate::model::ComposeObjectRequest::destination_predefined_acl].
     pub fn set_destination_predefined_acl<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -666,17 +677,6 @@ impl ComposeObjectRequest {
         v: T,
     ) -> Self {
         self.object_checksums = v.into();
-        self
-    }
-
-    /// Sets the value of [source_objects][crate::model::ComposeObjectRequest::source_objects].
-    pub fn set_source_objects<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::compose_object_request::SourceObject>,
-    {
-        use std::iter::Iterator;
-        self.source_objects = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -2906,6 +2906,28 @@ impl Bucket {
         self
     }
 
+    /// Sets the value of [acl][crate::model::Bucket::acl].
+    pub fn set_acl<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::BucketAccessControl>,
+    {
+        use std::iter::Iterator;
+        self.acl = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [default_object_acl][crate::model::Bucket::default_object_acl].
+    pub fn set_default_object_acl<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ObjectAccessControl>,
+    {
+        use std::iter::Iterator;
+        self.default_object_acl = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [lifecycle][crate::model::Bucket::lifecycle].
     pub fn set_lifecycle<
         T: std::convert::Into<std::option::Option<crate::model::bucket::Lifecycle>>,
@@ -2926,6 +2948,17 @@ impl Bucket {
         self
     }
 
+    /// Sets the value of [cors][crate::model::Bucket::cors].
+    pub fn set_cors<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::bucket::Cors>,
+    {
+        use std::iter::Iterator;
+        self.cors = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [update_time][crate::model::Bucket::update_time].
     pub fn set_update_time<T: std::convert::Into<std::option::Option<wkt::Timestamp>>>(
         mut self,
@@ -2938,6 +2971,18 @@ impl Bucket {
     /// Sets the value of [default_event_based_hold][crate::model::Bucket::default_event_based_hold].
     pub fn set_default_event_based_hold<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.default_event_based_hold = v.into();
+        self
+    }
+
+    /// Sets the value of [labels][crate::model::Bucket::labels].
+    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 
@@ -3076,51 +3121,6 @@ impl Bucket {
         self.soft_delete_policy = v.into();
         self
     }
-
-    /// Sets the value of [acl][crate::model::Bucket::acl].
-    pub fn set_acl<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::BucketAccessControl>,
-    {
-        use std::iter::Iterator;
-        self.acl = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [default_object_acl][crate::model::Bucket::default_object_acl].
-    pub fn set_default_object_acl<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ObjectAccessControl>,
-    {
-        use std::iter::Iterator;
-        self.default_object_acl = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [cors][crate::model::Bucket::cors].
-    pub fn set_cors<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::bucket::Cors>,
-    {
-        use std::iter::Iterator;
-        self.cors = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [labels][crate::model::Bucket::labels].
-    pub fn set_labels<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.labels = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-        self
-    }
 }
 
 impl wkt::message::Message for Bucket {
@@ -3208,12 +3208,6 @@ pub mod bucket {
             std::default::Default::default()
         }
 
-        /// Sets the value of [max_age_seconds][crate::model::bucket::Cors::max_age_seconds].
-        pub fn set_max_age_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.max_age_seconds = v.into();
-            self
-        }
-
         /// Sets the value of [origin][crate::model::bucket::Cors::origin].
         pub fn set_origin<T, V>(mut self, v: T) -> Self
         where
@@ -3244,6 +3238,12 @@ pub mod bucket {
         {
             use std::iter::Iterator;
             self.response_header = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [max_age_seconds][crate::model::bucket::Cors::max_age_seconds].
+        pub fn set_max_age_seconds<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
+            self.max_age_seconds = v.into();
             self
         }
     }
@@ -3675,6 +3675,17 @@ pub mod bucket {
                     self
                 }
 
+                /// Sets the value of [matches_storage_class][crate::model::bucket::lifecycle::rule::Condition::matches_storage_class].
+                pub fn set_matches_storage_class<T, V>(mut self, v: T) -> Self
+                where
+                    T: std::iter::IntoIterator<Item = V>,
+                    V: std::convert::Into<std::string::String>,
+                {
+                    use std::iter::Iterator;
+                    self.matches_storage_class = v.into_iter().map(|i| i.into()).collect();
+                    self
+                }
+
                 /// Sets the value of [days_since_custom_time][crate::model::bucket::lifecycle::rule::Condition::days_since_custom_time].
                 pub fn set_days_since_custom_time<
                     T: std::convert::Into<std::option::Option<i32>>,
@@ -3716,17 +3727,6 @@ pub mod bucket {
                     v: T,
                 ) -> Self {
                     self.noncurrent_time_before = v.into();
-                    self
-                }
-
-                /// Sets the value of [matches_storage_class][crate::model::bucket::lifecycle::rule::Condition::matches_storage_class].
-                pub fn set_matches_storage_class<T, V>(mut self, v: T) -> Self
-                where
-                    T: std::iter::IntoIterator<Item = V>,
-                    V: std::convert::Into<std::string::String>,
-                {
-                    use std::iter::Iterator;
-                    self.matches_storage_class = v.into_iter().map(|i| i.into()).collect();
                     self
                 }
 
@@ -4689,6 +4689,17 @@ impl Object {
         self
     }
 
+    /// Sets the value of [acl][crate::model::Object::acl].
+    pub fn set_acl<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::model::ObjectAccessControl>,
+    {
+        use std::iter::Iterator;
+        self.acl = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [content_language][crate::model::Object::content_language].
     pub fn set_content_language<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -4789,6 +4800,18 @@ impl Object {
         self
     }
 
+    /// Sets the value of [metadata][crate::model::Object::metadata].
+    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (K, V)>,
+        K: std::convert::Into<std::string::String>,
+        V: std::convert::Into<std::string::String>,
+    {
+        use std::iter::Iterator;
+        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+        self
+    }
+
     /// Sets the value of [event_based_hold][crate::model::Object::event_based_hold].
     pub fn set_event_based_hold<T: std::convert::Into<std::option::Option<bool>>>(
         mut self,
@@ -4842,29 +4865,6 @@ impl Object {
         v: T,
     ) -> Self {
         self.hard_delete_time = v.into();
-        self
-    }
-
-    /// Sets the value of [acl][crate::model::Object::acl].
-    pub fn set_acl<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ObjectAccessControl>,
-    {
-        use std::iter::Iterator;
-        self.acl = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
-    /// Sets the value of [metadata][crate::model::Object::metadata].
-    pub fn set_metadata<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<std::string::String>,
-        V: std::convert::Into<std::string::String>,
-    {
-        use std::iter::Iterator;
-        self.metadata = v.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -5047,12 +5047,6 @@ impl ListObjectsResponse {
         std::default::Default::default()
     }
 
-    /// Sets the value of [next_page_token][crate::model::ListObjectsResponse::next_page_token].
-    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_page_token = v.into();
-        self
-    }
-
     /// Sets the value of [objects][crate::model::ListObjectsResponse::objects].
     pub fn set_objects<T, V>(mut self, v: T) -> Self
     where
@@ -5072,6 +5066,12 @@ impl ListObjectsResponse {
     {
         use std::iter::Iterator;
         self.prefixes = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [next_page_token][crate::model::ListObjectsResponse::next_page_token].
+    pub fn set_next_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.next_page_token = v.into();
         self
     }
 }

--- a/src/wkt/src/generated/mod.rs
+++ b/src/wkt/src/generated/mod.rs
@@ -96,27 +96,6 @@ impl Api {
         self
     }
 
-    /// Sets the value of [version][crate::Api::version].
-    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.version = v.into();
-        self
-    }
-
-    /// Sets the value of [source_context][crate::Api::source_context].
-    pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_context = v.into();
-        self
-    }
-
-    /// Sets the value of [syntax][crate::Api::syntax].
-    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
-        self
-    }
-
     /// Sets the value of [methods][crate::Api::methods].
     pub fn set_methods<T, V>(mut self, v: T) -> Self
     where
@@ -139,6 +118,21 @@ impl Api {
         self
     }
 
+    /// Sets the value of [version][crate::Api::version].
+    pub fn set_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.version = v.into();
+        self
+    }
+
+    /// Sets the value of [source_context][crate::Api::source_context].
+    pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_context = v.into();
+        self
+    }
+
     /// Sets the value of [mixins][crate::Api::mixins].
     pub fn set_mixins<T, V>(mut self, v: T) -> Self
     where
@@ -147,6 +141,12 @@ impl Api {
     {
         use std::iter::Iterator;
         self.mixins = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [syntax][crate::Api::syntax].
+    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
         self
     }
 }
@@ -235,12 +235,6 @@ impl Method {
         self
     }
 
-    /// Sets the value of [syntax][crate::Method::syntax].
-    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
-        self
-    }
-
     /// Sets the value of [options][crate::Method::options].
     pub fn set_options<T, V>(mut self, v: T) -> Self
     where
@@ -249,6 +243,12 @@ impl Method {
     {
         use std::iter::Iterator;
         self.options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [syntax][crate::Method::syntax].
+    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
         self
     }
 }
@@ -508,38 +508,6 @@ impl FileDescriptorProto {
         self
     }
 
-    /// Sets the value of [options][crate::FileDescriptorProto::options].
-    pub fn set_options<T: std::convert::Into<std::option::Option<crate::FileOptions>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
-    /// Sets the value of [source_code_info][crate::FileDescriptorProto::source_code_info].
-    pub fn set_source_code_info<
-        T: std::convert::Into<std::option::Option<crate::SourceCodeInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_code_info = v.into();
-        self
-    }
-
-    /// Sets the value of [syntax][crate::FileDescriptorProto::syntax].
-    pub fn set_syntax<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
-        self
-    }
-
-    /// Sets the value of [edition][crate::FileDescriptorProto::edition].
-    pub fn set_edition<T: std::convert::Into<crate::Edition>>(mut self, v: T) -> Self {
-        self.edition = v.into();
-        self
-    }
-
     /// Sets the value of [dependency][crate::FileDescriptorProto::dependency].
     pub fn set_dependency<T, V>(mut self, v: T) -> Self
     where
@@ -616,6 +584,38 @@ impl FileDescriptorProto {
         self.extension = v.into_iter().map(|i| i.into()).collect();
         self
     }
+
+    /// Sets the value of [options][crate::FileDescriptorProto::options].
+    pub fn set_options<T: std::convert::Into<std::option::Option<crate::FileOptions>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.options = v.into();
+        self
+    }
+
+    /// Sets the value of [source_code_info][crate::FileDescriptorProto::source_code_info].
+    pub fn set_source_code_info<
+        T: std::convert::Into<std::option::Option<crate::SourceCodeInfo>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_code_info = v.into();
+        self
+    }
+
+    /// Sets the value of [syntax][crate::FileDescriptorProto::syntax].
+    pub fn set_syntax<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
+        self
+    }
+
+    /// Sets the value of [edition][crate::FileDescriptorProto::edition].
+    pub fn set_edition<T: std::convert::Into<crate::Edition>>(mut self, v: T) -> Self {
+        self.edition = v.into();
+        self
+    }
 }
 
 impl wkt::message::Message for FileDescriptorProto {
@@ -674,15 +674,6 @@ impl DescriptorProto {
     /// Sets the value of [name][crate::DescriptorProto::name].
     pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.name = v.into();
-        self
-    }
-
-    /// Sets the value of [options][crate::DescriptorProto::options].
-    pub fn set_options<T: std::convert::Into<std::option::Option<crate::MessageOptions>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
         self
     }
 
@@ -749,6 +740,15 @@ impl DescriptorProto {
     {
         use std::iter::Iterator;
         self.oneof_decl = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::DescriptorProto::options].
+    pub fn set_options<T: std::convert::Into<std::option::Option<crate::MessageOptions>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.options = v.into();
         self
     }
 
@@ -915,26 +915,6 @@ impl ExtensionRangeOptions {
         std::default::Default::default()
     }
 
-    /// Sets the value of [features][crate::ExtensionRangeOptions::features].
-    pub fn set_features<T: std::convert::Into<std::option::Option<crate::FeatureSet>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.features = v.into();
-        self
-    }
-
-    /// Sets the value of [verification][crate::ExtensionRangeOptions::verification].
-    pub fn set_verification<
-        T: std::convert::Into<crate::extension_range_options::VerificationState>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.verification = v.into();
-        self
-    }
-
     /// Sets the value of [uninterpreted_option][crate::ExtensionRangeOptions::uninterpreted_option].
     pub fn set_uninterpreted_option<T, V>(mut self, v: T) -> Self
     where
@@ -954,6 +934,26 @@ impl ExtensionRangeOptions {
     {
         use std::iter::Iterator;
         self.declaration = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [features][crate::ExtensionRangeOptions::features].
+    pub fn set_features<T: std::convert::Into<std::option::Option<crate::FeatureSet>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.features = v.into();
+        self
+    }
+
+    /// Sets the value of [verification][crate::ExtensionRangeOptions::verification].
+    pub fn set_verification<
+        T: std::convert::Into<crate::extension_range_options::VerificationState>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.verification = v.into();
         self
     }
 }
@@ -1793,15 +1793,6 @@ impl EnumDescriptorProto {
         self
     }
 
-    /// Sets the value of [options][crate::EnumDescriptorProto::options].
-    pub fn set_options<T: std::convert::Into<std::option::Option<crate::EnumOptions>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
     /// Sets the value of [value][crate::EnumDescriptorProto::value].
     pub fn set_value<T, V>(mut self, v: T) -> Self
     where
@@ -1810,6 +1801,15 @@ impl EnumDescriptorProto {
     {
         use std::iter::Iterator;
         self.value = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::EnumDescriptorProto::options].
+    pub fn set_options<T: std::convert::Into<std::option::Option<crate::EnumOptions>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.options = v.into();
         self
     }
 
@@ -1975,15 +1975,6 @@ impl ServiceDescriptorProto {
         self
     }
 
-    /// Sets the value of [options][crate::ServiceDescriptorProto::options].
-    pub fn set_options<T: std::convert::Into<std::option::Option<crate::ServiceOptions>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = v.into();
-        self
-    }
-
     /// Sets the value of [method][crate::ServiceDescriptorProto::method].
     pub fn set_method<T, V>(mut self, v: T) -> Self
     where
@@ -1992,6 +1983,15 @@ impl ServiceDescriptorProto {
     {
         use std::iter::Iterator;
         self.method = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [options][crate::ServiceDescriptorProto::options].
+    pub fn set_options<T: std::convert::Into<std::option::Option<crate::ServiceOptions>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.options = v.into();
         self
     }
 }
@@ -2854,26 +2854,6 @@ impl FieldOptions {
         self
     }
 
-    /// Sets the value of [features][crate::FieldOptions::features].
-    pub fn set_features<T: std::convert::Into<std::option::Option<crate::FeatureSet>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.features = v.into();
-        self
-    }
-
-    /// Sets the value of [feature_support][crate::FieldOptions::feature_support].
-    pub fn set_feature_support<
-        T: std::convert::Into<std::option::Option<crate::field_options::FeatureSupport>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.feature_support = v.into();
-        self
-    }
-
     /// Sets the value of [targets][crate::FieldOptions::targets].
     pub fn set_targets<T, V>(mut self, v: T) -> Self
     where
@@ -2893,6 +2873,26 @@ impl FieldOptions {
     {
         use std::iter::Iterator;
         self.edition_defaults = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [features][crate::FieldOptions::features].
+    pub fn set_features<T: std::convert::Into<std::option::Option<crate::FeatureSet>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.features = v.into();
+        self
+    }
+
+    /// Sets the value of [feature_support][crate::FieldOptions::feature_support].
+    pub fn set_feature_support<
+        T: std::convert::Into<std::option::Option<crate::field_options::FeatureSupport>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.feature_support = v.into();
         self
     }
 
@@ -4151,6 +4151,17 @@ impl UninterpretedOption {
         std::default::Default::default()
     }
 
+    /// Sets the value of [name][crate::UninterpretedOption::name].
+    pub fn set_name<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::uninterpreted_option::NamePart>,
+    {
+        use std::iter::Iterator;
+        self.name = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [identifier_value][crate::UninterpretedOption::identifier_value].
     pub fn set_identifier_value<T: std::convert::Into<std::string::String>>(
         mut self,
@@ -4187,17 +4198,6 @@ impl UninterpretedOption {
     /// Sets the value of [aggregate_value][crate::UninterpretedOption::aggregate_value].
     pub fn set_aggregate_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.aggregate_value = v.into();
-        self
-    }
-
-    /// Sets the value of [name][crate::UninterpretedOption::name].
-    pub fn set_name<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::uninterpreted_option::NamePart>,
-    {
-        use std::iter::Iterator;
-        self.name = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5162,6 +5162,17 @@ impl FeatureSetDefaults {
         std::default::Default::default()
     }
 
+    /// Sets the value of [defaults][crate::FeatureSetDefaults::defaults].
+    pub fn set_defaults<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::feature_set_defaults::FeatureSetEditionDefault>,
+    {
+        use std::iter::Iterator;
+        self.defaults = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [minimum_edition][crate::FeatureSetDefaults::minimum_edition].
     pub fn set_minimum_edition<T: std::convert::Into<crate::Edition>>(mut self, v: T) -> Self {
         self.minimum_edition = v.into();
@@ -5171,17 +5182,6 @@ impl FeatureSetDefaults {
     /// Sets the value of [maximum_edition][crate::FeatureSetDefaults::maximum_edition].
     pub fn set_maximum_edition<T: std::convert::Into<crate::Edition>>(mut self, v: T) -> Self {
         self.maximum_edition = v.into();
-        self
-    }
-
-    /// Sets the value of [defaults][crate::FeatureSetDefaults::defaults].
-    pub fn set_defaults<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::feature_set_defaults::FeatureSetEditionDefault>,
-    {
-        use std::iter::Iterator;
-        self.defaults = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -5450,24 +5450,6 @@ pub mod source_code_info {
             std::default::Default::default()
         }
 
-        /// Sets the value of [leading_comments][crate::source_code_info::Location::leading_comments].
-        pub fn set_leading_comments<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.leading_comments = v.into();
-            self
-        }
-
-        /// Sets the value of [trailing_comments][crate::source_code_info::Location::trailing_comments].
-        pub fn set_trailing_comments<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.trailing_comments = v.into();
-            self
-        }
-
         /// Sets the value of [path][crate::source_code_info::Location::path].
         pub fn set_path<T, V>(mut self, v: T) -> Self
         where
@@ -5487,6 +5469,24 @@ pub mod source_code_info {
         {
             use std::iter::Iterator;
             self.span = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
+        /// Sets the value of [leading_comments][crate::source_code_info::Location::leading_comments].
+        pub fn set_leading_comments<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.leading_comments = v.into();
+            self
+        }
+
+        /// Sets the value of [trailing_comments][crate::source_code_info::Location::trailing_comments].
+        pub fn set_trailing_comments<T: std::convert::Into<std::string::String>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.trailing_comments = v.into();
             self
         }
 
@@ -5590,6 +5590,17 @@ pub mod generated_code_info {
             std::default::Default::default()
         }
 
+        /// Sets the value of [path][crate::generated_code_info::Annotation::path].
+        pub fn set_path<T, V>(mut self, v: T) -> Self
+        where
+            T: std::iter::IntoIterator<Item = V>,
+            V: std::convert::Into<i32>,
+        {
+            use std::iter::Iterator;
+            self.path = v.into_iter().map(|i| i.into()).collect();
+            self
+        }
+
         /// Sets the value of [source_file][crate::generated_code_info::Annotation::source_file].
         pub fn set_source_file<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
             self.source_file = v.into();
@@ -5616,17 +5627,6 @@ pub mod generated_code_info {
             v: T,
         ) -> Self {
             self.semantic = v.into();
-            self
-        }
-
-        /// Sets the value of [path][crate::generated_code_info::Annotation::path].
-        pub fn set_path<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<i32>,
-        {
-            use std::iter::Iterator;
-            self.path = v.into_iter().map(|i| i.into()).collect();
             self
         }
     }
@@ -5862,27 +5862,6 @@ impl Type {
         self
     }
 
-    /// Sets the value of [source_context][crate::Type::source_context].
-    pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_context = v.into();
-        self
-    }
-
-    /// Sets the value of [syntax][crate::Type::syntax].
-    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
-        self
-    }
-
-    /// Sets the value of [edition][crate::Type::edition].
-    pub fn set_edition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.edition = v.into();
-        self
-    }
-
     /// Sets the value of [fields][crate::Type::fields].
     pub fn set_fields<T, V>(mut self, v: T) -> Self
     where
@@ -5913,6 +5892,27 @@ impl Type {
     {
         use std::iter::Iterator;
         self.options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [source_context][crate::Type::source_context].
+    pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_context = v.into();
+        self
+    }
+
+    /// Sets the value of [syntax][crate::Type::syntax].
+    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
+        self
+    }
+
+    /// Sets the value of [edition][crate::Type::edition].
+    pub fn set_edition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.edition = v.into();
         self
     }
 }
@@ -6023,6 +6023,17 @@ impl Field {
         self
     }
 
+    /// Sets the value of [options][crate::Field::options].
+    pub fn set_options<T, V>(mut self, v: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = V>,
+        V: std::convert::Into<crate::Option>,
+    {
+        use std::iter::Iterator;
+        self.options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
     /// Sets the value of [json_name][crate::Field::json_name].
     pub fn set_json_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.json_name = v.into();
@@ -6032,17 +6043,6 @@ impl Field {
     /// Sets the value of [default_value][crate::Field::default_value].
     pub fn set_default_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.default_value = v.into();
-        self
-    }
-
-    /// Sets the value of [options][crate::Field::options].
-    pub fn set_options<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::Option>,
-    {
-        use std::iter::Iterator;
-        self.options = v.into_iter().map(|i| i.into()).collect();
         self
     }
 }
@@ -6486,27 +6486,6 @@ impl Enum {
         self
     }
 
-    /// Sets the value of [source_context][crate::Enum::source_context].
-    pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_context = v.into();
-        self
-    }
-
-    /// Sets the value of [syntax][crate::Enum::syntax].
-    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
-        self.syntax = v.into();
-        self
-    }
-
-    /// Sets the value of [edition][crate::Enum::edition].
-    pub fn set_edition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.edition = v.into();
-        self
-    }
-
     /// Sets the value of [enumvalue][crate::Enum::enumvalue].
     pub fn set_enumvalue<T, V>(mut self, v: T) -> Self
     where
@@ -6526,6 +6505,27 @@ impl Enum {
     {
         use std::iter::Iterator;
         self.options = v.into_iter().map(|i| i.into()).collect();
+        self
+    }
+
+    /// Sets the value of [source_context][crate::Enum::source_context].
+    pub fn set_source_context<T: std::convert::Into<std::option::Option<crate::SourceContext>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.source_context = v.into();
+        self
+    }
+
+    /// Sets the value of [syntax][crate::Enum::syntax].
+    pub fn set_syntax<T: std::convert::Into<crate::Syntax>>(mut self, v: T) -> Self {
+        self.syntax = v.into();
+        self
+    }
+
+    /// Sets the value of [edition][crate::Enum::edition].
+    pub fn set_edition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.edition = v.into();
         self
     }
 }


### PR DESCRIPTION
Now that fields are classified as `Map`, `Repeated`, or `Singular` we
can refactor the mustache templates to eliminate some duplication. This
will reorder the output, but it will be a one-time event.

The main motivation is to avoid duplication for the comments and (maybe) skipping fields (see #1940 and #1941).
