### PR TITLE
cleanup: wrap markdown lines

### DIFF
--- a/.gcb/bootstrap/README.md
+++ b/.gcb/bootstrap/README.md
@@ -1,8 +1,8 @@
 # Terraform configuration Bootstrap
 
 We use terraform (https://terraform.io) to create and update the state of our
-testing infrastructure. We describe the desired state of the infrastructure
-to terraform using `.tf` scripts. By default, Terraform stores [state][tf-state]
+testing infrastructure. We describe the desired state of the infrastructure to
+terraform using `.tf` scripts. By default, Terraform stores [state][tf-state]
 locally, in a file called `terraform.tfstate`. This default configuration can
 make Terraform usage difficult for teams. If multiple team members run Terraform
 at the same time on different machine each state may have a different definition
@@ -30,8 +30,8 @@ Initialize terraform:
 terraform init
 ```
 
-Restore the current state. This may result in no action if you happen to have
-an up-to-date state in your local files.
+Restore the current state. This may result in no action if you happen to have an
+up-to-date state in your local files.
 
 ```shell
 terraform plan -out /tmp/bootstrap.tplan

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,18 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrap lines to 80 characters.
+#
+# Possible values: {"keep", "no", INTEGER}
+wrap = 80

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,8 +36,8 @@ More specifically, the functionality offered by these libraries include:
 - The libraries convert pagination APIs into streams.
 - The libraries convert long-running operations into an asynchronous function
   that simply returns the final outcome of the long-running operation.
-  Applications that need more fine-grained control over the request can still
-  do so.
+  Applications that need more fine-grained control over the request can still do
+  so.
 - The application can define retry policies for all RPCs in a client and
   override the policies for specific requests.
 - The libraries support best practices such as exponential backoff on retries
@@ -75,7 +75,7 @@ hand-crafted code. The main directories are:
 - `guide/samples`: the code samples for the user guide. In general, we want the
   code samples to be at least compiled
 
-[^required]: unfortunately some required parameters are not that easy to detect,
-    it is possible to create some requests with missing required parameters.
+[^required]: unfortunately some required parameters are not that easy to detect, it is
+    possible to create some requests with missing required parameters.
 
 [tokio]: https://tokio.rs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,9 +69,9 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *Carlos O'Ryan (coryan@google.com)*, the
-Project Steward(s) for *Google Cloud API Client Libraries for Rust*. It is the
-Project Steward’s duty to receive and address reported violations of the code of
+Reports should be directed to *Carlos O'Ryan (coryan@google.com)*, the Project
+Steward(s) for *Google Cloud API Client Libraries for Rust*. It is the Project
+Steward’s duty to receive and address reported violations of the code of
 conduct. They will then work with a committee consisting of representatives from
 the Open Source Programs Office and the Google Open Source Strategy team. If for
 any reason you are uncomfortable reaching out to the Project Steward, please

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,5 +24,5 @@ information on using pull requests.
 
 ## Community Guidelines
 
-This project follows [Google's Open Source Community
-Guidelines](https://opensource.google/conduct/).
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![build status](https://github.com/googleapis/google-cloud-rust/actions/workflows/sdk.yaml/badge.svg)](https://github.com/googleapis/google-cloud-rust/actions/workflows/sdk.yaml)
 [![dependency status](https://deps.rs/repo/github/googleapis/google-cloud-rust/status.svg)](https://deps.rs/repo/github/googleapis/google-cloud-rust)
 
-Idiomatic Rust client libraries for [Google Cloud Platform](https://cloud.google.com/) services.
+Idiomatic Rust client libraries for
+[Google Cloud Platform](https://cloud.google.com/) services.
 
 > **NOTE:** this project is under development, all APIs are subject to change
 > without notice. Some documentation is aspirational.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,8 @@
 
 To report a security issue, please use [g.co/vulnz](https://g.co/vulnz).
 
-The Google Security Team will respond within 5 working days of your report on g.co/vulnz.
+The Google Security Team will respond within 5 working days of your report on
+g.co/vulnz.
 
-We use g.co/vulnz for our intake, and do coordination and disclosure here using GitHub Security Advisory to privately discuss and fix the issue.
+We use g.co/vulnz for our intake, and do coordination and disclosure here using
+GitHub Security Advisory to privately discuss and fix the issue.

--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -7,7 +7,8 @@ when the generator changes.
 
 ## Prerequisites
 
-The generator and its unit tests use `protoc`, the Protobuf compiler. Ensure you have `protoc >= v23.0` installed and it is found via your `$PATH`.
+The generator and its unit tests use `protoc`, the Protobuf compiler. Ensure you
+have `protoc >= v23.0` installed and it is found via your `$PATH`.
 
 ```bash
 protoc --version
@@ -61,8 +62,8 @@ git commit -m "feat(${library}): generate library"
 We may need to customize the target or source directory for some generated
 libraries. For example, you may need to leave room for other crates in the same
 directory. In this case you cannot use `rust-generate` and need to manually
-provide the source and output directories to the `generate` subcommand.
-We will use `google/api` as an example.
+provide the source and output directories to the `generate` subcommand. We will
+use `google/api` as an example.
 
 ```bash
 cargo new --lib --vcs none src/generated/api/types
@@ -126,8 +127,8 @@ go -C generator/ run ./cmd/sidekick refresh \
 ## The Glorious Future
 
 Someday `sidekick` will be stable enough that (a) it will not be part of the
-`google-cloud-rust` repository, and we will be able to install it. At that
-point we will be able to say:
+`google-cloud-rust` repository, and we will be able to install it. At that point
+we will be able to say:
 
 ```bash
 go install github.com/googleapis/google-cloud-generator/sidekick@v1.0.0

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -89,7 +89,8 @@ Some of the samples are integration tests, you can verify they build using:
 cargo build --package user-guide-samples
 ```
 
-and verify they run using the instructions in the [Integration Tests](#integration-tests) section.
+and verify they run using the instructions in the
+[Integration Tests](#integration-tests) section.
 
 ### Using `mdbook serve`
 
@@ -145,8 +146,8 @@ project.
 
 We use [Secret Manager], [Workflows], [Firestore], and [Speech-to-Text] to run
 integration tests. Follow the [Enable the Secret Manager API] guide to, as it
-says, enable the API and make sure that billing is enabled in your projects.
-To enable the Workflows, Firestore, and Speech-to-Text APIs you can run this
+says, enable the API and make sure that billing is enabled in your projects. To
+enable the Workflows, Firestore, and Speech-to-Text APIs you can run this
 command:
 
 ```bash
@@ -189,8 +190,8 @@ gcloud iam service-accounts disable rust-sdk-test@${GOOGLE_CLOUD_PROJECT}.iam.gs
 
 ### Create a database
 
-The integration tests need the default Firestore database in your project.
-You can create this database using:
+The integration tests need the default Firestore database in your project. You
+can create this database using:
 
 ```bash
 gcloud firestore databases create --location=us-central1
@@ -227,8 +228,8 @@ with logging enabled and with logging disabled.
 ## Miscellaneous Tools
 
 We use a number of tools to format non-Rust code. The CI builds enforce
-formatting, you can fix any formatting problems manually (using the CI logs),
-or may prefer to install these tools locally to fix formatting problems.
+formatting, you can fix any formatting problems manually (using the CI logs), or
+may prefer to install these tools locally to fix formatting problems.
 
 Typically we do not format these files for generated code, so local runs
 requires skipping the generated files.

--- a/generator/README.md
+++ b/generator/README.md
@@ -56,7 +56,8 @@ Or from `generator/`: `go test ./...`
 
 ### Installing `protoc`: the Protobuf Compiler
 
-The generator and its unit tests use `protoc`, the Protobuf compiler. Ensure you have `protoc >= v23.0` installed and it is found via your `$PATH`.
+The generator and its unit tests use `protoc`, the Protobuf compiler. Ensure you
+have `protoc >= v23.0` installed and it is found via your `$PATH`.
 
 ```bash
 protoc --version

--- a/generator/doc/contributor/howto-guide-new-sidekick-codec.md
+++ b/generator/doc/contributor/howto-guide-new-sidekick-codec.md
@@ -1,9 +1,9 @@
 # How-To Guide: Implementing a new Codec
 
-This guide is intended for contributors to the `sidekick` project. It will
-walk you through the steps necessary to add a new `codec`. If you are just
-looking for instructions on how to use the `sidekick` consult the top-level
-README or the specific guide for your SDK.
+This guide is intended for contributors to the `sidekick` project. It will walk
+you through the steps necessary to add a new `codec`. If you are just looking
+for instructions on how to use the `sidekick` consult the top-level README or
+the specific guide for your SDK.
 
 ## What is a `codec`
 
@@ -18,8 +18,8 @@ The basic data flows is:
 - Sidekick parses the source specification of an API (Protobuf or OpenAPIv3) and
   converts this into a language-neutral, source-neutral abstract syntax tree. We
   often call this syntax tree "the model".
-- Sidekick then calls the `Generate()` function in a codec, and passes the
-  model (as a `api.API` data structure, and some configuration options).
+- Sidekick then calls the `Generate()` function in a codec, and passes the model
+  (as a `api.API` data structure, and some configuration options).
 - The codec annotates the syntax tree. Each node in the tree has a `Codec`
   field. The codec is expected to put its own data structure in that node.
 - The code then loads a number of mustache templates and calls these templates

--- a/guide/src/configuring_polling_policies.md
+++ b/guide/src/configuring_polling_policies.md
@@ -18,18 +18,17 @@ limitations under the License.
 
 The Google Cloud Client Libraries for Rust provide helper functions to simplify
 waiting and monitoring the progress of
-[LROs (Long-Running Operations)](working_with_long_running_operations.md).
-These helpers use policies to configure the polling frequency and to determine
-what polling errors are transient and may be ignored until the next polling
-event.
+[LROs (Long-Running Operations)](working_with_long_running_operations.md). These
+helpers use policies to configure the polling frequency and to determine what
+polling errors are transient and may be ignored until the next polling event.
 
 This guide will walk you through the configuration of these policies for all the
 long-running operations started by a client, or just for one specific request.
 
 There are two different policies controlling the behavior of the LRO loops:
 
-- The polling backoff policy controls how long the loop waits before polling
-  the status of a LRO that is still in progress.
+- The polling backoff policy controls how long the loop waits before polling the
+  status of a LRO that is still in progress.
 - The polling error policy controls what to do on an polling error. Some polling
   errors are unrecoverable, and indicate that the operation was aborted or the
   caller has no permissions to check the status of the LRO. Other polling errors
@@ -53,8 +52,8 @@ diagnose.
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:speech}}
@@ -95,7 +94,9 @@ The client library will first wait for 500ms, after the first polling attempt,
 then for 1,000ms (or 1s) for the second attempt, and sub-sequent attempts will
 wait 2s, 4s, 8s and then all attempts will wait 10s.
 
-See [below](#configuring-the-polling-frequency-for-all-requests-in-a-client-complete-code) for the complete code.
+See
+[below](#configuring-the-polling-frequency-for-all-requests-in-a-client-complete-code)
+for the complete code.
 
 ## Configuring the polling frequency for a specific request
 
@@ -131,7 +132,9 @@ You can issue this request as usual. For example:
 {{#include ../samples/src/polling_policies.rs:rpc-backoff-print}}
 ```
 
-See [below](#configuring-the-polling-frequency-for-a-specific-request-complete-code) for the complete code.
+See
+[below](#configuring-the-polling-frequency-for-a-specific-request-complete-code)
+for the complete code.
 
 ## Configuring the retryable polling errors for all requests in a client
 
@@ -168,7 +171,9 @@ The client library will only treat `UNAVAILABLE` (see [AIP-194]) as a retryable
 error, and will stop polling after 100 attempts or 300 seconds, whichever comes
 first.
 
-See [below](#configuring-the-retryable-polling-errors-for-all-requests-in-a-client-complete-code) for the complete code.
+See
+[below](#configuring-the-retryable-polling-errors-for-all-requests-in-a-client-complete-code)
+for the complete code.
 
 ## Configuring the retryable polling errors for a specific request
 
@@ -204,7 +209,9 @@ You can issue this request as usual. For example:
 {{#include ../samples/src/polling_policies.rs:rpc-errors-print}}
 ```
 
-See [below](#configuring-the-retryable-polling-errors-for-a-specific-request-complete-code) for the complete code.
+See
+[below](#configuring-the-retryable-polling-errors-for-a-specific-request-complete-code)
+for the complete code.
 
 ## Configuring the polling frequency for all requests in a client: complete code
 

--- a/guide/src/configuring_retry_policies.md
+++ b/guide/src/configuring_retry_policies.md
@@ -18,11 +18,11 @@ limitations under the License.
 
 The Google Cloud client libraries for Rust can automatically retry operations
 that fail due to transient errors. However, the clients do not automatically
-enable the retry loop. The application must set the retry policy to enable
-this feature.
+enable the retry loop. The application must set the retry policy to enable this
+feature.
 
-This guide will show you how to enable the retry loop. First we will show how
-to enable a common retry policy for all requests in a client, and then how to
+This guide will show you how to enable the retry loop. First we will show how to
+enable a common retry policy for all requests in a client, and then how to
 override this default for a specific request.
 
 ## Prerequisites
@@ -37,8 +37,8 @@ and that your account has the necessary permissions.
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:secretmanager}}
@@ -66,8 +66,8 @@ Then use the service as usual:
 {{#include ../samples/src/retry_policies.rs:client-retry-request}}
 ```
 
-See [below](#configuring-the-default-retry-policy-complete-code)
-for the complete code.
+See [below](#configuring-the-default-retry-policy-complete-code) for the
+complete code.
 
 ## Configuring the default retry policy with limits
 
@@ -86,8 +86,8 @@ Requests work as usual too:
 {{#include ../samples/src/retry_policies.rs:client-retry-full-request}}
 ```
 
-See [below](#configuring-the-default-retry-policy-with-limits-complete-code)
-for the complete code.
+See [below](#configuring-the-default-retry-policy-with-limits-complete-code) for
+the complete code.
 
 ## Override the retry policy for one request
 
@@ -103,8 +103,8 @@ can override the policy for one request:
 {{#include ../samples/src/retry_policies.rs:request-retry-request}}
 ```
 
-See [below](#configuring-the-default-retry-policy-with-limits-complete-code)
-for the complete code.
+See [below](#configuring-the-default-retry-policy-with-limits-complete-code) for
+the complete code.
 
 ## Configuring the default retry policy: complete code
 

--- a/guide/src/error_handling.md
+++ b/guide/src/error_handling.md
@@ -16,15 +16,15 @@ limitations under the License.
 
 # Error handling
 
-Sometimes applications need to branch based on the type and details of the
-error returned by the client library. This guide will show you how to write
-code to handle such errors.
+Sometimes applications need to branch based on the type and details of the error
+returned by the client library. This guide will show you how to write code to
+handle such errors.
 
-> **Retryable errors:** one of the most common reasons to handle
-> errors in distributed systems is to retry requests that fail due to transient
-> errors. The Google Cloud client libraries for Rust implement a policy-based
-> retry loop. You only need to configure the policies to enable the retry loop,
-> and the libraries implement common retry policies. Consult the
+> **Retryable errors:** one of the most common reasons to handle errors in
+> distributed systems is to retry requests that fail due to transient errors.
+> The Google Cloud client libraries for Rust implement a policy-based retry
+> loop. You only need to configure the policies to enable the retry loop, and
+> the libraries implement common retry policies. Consult the
 > [Configuring Retry Policies] section before implementing your own retry loop.
 
 ## Prerequisites
@@ -39,8 +39,8 @@ and that your account has the necessary permissions.
 
 ### Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:secretmanager}}
@@ -57,11 +57,11 @@ In addition, this guide uses `crc32c` to calculate the checksum:
 In this guide we will create a new *secret version*. Secret versions are
 contained in *secrets*. One must create the secret before creating secret
 versions. A common pattern in cloud services is to use a resource as-if the
-container for it existed, and only create the container if there is an error.
-If the container exists most of the time, such an approach is more efficient
-than checking if the container exists before making the request. Checking if
-the container exists consumes more quota, results in more RPC charges, and is
-slower when the container already exists.
+container for it existed, and only create the container if there is an error. If
+the container exists most of the time, such an approach is more efficient than
+checking if the container exists before making the request. Checking if the
+container exists consumes more quota, results in more RPC charges, and is slower
+when the container already exists.
 
 ## Handling the error
 

--- a/guide/src/examine_error_details.md
+++ b/guide/src/examine_error_details.md
@@ -37,8 +37,8 @@ and that your account has the necessary permissions.
 
 ### Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file:
 
 ```toml
 [dependencies]
@@ -122,8 +122,8 @@ rest of the example we will traverse the data structure and print the most
 relevant fields.
 
 Only errors returned by the service contain detailed information, so we first
-query the error to see if it contains the correct error type. If it does, we
-can break down some top-level information about the error:
+query the error to see if it contains the correct error type. If it does, we can
+break down some top-level information about the error:
 
 ```rust,ignore
 {{#include ../samples/src/examine_error_details.rs:examine-error-details-service-error}}
@@ -135,8 +135,8 @@ And then iterate over all the details:
 {{#include ../samples/src/examine_error_details.rs:examine-error-details-service-error}}
 ```
 
-The client libraries return a [`StatusDetails`] enum with the different
-types of error details. In this example we will only examine `BadRequest` errors:
+The client libraries return a [`StatusDetails`] enum with the different types of
+error details. In this example we will only examine `BadRequest` errors:
 
 ```rust,ignore
 {{#include ../samples/src/examine_error_details.rs:examine-error-details-bad-request}}

--- a/guide/src/initialize_a_client.md
+++ b/guide/src/initialize_a_client.md
@@ -16,18 +16,17 @@ limitations under the License.
 
 # How to initialize a client
 
-The Google Cloud Client Libraries for Rust use "clients" as the main
-abstraction to interface with specific services. Clients are implemented
-as Rust structs, with methods corresponding to each RPC offered by the
-service. In other words, to use a Google Cloud service using the Rust
-client libraries you need to first initialize a client.
+The Google Cloud Client Libraries for Rust use "clients" as the main abstraction
+to interface with specific services. Clients are implemented as Rust structs,
+with methods corresponding to each RPC offered by the service. In other words,
+to use a Google Cloud service using the Rust client libraries you need to first
+initialize a client.
 
 ## Prerequisites
 
-In this guide we will initialize a client and then use the client to make
-a simple RPC. To make this guide concrete, we will use the
-[Secret Manager API]. The same structure applies to any other service in
-Google Cloud.
+In this guide we will initialize a client and then use the client to make a
+simple RPC. To make this guide concrete, we will use the [Secret Manager API].
+The same structure applies to any other service in Google Cloud.
 
 We recommend you follow one of the "Getting Started" guides for Secret Manager
 before attempting to use the client library, such as how to [Create a secret].
@@ -41,8 +40,8 @@ login to configure the [Application Default Credentials] used in this guide.
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:secretmanager}}

--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -22,8 +22,8 @@ interact with Google Cloud Services.
 This guide is organized as a series of small tutorials showing how to perform
 specific actions with the client libraries. Most Google Cloud services follow a
 series of guidelines, collectively known as the [AIPs](https://google.aip.dev).
-This makes the client libraries more consistent from one service to the next. The functions
-to delete or list resources almost always have the same interface.
+This makes the client libraries more consistent from one service to the next.
+The functions to delete or list resources almost always have the same interface.
 
 ## Audience
 
@@ -33,19 +33,19 @@ supporting toolchain.
 
 At the risk of being repetitive, most of the guides do not assume you have used
 any Google Service or client library before (in Rust or other language).
-However, the guides will refer you to service specific tutorials to
-initialize their projects and services.
+However, the guides will refer you to service specific tutorials to initialize
+their projects and services.
 
 ## Service specific documentation
 
-These guides are not intended as tutorials for each service or as extended guides
-on how to design Rust applications to work on Google Cloud. They are starting
-points to get you productive with the client libraries for Rust.
+These guides are not intended as tutorials for each service or as extended
+guides on how to design Rust applications to work on Google Cloud. They are
+starting points to get you productive with the client libraries for Rust.
 
 We recommend you read the service documentation at <https://cloud.google.com> to
-learn more about each service. If you need guidance on how to design your application
-for Google Cloud, the [Cloud Architecture Center] may have what you are looking
-for.
+learn more about each service. If you need guidance on how to design your
+application for Google Cloud, the [Cloud Architecture Center] may have what you
+are looking for.
 
 ## Reporting bugs
 

--- a/guide/src/mock_a_client.md
+++ b/guide/src/mock_a_client.md
@@ -33,8 +33,8 @@ which seems to be the most popular.
 {{#include ../samples/Cargo.toml:mockall}}
 ```
 
-This guide will use a [`Speech`][speech-client] client. Note that the same
-ideas in this guide apply to all of the clients, not just the `Speech` client.
+This guide will use a [`Speech`][speech-client] client. Note that the same ideas
+in this guide apply to all of the clients, not just the `Speech` client.
 
 We declare the dependency in our `Cargo.toml`. Yours will be similar, but
 without the custom `path`.
@@ -60,7 +60,8 @@ make an RPC, and process the response from the server.
 
 We want to test how our code handles different responses from the service.
 
-First we will define the mock class. This class implements the [`speech::stub::Speech`][speech-stub] trait.
+First we will define the mock class. This class implements the
+[`speech::stub::Speech`][speech-stub] trait.
 
 ```rust,ignore
 {{#include ../samples/tests/mocking.rs:mockall_macro}}

--- a/guide/src/mocking_lros.md
+++ b/guide/src/mocking_lros.md
@@ -69,7 +69,8 @@ that the operation has completed, thus ending the polling loop.
 
 Now we are ready to write our test.
 
-First we define our mock class, which implements the [`speech::stub::Speech`][speech-stub] trait.
+First we define our mock class, which implements the
+[`speech::stub::Speech`][speech-stub] trait.
 
 ```rust,ignore
 {{#rustdoc_include ../samples/tests/mocking_lros_auto.rs:mockall-macro}}
@@ -164,8 +165,8 @@ Errors can arise in an LRO from a few places.
 If your application uses automatic polling, the following cases are all
 equivalent: `until_done()` returns the error in the `Result`, regardless of
 where it originated.
-[Simulating an error starting an LRO](#simulating-an-error-starting-an-lro)
-will yield the simplest test.
+[Simulating an error starting an LRO](#simulating-an-error-starting-an-lro) will
+yield the simplest test.
 
 Note that the stubbed out client does not have a retry or polling policy. In all
 cases, the polling loop will terminate on the first error, even if the error is

--- a/guide/src/pagination.md
+++ b/guide/src/pagination.md
@@ -37,8 +37,8 @@ and that your account has the necessary permissions.
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:secretmanager}}
@@ -71,7 +71,7 @@ individual items.
 ### Working with futures::Stream
 
 You may want to use these APIs in the larger Rust ecosystem of asynchronous
-streams, such as `tokio::Stream`.  This is readily done, but you must first
+streams, such as `tokio::Stream`. This is readily done, but you must first
 enable the `unstable-streams` feature in the `google_cloud_gax` crate:
 
 ```toml

--- a/guide/src/setting_up_rust_on_cloud_shell.md
+++ b/guide/src/setting_up_rust_on_cloud_shell.md
@@ -26,7 +26,8 @@ Cloud Shell is a great environment to run small examples and tests.
 
 ## Configure Rust
 
-1. [Cloud Shell] comes with [rustup] pre-installed. You can use it to install and configure the default version of Rust:
+1. [Cloud Shell] comes with [rustup] pre-installed. You can use it to install
+   and configure the default version of Rust:
 
    ```shell
    rustup default stable

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -16,8 +16,8 @@ limitations under the License.
 
 # Setting up your development environment
 
-Prepare your environment for [Rust] app development and deployment on
-Google Cloud by installing the following tools.
+Prepare your environment for [Rust] app development and deployment on Google
+Cloud by installing the following tools.
 
 ## Install Rust
 
@@ -41,21 +41,22 @@ and IDEs, which provide the following features:
 ## Install the Google Cloud CLI
 
 The [Google Cloud CLI] is a set of tools for Google Cloud. It contains the
-[`gcloud`](https://cloud.google.com/sdk/gcloud/)
-and [`bq`](https://cloud.google.com/bigquery/docs/bq-command-line-tool)
-command-line tools used to access Compute Engine, Cloud Storage,
-BigQuery, and other services from the command line. You can run these
-tools interactively or in your automated scripts.
+[`gcloud`](https://cloud.google.com/sdk/gcloud/) and
+[`bq`](https://cloud.google.com/bigquery/docs/bq-command-line-tool) command-line
+tools used to access Compute Engine, Cloud Storage, BigQuery, and other services
+from the command line. You can run these tools interactively or in your
+automated scripts.
 
-To install the gcloud CLI, see [Installing the gcloud CLI](https://cloud.google.com/sdk/install).
+To install the gcloud CLI, see
+[Installing the gcloud CLI](https://cloud.google.com/sdk/install).
 
 ## Install the Cloud Client Libraries for Rust in a New Project
 
 The Cloud Client Libraries for Rust is the idiomatic way for Rust developers to
 integrate with Google Cloud services, such as Secret Manager and Workflows.
 
-For example, to use the package for an individual API, such as the
-Secret Manager API, do the following:
+For example, to use the package for an individual API, such as the Secret
+Manager API, do the following:
 
 1. Create a new Rust project:
 
@@ -104,8 +105,8 @@ Note: The source of the Cloud Client Libraries for Rust is
 
 ### Running the program
 
-1. To use the Cloud Client Libraries in a local development environment, set
-   up Application Default Credentials.
+1. To use the Cloud Client Libraries in a local development environment, set up
+   Application Default Credentials.
 
    ```shell
    gcloud auth application-default login

--- a/guide/src/working_with_enums.md
+++ b/guide/src/working_with_enums.md
@@ -32,14 +32,14 @@ working with values introduced after the library release.
 ## Prerequisites
 
 This guide does not make any calls to Google Cloud services. You can run the
-examples without having a project or account in Google Cloud. The guide will
-use the client library for [Secret Manager]. The same principles apply to any
-other enumeration in any other client library.
+examples without having a project or account in Google Cloud. The guide will use
+the client library for [Secret Manager]. The same principles apply to any other
+enumeration in any other client library.
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:secretmanager}}
@@ -93,7 +93,8 @@ case, consider using the [`wildcard_enum_match_arm`] clippy warning:
 {{#include ../samples/tests/enums.rs:match_with_warnings}}
 ```
 
-You may also consider the (currently unstable) [`non_exhaustive_omitted_patterns`] lint.
+You may also consider the (currently unstable)
+[`non_exhaustive_omitted_patterns`] lint.
 
 [secret manager]: https://cloud.google.com/secret-manager
 [wildcard pattern]: https://doc.rust-lang.org/reference/patterns.html#wildcard-pattern

--- a/guide/src/working_with_long_running_operations.md
+++ b/guide/src/working_with_long_running_operations.md
@@ -39,8 +39,8 @@ diagnose.
 
 ## Dependencies
 
-As it is usual with Rust, you must declare the dependency in your
-`Cargo.toml` file. We use:
+As it is usual with Rust, you must declare the dependency in your `Cargo.toml`
+file. We use:
 
 ```toml
 {{#include ../samples/Cargo.toml:speech}}
@@ -55,8 +55,8 @@ And:
 ## Starting a long-running operation
 
 To start a long-running operation first initialize a client as
-[usual](./initialize_a_client.md) and then make the RPC. But first, add some
-use declarations to avoid the long package names:
+[usual](./initialize_a_client.md) and then make the RPC. But first, add some use
+declarations to avoid the long package names:
 
 ```rust,ignore
 {{#include ../samples/src/lro.rs:use}}
@@ -115,7 +115,9 @@ Finally, we need to poll this promise until it completes:
 We will examine the `manual_poll_lro()` function in the
 [Manually polling a long-running operation] section.
 
-You can find the [full function](#automatically-polling-a-long-running-operation-complete-code) below.
+You can find the
+[full function](#automatically-polling-a-long-running-operation-complete-code)
+below.
 
 ## Automatically polling a long-running operation
 
@@ -153,7 +155,9 @@ And then we poll until the operation is completed and print the result:
 {{#include ../samples/src/lro.rs:automatic-print}}
 ```
 
-You can find the [full function](#automatically-polling-a-long-running-operation-complete-code) below.
+You can find the
+[full function](#automatically-polling-a-long-running-operation-complete-code)
+below.
 
 ## Polling a long-running operation
 
@@ -183,15 +187,16 @@ The poller uses a policy to determine what polling errors are transient and may
 resolve themselves. The [Configuring polling policies] chapter covers this topic
 in detail.
 
-You can find the [full function](#polling-a-long-running-operation-complete-code) below.
+You can find the
+[full function](#polling-a-long-running-operation-complete-code) below.
 
 ## Manually polling a long-running operation
 
 In general, we recommend you use the previous two approaches in your
 application. Manually polling a long-running operation can be quite tedious, and
-it is easy to get the types involved wrong. If you do need to manually poll
-a long-running operation this guide will walk you through the required steps.
-You may want to read the [Operation][longrunning::model::operation] message
+it is easy to get the types involved wrong. If you do need to manually poll a
+long-running operation this guide will walk you through the required steps. You
+may want to read the [Operation][longrunning::model::operation] message
 reference documentation, as some of the fields and types are used below.
 
 Recall that we started the long-running operation using the client:
@@ -230,8 +235,8 @@ to check for both. First check for errors:
 ```
 
 The error type is a [Status][rpc::model::status] message type. This does **not**
-implement the standard `Error` interface, you need to manually convert that to
-a valid error. You can use [ServiceError::from] to perform this conversion.
+implement the standard `Error` interface, you need to manually convert that to a
+valid error. You can use [ServiceError::from] to perform this conversion.
 
 Assuming the result is successful, you need to extract the response type. You
 can find this type in the documentation for the LRO method, or by reading the
@@ -277,11 +282,12 @@ And then poll the operation to get its new status:
 {{#rustdoc_include ../samples/src/lro.rs:manual-poll-again}}
 ```
 
-For simplicity, we have chosen to ignore all errors. In your application you
-may choose to treat only a subset of the errors as non-recoverable, and may want
-to limit the number of polling attempts if these fail.
+For simplicity, we have chosen to ignore all errors. In your application you may
+choose to treat only a subset of the errors as non-recoverable, and may want to
+limit the number of polling attempts if these fail.
 
-You can find the [full function](#manually-polling-a-long-running-operation-complete-code) below.
+You can find the
+[full function](#manually-polling-a-long-running-operation-complete-code) below.
 
 ## Starting a long-running operation: complete code
 

--- a/src/auth/.gcb/bootstrap/README.md
+++ b/src/auth/.gcb/bootstrap/README.md
@@ -5,7 +5,8 @@ This document assumes you are familiar with the
 
 The terraform configuration for auth is separate because:
 
-- the resources belong to a different project (`rust-auth-testing` vs. `rust-sdk-testing`)
+- the resources belong to a different project (`rust-auth-testing` vs.
+  `rust-sdk-testing`)
 - accessing the different projects requires different permissions
 
 ## Usage
@@ -22,8 +23,8 @@ Initialize terraform:
 terraform init
 ```
 
-Restore the current state. This may result in no action if you happen to have
-an up-to-date state in your local files.
+Restore the current state. This may result in no action if you happen to have an
+up-to-date state in your local files.
 
 ```shell
 terraform plan -out /tmp/bootstrap.tplan

--- a/src/gax-internal/README.md
+++ b/src/gax-internal/README.md
@@ -1,9 +1,9 @@
 # Google Cloud Client Libraries for Rust - Implementation Details
 
-This crate contains implementation details shared by many client libraries.
-The types, traits, and functions defined in this crate are undocumented.
-This is intentional, as they are not intended for general use and will be
-changed without notice.
+This crate contains implementation details shared by many client libraries. The
+types, traits, and functions defined in this crate are undocumented. This is
+intentional, as they are not intended for general use and will be changed
+without notice.
 
 Maybe you were looking for [google-cloud-gax]? That crate contains public APIs
 intended for general use.


### PR DESCRIPTION
Enforce 80 character line limits in markdown files. Sorry in advance for all the `lint` build failures.