### PR TITLE
cleanup!: remove `unstable-sdk-client` feature

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -101,7 +101,6 @@ jobs:
           echo "==== google-cloud-gax ===="
           for sub in test doc; do
             cargo "${sub}" --package google-cloud-gax --no-default-features
-            cargo "${sub}" --package google-cloud-gax --no-default-features --features unstable-sdk-client
             cargo "${sub}" --package google-cloud-gax --no-default-features --features unstable-stream
             cargo "${sub}" --package google-cloud-gax --no-default-features --features _internal-semver
             cargo "${sub}" --package google-cloud-gax --all-features

--- a/.sidekick.toml
+++ b/.sidekick.toml
@@ -45,7 +45,7 @@ disabled-rustdoc-warnings = "redundant_explicit_links,broken_intra_doc_links"
 'package:serde_with' = 'force-used=true,package=serde_with'
 # These are used by crates with services.
 'package:async-trait' = 'used-if=services,package=async-trait'
-'package:gax'         = 'used-if=services,package=google-cloud-gax,feature=unstable-sdk-client'
+'package:gax'         = 'used-if=services,package=google-cloud-gax'
 'package:gaxi'        = 'used-if=services,package=google-cloud-gax-internal,feature=_internal-http-client'
 'package:lazy_static' = 'used-if=services,package=lazy_static'
 'package:reqwest'     = 'used-if=services,package=reqwest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,6 @@ dependencies = [
  "base64",
  "bytes",
  "futures",
- "google-cloud-gax",
  "google-cloud-rpc",
  "google-cloud-wkt",
  "http",

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -40,7 +40,7 @@ tonic.workspace       = true
 tokio                 = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing               = "0.1"
 # Local crates
-gax             = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace   = true
 gaxi            = { workspace = true, features = ["_internal-common", "_internal-grpc-client"] }
 gtype.workspace = true
 rpc.workspace   = true

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -35,12 +35,12 @@ features = []
 _internal-http-client = [
   "_internal-common",
   "dep:auth",
+  "dep:gax",
   "dep:reqwest",
   "dep:rpc",
   "dep:serde",
   "dep:serde_json",
   "dep:tokio",
-  "gax/unstable-sdk-client",
 ]
 _internal-grpc-client = [
   "_internal-common",
@@ -71,7 +71,7 @@ tokio            = { version = "1", features = ["macros", "rt-multi-thread"], op
 tonic            = { workspace = true, optional = true }
 # Local crates
 auth = { workspace = true, optional = true }
-gax  = { workspace = true, features = ["unstable-sdk-client"], optional = true }
+gax  = { workspace = true, optional = true }
 rpc  = { workspace = true, optional = true }
 wkt  = { workspace = true, optional = true }
 

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -27,8 +27,6 @@ rust-version.workspace = true
 
 [package.metadata.docs.rs]
 # We want to generate documentation for streaming APIs, gated by this feature.
-# We do not want to generate documentation for `unstable-sdk-client`, which
-# gates internal tpes.
 features = ["unstable-stream"]
 
 [dependencies]
@@ -46,9 +44,6 @@ rpc.workspace = true
 wkt.workspace = true
 
 [dev-dependencies]
-# This is a workaround to integration test features of this crate. Open issue
-# https://github.com/rust-lang/cargo/issues/2911.
-gax                 = { path = ".", package = "google-cloud-gax", features = ["unstable-sdk-client"] }
 anyhow.workspace    = true
 mockall             = "0.13"
 serde.workspace     = true
@@ -58,8 +53,7 @@ tokio               = { version = "1", features = ["test-util"] }
 tokio-test          = "0.4"
 
 [features]
-unstable-sdk-client = []
-unstable-stream     = []
+unstable-stream = []
 # DO NOT USE: this allows us to detect semver changes in types used in the
 # implementation of client libraries. None of the types or functions gated
 # by this feature are intended for general use. We do not plan to document these

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -23,10 +23,10 @@
 //! implementation of the Google Cloud Client Libraries for Rust.
 //!
 //! <div class="warning">
-//! All the types, traits, and functions defined in the <code>unstable-sdk-client</code>
-//! feature are <b>not</b> intended for general use. The APIs enabled by this
-//! feature will remain unstable for the foreseeable future, even if used in
-//! stable SDKs. We (the Google Cloud Client Libraries for Rust team) control both and will
+//! All the types, traits, and functions defined in any module with `internal`
+//! in its name are <b>not</b> intended for general use. Such symbols will
+//! remain unstable for the foreseeable future, even if used in stable SDKs.
+//! We (the Google Cloud Client Libraries for Rust team) control both and will
 //! change both if needed.
 //! </div>
 
@@ -53,6 +53,5 @@ pub mod polling_error_policy;
 pub mod retry_policy;
 pub mod retry_throttler;
 
-#[cfg(feature = "unstable-sdk-client")]
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 pub mod retry_loop_internal;

--- a/src/generated/api/apikeys/v2/Cargo.toml
+++ b/src/generated/api/apikeys/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/api/servicecontrol/v1/Cargo.toml
+++ b/src/generated/api/servicecontrol/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 logging_type.workspace = true

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/api/servicemanagement/v1/Cargo.toml
+++ b/src/generated/api/servicemanagement/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/api/serviceusage/v1/Cargo.toml
+++ b/src/generated/api/serviceusage/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/appengine/v1/Cargo.toml
+++ b/src/generated/appengine/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/bigtable/admin/v2/Cargo.toml
+++ b/src/generated/bigtable/admin/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/accessapproval/v1/Cargo.toml
+++ b/src/generated/cloud/accessapproval/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/advisorynotifications/v1/Cargo.toml
+++ b/src/generated/cloud/advisorynotifications/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/aiplatform/v1/Cargo.toml
+++ b/src/generated/cloud/aiplatform/v1/Cargo.toml
@@ -130,7 +130,7 @@ vizier-service = []
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/alloydb/v1/Cargo.toml
+++ b/src/generated/cloud/alloydb/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/apigateway/v1/Cargo.toml
+++ b/src/generated/cloud/apigateway/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/apigeeconnect/v1/Cargo.toml
+++ b/src/generated/cloud/apigeeconnect/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/apihub/v1/Cargo.toml
+++ b/src/generated/cloud/apihub/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/apphub/v1/Cargo.toml
+++ b/src/generated/cloud/apphub/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/asset/v1/Cargo.toml
+++ b/src/generated/cloud/asset/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 accesscontextmanager_v1.workspace = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/assuredworkloads/v1/Cargo.toml
+++ b/src/generated/cloud/assuredworkloads/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/backupdr/v1/Cargo.toml
+++ b/src/generated/cloud/backupdr/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/baremetalsolution/v2/Cargo.toml
+++ b/src/generated/cloud/baremetalsolution/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/analyticshub/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/bigquery/connection/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/connection/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datapolicies/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/datatransfer/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/bigquery/migration/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/migration/v2/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
+++ b/src/generated/cloud/bigquery/reservation/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -30,7 +30,7 @@ publish                = false
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/billing/v1/Cargo.toml
+++ b/src/generated/cloud/billing/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/binaryauthorization/v1/Cargo.toml
+++ b/src/generated/cloud/binaryauthorization/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 grafeas.workspace    = true
 lazy_static.workspace = true

--- a/src/generated/cloud/certificatemanager/v1/Cargo.toml
+++ b/src/generated/cloud/certificatemanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/chronicle/v1/Cargo.toml
+++ b/src/generated/cloud/chronicle/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
+++ b/src/generated/cloud/cloudcontrolspartner/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/clouddms/v1/Cargo.toml
+++ b/src/generated/cloud/clouddms/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
+++ b/src/generated/cloud/confidentialcomputing/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/config/v1/Cargo.toml
+++ b/src/generated/cloud/config/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/connectors/v1/Cargo.toml
+++ b/src/generated/cloud/connectors/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
+++ b/src/generated/cloud/contactcenterinsights/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/lineage/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/datacatalog/v1/Cargo.toml
+++ b/src/generated/cloud/datacatalog/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/datafusion/v1/Cargo.toml
+++ b/src/generated/cloud/datafusion/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/dataplex/v1/Cargo.toml
+++ b/src/generated/cloud/dataplex/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/dataproc/v1/Cargo.toml
+++ b/src/generated/cloud/dataproc/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/datastream/v1/Cargo.toml
+++ b/src/generated/cloud/datastream/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/deploy/v1/Cargo.toml
+++ b/src/generated/cloud/deploy/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/developerconnect/v1/Cargo.toml
+++ b/src/generated/cloud/developerconnect/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/dialogflow/v2/Cargo.toml
+++ b/src/generated/cloud/dialogflow/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/discoveryengine/v1/Cargo.toml
+++ b/src/generated/cloud/discoveryengine/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/documentai/v1/Cargo.toml
+++ b/src/generated/cloud/documentai/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/domains/v1/Cargo.toml
+++ b/src/generated/cloud/domains/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/edgecontainer/v1/Cargo.toml
+++ b/src/generated/cloud/edgecontainer/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/edgenetwork/v1/Cargo.toml
+++ b/src/generated/cloud/edgenetwork/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/essentialcontacts/v1/Cargo.toml
+++ b/src/generated/cloud/essentialcontacts/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/eventarc/v1/Cargo.toml
+++ b/src/generated/cloud/eventarc/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/filestore/v1/Cargo.toml
+++ b/src/generated/cloud/filestore/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 async-trait.workspace = true
 bytes.workspace      = true
 cloud_common.workspace = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/financialservices/v1/Cargo.toml
+++ b/src/generated/cloud/financialservices/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/functions/v2/Cargo.toml
+++ b/src/generated/cloud/functions/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/gkebackup/v1/Cargo.toml
+++ b/src/generated/cloud/gkebackup/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
+++ b/src/generated/cloud/gkeconnect/gateway/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/gkehub/v1/Cargo.toml
+++ b/src/generated/cloud/gkehub/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gkehub_configmanagement_v1.workspace = true
 gkehub_multiclusteringress_v1.workspace = true

--- a/src/generated/cloud/gkemulticloud/v1/Cargo.toml
+++ b/src/generated/cloud/gkemulticloud/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
+++ b/src/generated/cloud/gsuiteaddons/v1/Cargo.toml
@@ -36,7 +36,7 @@ apps_script_slides.workspace = true
 apps_script_type.workspace = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/iap/v1/Cargo.toml
+++ b/src/generated/cloud/iap/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/ids/v1/Cargo.toml
+++ b/src/generated/cloud/ids/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/kms/inventory/v1/Cargo.toml
+++ b/src/generated/cloud/kms/inventory/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 kms.workspace        = true
 lazy_static.workspace = true

--- a/src/generated/cloud/kms/v1/Cargo.toml
+++ b/src/generated/cloud/kms/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/language/v2/Cargo.toml
+++ b/src/generated/cloud/language/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/licensemanager/v1/Cargo.toml
+++ b/src/generated/cloud/licensemanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/location/Cargo.toml
+++ b/src/generated/cloud/location/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/lustre/v1/Cargo.toml
+++ b/src/generated/cloud/lustre/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/managedidentities/v1/Cargo.toml
+++ b/src/generated/cloud/managedidentities/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/memcache/v1/Cargo.toml
+++ b/src/generated/cloud/memcache/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/memorystore/v1/Cargo.toml
+++ b/src/generated/cloud/memorystore/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/metastore/v1/Cargo.toml
+++ b/src/generated/cloud/metastore/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/migrationcenter/v1/Cargo.toml
+++ b/src/generated/cloud/migrationcenter/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/modelarmor/v1/Cargo.toml
+++ b/src/generated/cloud/modelarmor/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/networkconnectivity/v1/Cargo.toml
+++ b/src/generated/cloud/networkconnectivity/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/networkmanagement/v1/Cargo.toml
+++ b/src/generated/cloud/networkmanagement/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/networksecurity/v1/Cargo.toml
+++ b/src/generated/cloud/networksecurity/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/networkservices/v1/Cargo.toml
+++ b/src/generated/cloud/networkservices/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/notebooks/v2/Cargo.toml
+++ b/src/generated/cloud/notebooks/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/optimization/v1/Cargo.toml
+++ b/src/generated/cloud/optimization/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/oracledatabase/v1/Cargo.toml
+++ b/src/generated/cloud/oracledatabase/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
+++ b/src/generated/cloud/orchestration/airflow/service/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/orgpolicy/v2/Cargo.toml
+++ b/src/generated/cloud/orgpolicy/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/osconfig/v1/Cargo.toml
+++ b/src/generated/cloud/osconfig/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/oslogin/v1/Cargo.toml
+++ b/src/generated/cloud/oslogin/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 oslogin_common.workspace = true

--- a/src/generated/cloud/parallelstore/v1/Cargo.toml
+++ b/src/generated/cloud/parallelstore/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/parametermanager/v1/Cargo.toml
+++ b/src/generated/cloud/parametermanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/policysimulator/v1/Cargo.toml
+++ b/src/generated/cloud/policysimulator/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
+++ b/src/generated/cloud/policytroubleshooter/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
+++ b/src/generated/cloud/privilegedaccessmanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
+++ b/src/generated/cloud/rapidmigrationassessment/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
+++ b/src/generated/cloud/recaptchaenterprise/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/recommender/v1/Cargo.toml
+++ b/src/generated/cloud/recommender/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/redis/cluster/v1/Cargo.toml
+++ b/src/generated/cloud/redis/cluster/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/redis/v1/Cargo.toml
+++ b/src/generated/cloud/redis/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/resourcemanager/v3/Cargo.toml
+++ b/src/generated/cloud/resourcemanager/v3/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/retail/v2/Cargo.toml
+++ b/src/generated/cloud/retail/v2/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/run/v2/Cargo.toml
+++ b/src/generated/cloud/run/v2/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/scheduler/v1/Cargo.toml
+++ b/src/generated/cloud/scheduler/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/secretmanager/v1/Cargo.toml
+++ b/src/generated/cloud/secretmanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/securesourcemanager/v1/Cargo.toml
+++ b/src/generated/cloud/securesourcemanager/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/security/privateca/v1/Cargo.toml
+++ b/src/generated/cloud/security/privateca/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/cloud/security/publicca/v1/Cargo.toml
+++ b/src/generated/cloud/security/publicca/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/securitycenter/v2/Cargo.toml
+++ b/src/generated/cloud/securitycenter/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/securityposture/v1/Cargo.toml
+++ b/src/generated/cloud/securityposture/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/servicedirectory/v1/Cargo.toml
+++ b/src/generated/cloud/servicedirectory/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/servicehealth/v1/Cargo.toml
+++ b/src/generated/cloud/servicehealth/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/shell/v1/Cargo.toml
+++ b/src/generated/cloud/shell/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/speech/v2/Cargo.toml
+++ b/src/generated/cloud/speech/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/sql/v1/Cargo.toml
+++ b/src/generated/cloud/sql/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
+++ b/src/generated/cloud/storagebatchoperations/v1/Cargo.toml
@@ -30,7 +30,7 @@ publish                = false
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/storageinsights/v1/Cargo.toml
+++ b/src/generated/cloud/storageinsights/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/support/v2/Cargo.toml
+++ b/src/generated/cloud/support/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/talent/v4/Cargo.toml
+++ b/src/generated/cloud/talent/v4/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/tasks/v2/Cargo.toml
+++ b/src/generated/cloud/tasks/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/telcoautomation/v1/Cargo.toml
+++ b/src/generated/cloud/telcoautomation/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/texttospeech/v1/Cargo.toml
+++ b/src/generated/cloud/texttospeech/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
+++ b/src/generated/cloud/timeseriesinsights/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/tpu/v2/Cargo.toml
+++ b/src/generated/cloud/tpu/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/translate/v3/Cargo.toml
+++ b/src/generated/cloud/translate/v3/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/video/livestream/v1/Cargo.toml
+++ b/src/generated/cloud/video/livestream/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/video/stitcher/v1/Cargo.toml
+++ b/src/generated/cloud/video/stitcher/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/video/transcoder/v1/Cargo.toml
+++ b/src/generated/cloud/video/transcoder/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/videointelligence/v1/Cargo.toml
+++ b/src/generated/cloud/videointelligence/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/vision/v1/Cargo.toml
+++ b/src/generated/cloud/vision/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/cloud/vmmigration/v1/Cargo.toml
+++ b/src/generated/cloud/vmmigration/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/vmwareengine/v1/Cargo.toml
+++ b/src/generated/cloud/vmwareengine/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/cloud/vpcaccess/v1/Cargo.toml
+++ b/src/generated/cloud/vpcaccess/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/webrisk/v1/Cargo.toml
+++ b/src/generated/cloud/webrisk/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/cloud/websecurityscanner/v1/Cargo.toml
+++ b/src/generated/cloud/websecurityscanner/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/workflows/executions/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/executions/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/cloud/workflows/v1/Cargo.toml
+++ b/src/generated/cloud/workflows/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 location.workspace   = true

--- a/src/generated/cloud/workstations/v1/Cargo.toml
+++ b/src/generated/cloud/workstations/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/container/v1/Cargo.toml
+++ b/src/generated/container/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/datastore/admin/v1/Cargo.toml
+++ b/src/generated/datastore/admin/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/devtools/artifactregistry/v1/Cargo.toml
+++ b/src/generated/devtools/artifactregistry/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/devtools/cloudbuild/v1/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/devtools/cloudbuild/v2/Cargo.toml
+++ b/src/generated/devtools/cloudbuild/v2/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/devtools/cloudprofiler/v2/Cargo.toml
+++ b/src/generated/devtools/cloudprofiler/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/devtools/cloudtrace/v2/Cargo.toml
+++ b/src/generated/devtools/cloudtrace/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/devtools/containeranalysis/v1/Cargo.toml
+++ b/src/generated/devtools/containeranalysis/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 grafeas.workspace    = true
 iam_v1.workspace     = true

--- a/src/generated/firestore/admin/v1/Cargo.toml
+++ b/src/generated/firestore/admin/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/grafeas/v1/Cargo.toml
+++ b/src/generated/grafeas/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/iam/admin/v1/Cargo.toml
+++ b/src/generated/iam/admin/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/iam/credentials/v1/Cargo.toml
+++ b/src/generated/iam/credentials/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/iam/v1/Cargo.toml
+++ b/src/generated/iam/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/iam/v2/Cargo.toml
+++ b/src/generated/iam/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/iam/v3/Cargo.toml
+++ b/src/generated/iam/v3/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/identity/accesscontextmanager/v1/Cargo.toml
+++ b/src/generated/identity/accesscontextmanager/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 accesscontextmanager_type.workspace = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 iam_v1.workspace     = true

--- a/src/generated/logging/v2/Cargo.toml
+++ b/src/generated/logging/v2/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 logging_type.workspace = true

--- a/src/generated/longrunning/Cargo.toml
+++ b/src/generated/longrunning/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/monitoring/dashboard/v1/Cargo.toml
+++ b/src/generated/monitoring/dashboard/v1/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/monitoring/metricsscope/v1/Cargo.toml
+++ b/src/generated/monitoring/metricsscope/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 longrunning.workspace = true

--- a/src/generated/monitoring/v3/Cargo.toml
+++ b/src/generated/monitoring/v3/Cargo.toml
@@ -30,7 +30,7 @@ rust-version.workspace = true
 api.workspace        = true
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/openapi-validation/Cargo.toml
+++ b/src/generated/openapi-validation/Cargo.toml
@@ -30,7 +30,7 @@ publish                = false
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 lazy_static.workspace = true
 reqwest.workspace    = true

--- a/src/generated/privacy/dlp/v2/Cargo.toml
+++ b/src/generated/privacy/dlp/v2/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/generated/showcase/Cargo.toml
+++ b/src/generated/showcase/Cargo.toml
@@ -30,7 +30,7 @@ publish                = false
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/spanner/admin/database/v1/Cargo.toml
+++ b/src/generated/spanner/admin/database/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/spanner/admin/instance/v1/Cargo.toml
+++ b/src/generated/spanner/admin/instance/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 iam_v1.workspace     = true
 lazy_static.workspace = true

--- a/src/generated/storagetransfer/v1/Cargo.toml
+++ b/src/generated/storagetransfer/v1/Cargo.toml
@@ -29,7 +29,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes.workspace      = true
-gax                  = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace        = true
 gaxi                 = { workspace = true, features = ["_internal-http-client"] }
 gtype.workspace      = true
 lazy_static.workspace = true

--- a/src/storage-control/Cargo.toml
+++ b/src/storage-control/Cargo.toml
@@ -40,7 +40,7 @@ tonic.workspace       = true
 tokio                 = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace     = true
 # Local crates
-gax              = { workspace = true, features = ["unstable-sdk-client"] }
+gax.workspace    = true
 gaxi             = { workspace = true, features = ["_internal-common", "_internal-grpc-client"] }
 gtype.workspace  = true
 iam_v1.workspace = true


### PR DESCRIPTION
In practice, this feature was always turned on.

Part of the work for #1780
