### PR TITLE
impl(storage-control): hide unused builders

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -83,8 +83,8 @@ type serviceAnnotations struct {
 	APITitle string
 	// If set, gate this service under a feature named `ModuleName`.
 	PerServiceFeatures bool
-	// If set, skip the builder documentation.
-	SkipBuilderDocs bool
+	// If true, there is a handwritten client surface.
+	HasVeneer bool
 }
 
 func (a *serviceAnnotations) FeatureName() string {
@@ -156,7 +156,7 @@ type methodAnnotation struct {
 	OperationInfo       *operationInfo
 	SystemParameters    []systemParameter
 	ReturnType          string
-	SkipBuilderDocs     bool
+	HasVeneer           bool
 }
 
 type pathInfoAnnotation struct {
@@ -461,7 +461,7 @@ func (c *codec) annotateService(s *api.Service, model *api.API) {
 		HasLROs:            hasLROs,
 		APITitle:           model.Title,
 		PerServiceFeatures: c.perServiceFeatures,
-		SkipBuilderDocs:    c.skipBuilderDocs,
+		HasVeneer:          c.hasVeneer,
 	}
 	s.Codec = ann
 }
@@ -549,7 +549,7 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		ServiceNameToSnake:  toSnake(s.Name),
 		SystemParameters:    c.systemParameters,
 		ReturnType:          returnType,
-		SkipBuilderDocs:     c.skipBuilderDocs,
+		HasVeneer:           c.hasVeneer,
 	}
 	if m.OperationInfo != nil {
 		metadataType := c.methodInOutTypeName(m.OperationInfo.MetadataTypeID, state, sourceSpecificationPackageName)

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -117,12 +117,12 @@ func newCodec(protobufSource bool, options map[string]string) (*codec, error) {
 				return nil, fmt.Errorf("cannot convert `per-service-features` value %q to boolean: %w", definition, err)
 			}
 			codec.perServiceFeatures = value
-		case key == "skip-builder-docs":
+		case key == "has-veneer":
 			value, err := strconv.ParseBool(definition)
 			if err != nil {
-				return nil, fmt.Errorf("cannot convert `skip-builder-docs` value %q to boolean: %w", definition, err)
+				return nil, fmt.Errorf("cannot convert `has-veneer` value %q to boolean: %w", definition, err)
 			}
-			codec.skipBuilderDocs = value
+			codec.hasVeneer = value
 		default:
 			return nil, fmt.Errorf("unknown Rust codec option %q", key)
 		}
@@ -227,8 +227,8 @@ type codec struct {
 	includeGrpcOnlyMethods bool
 	// If true, the generator will produce per-client features.
 	perServiceFeatures bool
-	// If true, skip the documentation for Client and Request builders.
-	skipBuilderDocs bool
+	// If true, there is a handwritten client surface.
+	hasVeneer bool
 }
 
 type systemParameter struct {

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -26,7 +26,7 @@ limitations under the License.
 pub mod {{Codec.ModuleName}} {
     use crate::Result;
 
-    {{^Codec.SkipBuilderDocs}}
+    {{^Codec.HasVeneer}}
     /// A builder for [{{Codec.Name}}][super::super::client::{{Codec.Name}}].
     ///
     /// ```
@@ -40,9 +40,9 @@ pub mod {{Codec.ModuleName}} {
     ///     .build().await?;
     /// # gax::Result::<()>::Ok(()) });
     /// ```
-    {{/Codec.SkipBuilderDocs}}
     pub type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
+    {{/Codec.HasVeneer}}
 
     pub(crate) mod client {
         use super::super::super::client::{{Codec.Name}};
@@ -76,9 +76,10 @@ pub mod {{Codec.ModuleName}} {
     }
 
     {{#Codec.Methods}}
-    {{^Codec.SkipBuilderDocs}}
+    {{! TODO(#1813) - fix and generate builder docs for veneers }}
+    {{^Codec.HasVeneer}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][super::super::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
-    {{/Codec.SkipBuilderDocs}}
+    {{/Codec.HasVeneer}}
     #[derive(Clone, Debug)]
     pub struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);
 

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -25,8 +25,8 @@ limitations under the License.
 {{/Codec.PerServiceFeatures}}
 pub mod {{Codec.ModuleName}} {
     use crate::Result;
-
     {{^Codec.HasVeneer}}
+
     /// A builder for [{{Codec.Name}}][super::super::client::{{Codec.Name}}].
     ///
     /// ```
@@ -42,7 +42,6 @@ pub mod {{Codec.ModuleName}} {
     /// ```
     pub type ClientBuilder =
         gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
-    {{/Codec.HasVeneer}}
 
     pub(crate) mod client {
         use super::super::super::client::{{Codec.Name}};
@@ -55,6 +54,7 @@ pub mod {{Codec.ModuleName}} {
             }
         }
     }
+    {{/Codec.HasVeneer}}
 
     /// Common implementation for [super::super::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]

--- a/generator/internal/rust/templates/crate/src/client.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/client.rs.mustache
@@ -31,6 +31,7 @@ use crate::Result;
 {{#Codec.Services}}
 
 /// Implements a client for the {{Codec.APITitle}}.
+{{^Codec.HasVeneer}}
 ///
 /// # Example
 /// ```
@@ -73,6 +74,7 @@ use crate::Result;
 /// create one and the reuse it.  You do not need to wrap `{{Codec.Name}}` in
 /// an [Rc](std::rc::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
+{{/Codec.HasVeneer}}
 {{#Codec.PerServiceFeatures}}
 #[cfg(feature = "{{Codec.FeatureName}}")]
 #[cfg_attr(docsrs, doc(cfg(feature = "{{Codec.FeatureName}}")))]
@@ -89,6 +91,7 @@ pub struct {{Codec.Name}} {
 #[cfg(feature = "{{Codec.FeatureName}}")]
 {{/Codec.PerServiceFeatures}}
 impl {{Codec.Name}} {
+    {{^Codec.HasVeneer}}
     /// Returns a builder for [{{Codec.Name}}].
     ///
     /// ```
@@ -100,6 +103,7 @@ impl {{Codec.Name}} {
     pub fn builder() -> super::builder::{{Codec.ModuleName}}::ClientBuilder {
         gax::client_builder::internal::new_builder(super::builder::{{Codec.ModuleName}}::client::Factory)
     }
+    {{/Codec.HasVeneer}}
 
     /// Creates a new client from the provided stub.
     ///

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -75,8 +75,8 @@
 ///   Note that object names can contain `/` characters, which are treated as
 ///   any other character (no special directory semantics).
 ///
-/// [with_endpoint()]: super::builder::storage::ClientBuilder::with_endpoint
-/// [with_credentials()]: super::builder::storage::ClientBuilder::with_credentials
+/// [with_endpoint()]: ClientBuilder::with_endpoint
+/// [with_credentials()]: ClientBuilder::with_credentials
 /// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
 /// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 #[derive(Clone, Debug)]

--- a/src/storage-control/src/generated/gapic/.sidekick.toml
+++ b/src/storage-control/src/generated/gapic/.sidekick.toml
@@ -18,7 +18,6 @@ specification-source = 'google/storage/v2'
 service-config       = 'google/storage/v2/storage_v2.yaml'
 
 [source]
-# TODO(#1813) - handle IAM mixin for gRPC-based clients
 skipped-ids = """\
     .google.storage.v2.BidiReadHandle,\
     .google.storage.v2.BidiReadObjectError,\
@@ -57,5 +56,4 @@ copyright-year            = '2025'
 template-override         = 'templates/grpc-client'
 package-name-override     = 'google-cloud-storage-control'
 include-grpc-only-methods = 'true'
-# TODO(#1813) - temporarily disable the docs because they don't compile.
-skip-builder-docs = 'true'
+has-veneer                = 'true'

--- a/src/storage-control/src/generated/gapic/builder.rs
+++ b/src/storage-control/src/generated/gapic/builder.rs
@@ -17,9 +17,6 @@
 pub mod storage {
     use crate::Result;
 
-    pub type ClientBuilder =
-        gax::client_builder::ClientBuilder<client::Factory, gaxi::options::Credentials>;
-
     pub(crate) mod client {
         use super::super::super::client::Storage;
         pub struct Factory;

--- a/src/storage-control/src/generated/gapic/builder.rs
+++ b/src/storage-control/src/generated/gapic/builder.rs
@@ -17,18 +17,6 @@
 pub mod storage {
     use crate::Result;
 
-    pub(crate) mod client {
-        use super::super::super::client::Storage;
-        pub struct Factory;
-        impl gax::client_builder::internal::ClientFactory for Factory {
-            type Client = Storage;
-            type Credentials = gaxi::options::Credentials;
-            async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
-                Self::Client::new(config).await
-            }
-        }
-    }
-
     /// Common implementation for [super::super::client::Storage] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {

--- a/src/storage-control/src/generated/gapic/client.rs
+++ b/src/storage-control/src/generated/gapic/client.rs
@@ -19,88 +19,12 @@
 use crate::Result;
 
 /// Implements a client for the Cloud Storage API.
-///
-/// # Example
-/// ```
-/// # tokio_test::block_on(async {
-/// # use google_cloud_storage_control::client::Storage;
-/// let client = Storage::builder().build().await?;
-/// // use `client` to make requests to the Cloud Storage API.
-/// # gax::Result::<()>::Ok(()) });
-/// ```
-///
-/// # Service Description
-///
-/// ## API Overview and Naming Syntax
-///
-/// The Cloud Storage gRPC API allows applications to read and write data through
-/// the abstractions of buckets and objects. For a description of these
-/// abstractions please see <https://cloud.google.com/storage/docs>.
-///
-/// Resources are named as follows:
-///
-/// - Projects are referred to as they are defined by the Resource Manager API,
-///   using strings like `projects/123456` or `projects/my-string-id`.
-///
-/// - Buckets are named using string names of the form:
-///   `projects/{project}/buckets/{bucket}`
-///   For globally unique buckets, `_` may be substituted for the project.
-///
-/// - Objects are uniquely identified by their name along with the name of the
-///   bucket they belong to, as separate strings in this API. For example:
-///
-/// - ReadObjectRequest {
-///   bucket: 'projects/_/buckets/my-bucket'
-///   object: 'my-object'
-///   }
-///   Note that object names can contain `/` characters, which are treated as
-///   any other character (no special directory semantics).
-///
-///
-/// # Configuration
-///
-/// To configure `Storage` use the `with_*` methods in the type returned
-/// by [builder()][Storage::builder]. The default configuration should
-/// work for most applications. Common configuration changes include
-///
-/// * [with_endpoint()]: by default this client uses the global default endpoint
-///   (`https://storage.googleapis.com`). Applications using regional
-///   endpoints or running in restricted networks (e.g. a network configured
-//    with [Private Google Access with VPC Service Controls]) may want to
-///   override this default.
-/// * [with_credentials()]: by default this client uses
-///   [Application Default Credentials]. Applications using custom
-///   authentication may need to override this default.
-///
-/// [with_endpoint()]: super::builder::storage::ClientBuilder::with_endpoint
-/// [with_credentials()]: super::builder::storage::ClientBuilder::credentials
-/// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
-/// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
-///
-/// # Pooling and Cloning
-///
-/// `Storage` holds a connection pool internally, it is advised to
-/// create one and the reuse it.  You do not need to wrap `Storage` in
-/// an [Rc](std::rc::Rc) or [Arc](std::sync::Arc) to reuse it, because it
-/// already uses an `Arc` internally.
 #[derive(Clone, Debug)]
 pub struct Storage {
     inner: std::sync::Arc<dyn super::stub::dynamic::Storage>,
 }
 
 impl Storage {
-    /// Returns a builder for [Storage].
-    ///
-    /// ```
-    /// # tokio_test::block_on(async {
-    /// # use google_cloud_storage_control::client::Storage;
-    /// let client = Storage::builder().build().await?;
-    /// # gax::Result::<()>::Ok(()) });
-    /// ```
-    pub fn builder() -> super::builder::storage::ClientBuilder {
-        gax::client_builder::internal::new_builder(super::builder::storage::client::Factory)
-    }
-
     /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is in tests mocking the


### PR DESCRIPTION
Part of the work for #1813 

We are going to add another client (for StorageControl), which also has a `ClientBuilder`. We do not use either, and the types will clash, so stop generating them for veneers.

We also skip most of the client documentation (which references the `builder()`), if we will not be exposing the client.