### PR TITLE
feat(auth): Introduce GCE_METADATA_HOST env var to set the metadata server host

### DIFF
--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -19,7 +19,9 @@
 //! This is a local service to the VM (or pod) which (as the name implies) provides
 //! metadata information about the VM. The service also provides access
 //! tokens associated with the [default service account] for the corresponding
-//! VM. The default host name of the metadata service is `metadata.google.internal`.
+//! VM.
+//!
+//! The default host name of the metadata service is `metadata.google.internal`.
 //! If you would like to use a different hostname, you can set it using the
 //! `GCE_METADATA_HOST` environment variable.
 //!
@@ -488,7 +490,10 @@ mod test {
         .await;
 
         // Trim out 'http://' from the endpoint provided by the fake server
-        let _e = ScopedEnv::set(super::GCE_METADATA_HOST_ENV_VAR, &endpoint[7..]);
+        let _e = ScopedEnv::set(
+            super::GCE_METADATA_HOST_ENV_VAR,
+            &endpoint.strip_prefix("http://").unwrap_or(&endpoint),
+        );
         let mdsc = Builder::default()
             .with_scopes(["scope1", "scope2"])
             .build()

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -500,6 +500,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[parallel]
     async fn get_default_service_account_info_success() {
         let service_account_info = ServiceAccountInfo {
             email: "test@test.com".to_string(),
@@ -531,6 +532,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[parallel]
     async fn get_service_account_info_server_error() {
         let (endpoint, _server) = start(Handlers::from([(
             MDS_DEFAULT_URI.to_string(),
@@ -554,6 +556,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[parallel]
     async fn headers_success_with_quota_project() -> TestResult {
         let scopes = ["scope1".to_string(), "scope2".to_string()];
         let response = MDSTokenResponse {

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -492,7 +492,7 @@ mod test {
         // Trim out 'http://' from the endpoint provided by the fake server
         let _e = ScopedEnv::set(
             super::GCE_METADATA_HOST_ENV_VAR,
-            &endpoint.strip_prefix("http://").unwrap_or(&endpoint),
+            endpoint.strip_prefix("http://").unwrap_or(&endpoint),
         );
         let mdsc = Builder::default()
             .with_scopes(["scope1", "scope2"])


### PR DESCRIPTION
By default MDS uses `metadata.google.internal`  host for the metadata server. If a user wants to use a different host name, currently the only was is to use builder and set the `endpoint`.

This change introduces another way: set the `GCE_METADATA_HOST` environment variable.

Note: If user sets the env var and also provides an endpoint override through builder, we will use the env var.