### PR TITLE
test(auth): Re-Enable API Key integration test

### DIFF
--- a/src/auth/integration-tests/tests/driver.rs
+++ b/src/auth/integration-tests/tests/driver.rs
@@ -24,7 +24,6 @@ mod driver {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_api_key() -> Result<()> {
-        // auth_integration_tests::api_key().await
-        Ok(())
+        auth_integration_tests::api_key().await
     }
 }


### PR DESCRIPTION
Re enabling the API key integration test as discussed offline.

The flakiness was likely due to temporary issue with language service. If we see further flakiness, we can switch to a different API for testing.