### PR TITLE
impl: support semver checks for internal

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -92,6 +92,7 @@ jobs:
             cargo "${sub}" --package google-cloud-wkt --no-default-features
             cargo "${sub}" --package google-cloud-wkt --no-default-features --features chrono
             cargo "${sub}" --package google-cloud-wkt --no-default-features --features time
+            cargo "${sub}" --package google-cloud-wkt --no-default-features --features _internal-semver
             cargo "${sub}" --package google-cloud-wkt --all-features
           done
           cargo clippy --no-deps --package google-cloud-wkt --all-features --all-targets --profile=test -- --deny warnings
@@ -101,6 +102,8 @@ jobs:
           for sub in test doc; do
             cargo "${sub}" --package google-cloud-gax --no-default-features
             cargo "${sub}" --package google-cloud-gax --no-default-features --features unstable-sdk-client
+            cargo "${sub}" --package google-cloud-gax --no-default-features --features unstable-stream
+            cargo "${sub}" --package google-cloud-gax --no-default-features --features _internal-semver
             cargo "${sub}" --package google-cloud-gax --all-features
           done
           cargo clippy --no-deps --package google-cloud-gax --all-features --all-targets --profile=test -- --deny warnings
@@ -121,6 +124,7 @@ jobs:
           for sub in test doc; do
             cargo "${sub}" --profile=ci --package google-cloud-lro --no-default-features
             cargo "${sub}" --profile=ci --package google-cloud-lro --no-default-features --features unstable-stream
+            cargo "${sub}" --profile=ci --package google-cloud-lro --no-default-features --features _internal-semver
             cargo "${sub}" --profile=ci --package google-cloud-lro --all-features
           done
           cargo clippy --no-deps --package google-cloud-lro --all-features --all-targets --profile=test -- --deny warnings

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -62,6 +62,6 @@ unstable-sdk-client = []
 unstable-stream     = []
 # DO NOT USE: this allows us to detect semver changes in types used in the
 # implementation of client libraries. None of the types or functions gated
-# by this feature as intended for general use. We do not plan to document these
+# by this feature are intended for general use. We do not plan to document these
 # features and offer no guarantees on their stability.
 _internal-semver = []

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -60,3 +60,8 @@ tokio-test          = "0.4"
 [features]
 unstable-sdk-client = []
 unstable-stream     = []
+# DO NOT USE: this allows us to detect semver changes in types used in the
+# implementation of client libraries. None of the types or functions gated
+# by this feature as intended for general use. We do not plan to document these
+# features and offer no guarantees on their stability.
+_internal-semver = []

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -287,7 +287,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     }
 }
 
-#[doc(hidden)]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod internal {
     use super::*;
 
@@ -349,6 +349,10 @@ pub mod internal {
 
 #[doc(hidden)]
 pub mod examples {
+    //! This module contains helper types used in the rustdoc examples.
+    //!
+    //! The examples require relatively complex types to be useful.
+
     type Config = super::internal::ClientConfig<Credentials>;
     use super::Result;
 

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -54,5 +54,5 @@ pub mod retry_policy;
 pub mod retry_throttler;
 
 #[cfg(feature = "unstable-sdk-client")]
-#[doc(hidden)]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod retry_loop_internal;

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -190,11 +190,12 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
     fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(self, v: V) -> Self;
 }
 
-/// This module contains implementation details. It is not part of the public
-/// API. Types inside may be changed or removed without warnings. Applications
-/// should not use any types contained within.
-#[doc(hidden)]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod internal {
+    //! This module contains implementation details. It is not part of the
+    //! public API. Types and functions in this module may be changed or removed
+    //! without warnings. Applications should not use any types contained
+    //! within.
     use super::RequestOptions;
 
     /// Simplify implementation of the [super::RequestOptionsBuilder] trait in

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -18,11 +18,12 @@ use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 
-/// This module contains implementation details. It is not part of the public
-/// API. Types inside may be changed or removed without warnings. Applications
-/// should not use any types contained within.
-#[doc(hidden)]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod internal {
+    //! This module contains implementation details. It is not part of the
+    //! public API. Types and functions in this module may be changed or removed
+    //! without warnings. Applications should not use any types contained
+    //! within.
     use super::*;
 
     /// Describes a type that can be iterated over asynchronously when used with

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -41,6 +41,11 @@ wkt.workspace         = true
 
 [features]
 unstable-stream = ["dep:futures", "dep:pin-project"]
+# DO NOT USE: this allows us to detect semver changes in types used in the
+# implementation of client libraries. None of the types or functions gated
+# by this feature as intended for general use. We do not plan to document these
+# features and offer no guarantees on their stability.
+_internal-semver = []
 
 [dev-dependencies]
 axum       = "0.8"

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -43,7 +43,7 @@ wkt.workspace         = true
 unstable-stream = ["dep:futures", "dep:pin-project"]
 # DO NOT USE: this allows us to detect semver changes in types used in the
 # implementation of client libraries. None of the types or functions gated
-# by this feature as intended for general use. We do not plan to document these
+# by this feature are intended for general use. We do not plan to document these
 # features and offer no guarantees on their stability.
 _internal-semver = []
 

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -25,7 +25,6 @@ use std::time::Instant;
 ///
 /// This is intended as an implementation detail of the generated clients.
 /// Applications should have no need to create or use this struct.
-#[doc(hidden)]
 pub struct Operation<R, M> {
     inner: longrunning::model::Operation,
     response: std::marker::PhantomData<R>,

--- a/src/lro/src/internal.rs
+++ b/src/lro/src/internal.rs
@@ -12,20 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Implementation details for the LRO helpers used from other traits.
+//! This module contains common implementation details for generated code.
+//!
+//! It is not part of the public API of this crate. Types and functions in this
+//! module may be changed or removed without warnings. Applications should not
+//! use any types contained within.
 
 use super::{Poller, PollingBackoffPolicy, PollingErrorPolicy, PollingResult, Result};
 use std::sync::Arc;
 use std::time::Instant;
 
-#[doc(hidden)]
 pub type Operation<R, M> = super::details::Operation<R, M>;
 
 /// Creates a new `impl Poller<R, M>` from the closures created by the generator.
 ///
 /// This is intended as an implementation detail of the generated clients.
 /// Applications should have no need to create or use this struct.
-#[doc(hidden)]
 pub fn new_poller<ResponseType, MetadataType, S, SF, Q, QF>(
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -50,7 +50,7 @@ pub enum PollingResult<R, M> {
     PollingError(Error),
 }
 
-#[doc(hidden)]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod internal;
 
 mod sealed {

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -35,7 +35,7 @@ chrono = ["dep:chrono"]
 time   = []
 # DO NOT USE: this allows us to detect semver changes in types used in the
 # implementation of client libraries. None of the types or functions gated
-# by this feature as intended for general use. We do not plan to document these
+# by this feature are intended for general use. We do not plan to document these
 # features and offer no guarantees on their stability.
 _internal-semver = []
 

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -33,6 +33,11 @@ features = ["chrono", "time"]
 [features]
 chrono = ["dep:chrono"]
 time   = []
+# DO NOT USE: this allows us to detect semver changes in types used in the
+# implementation of client libraries. None of the types or functions gated
+# by this feature as intended for general use. We do not plan to document these
+# features and offer no guarantees on their stability.
+_internal-semver = []
 
 [dependencies]
 base64     = "0.22"

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::field_mask::*;
 // The generated code contains (and uses) deprecated code.
 #[allow(deprecated)]
 mod generated;
-#[doc(hidden)]
+#[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod internal;
 pub use crate::generated::*;
 mod timestamp;


### PR DESCRIPTION
Implement features and set the attributes to keep implementation details
hidden until we want to run `cargo semver-checks`.