### PR TITLE
feat(auth): optimize common path for MDS

### DIFF
--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -234,45 +234,22 @@ struct MDSAccessTokenProvider {
     endpoint: String,
 }
 
-impl MDSAccessTokenProvider {
-    async fn get_service_account_info(&self, client: &Client) -> Result<ServiceAccountInfo> {
-        let request = client
-            .get(format!("{}{}", self.endpoint, MDS_DEFAULT_URI))
-            .query(&[("recursive", "true")])
-            .header(
-                METADATA_FLAVOR,
-                HeaderValue::from_static(METADATA_FLAVOR_VALUE),
-            );
-
-        let response = request.send().await.map_err(errors::retryable)?;
-
-        response
-            .json::<ServiceAccountInfo>()
-            .await
-            .map_err(errors::non_retryable)
-    }
-}
-
 #[async_trait]
 impl TokenProvider for MDSAccessTokenProvider {
     async fn token(&self) -> Result<Token> {
         let client = Client::new();
-        // Determine scopes, fetching from metadata server if needed.
-        let scopes = match &self.scopes {
-            Some(s) => s.clone().join(","),
-            None => {
-                let service_account_info = self.get_service_account_info(&client).await?;
-                service_account_info.scopes.unwrap_or_default().join(",")
-            }
-        };
-
         let request = client
             .get(format!("{}{}/token", self.endpoint, MDS_DEFAULT_URI))
-            .query(&[("scopes", scopes)])
             .header(
                 METADATA_FLAVOR,
                 HeaderValue::from_static(METADATA_FLAVOR_VALUE),
             );
+        // Use the `scopes` option if set, otherwise let the MDS use the default
+        // scopes.
+        let scopes = self.scopes.as_ref().map(|v| v.join(","));
+        let request = scopes
+            .into_iter()
+            .fold(request, |r, s| r.query(&[("scopes", s)]));
 
         let response = request.send().await.map_err(errors::retryable)?;
         // Process the response
@@ -502,62 +479,6 @@ mod test {
         let _e = ScopedEnv::remove(super::GCE_METADATA_HOST_ENV_VAR);
 
         assert_eq!(token.token, "test-access-token");
-    }
-
-    #[tokio::test]
-    #[parallel]
-    async fn get_default_service_account_info_success() {
-        let service_account_info = ServiceAccountInfo {
-            email: "test@test.com".to_string(),
-            scopes: Some(vec!["scope 1".to_string(), "scope 2".to_string()]),
-            aliases: None,
-        };
-        let service_account_info_json = serde_json::to_value(service_account_info.clone()).unwrap();
-        let (endpoint, _server) = start(Handlers::from([(
-            MDS_DEFAULT_URI.to_string(),
-            (
-                StatusCode::OK,
-                service_account_info_json,
-                TokenQueryParams {
-                    scopes: None,
-                    recursive: Some("true".to_string()),
-                },
-                Arc::new(Mutex::new(0)),
-            ),
-        )]))
-        .await;
-
-        let request = Client::new();
-        let token_provider = MDSAccessTokenProvider::builder().endpoint(endpoint).build();
-
-        let result = token_provider.get_service_account_info(&request).await;
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), service_account_info);
-    }
-
-    #[tokio::test]
-    #[parallel]
-    async fn get_service_account_info_server_error() {
-        let (endpoint, _server) = start(Handlers::from([(
-            MDS_DEFAULT_URI.to_string(),
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                serde_json::to_value("try again").unwrap(),
-                TokenQueryParams {
-                    scopes: None,
-                    recursive: Some("true".to_string()),
-                },
-                Arc::new(Mutex::new(0)),
-            ),
-        )]))
-        .await;
-
-        let request = Client::new();
-        let token_provider = MDSAccessTokenProvider::builder().endpoint(endpoint).build();
-
-        let result = token_provider.get_service_account_info(&request).await;
-        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Normally we do not set the scopes, querying the default service account
to get the scopes is wasteful, we can just omit the query parameter and
get the same result.