### PR TITLE
cleanup(storage): future-proof CreateFolder API

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -211,7 +211,8 @@ async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -
 
     println!("\nTesting create_folder()");
     let create = client
-        .create_folder(bucket_name, "test-folder/")
+        .create_folder(bucket_name)
+        .set_folder_id("test-folder/")
         .send()
         .await?;
     println!("SUCCESS on create_folder: {create:?}");

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -363,8 +363,6 @@ impl Storage {
     /// # Parameters
     /// * `parent` - the bucket name. In `projects/_/buckets/{bucket_id}`
     ///   format.
-    /// * `folder_id` - the full name of a folder, including all its parent
-    ///   folders. This must end in a `/`.
     ///
     /// # Example
     /// ```

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -370,9 +370,9 @@ impl Storage {
     /// ```
     /// # use google_cloud_storage_control::client::Storage;
     /// async fn example(client: &Storage) -> gax::Result<()> {
-    ///     let folder = client.create_folder(
-    ///         "projects/my-project/buckets/my-bucket",
-    ///         "my-folder/my-subfolder/")
+    ///     let folder = client
+    ///         .create_folder("projects/my-project/buckets/my-bucket")
+    ///         .set_folder_id("my-folder/my-subfolder/")
     ///         .send()
     ///         .await?;
     ///     println!("folder details={folder:?}");
@@ -382,12 +382,8 @@ impl Storage {
     pub fn create_folder(
         &self,
         parent: impl Into<String>,
-        folder_id: impl Into<String>,
     ) -> super::builder::storage::CreateFolder {
-        self.control
-            .create_folder()
-            .set_parent(parent.into())
-            .set_folder_id(folder_id.into())
+        self.control.create_folder().set_parent(parent.into())
     }
 
     /// Returns metadata for the specified folder.


### PR DESCRIPTION
Part of the work for #1813 

Internal annotations reveal that `folder_id` is a query param, not in the path. So let's remove it from our client signature, even though it is required.