### PR TITLE
docs: document features and internal modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,34 @@ Idiomatic Rust client libraries for
 The [User Guide] includes basic tutorials to get started with the Google Cloud
 client libraries for Rust.
 
-## Supported Rust Versions
+## Non-public API
+
+Some crates export "public" types and functions that are intended only for use
+as implementation details of other crates. Chief amongst these are all the
+symbols exported by the `google-cloud-gax-internal` crate. As the name
+indicates, this crate is intended to hold internal-only types. No application
+should take a direct dependency on this crate or use their types in their
+application. We reserve the right to make changs to this crate without notice.
+
+In other crates, any public symbol that is not part of the public API have the
+`#[doc(hidden)]` attribute set. This is conventional in Rust.
+
+In addition, we also use a number of crate features prefixed with `_internal-`.
+None of these features (or the symbols they enable) are intended for application
+developers to use.
+
+## Unstable APIs
+
+Rust does not have a stable API for asynchronous iterators (also known as
+asynchronous streams, or simply streams). Where needed, we provide
+implementations of the [futures::stream::Stream] trait.
+
+For crates that offer implementations of the trait, the functionality is gated
+by the `unstable-streams` feature. As the name indicates, this feature is
+unstable. When Rust stabilizes the streams trait we may chose to rename the
+feature, and may even need to change the trait implementation.
+
+## Minimum Supported Rust Version
 
 We require Rust >= 1.85, as we anticipate this will be at least six months old
 by the time this project is stabilized (GA may be even later).
@@ -36,6 +63,7 @@ Apache 2.0 - See [LICENSE] for more information.
 
 [architecture]: ARCHITECTURE.md
 [contributing]: CONTRIBUTING.md
+[futures::stream::stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 [license]: LICENSE
 [set up development environment]: doc/contributor/howto-guide-set-up-development-environment.md
 [user guide]: https://googleapis.github.io/google-cloud-rust

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ client libraries for Rust.
 ## Non-public API
 
 Some crates export "public" types and functions that are intended only for use
-as implementation details of other crates. Chief amongst these are all the
-symbols exported by the `google-cloud-gax-internal` crate. As the name
-indicates, this crate is intended to hold internal-only types. No application
-should take a direct dependency on this crate or use their types in their
-application. We reserve the right to make changs to this crate without notice.
+as implementation details of other crates in this repository. Chief amongst
+these are all the symbols exported by the `google-cloud-gax-internal` crate. As
+the name indicates, this crate is intended to hold internal-only types. No
+application should take a direct dependency on this crate or use their types in
+their code. We reserve the right to make changes to this crate without notice.
 
 In other crates, any public symbol that is not part of the public API have the
 `#[doc(hidden)]` attribute set. This is conventional in Rust.

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -53,6 +53,10 @@ tokio               = { version = "1", features = ["test-util"] }
 tokio-test          = "0.4"
 
 [features]
+# Enable functionality that depend on the [futures::stream::Stream] trait. This
+# functionality may change as the trait is stabilized.
+#
+# [futures::stream::Stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 unstable-stream = []
 # DO NOT USE: this allows us to detect semver changes in types used in the
 # implementation of client libraries. None of the types or functions gated

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -53,7 +53,7 @@ tokio               = { version = "1", features = ["test-util"] }
 tokio-test          = "0.4"
 
 [features]
-# Enable functionality that depend on the [futures::stream::Stream] trait. This
+# Enable functionality that depends on the [futures::stream::Stream] trait. This
 # functionality may change as the trait is stabilized.
 #
 # [futures::stream::Stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -30,6 +30,8 @@
 //! change both if needed.
 //! </div>
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 /// An alias of [std::result::Result] where the error is always [Error][crate::error::Error].
 ///
 /// This is the result type used by all functions wrapping RPCs.

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -57,8 +57,21 @@ mod sealed {
     pub trait Paginator {}
 }
 
-/// An adapter that converts list RPCs as defined by [AIP-4233](https://google.aip.dev/client-libraries/4233)
-/// into a [futures::Stream] that can be iterated over in an async fashion.
+/// Automatically streams pages in list RPCs.
+/// 
+/// When listing large collections of items Google Cloud services typically
+/// break the responses in "pages", where each page contains a limited number
+/// of items, and a token to request the next page. The caller must
+/// repeatedly call the list RPC (using the token from the previous pag) to
+/// obtain additional items.
+/// 
+/// Sequencing these calls can be tedious. The Google Cloud client libraries
+/// for Rust provide implementations of this trait to simplify the use of
+/// these paginated APIs.
+/// 
+/// For more information on the RPCs with paginated responses see [AIP-4233].
+///
+/// [AIP-4233]: https://google.aip.dev/client-libraries/4233
 pub trait Paginator<T, E>: Send + sealed::Paginator
 where
     T: internal::PageableResponse,
@@ -70,9 +83,8 @@ where
     fn next(&mut self) -> impl Future<Output = Option<Result<T, E>>> + Send;
 
     #[cfg(feature = "unstable-stream")]
-    /// Convert the paginator to a stream.
-    ///
-    /// This API is gated by the `unstable-stream` feature.
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
+    /// Convert the paginator to a [Stream].
     fn into_stream(self) -> impl futures::Stream<Item = Result<T, E>> + Unpin;
 }
 
@@ -139,9 +151,8 @@ where
     }
 
     #[cfg(feature = "unstable-stream")]
-    /// Convert the paginator to a stream.
-    ///
-    /// This API is gated by the `unstable-stream` feature.
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
+    /// Convert the paginator to a [Stream][futures::stream::Stream].
     fn into_stream(self) -> impl futures::Stream<Item = Result<T, E>> + Unpin {
         Box::pin(unfold(Some(self), move |state| async move {
             if let Some(mut paginator) = state {
@@ -162,26 +173,41 @@ impl<T, E> std::fmt::Debug for PaginatorImpl<T, E> {
     }
 }
 
+/// Automatically stream items in list RPCs.
+/// 
+/// When listing large collections of items Google Cloud services typically
+/// break the responses in "pages", where each page contains a subset of
+/// the items, and a token to request the next page. The caller must
+/// repeatedly call the list RPC using the token from the previous page.
+/// 
+/// Sequencing these calls can be tedious. The Google Cloud client libraries
+/// for rust provide implementations of this trait to simplify the use of
+/// these paginated APIs.
+/// 
+/// Many applications want to operate on one item at a time. The Google Cloud
+/// client libraries for Rust provide implementations of this trait that
+/// automatically iterate over each item and then fetch the next page, stopping
+/// when all the pages are processed.
+/// 
+/// For more information on the RPCs with paginated responses see [AIP-4233].
+///
+/// [AIP-4233]: https://google.aip.dev/client-libraries/4233
 pub trait ItemPaginator<T, E>: Send + sealed::Paginator
 where
     T: internal::PageableResponse,
 {
-    /// Returns the next mutation of the wrapped stream.
+    /// Returns the next item from the stream of (paginated) responses.
     ///
-    /// Enable the `unstable-stream` feature to interact with a [`futures::stream::Stream`].
-    ///
-    /// [`futures::stream::Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
+    /// Enable the `unstable-stream` feature to convert this type to a
+    /// [Stream].
     fn next(&mut self) -> impl Future<Output = Option<Result<T::PageItem, E>>> + Send;
 
     #[cfg(feature = "unstable-stream")]
-    /// Convert the paginator to a stream.
-    ///
-    /// This API is gated by the `unstable-stream` feature.
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
+    /// Convert the paginator to a [Stream].
     fn into_stream(self) -> impl futures::Stream<Item = Result<T::PageItem, E>> + Unpin;
 }
 
-/// An adapter that converts a [Paginator] into a stream of individual page
-/// items.
 #[pin_project]
 struct ItemPaginatorImpl<T, E>
 where
@@ -209,11 +235,9 @@ impl<T, E> ItemPaginator<T, E> for ItemPaginatorImpl<T, E>
 where
     T: internal::PageableResponse,
 {
-    /// Returns the next mutation of the wrapped stream.
+    /// Returns the next item in the stream of (paginated) responses.
     ///
-    /// Enable the `unstable-stream` feature to interact with a [`futures::stream::Stream`].
-    ///
-    /// [`futures::stream::Stream`]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
+    /// Enable the `unstable-stream` feature to convert this to a [Stream].
     async fn next(&mut self) -> Option<Result<T::PageItem, E>> {
         loop {
             if let Some(ref mut iter) = self.current_items {
@@ -236,9 +260,8 @@ where
     }
 
     #[cfg(feature = "unstable-stream")]
-    /// Convert the paginator to a stream.
-    ///
-    /// This API is gated by the `unstable-stream` feature.
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
+    /// Convert the paginator to a [Stream].
     fn into_stream(self) -> impl Stream<Item = Result<T::PageItem, E>> + Unpin {
         Box::pin(unfold(Some(self), move |state| async move {
             if let Some(mut paginator) = state {

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -62,7 +62,7 @@ mod sealed {
 /// When listing large collections of items Google Cloud services typically
 /// break the responses in "pages", where each page contains a limited number
 /// of items, and a token to request the next page. The caller must
-/// repeatedly call the list RPC (using the token from the previous pag) to
+/// repeatedly call the list RPC (using the token from the previous page) to
 /// obtain additional items.
 ///
 /// Sequencing these calls can be tedious. The Google Cloud client libraries

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -58,17 +58,17 @@ mod sealed {
 }
 
 /// Automatically streams pages in list RPCs.
-/// 
+///
 /// When listing large collections of items Google Cloud services typically
 /// break the responses in "pages", where each page contains a limited number
 /// of items, and a token to request the next page. The caller must
 /// repeatedly call the list RPC (using the token from the previous pag) to
 /// obtain additional items.
-/// 
+///
 /// Sequencing these calls can be tedious. The Google Cloud client libraries
 /// for Rust provide implementations of this trait to simplify the use of
 /// these paginated APIs.
-/// 
+///
 /// For more information on the RPCs with paginated responses see [AIP-4233].
 ///
 /// [AIP-4233]: https://google.aip.dev/client-libraries/4233
@@ -174,21 +174,21 @@ impl<T, E> std::fmt::Debug for PaginatorImpl<T, E> {
 }
 
 /// Automatically stream items in list RPCs.
-/// 
+///
 /// When listing large collections of items Google Cloud services typically
 /// break the responses in "pages", where each page contains a subset of
 /// the items, and a token to request the next page. The caller must
 /// repeatedly call the list RPC using the token from the previous page.
-/// 
+///
 /// Sequencing these calls can be tedious. The Google Cloud client libraries
 /// for rust provide implementations of this trait to simplify the use of
 /// these paginated APIs.
-/// 
+///
 /// Many applications want to operate on one item at a time. The Google Cloud
 /// client libraries for Rust provide implementations of this trait that
 /// automatically iterate over each item and then fetch the next page, stopping
 /// when all the pages are processed.
-/// 
+///
 /// For more information on the RPCs with paginated responses see [AIP-4233].
 ///
 /// [AIP-4233]: https://google.aip.dev/client-libraries/4233

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -26,6 +26,10 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [package.metadata.docs.rs]
+# Enable functionality that depend on the [futures::stream::Stream] trait. This
+# functionality may change as the trait is stabilized.
+#
+# [futures::stream::Stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 features = ["unstable-stream"]
 
 [dependencies]

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -26,7 +26,7 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [package.metadata.docs.rs]
-# Enable functionality that depend on the [futures::stream::Stream] trait. This
+# Enable functionality that depends on the [futures::stream::Stream] trait. This
 # functionality may change as the trait is stabilized.
 #
 # [futures::stream::Stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! Types and functions to make LROs easier to use and to require less boilerplate.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use gax::Result;
 use gax::error::Error;
 use gax::polling_backoff_policy::PollingBackoffPolicy;
@@ -57,7 +59,21 @@ mod sealed {
     pub trait Poller {}
 }
 
-/// The trait implemented by LRO helpers.
+/// Automatically polls long-running operations.
+/// 
+/// Occasionally, a Google Cloud service may need to expose a method that takes
+/// a significant amount of time to complete. In these situations, it is often
+/// a poor user experience to simply block while the task runs. Such services
+/// return a long-running operation, a type of promise that can be polled until
+/// it completes successfully.
+/// 
+/// Polling these operations can be tedious. The application needs to
+/// periodically make RPCs, extract the result from the response, and may need
+/// to implement a stream to return metadata representing any progress in the
+/// RPC.
+/// 
+/// The Google Cloud client libraries for Rust return implementations of this
+/// trait to simplify working with these long-running operations.
 ///
 /// # Parameters
 /// * `R` - the response type, that is, the type of response included when the
@@ -71,8 +87,9 @@ pub trait Poller<R, M>: Send + sealed::Poller {
     /// Poll the long-running operation until it completes.
     fn until_done(self) -> impl Future<Output = Result<R>> + Send;
 
-    /// Convert a poller to a [futures::Stream].
+    /// Convert a poller to a [Stream][futures::Stream].
     #[cfg(feature = "unstable-stream")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-stream")))]
     fn into_stream(self) -> impl futures::Stream<Item = PollingResult<R, M>>;
 }
 

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -60,18 +60,18 @@ mod sealed {
 }
 
 /// Automatically polls long-running operations.
-/// 
+///
 /// Occasionally, a Google Cloud service may need to expose a method that takes
 /// a significant amount of time to complete. In these situations, it is often
 /// a poor user experience to simply block while the task runs. Such services
 /// return a long-running operation, a type of promise that can be polled until
 /// it completes successfully.
-/// 
+///
 /// Polling these operations can be tedious. The application needs to
 /// periodically make RPCs, extract the result from the response, and may need
 /// to implement a stream to return metadata representing any progress in the
 /// RPC.
-/// 
+///
 /// The Google Cloud client libraries for Rust return implementations of this
 /// trait to simplify working with these long-running operations.
 ///


### PR DESCRIPTION
Document why we have internal modules, `_internal-*` features,
and `unstable-*` features.

Add documentation to the `unstable-stream` features and properly tag
any functions that are enabled with these features. Updated the
documentation around these functions.

Fixes #1780
