### PR TITLE
cleanup(gax-internal): enable semver checks

### DIFF
--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -26,6 +26,11 @@ license.workspace      = true
 repository.workspace   = true
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+# Disable all features during document generation. All the types in this crate
+# are implementation details, and subject to change without notice.
+features = []
+
 [features]
 _internal_http_client = [
   "_internal_common",

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -27,10 +27,8 @@ use http::HeaderMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[doc(hidden)]
 pub type InnerClient = tonic::client::Grpc<tonic::transport::Channel>;
 
-#[doc(hidden)]
 #[derive(Clone, Debug)]
 pub struct Client {
     inner: InnerClient,

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -27,7 +27,6 @@ use gax::retry_policy::RetryPolicy;
 use gax::retry_throttler::SharedRetryThrottler;
 use std::sync::Arc;
 
-#[doc(hidden)]
 #[derive(Clone, Debug)]
 pub struct ReqwestClient {
     inner: reqwest::Client,
@@ -247,7 +246,6 @@ impl ReqwestClient {
     }
 }
 
-#[doc(hidden)]
 #[derive(serde::Serialize)]
 pub struct NoBody {}
 

--- a/src/gax-internal/src/lib.rs
+++ b/src/gax-internal/src/lib.rs
@@ -25,33 +25,25 @@
 //! changed without notice.
 
 #[cfg(feature = "_internal_common")]
-#[doc(hidden)]
 pub mod api_header;
 
 #[cfg(feature = "_internal_common")]
-#[doc(hidden)]
 pub mod path_parameter;
 
 #[cfg(feature = "_internal_http_client")]
-#[doc(hidden)]
 pub mod query_parameter;
 
 #[cfg(feature = "_internal_http_client")]
-#[doc(hidden)]
 pub mod http;
 
 #[cfg(feature = "_internal_grpc_client")]
-#[doc(hidden)]
 pub mod grpc;
 
 #[cfg(feature = "_internal_grpc_client")]
-#[doc(hidden)]
 pub mod prost;
 
 #[cfg(feature = "_internal_common")]
-#[doc(hidden)]
 pub mod options;
 
 #[cfg(feature = "_internal_common")]
-#[doc(hidden)]
 pub mod routing_parameter;


### PR DESCRIPTION
We want to use `cargo-semver-checks` with this crate, and
`#[doc(hidden)]` disables all semantic version checks. The generated
documentation is still empty, because none of the features are enabled
by default and therefore no documentation is generated for them.
