### PR TITLE
refactor(auth)!: replace create_api_key_credentials with builder

### DIFF
--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use auth::credentials::{
-    ApiKeyOptions, Builder as AccessTokenCredentialBuilder, ApiKeyCredentialsBuilder,
+    Builder as AccessTokenCredentialBuilder, api_key_credentials::Builder as ApiKeyCredentialsBuilder,
 };
 use gax::error::Error;
 use language::client::LanguageService;
@@ -100,8 +100,7 @@ pub async fn api_key() -> Result<()> {
     let api_key = std::str::from_utf8(&api_key).unwrap();
 
     // Create credentials using the API key.
-    let creds = ApiKeyCredentialsBuilder::default()
-        .with_api_key(api_key)
+    let creds = ApiKeyCredentialsBuilder::new(api_key)
         .build()
         .await
         .map_err(Error::authentication)?;

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use auth::credentials::{
-    ApiKeyOptions, Builder as AccessTokenCredentialBuilder, create_api_key_credentials,
+    ApiKeyOptions, Builder as AccessTokenCredentialBuilder, ApiKeyCredentialsBuilder,
 };
 use gax::error::Error;
 use language::client::LanguageService;
@@ -100,7 +100,9 @@ pub async fn api_key() -> Result<()> {
     let api_key = std::str::from_utf8(&api_key).unwrap();
 
     // Create credentials using the API key.
-    let creds = create_api_key_credentials(api_key, ApiKeyOptions::default())
+    let creds = ApiKeyCredentialsBuilder::default()
+        .with_api_key(api_key)
+        .build()
         .await
         .map_err(Error::authentication)?;
 

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use auth::credentials::{
-    Builder as AccessTokenCredentialBuilder, api_key_credentials::Builder as ApiKeyCredentialsBuilder,
+    Builder as AccessTokenCredentialBuilder,
+    api_key_credentials::Builder as ApiKeyCredentialsBuilder,
 };
 use gax::error::Error;
 use language::client::LanguageService;

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 mod api_key_credentials;
-// Export API Key factory function and options
-pub use api_key_credentials::{ApiKeyOptions, create_api_key_credentials};
+// Export API Key credentials builder and options
+pub use api_key_credentials::{ApiKeyOptions, Builder as ApiKeyCredentialsBuilder};
 
 pub mod mds;
 pub mod service_account;

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod api_key_credentials;
-// Export API Key credentials builder and options
-pub use api_key_credentials::{ApiKeyOptions, Builder as ApiKeyCredentialsBuilder};
-
+pub mod api_key_credentials;
 pub mod mds;
 pub mod service_account;
 pub mod user_account;

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -17,8 +17,8 @@ use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBu
 use google_cloud_auth::credentials::testing::test_credentials;
 use google_cloud_auth::credentials::user_account::Builder as UserAccountCredentialBuilder;
 use google_cloud_auth::credentials::{
-    ApiKeyOptions, Builder as AccessTokenCredentialBuilder, Credentials, CredentialsProvider,
-    create_api_key_credentials,
+    ApiKeyCredentialsBuilder, Builder as AccessTokenCredentialBuilder, Credentials,
+    CredentialsProvider,
 };
 use google_cloud_auth::errors::CredentialsError;
 use google_cloud_auth::token::Token;
@@ -186,7 +186,9 @@ mod test {
 
     #[tokio::test]
     async fn create_api_key_credentials_success() {
-        let creds = create_api_key_credentials("test-api-key", ApiKeyOptions::default())
+        let creds = ApiKeyCredentialsBuilder::default()
+            .with_api_key("test-api-key")
+            .build()
             .await
             .unwrap();
         let fmt = format!("{:?}", creds);

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -17,8 +17,8 @@ use google_cloud_auth::credentials::service_account::Builder as ServiceAccountBu
 use google_cloud_auth::credentials::testing::test_credentials;
 use google_cloud_auth::credentials::user_account::Builder as UserAccountCredentialBuilder;
 use google_cloud_auth::credentials::{
-    ApiKeyCredentialsBuilder, Builder as AccessTokenCredentialBuilder, Credentials,
-    CredentialsProvider,
+    Builder as AccessTokenCredentialBuilder, Credentials, CredentialsProvider,
+    api_key_credentials::Builder as ApiKeyCredentialsBuilder,
 };
 use google_cloud_auth::errors::CredentialsError;
 use google_cloud_auth::token::Token;
@@ -186,8 +186,7 @@ mod test {
 
     #[tokio::test]
     async fn create_api_key_credentials_success() {
-        let creds = ApiKeyCredentialsBuilder::default()
-            .with_api_key("test-api-key")
+        let creds = ApiKeyCredentialsBuilder::new("test-api-key")
             .build()
             .await
             .unwrap();


### PR DESCRIPTION
This PR resolves #2075.

It replaces the `create_api_key_credentials` factory function with a builder.

cc: @sai-sunder-s 