### PR TITLE
feat(generator/rust): LROs with unit types

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -175,11 +175,25 @@ func (a *pathInfoAnnotation) RequiresContentLength() bool {
 }
 
 type operationInfo struct {
-	MetadataType       string
-	ResponseType       string
-	MetadataTypeInDocs string
-	ResponseTypeInDocs string
-	PackageNamespace   string
+	MetadataType     string
+	ResponseType     string
+	PackageNamespace string
+}
+
+func (info *operationInfo) OnlyMetadataIsEmpty() bool {
+	return info.MetadataType == "wkt::Empty" && info.ResponseType != "wkt::Empty"
+}
+
+func (info *operationInfo) OnlyResponseIsEmpty() bool {
+	return info.MetadataType != "wkt::Empty" && info.ResponseType == "wkt::Empty"
+}
+
+func (info *operationInfo) BothAreEmpty() bool {
+	return info.MetadataType == "wkt::Empty" && info.ResponseType == "wkt::Empty"
+}
+
+func (info *operationInfo) NoneAreEmpty() bool {
+	return info.MetadataType != "wkt::Empty" && info.ResponseType != "wkt::Empty"
 }
 
 type routingVariantAnnotations struct {
@@ -555,11 +569,9 @@ func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIStat
 		metadataType := c.methodInOutTypeName(m.OperationInfo.MetadataTypeID, state, sourceSpecificationPackageName)
 		responseType := c.methodInOutTypeName(m.OperationInfo.ResponseTypeID, state, sourceSpecificationPackageName)
 		m.OperationInfo.Codec = &operationInfo{
-			MetadataType:       metadataType,
-			ResponseType:       responseType,
-			MetadataTypeInDocs: strings.TrimPrefix(metadataType, "crate::"),
-			ResponseTypeInDocs: strings.TrimPrefix(responseType, "crate::"),
-			PackageNamespace:   packageNamespace,
+			MetadataType:     metadataType,
+			ResponseType:     responseType,
+			PackageNamespace: packageNamespace,
 		}
 	}
 	m.Codec = annotation

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -142,7 +142,19 @@ pub mod {{Codec.ModuleName}} {
         /// Creates a [Poller][lro::Poller] to work with `{{Method.Codec.Name}}`.
         pub fn poller(
             self
-        ) -> impl lro::Poller<{{Codec.ResponseType}}, {{Codec.MetadataType}}>
+        ) ->
+            {{#Codec.NoneAreEmpty}}
+            impl lro::Poller<{{Codec.ResponseType}}, {{Codec.MetadataType}}>
+            {{/Codec.NoneAreEmpty}}
+            {{#Codec.OnlyResponseIsEmpty}}
+            impl lro::Poller<(), {{Codec.MetadataType}}>
+            {{/Codec.OnlyResponseIsEmpty}}
+            {{#Codec.OnlyMetadataIsEmpty}}
+            impl lro::Poller<{{Codec.ResponseType}}, ()>
+            {{/Codec.OnlyMetadataIsEmpty}}
+            {{#Codec.BothAreEmpty}}
+            impl lro::Poller<(), ()>
+            {{/Codec.BothAreEmpty}}
         {
             type Operation = lro::internal::Operation<{{Codec.ResponseType}}, {{Codec.MetadataType}}>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -169,7 +181,18 @@ pub mod {{Codec.ModuleName}} {
                 Ok(Operation::new(op))
             };
 
+            {{#Codec.NoneAreEmpty}}
             lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            {{/Codec.NoneAreEmpty}}
+            {{#Codec.OnlyResponseIsEmpty}}
+            lro::internal::new_unit_response_poller(polling_error_policy, polling_backoff_policy, start, query)
+            {{/Codec.OnlyResponseIsEmpty}}
+            {{#Codec.OnlyMetadataIsEmpty}}
+            lro::internal::new_unit_metadata_poller(polling_error_policy, polling_backoff_policy, start, query)
+            {{/Codec.OnlyMetadataIsEmpty}}
+            {{#Codec.BothAreEmpty}}
+            lro::internal::new_unit_poller(polling_error_policy, polling_backoff_policy, start, query)
+            {{/Codec.BothAreEmpty}}
         }
         {{/OperationInfo}}
         {{#InputType.Codec.BasicFields}}

--- a/src/generated/api/apikeys/v2/src/builder.rs
+++ b/src/generated/api/apikeys/v2/src/builder.rs
@@ -101,7 +101,7 @@ pub mod api_keys {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `create_key`.
-        pub fn poller(self) -> impl lro::Poller<crate::model::Key, wkt::Empty> {
+        pub fn poller(self) -> impl lro::Poller<crate::model::Key, ()> {
             type Operation = lro::internal::Operation<crate::model::Key, wkt::Empty>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -127,7 +127,12 @@ pub mod api_keys {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_metadata_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::CreateKeyRequest::parent].
@@ -363,7 +368,7 @@ pub mod api_keys {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `update_key`.
-        pub fn poller(self) -> impl lro::Poller<crate::model::Key, wkt::Empty> {
+        pub fn poller(self) -> impl lro::Poller<crate::model::Key, ()> {
             type Operation = lro::internal::Operation<crate::model::Key, wkt::Empty>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -389,7 +394,12 @@ pub mod api_keys {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_metadata_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [key][crate::model::UpdateKeyRequest::key].
@@ -452,7 +462,7 @@ pub mod api_keys {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_key`.
-        pub fn poller(self) -> impl lro::Poller<crate::model::Key, wkt::Empty> {
+        pub fn poller(self) -> impl lro::Poller<crate::model::Key, ()> {
             type Operation = lro::internal::Operation<crate::model::Key, wkt::Empty>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -478,7 +488,12 @@ pub mod api_keys {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_metadata_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteKeyRequest::name].
@@ -538,7 +553,7 @@ pub mod api_keys {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `undelete_key`.
-        pub fn poller(self) -> impl lro::Poller<crate::model::Key, wkt::Empty> {
+        pub fn poller(self) -> impl lro::Poller<crate::model::Key, ()> {
             type Operation = lro::internal::Operation<crate::model::Key, wkt::Empty>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -564,7 +579,12 @@ pub mod api_keys {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_metadata_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::UndeleteKeyRequest::name].

--- a/src/generated/api/servicemanagement/v1/src/builder.rs
+++ b/src/generated/api/servicemanagement/v1/src/builder.rs
@@ -322,7 +322,7 @@ pub mod service_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -348,7 +348,12 @@ pub mod service_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [service_name][crate::model::DeleteServiceRequest::service_name].

--- a/src/generated/appengine/v1/src/builder.rs
+++ b/src/generated/appengine/v1/src/builder.rs
@@ -836,7 +836,7 @@ pub mod services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadataV1> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadataV1> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::OperationMetadataV1>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -863,7 +863,12 @@ pub mod services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceRequest::name].
@@ -1410,7 +1415,7 @@ pub mod versions {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_version`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadataV1> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadataV1> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::OperationMetadataV1>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1437,7 +1442,12 @@ pub mod versions {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVersionRequest::name].
@@ -1788,7 +1798,7 @@ pub mod instances {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadataV1> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadataV1> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::OperationMetadataV1>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1815,7 +1825,12 @@ pub mod instances {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
@@ -3771,7 +3786,7 @@ pub mod domain_mappings {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_domain_mapping`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadataV1> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadataV1> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::OperationMetadataV1>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -3798,7 +3813,12 @@ pub mod domain_mappings {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDomainMappingRequest::name].

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -412,7 +412,7 @@ pub mod dataset_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_dataset`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -439,7 +439,12 @@ pub mod dataset_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDatasetRequest::name].
@@ -866,7 +871,7 @@ pub mod dataset_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_dataset_version`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -893,7 +898,12 @@ pub mod dataset_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDatasetVersionRequest::name].
@@ -1558,7 +1568,7 @@ pub mod dataset_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_saved_query`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1585,7 +1595,12 @@ pub mod dataset_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSavedQueryRequest::name].
@@ -2805,7 +2820,7 @@ pub mod deployment_resource_pool_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_deployment_resource_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -2832,7 +2847,12 @@ pub mod deployment_resource_pool_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDeploymentResourcePoolRequest::name].
@@ -4014,7 +4034,7 @@ pub mod endpoint_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_endpoint`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -4041,7 +4061,12 @@ pub mod endpoint_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEndpointRequest::name].
@@ -6542,7 +6567,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_feature_online_store`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -6569,7 +6594,12 @@ pub mod feature_online_store_admin_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeatureOnlineStoreRequest::name].
@@ -6989,7 +7019,7 @@ pub mod feature_online_store_admin_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_feature_view`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -7016,7 +7046,12 @@ pub mod feature_online_store_admin_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeatureViewRequest::name].
@@ -9045,7 +9080,7 @@ pub mod feature_registry_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_feature_group`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -9072,7 +9107,12 @@ pub mod feature_registry_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeatureGroupRequest::name].
@@ -9592,7 +9632,7 @@ pub mod feature_registry_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_feature`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -9619,7 +9659,12 @@ pub mod feature_registry_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeatureRequest::name].
@@ -11465,7 +11510,7 @@ pub mod featurestore_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_featurestore`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -11492,7 +11537,12 @@ pub mod featurestore_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeaturestoreRequest::name].
@@ -11866,7 +11916,7 @@ pub mod featurestore_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_entity_type`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -11893,7 +11943,12 @@ pub mod featurestore_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEntityTypeRequest::name].
@@ -12372,7 +12427,7 @@ pub mod featurestore_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_feature`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -12399,7 +12454,12 @@ pub mod featurestore_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeatureRequest::name].
@@ -16176,7 +16236,7 @@ pub mod index_endpoint_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_index_endpoint`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -16203,7 +16263,12 @@ pub mod index_endpoint_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteIndexEndpointRequest::name].
@@ -17542,7 +17607,7 @@ pub mod index_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_index`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -17569,7 +17634,12 @@ pub mod index_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteIndexRequest::name].
@@ -18595,7 +18665,7 @@ pub mod job_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_custom_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -18622,7 +18692,12 @@ pub mod job_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCustomJobRequest::name].
@@ -18936,7 +19011,7 @@ pub mod job_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_data_labeling_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -18963,7 +19038,12 @@ pub mod job_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDataLabelingJobRequest::name].
@@ -19284,7 +19364,7 @@ pub mod job_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_hyperparameter_tuning_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -19311,7 +19391,12 @@ pub mod job_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteHyperparameterTuningJobRequest::name].
@@ -19610,7 +19695,7 @@ pub mod job_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_nas_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -19637,7 +19722,12 @@ pub mod job_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNasJobRequest::name].
@@ -20080,7 +20170,7 @@ pub mod job_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_batch_prediction_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -20107,7 +20197,12 @@ pub mod job_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBatchPredictionJobRequest::name].
@@ -20671,7 +20766,7 @@ pub mod job_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_model_deployment_monitoring_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -20698,7 +20793,12 @@ pub mod job_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteModelDeploymentMonitoringJobRequest::name].
@@ -23362,8 +23462,7 @@ pub mod metadata_service {
         /// Creates a [Poller][lro::Poller] to work with `delete_metadata_store`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteMetadataStoreOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::DeleteMetadataStoreOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::DeleteMetadataStoreOperationMetadata,
@@ -23392,7 +23491,12 @@ pub mod metadata_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteMetadataStoreRequest::name].
@@ -23717,7 +23821,7 @@ pub mod metadata_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_artifact`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -23744,7 +23848,12 @@ pub mod metadata_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteArtifactRequest::name].
@@ -24170,7 +24279,7 @@ pub mod metadata_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_context`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -24197,7 +24306,12 @@ pub mod metadata_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteContextRequest::name].
@@ -24877,7 +24991,7 @@ pub mod metadata_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_execution`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -24904,7 +25018,12 @@ pub mod metadata_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteExecutionRequest::name].
@@ -28255,7 +28374,7 @@ pub mod model_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_model`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -28282,7 +28401,12 @@ pub mod model_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteModelRequest::name].
@@ -28341,7 +28465,7 @@ pub mod model_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_model_version`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -28368,7 +28492,12 @@ pub mod model_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteModelVersionRequest::name].
@@ -30128,7 +30257,7 @@ pub mod notebook_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_notebook_runtime_template`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -30155,7 +30284,12 @@ pub mod notebook_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNotebookRuntimeTemplateRequest::name].
@@ -30545,7 +30679,7 @@ pub mod notebook_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_notebook_runtime`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -30572,7 +30706,12 @@ pub mod notebook_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNotebookRuntimeRequest::name].
@@ -31183,7 +31322,7 @@ pub mod notebook_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_notebook_execution_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -31210,7 +31349,12 @@ pub mod notebook_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNotebookExecutionJobRequest::name].
@@ -32166,7 +32310,7 @@ pub mod persistent_resource_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_persistent_resource`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -32193,7 +32337,12 @@ pub mod persistent_resource_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePersistentResourceRequest::name].
@@ -33308,7 +33457,7 @@ pub mod pipeline_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_training_pipeline`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -33335,7 +33484,12 @@ pub mod pipeline_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTrainingPipelineRequest::name].
@@ -33653,7 +33807,7 @@ pub mod pipeline_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_pipeline_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -33680,7 +33834,12 @@ pub mod pipeline_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePipelineJobRequest::name].
@@ -36815,7 +36974,7 @@ pub mod reasoning_engine_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_reasoning_engine`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -36842,7 +37001,12 @@ pub mod reasoning_engine_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteReasoningEngineRequest::name].
@@ -37610,7 +37774,7 @@ pub mod schedule_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_schedule`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -37637,7 +37801,12 @@ pub mod schedule_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteScheduleRequest::name].
@@ -38875,7 +39044,7 @@ pub mod specialist_pool_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_specialist_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -38902,7 +39071,12 @@ pub mod specialist_pool_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSpecialistPoolRequest::name].
@@ -40071,7 +40245,7 @@ pub mod tensorboard_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tensorboard`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -40098,7 +40272,12 @@ pub mod tensorboard_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTensorboardRequest::name].
@@ -40549,7 +40728,7 @@ pub mod tensorboard_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tensorboard_experiment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -40576,7 +40755,12 @@ pub mod tensorboard_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTensorboardExperimentRequest::name].
@@ -40978,7 +41162,7 @@ pub mod tensorboard_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tensorboard_run`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -41005,7 +41189,12 @@ pub mod tensorboard_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTensorboardRunRequest::name].
@@ -41424,7 +41613,7 @@ pub mod tensorboard_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tensorboard_time_series`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -41451,7 +41640,12 @@ pub mod tensorboard_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTensorboardTimeSeriesRequest::name].
@@ -42820,7 +43014,7 @@ pub mod vertex_rag_data_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_rag_corpus`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -42847,7 +43041,12 @@ pub mod vertex_rag_data_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRagCorpusRequest::name].
@@ -43204,7 +43403,7 @@ pub mod vertex_rag_data_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_rag_file`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -43231,7 +43430,12 @@ pub mod vertex_rag_data_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRagFileRequest::name].

--- a/src/generated/cloud/alloydb/v1/src/builder.rs
+++ b/src/generated/cloud/alloydb/v1/src/builder.rs
@@ -475,7 +475,7 @@ pub mod alloy_db_admin {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -501,7 +501,12 @@ pub mod alloy_db_admin {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClusterRequest::name].
@@ -1660,7 +1665,7 @@ pub mod alloy_db_admin {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1686,7 +1691,12 @@ pub mod alloy_db_admin {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
@@ -2535,7 +2545,7 @@ pub mod alloy_db_admin {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2561,7 +2571,12 @@ pub mod alloy_db_admin {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupRequest::name].

--- a/src/generated/cloud/apigateway/v1/src/builder.rs
+++ b/src/generated/cloud/apigateway/v1/src/builder.rs
@@ -439,7 +439,7 @@ pub mod api_gateway_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_gateway`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -465,7 +465,12 @@ pub mod api_gateway_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGatewayRequest::name].
@@ -849,7 +854,7 @@ pub mod api_gateway_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_api`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -875,7 +880,12 @@ pub mod api_gateway_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteApiRequest::name].
@@ -1274,7 +1284,7 @@ pub mod api_gateway_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_api_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1300,7 +1310,12 @@ pub mod api_gateway_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteApiConfigRequest::name].

--- a/src/generated/cloud/apphub/v1/src/builder.rs
+++ b/src/generated/cloud/apphub/v1/src/builder.rs
@@ -418,7 +418,7 @@ pub mod app_hub {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service_project_attachment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -444,7 +444,12 @@ pub mod app_hub {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceProjectAttachmentRequest::name].
@@ -1089,7 +1094,7 @@ pub mod app_hub {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1115,7 +1120,12 @@ pub mod app_hub {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceRequest::name].
@@ -1712,7 +1722,7 @@ pub mod app_hub {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_workload`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1738,7 +1748,12 @@ pub mod app_hub {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteWorkloadRequest::name].
@@ -2154,7 +2169,7 @@ pub mod app_hub {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_application`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2180,7 +2195,12 @@ pub mod app_hub {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteApplicationRequest::name].

--- a/src/generated/cloud/backupdr/v1/src/builder.rs
+++ b/src/generated/cloud/backupdr/v1/src/builder.rs
@@ -361,7 +361,7 @@ pub mod backup_dr {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_management_server`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -387,7 +387,12 @@ pub mod backup_dr {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteManagementServerRequest::name].
@@ -924,7 +929,7 @@ pub mod backup_dr {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup_vault`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -950,7 +955,12 @@ pub mod backup_dr {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupVaultRequest::name].
@@ -2007,7 +2017,7 @@ pub mod backup_dr {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup_plan`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2033,7 +2043,12 @@ pub mod backup_dr {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupPlanRequest::name].
@@ -2354,7 +2369,7 @@ pub mod backup_dr {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup_plan_association`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2380,7 +2395,12 @@ pub mod backup_dr {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupPlanAssociationRequest::name].

--- a/src/generated/cloud/baremetalsolution/v2/src/builder.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builder.rs
@@ -1403,7 +1403,7 @@ pub mod bare_metal_solution {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `evict_volume`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1429,7 +1429,12 @@ pub mod bare_metal_solution {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::EvictVolumeRequest::name].
@@ -2300,7 +2305,7 @@ pub mod bare_metal_solution {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `evict_lun`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2326,7 +2331,12 @@ pub mod bare_metal_solution {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::EvictLunRequest::name].
@@ -2757,7 +2767,7 @@ pub mod bare_metal_solution {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_nfs_share`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2783,7 +2793,12 @@ pub mod bare_metal_solution {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNfsShareRequest::name].

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
@@ -490,9 +490,7 @@ pub mod app_connections_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_app_connection`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::AppConnectionOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::AppConnectionOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::AppConnectionOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -519,7 +517,12 @@ pub mod app_connections_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAppConnectionRequest::name].

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
@@ -481,9 +481,7 @@ pub mod app_connectors_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_app_connector`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::AppConnectorOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::AppConnectorOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::AppConnectorOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -510,7 +508,12 @@ pub mod app_connectors_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAppConnectorRequest::name].

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
@@ -361,9 +361,7 @@ pub mod app_gateways_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_app_gateway`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::AppGatewayOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::AppGatewayOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::AppGatewayOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -390,7 +388,12 @@ pub mod app_gateways_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAppGatewayRequest::name].

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
@@ -515,8 +515,7 @@ pub mod client_connector_services_service {
         /// Creates a [Poller][lro::Poller] to work with `delete_client_connector_service`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::ClientConnectorServiceOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::ClientConnectorServiceOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::ClientConnectorServiceOperationMetadata,
@@ -545,7 +544,12 @@ pub mod client_connector_services_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClientConnectorServiceRequest::name].

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
@@ -367,9 +367,7 @@ pub mod client_gateways_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_client_gateway`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::ClientGatewayOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::ClientGatewayOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::ClientGatewayOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -396,7 +394,12 @@ pub mod client_gateways_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClientGatewayRequest::name].

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
@@ -1363,7 +1363,7 @@ pub mod analytics_hub_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_subscription`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1389,7 +1389,12 @@ pub mod analytics_hub_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSubscriptionRequest::name].

--- a/src/generated/cloud/certificatemanager/v1/src/builder.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builder.rs
@@ -457,7 +457,7 @@ pub mod certificate_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_certificate`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -483,7 +483,12 @@ pub mod certificate_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCertificateRequest::name].
@@ -896,7 +901,7 @@ pub mod certificate_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_certificate_map`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -922,7 +927,12 @@ pub mod certificate_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCertificateMapRequest::name].
@@ -1349,7 +1359,7 @@ pub mod certificate_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_certificate_map_entry`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1375,7 +1385,12 @@ pub mod certificate_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCertificateMapEntryRequest::name].
@@ -1792,7 +1807,7 @@ pub mod certificate_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_dns_authorization`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1818,7 +1833,12 @@ pub mod certificate_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDnsAuthorizationRequest::name].
@@ -2141,7 +2161,7 @@ pub mod certificate_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_certificate_issuance_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2167,7 +2187,12 @@ pub mod certificate_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCertificateIssuanceConfigRequest::name].
@@ -2575,7 +2600,7 @@ pub mod certificate_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_trust_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2601,7 +2626,12 @@ pub mod certificate_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTrustConfigRequest::name].

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -469,7 +469,7 @@ pub mod data_migration_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_migration_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -495,7 +495,12 @@ pub mod data_migration_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteMigrationJobRequest::name].
@@ -1710,7 +1715,7 @@ pub mod data_migration_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connection_profile`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1736,7 +1741,12 @@ pub mod data_migration_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectionProfileRequest::name].
@@ -2076,7 +2086,7 @@ pub mod data_migration_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_private_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2102,7 +2112,12 @@ pub mod data_migration_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePrivateConnectionRequest::name].
@@ -2541,7 +2556,7 @@ pub mod data_migration_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_conversion_workspace`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2567,7 +2582,12 @@ pub mod data_migration_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConversionWorkspaceRequest::name].

--- a/src/generated/cloud/connectors/v1/src/builder.rs
+++ b/src/generated/cloud/connectors/v1/src/builder.rs
@@ -462,7 +462,7 @@ pub mod connectors {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -488,7 +488,12 @@ pub mod connectors {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectionRequest::name].

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -1674,9 +1674,7 @@ pub mod contact_center_insights {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_issue_model`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteIssueModelMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteIssueModelMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteIssueModelMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1703,7 +1701,12 @@ pub mod contact_center_insights {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteIssueModelRequest::name].

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -407,7 +407,7 @@ pub mod lineage {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_process`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -433,7 +433,12 @@ pub mod lineage {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteProcessRequest::name].
@@ -729,7 +734,7 @@ pub mod lineage {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_run`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -755,7 +760,12 @@ pub mod lineage {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRunRequest::name].

--- a/src/generated/cloud/datafusion/v1/src/builder.rs
+++ b/src/generated/cloud/datafusion/v1/src/builder.rs
@@ -423,7 +423,7 @@ pub mod data_fusion {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -449,7 +449,12 @@ pub mod data_fusion {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/dataplex/v1/src/builder.rs
+++ b/src/generated/cloud/dataplex/v1/src/builder.rs
@@ -320,7 +320,7 @@ pub mod catalog_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_entry_type`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -346,7 +346,12 @@ pub mod catalog_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEntryTypeRequest::name].
@@ -765,7 +770,7 @@ pub mod catalog_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_aspect_type`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -791,7 +796,12 @@ pub mod catalog_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAspectTypeRequest::name].
@@ -1210,7 +1220,7 @@ pub mod catalog_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_entry_group`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1236,7 +1246,12 @@ pub mod catalog_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEntryGroupRequest::name].
@@ -3069,7 +3084,7 @@ pub mod cmek_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_encryption_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3095,7 +3110,12 @@ pub mod cmek_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEncryptionConfigRequest::name].
@@ -5022,7 +5042,7 @@ pub mod data_taxonomy_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_data_taxonomy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5048,7 +5068,12 @@ pub mod data_taxonomy_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDataTaxonomyRequest::name].
@@ -5486,7 +5511,7 @@ pub mod data_taxonomy_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_data_attribute_binding`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5512,7 +5537,12 @@ pub mod data_taxonomy_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDataAttributeBindingRequest::name].
@@ -5951,7 +5981,7 @@ pub mod data_taxonomy_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_data_attribute`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5977,7 +6007,12 @@ pub mod data_taxonomy_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDataAttributeRequest::name].
@@ -6983,7 +7018,7 @@ pub mod data_scan_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_data_scan`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -7009,7 +7044,12 @@ pub mod data_scan_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDataScanRequest::name].
@@ -9411,7 +9451,7 @@ pub mod dataplex_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_lake`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -9437,7 +9477,12 @@ pub mod dataplex_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteLakeRequest::name].
@@ -9909,7 +9954,7 @@ pub mod dataplex_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_zone`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -9935,7 +9980,12 @@ pub mod dataplex_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteZoneRequest::name].
@@ -10413,7 +10463,7 @@ pub mod dataplex_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_asset`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -10439,7 +10489,12 @@ pub mod dataplex_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAssetRequest::name].
@@ -10914,7 +10969,7 @@ pub mod dataplex_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_task`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -10940,7 +10995,12 @@ pub mod dataplex_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTaskRequest::name].
@@ -11594,7 +11654,7 @@ pub mod dataplex_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_environment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -11620,7 +11680,12 @@ pub mod dataplex_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEnvironmentRequest::name].

--- a/src/generated/cloud/dataproc/v1/src/builder.rs
+++ b/src/generated/cloud/dataproc/v1/src/builder.rs
@@ -2121,9 +2121,7 @@ pub mod cluster_controller {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cluster`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::ClusterOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::ClusterOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::ClusterOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -2150,7 +2148,12 @@ pub mod cluster_controller {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [project_id][crate::model::DeleteClusterRequest::project_id].
@@ -6533,7 +6536,7 @@ pub mod workflow_template_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `instantiate_workflow_template`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::WorkflowMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::WorkflowMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::WorkflowMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -6559,7 +6562,12 @@ pub mod workflow_template_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::InstantiateWorkflowTemplateRequest::name].
@@ -6643,7 +6651,7 @@ pub mod workflow_template_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `instantiate_inline_workflow_template`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::WorkflowMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::WorkflowMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::WorkflowMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -6669,7 +6677,12 @@ pub mod workflow_template_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::InstantiateInlineWorkflowTemplateRequest::parent].

--- a/src/generated/cloud/datastream/v1/src/builder.rs
+++ b/src/generated/cloud/datastream/v1/src/builder.rs
@@ -508,7 +508,7 @@ pub mod datastream {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connection_profile`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -534,7 +534,12 @@ pub mod datastream {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectionProfileRequest::name].
@@ -1166,7 +1171,7 @@ pub mod datastream {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_stream`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1192,7 +1197,12 @@ pub mod datastream {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteStreamRequest::name].
@@ -1969,7 +1979,7 @@ pub mod datastream {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_private_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1995,7 +2005,12 @@ pub mod datastream {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePrivateConnectionRequest::name].
@@ -2306,7 +2321,7 @@ pub mod datastream {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_route`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2332,7 +2347,12 @@ pub mod datastream {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRouteRequest::name].

--- a/src/generated/cloud/deploy/v1/src/builder.rs
+++ b/src/generated/cloud/deploy/v1/src/builder.rs
@@ -496,7 +496,7 @@ pub mod cloud_deploy {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_delivery_pipeline`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -522,7 +522,12 @@ pub mod cloud_deploy {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDeliveryPipelineRequest::name].
@@ -1077,7 +1082,7 @@ pub mod cloud_deploy {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_target`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1103,7 +1108,12 @@ pub mod cloud_deploy {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTargetRequest::name].
@@ -1574,7 +1584,7 @@ pub mod cloud_deploy {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_custom_target_type`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1600,7 +1610,12 @@ pub mod cloud_deploy {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCustomTargetTypeRequest::name].
@@ -2233,7 +2248,7 @@ pub mod cloud_deploy {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_deploy_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2259,7 +2274,12 @@ pub mod cloud_deploy {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDeployPolicyRequest::name].
@@ -3559,7 +3579,7 @@ pub mod cloud_deploy {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_automation`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3585,7 +3605,12 @@ pub mod cloud_deploy {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAutomationRequest::name].

--- a/src/generated/cloud/developerconnect/v1/src/builder.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builder.rs
@@ -480,7 +480,7 @@ pub mod developer_connect {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -506,7 +506,12 @@ pub mod developer_connect {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectionRequest::name].
@@ -711,7 +716,7 @@ pub mod developer_connect {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_git_repository_link`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -737,7 +742,12 @@ pub mod developer_connect {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGitRepositoryLinkRequest::name].

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -495,7 +495,7 @@ pub mod agents {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `restore_agent`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -521,7 +521,12 @@ pub mod agents {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::RestoreAgentRequest::name].
@@ -5288,7 +5293,7 @@ pub mod flows {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `train_flow`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5314,7 +5319,12 @@ pub mod flows {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::TrainFlowRequest::name].
@@ -12600,7 +12610,7 @@ pub mod versions {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `load_version`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -12626,7 +12636,12 @@ pub mod versions {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::LoadVersionRequest::name].

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -320,7 +320,7 @@ pub mod agents {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `train_agent`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -346,7 +346,12 @@ pub mod agents {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::TrainAgentRequest::parent].
@@ -489,7 +494,7 @@ pub mod agents {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `import_agent`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -515,7 +520,12 @@ pub mod agents {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::ImportAgentRequest::parent].
@@ -601,7 +611,7 @@ pub mod agents {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `restore_agent`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -627,7 +637,12 @@ pub mod agents {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::RestoreAgentRequest::parent].
@@ -3763,7 +3778,7 @@ pub mod conversation_datasets {
         /// Creates a [Poller][lro::Poller] to work with `delete_conversation_dataset`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteConversationDatasetOperationMetadata>
+        ) -> impl lro::Poller<(), crate::model::DeleteConversationDatasetOperationMetadata>
         {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
@@ -3793,7 +3808,12 @@ pub mod conversation_datasets {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConversationDatasetRequest::name].
@@ -4553,8 +4573,7 @@ pub mod conversation_models {
         /// Creates a [Poller][lro::Poller] to work with `delete_conversation_model`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteConversationModelOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::DeleteConversationModelOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::DeleteConversationModelOperationMetadata,
@@ -4583,7 +4602,12 @@ pub mod conversation_models {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConversationModelRequest::name].
@@ -4646,8 +4670,7 @@ pub mod conversation_models {
         /// Creates a [Poller][lro::Poller] to work with `deploy_conversation_model`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeployConversationModelOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::DeployConversationModelOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::DeployConversationModelOperationMetadata,
@@ -4676,7 +4699,12 @@ pub mod conversation_models {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeployConversationModelRequest::name].
@@ -4739,7 +4767,7 @@ pub mod conversation_models {
         /// Creates a [Poller][lro::Poller] to work with `undeploy_conversation_model`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::UndeployConversationModelOperationMetadata>
+        ) -> impl lro::Poller<(), crate::model::UndeployConversationModelOperationMetadata>
         {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
@@ -4769,7 +4797,12 @@ pub mod conversation_models {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::UndeployConversationModelRequest::name].
@@ -6698,9 +6731,7 @@ pub mod documents {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_document`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::KnowledgeOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::KnowledgeOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::KnowledgeOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -6727,7 +6758,12 @@ pub mod documents {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDocumentRequest::name].
@@ -8464,7 +8500,7 @@ pub mod entity_types {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `batch_delete_entity_types`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -8490,7 +8526,12 @@ pub mod entity_types {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BatchDeleteEntityTypesRequest::parent].
@@ -8562,7 +8603,7 @@ pub mod entity_types {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `batch_create_entities`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -8588,7 +8629,12 @@ pub mod entity_types {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BatchCreateEntitiesRequest::parent].
@@ -8666,7 +8712,7 @@ pub mod entity_types {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `batch_update_entities`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -8692,7 +8738,12 @@ pub mod entity_types {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BatchUpdateEntitiesRequest::parent].
@@ -8779,7 +8830,7 @@ pub mod entity_types {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `batch_delete_entities`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -8805,7 +8856,12 @@ pub mod entity_types {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BatchDeleteEntitiesRequest::parent].
@@ -11575,7 +11631,7 @@ pub mod intents {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `batch_delete_intents`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Struct> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Struct> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Struct>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -11601,7 +11657,12 @@ pub mod intents {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BatchDeleteIntentsRequest::parent].

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -2862,7 +2862,7 @@ pub mod data_store_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_data_store`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteDataStoreMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteDataStoreMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteDataStoreMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -2889,7 +2889,12 @@ pub mod data_store_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDataStoreRequest::name].
@@ -4371,7 +4376,7 @@ pub mod engine_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_engine`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteEngineMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteEngineMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteEngineMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -4398,7 +4403,12 @@ pub mod engine_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEngineRequest::name].
@@ -6618,7 +6628,7 @@ pub mod schema_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_schema`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteSchemaMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteSchemaMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteSchemaMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -6645,7 +6655,12 @@ pub mod schema_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSchemaRequest::name].
@@ -8894,9 +8909,7 @@ pub mod site_search_engine_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_target_site`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteTargetSiteMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteTargetSiteMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteTargetSiteMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -8923,7 +8936,12 @@ pub mod site_search_engine_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTargetSiteRequest::name].
@@ -9151,7 +9169,7 @@ pub mod site_search_engine_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_sitemap`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteSitemapMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteSitemapMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteSitemapMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -9178,7 +9196,12 @@ pub mod site_search_engine_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSitemapRequest::name].

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -989,9 +989,7 @@ pub mod document_processor_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_processor_version`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteProcessorVersionMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteProcessorVersionMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteProcessorVersionMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1018,7 +1016,12 @@ pub mod document_processor_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteProcessorVersionRequest::name].
@@ -1320,7 +1323,7 @@ pub mod document_processor_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_processor`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteProcessorMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteProcessorMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteProcessorMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1347,7 +1350,12 @@ pub mod document_processor_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteProcessorRequest::name].

--- a/src/generated/cloud/domains/v1/src/builder.rs
+++ b/src/generated/cloud/domains/v1/src/builder.rs
@@ -1210,7 +1210,7 @@ pub mod domains {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_registration`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1236,7 +1236,12 @@ pub mod domains {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRegistrationRequest::name].

--- a/src/generated/cloud/edgecontainer/v1/src/builder.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builder.rs
@@ -557,7 +557,7 @@ pub mod edge_container {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -583,7 +583,12 @@ pub mod edge_container {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClusterRequest::name].
@@ -1091,7 +1096,7 @@ pub mod edge_container {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_node_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1117,7 +1122,12 @@ pub mod edge_container {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNodePoolRequest::name].
@@ -1570,7 +1580,7 @@ pub mod edge_container {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_vpn_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1596,7 +1606,12 @@ pub mod edge_container {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVpnConnectionRequest::name].

--- a/src/generated/cloud/edgenetwork/v1/src/builder.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builder.rs
@@ -575,7 +575,7 @@ pub mod edge_network {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_network`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -601,7 +601,12 @@ pub mod edge_network {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNetworkRequest::name].
@@ -1011,7 +1016,7 @@ pub mod edge_network {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_subnet`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1037,7 +1042,12 @@ pub mod edge_network {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSubnetRequest::name].
@@ -1558,7 +1568,7 @@ pub mod edge_network {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_interconnect_attachment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1584,7 +1594,12 @@ pub mod edge_network {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInterconnectAttachmentRequest::name].
@@ -2041,7 +2056,7 @@ pub mod edge_network {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_router`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2067,7 +2082,12 @@ pub mod edge_network {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRouterRequest::name].

--- a/src/generated/cloud/filestore/v1/src/builder.rs
+++ b/src/generated/cloud/filestore/v1/src/builder.rs
@@ -660,9 +660,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, cloud_common::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), cloud_common::model::OperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, cloud_common::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -689,7 +687,12 @@ pub mod cloud_filestore_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
@@ -997,9 +1000,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_snapshot`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, cloud_common::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), cloud_common::model::OperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, cloud_common::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1026,7 +1027,12 @@ pub mod cloud_filestore_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSnapshotRequest::name].
@@ -1424,9 +1430,7 @@ pub mod cloud_filestore_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, cloud_common::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), cloud_common::model::OperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, cloud_common::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1453,7 +1457,12 @@ pub mod cloud_filestore_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupRequest::name].

--- a/src/generated/cloud/financialservices/v1/src/builder.rs
+++ b/src/generated/cloud/financialservices/v1/src/builder.rs
@@ -439,7 +439,7 @@ pub mod aml {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -465,7 +465,12 @@ pub mod aml {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
@@ -1104,7 +1109,7 @@ pub mod aml {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_dataset`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1130,7 +1135,12 @@ pub mod aml {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDatasetRequest::name].
@@ -1630,7 +1640,7 @@ pub mod aml {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_model`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1656,7 +1666,12 @@ pub mod aml {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteModelRequest::name].
@@ -2176,7 +2191,7 @@ pub mod aml {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_engine_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2202,7 +2217,12 @@ pub mod aml {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEngineConfigRequest::name].
@@ -2866,7 +2886,7 @@ pub mod aml {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_prediction_result`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2892,7 +2912,12 @@ pub mod aml {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePredictionResultRequest::name].
@@ -3417,7 +3442,7 @@ pub mod aml {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backtest_result`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3443,7 +3468,12 @@ pub mod aml {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBacktestResultRequest::name].

--- a/src/generated/cloud/functions/v2/src/builder.rs
+++ b/src/generated/cloud/functions/v2/src/builder.rs
@@ -443,7 +443,7 @@ pub mod function_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_function`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -469,7 +469,12 @@ pub mod function_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFunctionRequest::name].

--- a/src/generated/cloud/gkebackup/v1/src/builder.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builder.rs
@@ -448,7 +448,7 @@ pub mod backup_for_gke {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup_plan`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -474,7 +474,12 @@ pub mod backup_for_gke {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupPlanRequest::name].
@@ -866,7 +871,7 @@ pub mod backup_for_gke {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -892,7 +897,12 @@ pub mod backup_for_gke {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
@@ -1446,7 +1456,7 @@ pub mod backup_for_gke {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_restore_plan`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1472,7 +1482,12 @@ pub mod backup_for_gke {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRestorePlanRequest::name].
@@ -1874,7 +1889,7 @@ pub mod backup_for_gke {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_restore`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1900,7 +1915,12 @@ pub mod backup_for_gke {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRestoreRequest::name].

--- a/src/generated/cloud/gkehub/v1/src/builder.rs
+++ b/src/generated/cloud/gkehub/v1/src/builder.rs
@@ -571,7 +571,7 @@ pub mod gke_hub {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_membership`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -597,7 +597,12 @@ pub mod gke_hub {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteMembershipRequest::name].
@@ -663,7 +668,7 @@ pub mod gke_hub {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_feature`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -689,7 +694,12 @@ pub mod gke_hub {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFeatureRequest::name].

--- a/src/generated/cloud/gkemulticloud/v1/src/builder.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builder.rs
@@ -592,7 +592,7 @@ pub mod attached_clusters {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_attached_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -618,7 +618,12 @@ pub mod attached_clusters {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAttachedClusterRequest::name].
@@ -1562,7 +1567,7 @@ pub mod aws_clusters {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_aws_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1588,7 +1593,12 @@ pub mod aws_clusters {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAwsClusterRequest::name].
@@ -2280,7 +2290,7 @@ pub mod aws_clusters {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_aws_node_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2306,7 +2316,12 @@ pub mod aws_clusters {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAwsNodePoolRequest::name].
@@ -3058,7 +3073,7 @@ pub mod azure_clusters {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_azure_client`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3084,7 +3099,12 @@ pub mod azure_clusters {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAzureClientRequest::name].
@@ -3504,7 +3524,7 @@ pub mod azure_clusters {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_azure_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3530,7 +3550,12 @@ pub mod azure_clusters {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAzureClusterRequest::name].
@@ -4131,7 +4156,7 @@ pub mod azure_clusters {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_azure_node_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4157,7 +4182,12 @@ pub mod azure_clusters {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAzureNodePoolRequest::name].

--- a/src/generated/cloud/ids/v1/src/builder.rs
+++ b/src/generated/cloud/ids/v1/src/builder.rs
@@ -338,7 +338,7 @@ pub mod ids {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_endpoint`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -364,7 +364,12 @@ pub mod ids {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEndpointRequest::name].

--- a/src/generated/cloud/licensemanager/v1/src/builder.rs
+++ b/src/generated/cloud/licensemanager/v1/src/builder.rs
@@ -472,7 +472,7 @@ pub mod license_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_configuration`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -498,7 +498,12 @@ pub mod license_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConfigurationRequest::name].

--- a/src/generated/cloud/lustre/v1/src/builder.rs
+++ b/src/generated/cloud/lustre/v1/src/builder.rs
@@ -439,7 +439,7 @@ pub mod lustre {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -465,7 +465,12 @@ pub mod lustre {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/managedidentities/v1/src/builder.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builder.rs
@@ -492,7 +492,7 @@ pub mod managed_identities_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_domain`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OpMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OpMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OpMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -518,7 +518,12 @@ pub mod managed_identities_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDomainRequest::name].

--- a/src/generated/cloud/memcache/v1/src/builder.rs
+++ b/src/generated/cloud/memcache/v1/src/builder.rs
@@ -549,7 +549,7 @@ pub mod cloud_memcache {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -575,7 +575,12 @@ pub mod cloud_memcache {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/memorystore/v1/src/builder.rs
+++ b/src/generated/cloud/memorystore/v1/src/builder.rs
@@ -451,7 +451,7 @@ pub mod memorystore {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -477,7 +477,12 @@ pub mod memorystore {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/metastore/v1/src/builder.rs
+++ b/src/generated/cloud/metastore/v1/src/builder.rs
@@ -453,7 +453,7 @@ pub mod dataproc_metastore {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -479,7 +479,12 @@ pub mod dataproc_metastore {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceRequest::name].
@@ -1388,7 +1393,7 @@ pub mod dataproc_metastore {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1414,7 +1419,12 @@ pub mod dataproc_metastore {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
@@ -2747,7 +2757,7 @@ pub mod dataproc_metastore_federation {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_federation`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2773,7 +2783,12 @@ pub mod dataproc_metastore_federation {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFederationRequest::name].

--- a/src/generated/cloud/migrationcenter/v1/src/builder.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builder.rs
@@ -891,7 +891,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_import_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -917,7 +917,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteImportJobRequest::name].
@@ -1093,7 +1098,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `validate_import_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1119,7 +1124,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::ValidateImportJobRequest::name].
@@ -1181,7 +1191,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `run_import_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1207,7 +1217,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::RunImportJobRequest::name].
@@ -1527,7 +1542,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_import_data_file`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1553,7 +1568,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteImportDataFileRequest::name].
@@ -1963,7 +1983,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_group`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1989,7 +2009,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGroupRequest::name].
@@ -2754,7 +2779,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_source`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2780,7 +2805,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSourceRequest::name].
@@ -3205,7 +3235,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_preference_set`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3231,7 +3261,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePreferenceSetRequest::name].
@@ -3699,7 +3734,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_report_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3725,7 +3760,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteReportConfigRequest::name].
@@ -4048,7 +4088,7 @@ pub mod migration_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_report`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4074,7 +4114,12 @@ pub mod migration_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteReportRequest::name].

--- a/src/generated/cloud/netapp/v1/src/builder.rs
+++ b/src/generated/cloud/netapp/v1/src/builder.rs
@@ -445,7 +445,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_storage_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -471,7 +471,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteStoragePoolRequest::name].
@@ -530,7 +535,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `validate_directory_service`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -556,7 +561,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::ValidateDirectoryServiceRequest::name].
@@ -1037,7 +1047,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_volume`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1063,7 +1073,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVolumeRequest::name].
@@ -1445,7 +1460,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_snapshot`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1471,7 +1486,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSnapshotRequest::name].
@@ -1971,7 +1991,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_active_directory`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1997,7 +2017,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteActiveDirectoryRequest::name].
@@ -2507,7 +2532,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_kms_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2533,7 +2558,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteKmsConfigRequest::name].
@@ -2829,7 +2859,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_replication`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2855,7 +2885,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteReplicationRequest::name].
@@ -3832,7 +3867,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup_vault`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3858,7 +3893,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupVaultRequest::name].
@@ -4143,7 +4183,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4169,7 +4209,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupRequest::name].
@@ -4664,7 +4709,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4690,7 +4735,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupPolicyRequest::name].
@@ -5070,7 +5120,7 @@ pub mod net_app {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_quota_rule`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5096,7 +5146,12 @@ pub mod net_app {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteQuotaRuleRequest::name].

--- a/src/generated/cloud/networkconnectivity/v1/src/builder.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builder.rs
@@ -486,7 +486,7 @@ pub mod cross_network_automation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service_connection_map`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -512,7 +512,12 @@ pub mod cross_network_automation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceConnectionMapRequest::name].
@@ -964,7 +969,7 @@ pub mod cross_network_automation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service_connection_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -990,7 +995,12 @@ pub mod cross_network_automation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceConnectionPolicyRequest::name].
@@ -1305,7 +1315,7 @@ pub mod cross_network_automation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service_class`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1331,7 +1341,12 @@ pub mod cross_network_automation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceClassRequest::name].
@@ -1670,7 +1685,7 @@ pub mod cross_network_automation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service_connection_token`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1696,7 +1711,12 @@ pub mod cross_network_automation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceConnectionTokenRequest::name].
@@ -2696,7 +2716,7 @@ pub mod hub_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_hub`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2722,7 +2742,12 @@ pub mod hub_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteHubRequest::name].
@@ -3770,7 +3795,7 @@ pub mod hub_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_spoke`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3796,7 +3821,12 @@ pub mod hub_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSpokeRequest::name].
@@ -5212,7 +5242,7 @@ pub mod policy_based_routing_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_policy_based_route`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5238,7 +5268,12 @@ pub mod policy_based_routing_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePolicyBasedRouteRequest::name].

--- a/src/generated/cloud/networkmanagement/v1/src/builder.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builder.rs
@@ -553,7 +553,7 @@ pub mod reachability_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connectivity_test`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -579,7 +579,12 @@ pub mod reachability_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectivityTestRequest::name].
@@ -1596,7 +1601,7 @@ pub mod vpc_flow_logs_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_vpc_flow_logs_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1622,7 +1627,12 @@ pub mod vpc_flow_logs_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVpcFlowLogsConfigRequest::name].

--- a/src/generated/cloud/networksecurity/v1/src/builder.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builder.rs
@@ -462,7 +462,7 @@ pub mod network_security {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_authorization_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -488,7 +488,12 @@ pub mod network_security {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAuthorizationPolicyRequest::name].
@@ -891,7 +896,7 @@ pub mod network_security {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_server_tls_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -917,7 +922,12 @@ pub mod network_security {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServerTlsPolicyRequest::name].
@@ -1320,7 +1330,7 @@ pub mod network_security {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_client_tls_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1346,7 +1356,12 @@ pub mod network_security {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClientTlsPolicyRequest::name].

--- a/src/generated/cloud/networkservices/v1/src/builder.rs
+++ b/src/generated/cloud/networkservices/v1/src/builder.rs
@@ -486,7 +486,7 @@ pub mod dep_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_lb_traffic_extension`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -512,7 +512,12 @@ pub mod dep_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteLbTrafficExtensionRequest::name].
@@ -945,7 +950,7 @@ pub mod dep_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_lb_route_extension`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -971,7 +976,12 @@ pub mod dep_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteLbRouteExtensionRequest::name].
@@ -1968,7 +1978,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_endpoint_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1994,7 +2004,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEndpointPolicyRequest::name].
@@ -2372,7 +2387,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_gateway`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2398,7 +2413,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGatewayRequest::name].
@@ -2776,7 +2796,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_grpc_route`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2802,7 +2822,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGrpcRouteRequest::name].
@@ -3180,7 +3205,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_http_route`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3206,7 +3231,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteHttpRouteRequest::name].
@@ -3584,7 +3614,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tcp_route`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3610,7 +3640,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTcpRouteRequest::name].
@@ -3988,7 +4023,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tls_route`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4014,7 +4049,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTlsRouteRequest::name].
@@ -4310,7 +4350,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_service_binding`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4336,7 +4376,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServiceBindingRequest::name].
@@ -4708,7 +4753,7 @@ pub mod network_services {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_mesh`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4734,7 +4779,12 @@ pub mod network_services {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteMeshRequest::name].

--- a/src/generated/cloud/notebooks/v2/src/builder.rs
+++ b/src/generated/cloud/notebooks/v2/src/builder.rs
@@ -453,7 +453,7 @@ pub mod notebook_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -479,7 +479,12 @@ pub mod notebook_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/oracledatabase/v1/src/builder.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builder.rs
@@ -366,7 +366,7 @@ pub mod oracle_database {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cloud_exadata_infrastructure`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -392,7 +392,12 @@ pub mod oracle_database {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCloudExadataInfrastructureRequest::name].
@@ -712,7 +717,7 @@ pub mod oracle_database {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cloud_vm_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -738,7 +743,12 @@ pub mod oracle_database {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCloudVmClusterRequest::name].
@@ -1450,7 +1460,7 @@ pub mod oracle_database {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_autonomous_database`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1476,7 +1486,12 @@ pub mod oracle_database {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAutonomousDatabaseRequest::name].

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
@@ -431,7 +431,7 @@ pub mod environments {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_environment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -457,7 +457,12 @@ pub mod environments {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEnvironmentRequest::name].

--- a/src/generated/cloud/osconfig/v1/src/builder.rs
+++ b/src/generated/cloud/osconfig/v1/src/builder.rs
@@ -1471,8 +1471,7 @@ pub mod os_config_zonal_service {
         /// Creates a [Poller][lro::Poller] to work with `delete_os_policy_assignment`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::OSPolicyAssignmentOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::OSPolicyAssignmentOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::OSPolicyAssignmentOperationMetadata,
@@ -1501,7 +1500,12 @@ pub mod os_config_zonal_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteOSPolicyAssignmentRequest::name].

--- a/src/generated/cloud/parallelstore/v1/src/builder.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builder.rs
@@ -453,7 +453,7 @@ pub mod parallelstore {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -479,7 +479,12 @@ pub mod parallelstore {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/redis/cluster/v1/src/builder.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builder.rs
@@ -328,7 +328,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Any> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Any> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Any>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -354,7 +354,12 @@ pub mod cloud_redis_cluster {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClusterRequest::name].
@@ -932,7 +937,7 @@ pub mod cloud_redis_cluster {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_backup`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, wkt::Any> {
+        pub fn poller(self) -> impl lro::Poller<(), wkt::Any> {
             type Operation = lro::internal::Operation<wkt::Empty, wkt::Any>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -958,7 +963,12 @@ pub mod cloud_redis_cluster {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBackupRequest::name].

--- a/src/generated/cloud/redis/v1/src/builder.rs
+++ b/src/generated/cloud/redis/v1/src/builder.rs
@@ -863,7 +863,7 @@ pub mod cloud_redis {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -889,7 +889,12 @@ pub mod cloud_redis {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].

--- a/src/generated/cloud/resourcemanager/v3/src/builder.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builder.rs
@@ -2526,9 +2526,7 @@ pub mod tag_bindings {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tag_binding`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteTagBindingMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteTagBindingMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteTagBindingMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -2555,7 +2553,12 @@ pub mod tag_bindings {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTagBindingRequest::name].
@@ -2889,7 +2892,7 @@ pub mod tag_holds {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_tag_hold`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteTagHoldMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteTagHoldMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteTagHoldMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -2916,7 +2919,12 @@ pub mod tag_holds {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTagHoldRequest::name].

--- a/src/generated/cloud/securesourcemanager/v1/src/builder.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builder.rs
@@ -348,7 +348,7 @@ pub mod secure_source_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_instance`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -374,7 +374,12 @@ pub mod secure_source_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInstanceRequest::name].
@@ -682,7 +687,7 @@ pub mod secure_source_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_repository`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -708,7 +713,12 @@ pub mod secure_source_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRepositoryRequest::name].
@@ -1295,7 +1305,7 @@ pub mod secure_source_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_branch_rule`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1321,7 +1331,12 @@ pub mod secure_source_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteBranchRuleRequest::name].

--- a/src/generated/cloud/security/privateca/v1/src/builder.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builder.rs
@@ -1783,7 +1783,7 @@ pub mod certificate_authority_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_ca_pool`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1809,7 +1809,12 @@ pub mod certificate_authority_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCaPoolRequest::name].
@@ -2315,7 +2320,7 @@ pub mod certificate_authority_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_certificate_template`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2341,7 +2346,12 @@ pub mod certificate_authority_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCertificateTemplateRequest::name].

--- a/src/generated/cloud/securitycenter/v2/src/builder.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builder.rs
@@ -173,9 +173,7 @@ pub mod security_center {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `bulk_mute_findings`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<crate::model::BulkMuteFindingsResponse, wkt::Empty> {
+        pub fn poller(self) -> impl lro::Poller<crate::model::BulkMuteFindingsResponse, ()> {
             type Operation =
                 lro::internal::Operation<crate::model::BulkMuteFindingsResponse, wkt::Empty>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -202,7 +200,12 @@ pub mod security_center {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_metadata_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BulkMuteFindingsRequest::parent].

--- a/src/generated/cloud/securityposture/v1/src/builder.rs
+++ b/src/generated/cloud/securityposture/v1/src/builder.rs
@@ -520,7 +520,7 @@ pub mod security_posture {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_posture`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -546,7 +546,12 @@ pub mod security_posture {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePostureRequest::name].
@@ -1072,7 +1077,7 @@ pub mod security_posture {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_posture_deployment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1098,7 +1103,12 @@ pub mod security_posture {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePostureDeploymentRequest::name].

--- a/src/generated/cloud/telcoautomation/v1/src/builder.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builder.rs
@@ -375,7 +375,7 @@ pub mod telco_automation {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_orchestration_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -401,7 +401,12 @@ pub mod telco_automation {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteOrchestrationClusterRequest::name].
@@ -706,7 +711,7 @@ pub mod telco_automation {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_edge_slm`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -732,7 +737,12 @@ pub mod telco_automation {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteEdgeSlmRequest::name].

--- a/src/generated/cloud/tpu/v2/src/builder.rs
+++ b/src/generated/cloud/tpu/v2/src/builder.rs
@@ -315,7 +315,7 @@ pub mod tpu {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_node`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -341,7 +341,12 @@ pub mod tpu {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNodeRequest::name].
@@ -893,7 +898,7 @@ pub mod tpu {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_queued_resource`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -919,7 +924,12 @@ pub mod tpu {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteQueuedResourceRequest::name].

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -1869,7 +1869,7 @@ pub mod translation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_dataset`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteDatasetMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteDatasetMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteDatasetMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1896,7 +1896,12 @@ pub mod translation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDatasetRequest::name].
@@ -2653,7 +2658,7 @@ pub mod translation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `import_data`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::ImportDataMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::ImportDataMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::ImportDataMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2679,7 +2684,12 @@ pub mod translation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [dataset][crate::model::ImportDataRequest::dataset].
@@ -2746,7 +2756,7 @@ pub mod translation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `export_data`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::ExportDataMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::ExportDataMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::ExportDataMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2772,7 +2782,12 @@ pub mod translation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [dataset][crate::model::ExportDataRequest::dataset].
@@ -3144,7 +3159,7 @@ pub mod translation_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_model`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::DeleteModelMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::DeleteModelMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::DeleteModelMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -3171,7 +3186,12 @@ pub mod translation_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteModelRequest::name].

--- a/src/generated/cloud/video/livestream/v1/src/builder.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builder.rs
@@ -348,7 +348,7 @@ pub mod livestream_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_channel`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -374,7 +374,12 @@ pub mod livestream_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteChannelRequest::name].
@@ -976,7 +981,7 @@ pub mod livestream_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_input`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1002,7 +1007,12 @@ pub mod livestream_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteInputRequest::name].
@@ -1665,7 +1675,7 @@ pub mod livestream_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_clip`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1691,7 +1701,12 @@ pub mod livestream_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClipRequest::name].
@@ -1863,7 +1878,7 @@ pub mod livestream_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_asset`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1889,7 +1904,12 @@ pub mod livestream_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAssetRequest::name].

--- a/src/generated/cloud/video/stitcher/v1/src/builder.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builder.rs
@@ -342,7 +342,7 @@ pub mod video_stitcher_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cdn_key`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -368,7 +368,12 @@ pub mod video_stitcher_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteCdnKeyRequest::name].
@@ -1354,7 +1359,7 @@ pub mod video_stitcher_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_slate`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1380,7 +1385,12 @@ pub mod video_stitcher_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSlateRequest::name].
@@ -1793,7 +1803,7 @@ pub mod video_stitcher_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_live_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1819,7 +1829,12 @@ pub mod video_stitcher_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteLiveConfigRequest::name].
@@ -2220,7 +2235,7 @@ pub mod video_stitcher_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_vod_config`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2246,7 +2261,12 @@ pub mod video_stitcher_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVodConfigRequest::name].

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -1737,7 +1737,7 @@ pub mod product_search {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `purge_products`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::BatchOperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::BatchOperationMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::BatchOperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1764,7 +1764,12 @@ pub mod product_search {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::PurgeProductsRequest::parent].

--- a/src/generated/cloud/vmmigration/v1/src/builder.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builder.rs
@@ -453,7 +453,7 @@ pub mod vm_migration {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_source`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -479,7 +479,12 @@ pub mod vm_migration {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteSourceRequest::name].
@@ -874,7 +879,7 @@ pub mod vm_migration {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_utilization_report`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -900,7 +905,12 @@ pub mod vm_migration {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteUtilizationReportRequest::name].
@@ -1232,7 +1242,7 @@ pub mod vm_migration {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_datacenter_connector`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1258,7 +1268,12 @@ pub mod vm_migration {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteDatacenterConnectorRequest::name].
@@ -1793,7 +1808,7 @@ pub mod vm_migration {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_migrating_vm`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1819,7 +1834,12 @@ pub mod vm_migration {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteMigratingVmRequest::name].
@@ -3250,7 +3270,7 @@ pub mod vm_migration {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_group`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3276,7 +3296,12 @@ pub mod vm_migration {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGroupRequest::name].
@@ -3901,7 +3926,7 @@ pub mod vm_migration {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_target_project`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3927,7 +3952,12 @@ pub mod vm_migration {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteTargetProjectRequest::name].

--- a/src/generated/cloud/vmwareengine/v1/src/builder.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builder.rs
@@ -1036,7 +1036,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_cluster`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1062,7 +1062,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteClusterRequest::name].
@@ -1697,7 +1702,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_external_address`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1723,7 +1728,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteExternalAddressRequest::name].
@@ -2388,7 +2398,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_external_access_rule`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2414,7 +2424,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteExternalAccessRuleRequest::name].
@@ -2845,7 +2860,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_logging_server`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2871,7 +2886,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteLoggingServerRequest::name].
@@ -3785,7 +3805,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_network_peering`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3811,7 +3831,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNetworkPeeringRequest::name].
@@ -4681,7 +4706,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_network_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -4707,7 +4732,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteNetworkPolicyRequest::name].
@@ -5157,7 +5187,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_management_dns_zone_binding`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5183,7 +5213,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteManagementDnsZoneBindingRequest::name].
@@ -5584,7 +5619,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_vmware_engine_network`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -5610,7 +5645,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVmwareEngineNetworkRequest::name].
@@ -6202,7 +6242,7 @@ pub mod vmware_engine {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_private_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -6228,7 +6268,12 @@ pub mod vmware_engine {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePrivateConnectionRequest::name].

--- a/src/generated/cloud/vpcaccess/v1/src/builder.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builder.rs
@@ -330,7 +330,7 @@ pub mod vpc_access_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connector`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -356,7 +356,12 @@ pub mod vpc_access_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectorRequest::name].

--- a/src/generated/cloud/workflows/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/v1/src/builder.rs
@@ -348,7 +348,7 @@ pub mod workflows {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_workflow`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -374,7 +374,12 @@ pub mod workflows {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteWorkflowRequest::name].

--- a/src/generated/datastore/admin/v1/src/builder.rs
+++ b/src/generated/datastore/admin/v1/src/builder.rs
@@ -221,7 +221,7 @@ pub mod datastore_admin {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `import_entities`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::ImportEntitiesMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::ImportEntitiesMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::ImportEntitiesMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -248,7 +248,12 @@ pub mod datastore_admin {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [project_id][crate::model::ImportEntitiesRequest::project_id].

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -1152,7 +1152,7 @@ pub mod artifact_registry {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_repository`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1178,7 +1178,12 @@ pub mod artifact_registry {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRepositoryRequest::name].
@@ -1367,7 +1372,7 @@ pub mod artifact_registry {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_package`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1393,7 +1398,12 @@ pub mod artifact_registry {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePackageRequest::name].
@@ -1590,7 +1600,7 @@ pub mod artifact_registry {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_version`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1616,7 +1626,12 @@ pub mod artifact_registry {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteVersionRequest::name].
@@ -1679,9 +1694,7 @@ pub mod artifact_registry {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `batch_delete_versions`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::BatchDeleteVersionsMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::BatchDeleteVersionsMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::BatchDeleteVersionsMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -1708,7 +1721,12 @@ pub mod artifact_registry {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [parent][crate::model::BatchDeleteVersionsRequest::parent].
@@ -1973,7 +1991,7 @@ pub mod artifact_registry {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_file`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1999,7 +2017,12 @@ pub mod artifact_registry {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteFileRequest::name].
@@ -3370,7 +3393,7 @@ pub mod artifact_registry {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_attachment`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -3396,7 +3419,12 @@ pub mod artifact_registry {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAttachmentRequest::name].

--- a/src/generated/devtools/cloudbuild/v1/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builder.rs
@@ -1312,7 +1312,7 @@ pub mod cloud_build {
         /// Creates a [Poller][lro::Poller] to work with `delete_worker_pool`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::DeleteWorkerPoolOperationMetadata> {
+        ) -> impl lro::Poller<(), crate::model::DeleteWorkerPoolOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::DeleteWorkerPoolOperationMetadata,
@@ -1341,7 +1341,12 @@ pub mod cloud_build {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteWorkerPoolRequest::name].

--- a/src/generated/devtools/cloudbuild/v2/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builder.rs
@@ -448,7 +448,7 @@ pub mod repository_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_connection`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -474,7 +474,12 @@ pub mod repository_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteConnectionRequest::name].
@@ -890,7 +895,7 @@ pub mod repository_manager {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_repository`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -916,7 +921,12 @@ pub mod repository_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteRepositoryRequest::name].

--- a/src/generated/firestore/admin/v1/src/builder.rs
+++ b/src/generated/firestore/admin/v1/src/builder.rs
@@ -724,7 +724,7 @@ pub mod firestore_admin {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `import_documents`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::ImportDocumentsMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::ImportDocumentsMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::ImportDocumentsMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -751,7 +751,12 @@ pub mod firestore_admin {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::ImportDocumentsRequest::name].

--- a/src/generated/iam/v3/src/builder.rs
+++ b/src/generated/iam/v3/src/builder.rs
@@ -383,7 +383,7 @@ pub mod policy_bindings {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_policy_binding`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -409,7 +409,12 @@ pub mod policy_bindings {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePolicyBindingRequest::name].
@@ -1045,7 +1050,7 @@ pub mod principal_access_boundary_policies {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_principal_access_boundary_policy`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -1071,7 +1076,12 @@ pub mod principal_access_boundary_policies {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeletePrincipalAccessBoundaryPolicyRequest::name].

--- a/src/generated/identity/accesscontextmanager/v1/src/builder.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builder.rs
@@ -476,8 +476,7 @@ pub mod access_context_manager {
         /// Creates a [Poller][lro::Poller] to work with `delete_access_policy`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::AccessContextManagerOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::AccessContextManagerOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::AccessContextManagerOperationMetadata,
@@ -506,7 +505,12 @@ pub mod access_context_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAccessPolicyRequest::name].
@@ -914,8 +918,7 @@ pub mod access_context_manager {
         /// Creates a [Poller][lro::Poller] to work with `delete_access_level`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::AccessContextManagerOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::AccessContextManagerOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::AccessContextManagerOperationMetadata,
@@ -944,7 +947,12 @@ pub mod access_context_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteAccessLevelRequest::name].
@@ -1459,8 +1467,7 @@ pub mod access_context_manager {
         /// Creates a [Poller][lro::Poller] to work with `delete_service_perimeter`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::AccessContextManagerOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::AccessContextManagerOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::AccessContextManagerOperationMetadata,
@@ -1489,7 +1496,12 @@ pub mod access_context_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteServicePerimeterRequest::name].
@@ -2119,8 +2131,7 @@ pub mod access_context_manager {
         /// Creates a [Poller][lro::Poller] to work with `delete_gcp_user_access_binding`.
         pub fn poller(
             self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::GcpUserAccessBindingOperationMetadata>
-        {
+        ) -> impl lro::Poller<(), crate::model::GcpUserAccessBindingOperationMetadata> {
             type Operation = lro::internal::Operation<
                 wkt::Empty,
                 crate::model::GcpUserAccessBindingOperationMetadata,
@@ -2149,7 +2160,12 @@ pub mod access_context_manager {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteGcpUserAccessBindingRequest::name].

--- a/src/generated/logging/v2/src/builder.rs
+++ b/src/generated/logging/v2/src/builder.rs
@@ -1974,7 +1974,7 @@ pub mod config_service_v_2 {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_link`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::LinkMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::LinkMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::LinkMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -2000,7 +2000,12 @@ pub mod config_service_v_2 {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteLinkRequest::name].

--- a/src/generated/monitoring/metricsscope/v1/src/builder.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builder.rs
@@ -316,7 +316,7 @@ pub mod metrics_scopes {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `delete_monitored_project`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::OperationMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::OperationMetadata> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::OperationMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -342,7 +342,12 @@ pub mod metrics_scopes {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [name][crate::model::DeleteMonitoredProjectRequest::name].

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -464,9 +464,7 @@ pub mod database_admin {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `update_database_ddl`.
-        pub fn poller(
-            self,
-        ) -> impl lro::Poller<wkt::Empty, crate::model::UpdateDatabaseDdlMetadata> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::UpdateDatabaseDdlMetadata> {
             type Operation =
                 lro::internal::Operation<wkt::Empty, crate::model::UpdateDatabaseDdlMetadata>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
@@ -493,7 +491,12 @@ pub mod database_admin {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [database][crate::model::UpdateDatabaseDdlRequest::database].

--- a/src/generated/storagetransfer/v1/src/builder.rs
+++ b/src/generated/storagetransfer/v1/src/builder.rs
@@ -522,7 +522,7 @@ pub mod storage_transfer_service {
         }
 
         /// Creates a [Poller][lro::Poller] to work with `run_transfer_job`.
-        pub fn poller(self) -> impl lro::Poller<wkt::Empty, crate::model::TransferOperation> {
+        pub fn poller(self) -> impl lro::Poller<(), crate::model::TransferOperation> {
             type Operation = lro::internal::Operation<wkt::Empty, crate::model::TransferOperation>;
             let polling_error_policy = self.0.stub.get_polling_error_policy(&self.0.options);
             let polling_backoff_policy = self.0.stub.get_polling_backoff_policy(&self.0.options);
@@ -548,7 +548,12 @@ pub mod storage_transfer_service {
                 Ok(Operation::new(op))
             };
 
-            lro::internal::new_poller(polling_error_policy, polling_backoff_policy, start, query)
+            lro::internal::new_unit_response_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
         }
 
         /// Sets the value of [job_name][crate::model::RunTransferJobRequest::job_name].

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -67,14 +67,14 @@ main:
     println!("    create LRO finished, response={response:?}");
 
     println!("\n\nStart delete_workflow() LRO and poll it to completion");
-    let delete = client
+    client
         .delete_workflow(format!(
             "projects/{project_id}/locations/{location_id}/workflows/{workflow_id}"
         ))
         .poller()
         .until_done()
         .await?;
-    println!("    delete LRO finished, response={delete:?}");
+    println!("    delete LRO finished");
 
     Ok(())
 }
@@ -159,9 +159,12 @@ main:
             wf::PollingResult::InProgress(m) => {
                 println!("    delete LRO still in progress, metadata={m:?}");
             }
-            wf::PollingResult::Completed(r) => {
-                println!("    delete LRO finished, result={r:?}");
-                let _ = r?;
+            wf::PollingResult::Completed(Ok(_)) => {
+                println!("    delete LRO finished successfully");
+            }
+            wf::PollingResult::Completed(Err(e)) => {
+                println!("    delete LRO finished with an error {e}");
+                return Err(e);
             }
         }
         tokio::time::sleep(backoff).await;

--- a/src/integration-tests/src/workflows_executions.rs
+++ b/src/integration-tests/src/workflows_executions.rs
@@ -83,7 +83,7 @@ pub async fn list(builder: wfe::builder::executions::ClientBuilder) -> Result<()
 
 async fn delete_test_workflow(name: String) -> Result<()> {
     let client = workflow_client().await?;
-    let _ = client.delete_workflow(name).poller().until_done().await?;
+    client.delete_workflow(name).poller().until_done().await?;
     Ok(())
 }
 


### PR DESCRIPTION
Call different `new_*poller()` functions when the LRO uses `wkt::Empty`
for neither the response, nor metadata, for only one, or for both.

Fixes #1934