### PR TITLE
feat(storage-control): add some of the Folders API

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -223,7 +223,7 @@ async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -
     assert_eq!(get.name, folder_name);
 
     println!("\nTesting list_folders()");
-    let mut folders = client.list_folders(bucket_name).paginator().await.items();
+    let mut folders = client.list_folders(bucket_name).by_item();
     let mut folder_names = Vec::new();
     while let Some(folder) = folders.next().await {
         folder_names.push(folder?.name);

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -207,7 +207,7 @@ async fn buckets_iam(client: &storage_control::client::Storage, bucket_name: &st
 }
 
 async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -> Result<()> {
-    let folder_name = format!("{bucket_name}/folders/test-folder");
+    let folder_name = format!("{bucket_name}/folders/test-folder/");
 
     println!("\nTesting create_folder()");
     let create = client

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -81,7 +81,8 @@
 /// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 #[derive(Clone, Debug)]
 pub struct Storage {
-    inner: super::generated::gapic::client::Storage,
+    storage: super::generated::gapic::client::Storage,
+    control: super::generated::gapic_control::client::StorageControl,
 }
 
 impl Storage {
@@ -115,7 +116,7 @@ impl Storage {
     /// }
     /// ```
     pub fn delete_bucket<T: Into<String>>(&self, name: T) -> super::builder::storage::DeleteBucket {
-        self.inner.delete_bucket().set_name(name)
+        self.storage.delete_bucket().set_name(name)
     }
 
     /// Returns metadata for the specified bucket.
@@ -134,7 +135,7 @@ impl Storage {
     /// }
     /// ```
     pub fn get_bucket<T: Into<String>>(&self, name: T) -> super::builder::storage::GetBucket {
-        self.inner.get_bucket().set_name(name)
+        self.storage.get_bucket().set_name(name)
     }
 
     /// Creates a new bucket.
@@ -161,7 +162,7 @@ impl Storage {
         V: Into<String>,
         U: Into<String>,
     {
-        self.inner
+        self.storage
             .create_bucket()
             .set_parent(parent)
             .set_bucket_id(bucket_id)
@@ -188,7 +189,7 @@ impl Storage {
     /// }
     /// ```
     pub fn list_buckets<T: Into<String>>(&self, parent: T) -> super::builder::storage::ListBuckets {
-        self.inner.list_buckets().set_parent(parent)
+        self.storage.list_buckets().set_parent(parent)
     }
 
     /// Permanently deletes an object and its metadata.
@@ -227,7 +228,7 @@ impl Storage {
         T: Into<String>,
         U: Into<String>,
     {
-        self.inner
+        self.storage
             .delete_object()
             .set_bucket(bucket)
             .set_object(object)
@@ -254,7 +255,7 @@ impl Storage {
     /// }
     /// ```
     pub fn list_objects<T: Into<String>>(&self, parent: T) -> super::builder::storage::ListObjects {
-        self.inner.list_objects().set_parent(parent)
+        self.storage.list_objects().set_parent(parent)
     }
 
     /// Gets the IAM policy for a specified bucket.
@@ -282,7 +283,7 @@ impl Storage {
         &self,
         resource: impl Into<String>,
     ) -> super::builder::storage::GetIamPolicy {
-        self.inner.get_iam_policy().set_resource(resource.into())
+        self.storage.get_iam_policy().set_resource(resource.into())
     }
 
     /// Updates the IAM policy for a specified bucket.
@@ -319,7 +320,7 @@ impl Storage {
         &self,
         resource: impl Into<String>,
     ) -> super::builder::storage::SetIamPolicy {
-        self.inner.set_iam_policy().set_resource(resource.into())
+        self.storage.set_iam_policy().set_resource(resource.into())
     }
 
     /// Tests a set of permissions on the given bucket, object, or managed folder
@@ -349,14 +350,130 @@ impl Storage {
         &self,
         resource: impl Into<String>,
     ) -> super::builder::storage::TestIamPermissions {
-        self.inner
+        self.storage
             .test_iam_permissions()
             .set_resource(resource.into())
     }
 
+    /// Creates a new folder.
+    ///
+    /// This operation is only applicable to a hierarchical namespace enabled
+    /// bucket.
+    ///
+    /// # Parameters
+    /// * `parent` - the bucket name. In `projects/_/buckets/{bucket_id}`
+    ///   format.
+    /// * `folder_id` - the full name of a folder, including all its parent
+    ///   folders. This must end in a `/`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     let folder = client.create_folder(
+    ///         "projects/my-project/buckets/my-bucket",
+    ///         "my-folder/my-subfolder/")
+    ///         .send()
+    ///         .await?;
+    ///     assert_eq!(&folder.name, "projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/");
+    ///     println!("folder details={folder:?}");
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn create_folder(
+        &self,
+        parent: impl Into<String>,
+        folder_id: impl Into<String>,
+    ) -> super::builder::storage::CreateFolder {
+        self.control
+            .create_folder()
+            .set_parent(parent.into())
+            .set_folder_id(folder_id.into())
+    }
+
+    /// Returns metadata for the specified folder.
+    ///
+    /// This operation is only applicable to a hierarchical namespace enabled
+    /// bucket.
+    ///
+    /// # Parameters
+    /// * `name` - the folder name. In
+    ///   `projects/_/buckets/{bucket_id}/folders/{folder}` format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     let folder = client
+    ///         .get_folder("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
+    ///         .send()
+    ///         .await?;
+    ///     assert_eq!(&folder.name, "projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/");
+    ///     println!("folder details={folder:?}");
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_folder(&self, name: impl Into<String>) -> super::builder::storage::GetFolder {
+        self.control.get_folder().set_name(name.into())
+    }
+
+    /// Permanently deletes an empty folder.
+    ///
+    /// This operation is only applicable to a hierarchical namespace enabled
+    /// bucket.
+    ///
+    /// # Parameters
+    /// * `name` - the folder name. In
+    ///   `projects/_/buckets/{bucket_id}/folders/{folder}` format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     client
+    ///         .delete_folder("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn delete_folder(&self, name: impl Into<String>) -> super::builder::storage::DeleteFolder {
+        self.control.delete_folder().set_name(name.into())
+    }
+
+    /// Retrieves a list of folders.
+    ///
+    /// This operation is only applicable to a hierarchical namespace enabled
+    /// bucket.
+    ///
+    /// # Parameters
+    /// * `parent` - the bucket name. In `projects/_/buckets/{bucket_id}` format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     use gax::paginator::ItemPaginator as _;
+    ///     let mut folders = client
+    ///         .list_folders("projects/_/buckets/my-bucket")
+    ///         .paginator
+    ///         .await
+    ///         .items();
+    ///     while let Some(folder) = folders.next().await {
+    ///         let folder = folder?;
+    ///         println!("  {folder:?}");
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn list_folders(&self, parent: impl Into<String>) -> super::builder::storage::ListFolders {
+        self.control.list_folders().set_parent(parent.into())
+    }
+
     pub(crate) async fn new(config: gaxi::options::ClientConfig) -> crate::Result<Self> {
-        let inner = super::generated::gapic::client::Storage::new(config).await?;
-        Ok(Self { inner })
+        let storage = super::generated::gapic::client::Storage::new(config.clone()).await?;
+        let control = super::generated::gapic_control::client::StorageControl::new(config).await?;
+        Ok(Self { storage, control })
     }
 }
 

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -375,7 +375,6 @@ impl Storage {
     ///         "my-folder/my-subfolder/")
     ///         .send()
     ///         .await?;
-    ///     assert_eq!(&folder.name, "projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/");
     ///     println!("folder details={folder:?}");
     ///     Ok(())
     /// }
@@ -408,7 +407,6 @@ impl Storage {
     ///         .get_folder("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
     ///         .send()
     ///         .await?;
-    ///     assert_eq!(&folder.name, "projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/");
     ///     println!("folder details={folder:?}");
     ///     Ok(())
     /// }
@@ -456,9 +454,7 @@ impl Storage {
     ///     use gax::paginator::ItemPaginator as _;
     ///     let mut folders = client
     ///         .list_folders("projects/_/buckets/my-bucket")
-    ///         .paginator
-    ///         .await
-    ///         .items();
+    ///         .by_item();
     ///     while let Some(folder) = folders.next().await {
     ///         let folder = folder?;
     ///         println!("  {folder:?}");


### PR DESCRIPTION
Part of the work for #1813 

Add `{create, get, delete, list}_folder` APIs to the storage control client.

I picked out the client signature, and handwrote the examples in the method documentation. We will lock down the surface later. For now, we just want to get a decent first iteration out.

These are validated in an integration test.