### PR TITLE
fix: POST and PUT requests with empty bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4989,10 +4989,12 @@ name = "integration-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "bytes",
  "crc32c",
  "futures",
  "google-cloud-aiplatform-v1",
+ "google-cloud-auth",
  "google-cloud-bigquery-v2",
  "google-cloud-firestore",
  "google-cloud-gax",
@@ -5006,6 +5008,7 @@ dependencies = [
  "google-cloud-workflows-v1",
  "mockall",
  "rand 0.9.0",
+ "reqwest",
  "secretmanager-openapi-v1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,6 +274,7 @@ incremental = false
 
 [workspace.dependencies]
 anyhow           = "1"
+axum             = { version = "0.8" }
 async-trait      = { version = "0.1" }
 bytes            = { version = "1", default-features = false, features = ["serde"] }
 http             = { version = "1", default-features = false }

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -164,6 +164,12 @@ type pathInfoAnnotation struct {
 	HasBody       bool
 }
 
+// Returns true if the HTTP request requires a payload. This is relevant for
+// POST and PUT requests that do not have a body parameter.
+func (a *pathInfoAnnotation) RequiresContentLength() bool {
+	return a.Method == "POST" || a.Method == "PUT"
+}
+
 type operationInfo struct {
 	MetadataType       string
 	ResponseType       string

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -97,8 +97,17 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
         {{/Codec.QueryParams}}
         self.inner.execute(
             builder,
-            {{#PathInfo.Codec.HasBody}}Some(req{{Codec.BodyAccessor}}){{/PathInfo.Codec.HasBody}}
-            {{^PathInfo.Codec.HasBody}}None::<gaxi::http::NoBody>{{/PathInfo.Codec.HasBody}},
+            {{#PathInfo.Codec.HasBody}}
+            Some(req{{Codec.BodyAccessor}}),
+            {{/PathInfo.Codec.HasBody}}
+            {{^PathInfo.Codec.HasBody}}
+            {{#PathInfo.Codec.RequiresContentLength}}
+            Some(gaxi::http::NoBody),
+            {{/PathInfo.Codec.RequiresContentLength}}
+            {{^PathInfo.Codec.RequiresContentLength}}
+            None::<gaxi::http::NoBody>,
+            {{/PathInfo.Codec.RequiresContentLength}}
+            {{/PathInfo.Codec.HasBody}}
             options,
         ).await
         {{#ReturnsEmpty}}

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -42,7 +42,7 @@ bon            = "3"
 gax.workspace = true
 
 [dev-dependencies]
-axum                = "0.8"
+axum.workspace      = true
 mockall             = "0.13"
 rand                = "0.8"
 regex               = "1"

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -77,7 +77,7 @@ wkt  = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace    = true
-axum                = "0.8"
+axum.workspace      = true
 bytes               = "1"
 mockall             = "0.13"
 scoped-env          = "2"

--- a/src/gax-internal/echo-server/Cargo.toml
+++ b/src/gax-internal/echo-server/Cargo.toml
@@ -20,7 +20,7 @@ edition.workspace = true
 publish           = false
 
 [dependencies]
-axum            = "0.8"
+axum.workspace  = true
 bytes.workspace = true
 serde_json      = "1"
 tokio           = { version = "1", features = ["macros"] }

--- a/src/gax-internal/grpc-server/Cargo.toml
+++ b/src/gax-internal/grpc-server/Cargo.toml
@@ -25,7 +25,7 @@ _generate-protos = ["dep:tonic-build"]
 
 [dependencies]
 anyhow.workspace = true
-axum             = "0.8"
+axum.workspace   = true
 http             = "1"
 prost            = { workspace = true, default-features = true }
 serde_json       = "1"

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -247,7 +247,7 @@ impl ReqwestClient {
 }
 
 #[derive(serde::Serialize)]
-pub struct NoBody {}
+pub struct NoBody;
 
 const SENSITIVE_HEADER: &str = "[sensitive]";
 

--- a/src/generated/api/servicemanagement/v1/src/transport.rs
+++ b/src/generated/api/servicemanagement/v1/src/transport.rs
@@ -144,7 +144,7 @@ impl super::stub::ServiceManager for ServiceManager {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 

--- a/src/generated/bigtable/admin/v2/src/transport.rs
+++ b/src/generated/bigtable/admin/v2/src/transport.rs
@@ -869,7 +869,7 @@ impl super::stub::BigtableInstanceAdmin for BigtableInstanceAdmin {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1655,7 +1655,7 @@ impl super::stub::BigtableTableAdmin for BigtableTableAdmin {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/aiplatform/v1/src/transport.rs
+++ b/src/generated/cloud/aiplatform/v1/src/transport.rs
@@ -672,7 +672,7 @@ impl super::stub::DatasetService for DatasetService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -698,7 +698,7 @@ impl super::stub::DatasetService for DatasetService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -781,7 +781,7 @@ impl super::stub::DatasetService for DatasetService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -814,7 +814,7 @@ impl super::stub::DatasetService for DatasetService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1088,7 +1088,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1114,7 +1114,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1197,7 +1197,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1230,7 +1230,7 @@ impl super::stub::DeploymentResourcePoolService for DeploymentResourcePoolServic
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1577,7 +1577,7 @@ impl super::stub::EndpointService for EndpointService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1603,7 +1603,7 @@ impl super::stub::EndpointService for EndpointService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1686,7 +1686,7 @@ impl super::stub::EndpointService for EndpointService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1719,7 +1719,7 @@ impl super::stub::EndpointService for EndpointService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1873,7 +1873,7 @@ impl super::stub::EvaluationService for EvaluationService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1899,7 +1899,7 @@ impl super::stub::EvaluationService for EvaluationService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1982,7 +1982,7 @@ impl super::stub::EvaluationService for EvaluationService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2015,7 +2015,7 @@ impl super::stub::EvaluationService for EvaluationService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -2444,7 +2444,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2470,7 +2470,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2553,7 +2553,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2586,7 +2586,7 @@ impl super::stub::FeatureOnlineStoreAdminService for FeatureOnlineStoreAdminServ
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2760,7 +2760,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2786,7 +2786,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2869,7 +2869,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2902,7 +2902,7 @@ impl super::stub::FeatureOnlineStoreService for FeatureOnlineStoreService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -3289,7 +3289,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -3315,7 +3315,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -3398,7 +3398,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3431,7 +3431,7 @@ impl super::stub::FeatureRegistryService for FeatureRegistryService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -3605,7 +3605,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -3631,7 +3631,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -3714,7 +3714,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3747,7 +3747,7 @@ impl super::stub::FeaturestoreOnlineServingService for FeaturestoreOnlineServing
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -4373,7 +4373,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -4399,7 +4399,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -4482,7 +4482,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4515,7 +4515,7 @@ impl super::stub::FeaturestoreService for FeaturestoreService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -4771,7 +4771,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -4797,7 +4797,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -4880,7 +4880,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4913,7 +4913,7 @@ impl super::stub::GenAiCacheService for GenAiCacheService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -5141,7 +5141,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -5167,7 +5167,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -5250,7 +5250,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -5283,7 +5283,7 @@ impl super::stub::GenAiTuningService for GenAiTuningService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -5604,7 +5604,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -5630,7 +5630,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -5713,7 +5713,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -5746,7 +5746,7 @@ impl super::stub::IndexEndpointService for IndexEndpointService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -6035,7 +6035,7 @@ impl super::stub::IndexService for IndexService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -6061,7 +6061,7 @@ impl super::stub::IndexService for IndexService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -6144,7 +6144,7 @@ impl super::stub::IndexService for IndexService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -6177,7 +6177,7 @@ impl super::stub::IndexService for IndexService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7113,7 +7113,7 @@ impl super::stub::JobService for JobService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7139,7 +7139,7 @@ impl super::stub::JobService for JobService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7222,7 +7222,7 @@ impl super::stub::JobService for JobService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -7255,7 +7255,7 @@ impl super::stub::JobService for JobService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7429,7 +7429,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7455,7 +7455,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7538,7 +7538,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -7571,7 +7571,7 @@ impl super::stub::LlmUtilityService for LlmUtilityService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -7731,7 +7731,7 @@ impl super::stub::MatchService for MatchService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7757,7 +7757,7 @@ impl super::stub::MatchService for MatchService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -7840,7 +7840,7 @@ impl super::stub::MatchService for MatchService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -7873,7 +7873,7 @@ impl super::stub::MatchService for MatchService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -8722,7 +8722,7 @@ impl super::stub::MetadataService for MetadataService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -8748,7 +8748,7 @@ impl super::stub::MetadataService for MetadataService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -8831,7 +8831,7 @@ impl super::stub::MetadataService for MetadataService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -8864,7 +8864,7 @@ impl super::stub::MetadataService for MetadataService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -9038,7 +9038,7 @@ impl super::stub::MigrationService for MigrationService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -9064,7 +9064,7 @@ impl super::stub::MigrationService for MigrationService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -9147,7 +9147,7 @@ impl super::stub::MigrationService for MigrationService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -9180,7 +9180,7 @@ impl super::stub::MigrationService for MigrationService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -9337,7 +9337,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -9363,7 +9363,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -9446,7 +9446,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -9479,7 +9479,7 @@ impl super::stub::ModelGardenService for ModelGardenService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -10032,7 +10032,7 @@ impl super::stub::ModelService for ModelService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -10058,7 +10058,7 @@ impl super::stub::ModelService for ModelService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -10141,7 +10141,7 @@ impl super::stub::ModelService for ModelService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -10174,7 +10174,7 @@ impl super::stub::ModelService for ModelService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -10668,7 +10668,7 @@ impl super::stub::NotebookService for NotebookService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -10694,7 +10694,7 @@ impl super::stub::NotebookService for NotebookService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -10777,7 +10777,7 @@ impl super::stub::NotebookService for NotebookService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -10810,7 +10810,7 @@ impl super::stub::NotebookService for NotebookService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -11080,7 +11080,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -11106,7 +11106,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -11189,7 +11189,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -11222,7 +11222,7 @@ impl super::stub::PersistentResourceService for PersistentResourceService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -11624,7 +11624,7 @@ impl super::stub::PipelineService for PipelineService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -11650,7 +11650,7 @@ impl super::stub::PipelineService for PipelineService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -11733,7 +11733,7 @@ impl super::stub::PipelineService for PipelineService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -11766,7 +11766,7 @@ impl super::stub::PipelineService for PipelineService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12020,7 +12020,7 @@ impl super::stub::PredictionService for PredictionService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12046,7 +12046,7 @@ impl super::stub::PredictionService for PredictionService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12129,7 +12129,7 @@ impl super::stub::PredictionService for PredictionService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -12162,7 +12162,7 @@ impl super::stub::PredictionService for PredictionService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -12299,7 +12299,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12325,7 +12325,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12408,7 +12408,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -12441,7 +12441,7 @@ impl super::stub::ReasoningEngineExecutionService for ReasoningEngineExecutionSe
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -12681,7 +12681,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12707,7 +12707,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -12790,7 +12790,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -12823,7 +12823,7 @@ impl super::stub::ReasoningEngineService for ReasoningEngineService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -13121,7 +13121,7 @@ impl super::stub::ScheduleService for ScheduleService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -13147,7 +13147,7 @@ impl super::stub::ScheduleService for ScheduleService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -13230,7 +13230,7 @@ impl super::stub::ScheduleService for ScheduleService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -13263,7 +13263,7 @@ impl super::stub::ScheduleService for ScheduleService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -13522,7 +13522,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -13548,7 +13548,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -13631,7 +13631,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -13664,7 +13664,7 @@ impl super::stub::SpecialistPoolService for SpecialistPoolService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -14500,7 +14500,7 @@ impl super::stub::TensorboardService for TensorboardService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -14526,7 +14526,7 @@ impl super::stub::TensorboardService for TensorboardService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -14609,7 +14609,7 @@ impl super::stub::TensorboardService for TensorboardService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -14642,7 +14642,7 @@ impl super::stub::TensorboardService for TensorboardService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -14988,7 +14988,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15014,7 +15014,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15097,7 +15097,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -15130,7 +15130,7 @@ impl super::stub::VertexRagDataService for VertexRagDataService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15324,7 +15324,7 @@ impl super::stub::VertexRagService for VertexRagService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15350,7 +15350,7 @@ impl super::stub::VertexRagService for VertexRagService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15433,7 +15433,7 @@ impl super::stub::VertexRagService for VertexRagService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -15466,7 +15466,7 @@ impl super::stub::VertexRagService for VertexRagService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -15880,7 +15880,7 @@ impl super::stub::VizierService for VizierService {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15906,7 +15906,7 @@ impl super::stub::VizierService for VizierService {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("permissions", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -15989,7 +15989,7 @@ impl super::stub::VizierService for VizierService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -16022,7 +16022,7 @@ impl super::stub::VizierService for VizierService {
                 v.add(builder, "timeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/transport.rs
@@ -1791,7 +1791,7 @@ impl super::stub::ContactCenterInsights for ContactCenterInsights {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/datacatalog/v1/src/transport.rs
+++ b/src/generated/cloud/datacatalog/v1/src/transport.rs
@@ -950,7 +950,7 @@ impl super::stub::DataCatalog for DataCatalog {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1379,7 +1379,7 @@ impl super::stub::PolicyTagManager for PolicyTagManager {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1558,7 +1558,7 @@ impl super::stub::PolicyTagManagerSerialization for PolicyTagManagerSerializatio
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/dataplex/v1/src/transport.rs
+++ b/src/generated/cloud/dataplex/v1/src/transport.rs
@@ -592,7 +592,7 @@ impl super::stub::CatalogService for CatalogService {
         let builder = builder.query(&[("orderBy", &req.order_by)]);
         let builder = builder.query(&[("scope", &req.scope)]);
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 

--- a/src/generated/cloud/dataproc/v1/src/transport.rs
+++ b/src/generated/cloud/dataproc/v1/src/transport.rs
@@ -291,7 +291,7 @@ impl super::stub::AutoscalingPolicyService for AutoscalingPolicyService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -545,7 +545,7 @@ impl super::stub::BatchController for BatchController {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -950,7 +950,7 @@ impl super::stub::ClusterController for ClusterController {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1316,7 +1316,7 @@ impl super::stub::JobController for JobController {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1560,7 +1560,7 @@ impl super::stub::NodeGroupController for NodeGroupController {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1861,7 +1861,7 @@ impl super::stub::SessionTemplateController for SessionTemplateController {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2133,7 +2133,7 @@ impl super::stub::SessionController for SessionController {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2478,7 +2478,7 @@ impl super::stub::WorkflowTemplateService for WorkflowTemplateService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/transport.rs
@@ -374,7 +374,7 @@ impl super::stub::Agents for Agents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -560,7 +560,7 @@ impl super::stub::Changelogs for Changelogs {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -731,7 +731,7 @@ impl super::stub::Deployments for Deployments {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1026,7 +1026,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1378,7 +1378,7 @@ impl super::stub::Environments for Environments {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1676,7 +1676,7 @@ impl super::stub::Experiments for Experiments {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2010,7 +2010,7 @@ impl super::stub::Flows for Flows {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2279,7 +2279,7 @@ impl super::stub::Generators for Generators {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2564,7 +2564,7 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2821,7 +2821,7 @@ impl super::stub::Pages for Pages {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3071,7 +3071,7 @@ impl super::stub::SecuritySettingsService for SecuritySettingsService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3285,7 +3285,7 @@ impl super::stub::Sessions for Sessions {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3535,7 +3535,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3929,7 +3929,7 @@ impl super::stub::TestCases for TestCases {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4198,7 +4198,7 @@ impl super::stub::TransitionRouteGroups for TransitionRouteGroups {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4482,7 +4482,7 @@ impl super::stub::Versions for Versions {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4744,7 +4744,7 @@ impl super::stub::Webhooks for Webhooks {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/dialogflow/v2/src/transport.rs
+++ b/src/generated/cloud/dialogflow/v2/src/transport.rs
@@ -338,7 +338,7 @@ impl super::stub::Agents for Agents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -539,7 +539,7 @@ impl super::stub::AnswerRecords for AnswerRecords {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -812,7 +812,7 @@ impl super::stub::Contexts for Contexts {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1175,7 +1175,7 @@ impl super::stub::Conversations for Conversations {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1407,7 +1407,7 @@ impl super::stub::ConversationDatasets for ConversationDatasets {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1731,7 +1731,7 @@ impl super::stub::ConversationModels for ConversationModels {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2041,7 +2041,7 @@ impl super::stub::ConversationProfiles for ConversationProfiles {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2356,7 +2356,7 @@ impl super::stub::Documents for Documents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2543,7 +2543,7 @@ impl super::stub::EncryptionSpecService for EncryptionSpecService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2911,7 +2911,7 @@ impl super::stub::EntityTypes for EntityTypes {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3201,7 +3201,7 @@ impl super::stub::Environments for Environments {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3382,7 +3382,7 @@ impl super::stub::Fulfillments for Fulfillments {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3633,7 +3633,7 @@ impl super::stub::Generators for Generators {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -3921,7 +3921,7 @@ impl super::stub::Intents for Intents {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4187,7 +4187,7 @@ impl super::stub::KnowledgeBases for KnowledgeBases {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4514,7 +4514,7 @@ impl super::stub::Participants for Participants {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4662,7 +4662,7 @@ impl super::stub::Sessions for Sessions {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -4912,7 +4912,7 @@ impl super::stub::SessionEntityTypes for SessionEntityTypes {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -5159,7 +5159,7 @@ impl super::stub::Versions for Versions {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/documentai/v1/src/transport.rs
+++ b/src/generated/cloud/documentai/v1/src/transport.rs
@@ -576,7 +576,7 @@ impl super::stub::DocumentProcessorService for DocumentProcessorService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/iap/v1/src/transport.rs
+++ b/src/generated/cloud/iap/v1/src/transport.rs
@@ -175,7 +175,7 @@ impl super::stub::IdentityAwareProxyAdminService for IdentityAwareProxyAdminServ
             );
         let builder = builder.query(&[("expression", &req.expression)]);
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 

--- a/src/generated/cloud/lustre/v1/src/transport.rs
+++ b/src/generated/cloud/lustre/v1/src/transport.rs
@@ -324,7 +324,7 @@ impl super::stub::Lustre for Lustre {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/memorystore/v1/src/transport.rs
+++ b/src/generated/cloud/memorystore/v1/src/transport.rs
@@ -306,7 +306,7 @@ impl super::stub::Memorystore for Memorystore {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/redis/cluster/v1/src/transport.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/transport.rs
@@ -455,7 +455,7 @@ impl super::stub::CloudRedisCluster for CloudRedisCluster {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/redis/v1/src/transport.rs
+++ b/src/generated/cloud/redis/v1/src/transport.rs
@@ -386,7 +386,7 @@ impl super::stub::CloudRedis for CloudRedis {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/securitycenter/v2/src/transport.rs
+++ b/src/generated/cloud/securitycenter/v2/src/transport.rs
@@ -1075,7 +1075,7 @@ impl super::stub::SecurityCenter for SecurityCenter {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/sql/v1/src/transport.rs
+++ b/src/generated/cloud/sql/v1/src/transport.rs
@@ -475,7 +475,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -796,7 +796,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
             );
         let builder = builder.query(&[("failover", &req.failover)]);
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -831,7 +831,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 v.add(builder, "dbTimeout")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -856,7 +856,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -881,7 +881,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -952,7 +952,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -977,7 +977,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -1259,7 +1259,7 @@ impl super::stub::SqlInstancesService for SqlInstancesService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 }
@@ -1354,7 +1354,7 @@ impl super::stub::SqlOperationsService for SqlOperationsService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/cloud/tpu/v2/src/transport.rs
+++ b/src/generated/cloud/tpu/v2/src/transport.rs
@@ -536,7 +536,7 @@ impl super::stub::Tpu for Tpu {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/datastore/admin/v1/src/transport.rs
+++ b/src/generated/datastore/admin/v1/src/transport.rs
@@ -248,7 +248,7 @@ impl super::stub::DatastoreAdmin for DatastoreAdmin {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/iam/admin/v1/src/transport.rs
+++ b/src/generated/iam/admin/v1/src/transport.rs
@@ -437,7 +437,7 @@ impl super::stub::Iam for Iam {
                 v.add(builder, "options")
             });
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -440,7 +440,7 @@ impl super::stub::Compliance for Compliance {
             });
         let builder = builder.query(&[("continent", &req.continent)]);
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -643,7 +643,7 @@ impl super::stub::Compliance for Compliance {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1022,7 +1022,7 @@ impl super::stub::Echo for Echo {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1378,7 +1378,7 @@ impl super::stub::Identity for Identity {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -1858,7 +1858,7 @@ impl super::stub::Messaging for Messaging {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2203,7 +2203,7 @@ impl super::stub::SequenceService for SequenceService {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();
@@ -2334,7 +2334,7 @@ impl super::stub::Testing for Testing {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2408,7 +2408,7 @@ impl super::stub::Testing for Testing {
             .iter()
             .fold(builder, |builder, p| builder.query(&[("answers", p)]));
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
     }
 
@@ -2611,7 +2611,7 @@ impl super::stub::Testing for Testing {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/spanner/admin/database/v1/src/transport.rs
+++ b/src/generated/spanner/admin/database/v1/src/transport.rs
@@ -716,7 +716,7 @@ impl super::stub::DatabaseAdmin for DatabaseAdmin {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/generated/spanner/admin/instance/v1/src/transport.rs
+++ b/src/generated/spanner/admin/instance/v1/src/transport.rs
@@ -623,7 +623,7 @@ impl super::stub::InstanceAdmin for InstanceAdmin {
                 reqwest::header::HeaderValue::from_static(&crate::info::X_GOOG_API_CLIENT_HEADER),
             );
         self.inner
-            .execute(builder, None::<gaxi::http::NoBody>, options)
+            .execute(builder, Some(gaxi::http::NoBody), options)
             .await
             .map(|r: gax::response::Response<wkt::Empty>| {
                 let (parts, _) = r.into_parts();

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -27,6 +27,7 @@ run-integration-tests = []
 bytes                 = "1"
 crc32c                = "0.6"
 futures               = "0.3"
+auth.workspace        = true
 gax                   = { workspace = true, features = ["unstable-stream"] }
 iam_v1.workspace      = true
 longrunning.workspace = true
@@ -38,8 +39,10 @@ tracing-subscriber    = { version = "0.3", optional = true }
 wkt.workspace         = true
 
 [dependencies.aiplatform]
-package = "google-cloud-aiplatform-v1"
-path    = "../../src/generated/cloud/aiplatform/v1"
+package          = "google-cloud-aiplatform-v1"
+path             = "../../src/generated/cloud/aiplatform/v1"
+default-features = false
+features         = ["endpoint_service", "job_service", "prediction_service"]
 
 [dependencies.bigquery]
 package = "google-cloud-bigquery-v2"
@@ -75,7 +78,9 @@ path    = "../../src/generated/cloud/workflows/executions/v1"
 
 [dev-dependencies]
 anyhow.workspace    = true
+axum.workspace      = true
 mockall             = "0.13"
+reqwest.workspace   = true
 serde               = { version = "1", features = ["serde_derive"] }
 serde_with          = { version = "3", features = ["base64"] }
 test-case.workspace = true

--- a/src/integration-tests/tests/requests.rs
+++ b/src/integration-tests/tests/requests.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verify generated clients correctly send POST requests with empty bodies.
+
+#[cfg(test)]
+mod requests {
+    use axum::extract::Path;
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::response::Json;
+    use serde_json::{Value, json};
+    use std::time::Duration;
+    use tokio::task::JoinHandle;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn post_with_empty_body() -> anyhow::Result<()> {
+        let (endpoint, _server) = start().await?;
+        let client = aiplatform::client::PredictionService::builder()
+            .with_endpoint(&endpoint)
+            .with_credentials(auth::credentials::testing::test_credentials())
+            .build()
+            .await?;
+
+        client
+            .cancel_operation("operations/test-001")
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    pub async fn start() -> anyhow::Result<(String, JoinHandle<()>)> {
+        let app = axum::Router::new()
+            .route("/", axum::routing::get(root))
+            .route("/ui/{*path}", axum::routing::post(cancel_operation));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let server = tokio::spawn(async {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("http://{}:{}", addr.ip(), addr.port());
+
+        const ATTEMPTS: i32 = 5;
+        for _ in 0..ATTEMPTS {
+            match reqwest::get(&url).await {
+                Ok(_) => {
+                    return Ok((url, server));
+                }
+                Err(e) => {
+                    eprintln!("error starting server {e}");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            };
+        }
+        Err(anyhow::Error::msg(format!(
+            "cannot connect to server after {ATTEMPTS} attempts"
+        )))
+    }
+
+    async fn root() -> Json<Value> {
+        Json(json!({"status": "ready"}))
+    }
+
+    async fn cancel_operation(
+        Path(_operation): Path<String>,
+        headers: HeaderMap,
+    ) -> (StatusCode, Json<Value>) {
+        if headers.get("content-length").is_none() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json! {"missing content-length"}),
+            );
+        }
+        (StatusCode::OK, Json(json!({})))
+    }
+}

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -43,10 +43,10 @@ wkt.workspace         = true
 unstable-stream = ["dep:futures", "dep:pin-project"]
 
 [dev-dependencies]
-axum       = "0.8"
-reqwest    = "0.12"
-serde_json = "1"
-tokio      = { version = "1", features = ["test-util"] }
+axum.workspace = true
+reqwest        = "0.12"
+serde_json     = "1"
+tokio          = { version = "1", features = ["test-util"] }
 # Local dependencies
 auth.workspace = true
 gaxi.workspace = true


### PR DESCRIPTION
POST and PUT requests require a content-length header. This was not
populated when the request had no body. And since we are using JSON as
the format for these requests, the minimum is a `{}` payload.

Fixes #1936
