### PR TITLE
fix(auth): Hide testing mod from public documentation

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -551,6 +551,7 @@ fn adc_well_known_path() -> Option<String> {
 // Skipping mutation testing for this module. As it exclusively provides
 // hardcoded credential stubs for testing purposes.
 #[cfg_attr(test, mutants::skip)]
+#[doc(hidden)]
 pub mod testing {
     use crate::Result;
     use crate::credentials::Credentials;


### PR DESCRIPTION
Fixed #2077 

The testing module is used in gax tests, so hiding it instead of making it `pub(crate)`