### PR TITLE
impl(storage): enable requests for media RPCs

### DIFF
--- a/src/storage-control/src/generated/gapic/.sidekick.toml
+++ b/src/storage-control/src/generated/gapic/.sidekick.toml
@@ -30,24 +30,19 @@ skipped-ids = """\
     .google.storage.v2.BidiWriteObjectRequest,\
     .google.storage.v2.BidiWriteObjectRequest.FirstMessage,\
     .google.storage.v2.BidiWriteObjectResponse,\
-    .google.storage.v2.CancelResumableWriteRequest,\
     .google.storage.v2.CancelResumableWriteResponse,\
     .google.storage.v2.ChecksummedData,\
     .google.storage.v2.ObjectRangeData,\
-    .google.storage.v2.QueryWriteStatusRequest,\
     .google.storage.v2.QueryWriteStatusResponse,\
-    .google.storage.v2.ReadObjectRequest,\
     .google.storage.v2.ReadObjectResponse,\
     .google.storage.v2.ReadRange,\
     .google.storage.v2.ReadRangeError,\
-    .google.storage.v2.StartResumableWriteRequest,\
     .google.storage.v2.StartResumableWriteResponse,\
     .google.storage.v2.Storage.CancelResumableWrite,\
     .google.storage.v2.Storage.QueryWriteStatus,\
     .google.storage.v2.Storage.StartResumableWrite,\
     .google.storage.v2.WriteObjectRequest,\
     .google.storage.v2.WriteObjectResponse,\
-    .google.storage.v2.WriteObjectSpec,\
     .google.storage.v2.AppendObjectSpec\
     """
 

--- a/src/storage-control/src/generated/gapic/model.rs
+++ b/src/storage-control/src/generated/gapic/model.rs
@@ -1098,6 +1098,226 @@ impl wkt::message::Message for RestoreObjectRequest {
     }
 }
 
+/// Message for canceling an in-progress resumable upload.
+/// `upload_id` **must** be set.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct CancelResumableWriteRequest {
+    /// Required. The upload_id of the resumable upload to cancel. This should be
+    /// copied from the `upload_id` field of `StartResumableWriteResponse`.
+    #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    pub upload_id: std::string::String,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl CancelResumableWriteRequest {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [upload_id][crate::model::CancelResumableWriteRequest::upload_id].
+    pub fn set_upload_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.upload_id = v.into();
+        self
+    }
+}
+
+impl wkt::message::Message for CancelResumableWriteRequest {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.storage.v2.CancelResumableWriteRequest"
+    }
+}
+
+/// Request message for ReadObject.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ReadObjectRequest {
+    /// Required. The name of the bucket containing the object to read.
+    #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    pub bucket: std::string::String,
+
+    /// Required. The name of the object to read.
+    #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    pub object: std::string::String,
+
+    /// If present, selects a specific revision of this object (as opposed
+    /// to the latest version, the default).
+    #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub generation: i64,
+
+    /// The offset for the first byte to return in the read, relative to the start
+    /// of the object.
+    ///
+    /// A negative `read_offset` value will be interpreted as the number of bytes
+    /// back from the end of the object to be returned. For example, if an object's
+    /// length is 15 bytes, a ReadObjectRequest with `read_offset` = -5 and
+    /// `read_limit` = 3 would return bytes 10 through 12 of the object. Requesting
+    /// a negative offset with magnitude larger than the size of the object will
+    /// return the entire object.
+    #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub read_offset: i64,
+
+    /// The maximum number of `data` bytes the server is allowed to return in the
+    /// sum of all `Object` messages. A `read_limit` of zero indicates that there
+    /// is no limit, and a negative `read_limit` will cause an error.
+    ///
+    /// If the stream returns fewer bytes than allowed by the `read_limit` and no
+    /// error occurred, the stream includes all data from the `read_offset` to the
+    /// end of the resource.
+    #[serde(skip_serializing_if = "wkt::internal::is_default")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub read_limit: i64,
+
+    /// Makes the operation conditional on whether the object's current generation
+    /// matches the given value. Setting to 0 makes the operation succeed only if
+    /// there are no live versions of the object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_generation_match: std::option::Option<i64>,
+
+    /// Makes the operation conditional on whether the object's live generation
+    /// does not match the given value. If no live object exists, the precondition
+    /// fails. Setting to 0 makes the operation succeed only if there is a live
+    /// version of the object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_generation_not_match: std::option::Option<i64>,
+
+    /// Makes the operation conditional on whether the object's current
+    /// metageneration matches the given value.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_metageneration_match: std::option::Option<i64>,
+
+    /// Makes the operation conditional on whether the object's current
+    /// metageneration does not match the given value.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_metageneration_not_match: std::option::Option<i64>,
+
+    /// A set of parameters common to Storage API requests concerning an object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub common_object_request_params: std::option::Option<crate::model::CommonObjectRequestParams>,
+
+    /// Mask specifying which fields to read.
+    /// The checksummed_data field and its children will always be present.
+    /// If no mask is specified, will default to all fields except metadata.owner
+    /// and metadata.acl.
+    ///
+    /// * may be used to mean "all fields".
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub read_mask: std::option::Option<wkt::FieldMask>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl ReadObjectRequest {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [bucket][crate::model::ReadObjectRequest::bucket].
+    pub fn set_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.bucket = v.into();
+        self
+    }
+
+    /// Sets the value of [object][crate::model::ReadObjectRequest::object].
+    pub fn set_object<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.object = v.into();
+        self
+    }
+
+    /// Sets the value of [generation][crate::model::ReadObjectRequest::generation].
+    pub fn set_generation<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.generation = v.into();
+        self
+    }
+
+    /// Sets the value of [read_offset][crate::model::ReadObjectRequest::read_offset].
+    pub fn set_read_offset<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.read_offset = v.into();
+        self
+    }
+
+    /// Sets the value of [read_limit][crate::model::ReadObjectRequest::read_limit].
+    pub fn set_read_limit<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
+        self.read_limit = v.into();
+        self
+    }
+
+    /// Sets the value of [if_generation_match][crate::model::ReadObjectRequest::if_generation_match].
+    pub fn set_if_generation_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_generation_match = v.into();
+        self
+    }
+
+    /// Sets the value of [if_generation_not_match][crate::model::ReadObjectRequest::if_generation_not_match].
+    pub fn set_if_generation_not_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_generation_not_match = v.into();
+        self
+    }
+
+    /// Sets the value of [if_metageneration_match][crate::model::ReadObjectRequest::if_metageneration_match].
+    pub fn set_if_metageneration_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_metageneration_match = v.into();
+        self
+    }
+
+    /// Sets the value of [if_metageneration_not_match][crate::model::ReadObjectRequest::if_metageneration_not_match].
+    pub fn set_if_metageneration_not_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_metageneration_not_match = v.into();
+        self
+    }
+
+    /// Sets the value of [common_object_request_params][crate::model::ReadObjectRequest::common_object_request_params].
+    pub fn set_common_object_request_params<
+        T: std::convert::Into<std::option::Option<crate::model::CommonObjectRequestParams>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.common_object_request_params = v.into();
+        self
+    }
+
+    /// Sets the value of [read_mask][crate::model::ReadObjectRequest::read_mask].
+    pub fn set_read_mask<T: std::convert::Into<std::option::Option<wkt::FieldMask>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.read_mask = v.into();
+        self
+    }
+}
+
+impl wkt::message::Message for ReadObjectRequest {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.storage.v2.ReadObjectRequest"
+    }
+}
+
 /// Request message for GetObject.
 #[serde_with::serde_as]
 #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -1271,6 +1491,150 @@ impl GetObjectRequest {
 impl wkt::message::Message for GetObjectRequest {
     fn typename() -> &'static str {
         "type.googleapis.com/google.storage.v2.GetObjectRequest"
+    }
+}
+
+/// Describes an attempt to insert an object, possibly over multiple requests.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct WriteObjectSpec {
+    /// Required. Destination object, including its name and its metadata.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub resource: std::option::Option<crate::model::Object>,
+
+    /// Apply a predefined set of access controls to this object.
+    /// Valid values are "authenticatedRead", "bucketOwnerFullControl",
+    /// "bucketOwnerRead", "private", "projectPrivate", or "publicRead".
+    #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    pub predefined_acl: std::string::String,
+
+    /// Makes the operation conditional on whether the object's current
+    /// generation matches the given value. Setting to 0 makes the operation
+    /// succeed only if there are no live versions of the object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_generation_match: std::option::Option<i64>,
+
+    /// Makes the operation conditional on whether the object's live
+    /// generation does not match the given value. If no live object exists, the
+    /// precondition fails. Setting to 0 makes the operation succeed only if
+    /// there is a live version of the object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_generation_not_match: std::option::Option<i64>,
+
+    /// Makes the operation conditional on whether the object's current
+    /// metageneration matches the given value.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_metageneration_match: std::option::Option<i64>,
+
+    /// Makes the operation conditional on whether the object's current
+    /// metageneration does not match the given value.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub if_metageneration_not_match: std::option::Option<i64>,
+
+    /// The expected final object size being uploaded.
+    /// If this value is set, closing the stream after writing fewer or more than
+    /// `object_size` bytes will result in an OUT_OF_RANGE error.
+    ///
+    /// This situation is considered a client error, and if such an error occurs
+    /// you must start the upload over from scratch, this time sending the correct
+    /// number of bytes.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    #[serde_as(as = "std::option::Option<serde_with::DisplayFromStr>")]
+    pub object_size: std::option::Option<i64>,
+
+    /// If true, the object will be created in appendable mode.
+    /// This field may only be set when using BidiWriteObject.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub appendable: std::option::Option<bool>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl WriteObjectSpec {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [resource][crate::model::WriteObjectSpec::resource].
+    pub fn set_resource<T: std::convert::Into<std::option::Option<crate::model::Object>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.resource = v.into();
+        self
+    }
+
+    /// Sets the value of [predefined_acl][crate::model::WriteObjectSpec::predefined_acl].
+    pub fn set_predefined_acl<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.predefined_acl = v.into();
+        self
+    }
+
+    /// Sets the value of [if_generation_match][crate::model::WriteObjectSpec::if_generation_match].
+    pub fn set_if_generation_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_generation_match = v.into();
+        self
+    }
+
+    /// Sets the value of [if_generation_not_match][crate::model::WriteObjectSpec::if_generation_not_match].
+    pub fn set_if_generation_not_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_generation_not_match = v.into();
+        self
+    }
+
+    /// Sets the value of [if_metageneration_match][crate::model::WriteObjectSpec::if_metageneration_match].
+    pub fn set_if_metageneration_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_metageneration_match = v.into();
+        self
+    }
+
+    /// Sets the value of [if_metageneration_not_match][crate::model::WriteObjectSpec::if_metageneration_not_match].
+    pub fn set_if_metageneration_not_match<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.if_metageneration_not_match = v.into();
+        self
+    }
+
+    /// Sets the value of [object_size][crate::model::WriteObjectSpec::object_size].
+    pub fn set_object_size<T: std::convert::Into<std::option::Option<i64>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.object_size = v.into();
+        self
+    }
+
+    /// Sets the value of [appendable][crate::model::WriteObjectSpec::appendable].
+    pub fn set_appendable<T: std::convert::Into<std::option::Option<bool>>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.appendable = v.into();
+        self
+    }
+}
+
+impl wkt::message::Message for WriteObjectSpec {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.storage.v2.WriteObjectSpec"
     }
 }
 
@@ -1461,6 +1825,54 @@ impl ListObjectsRequest {
 impl wkt::message::Message for ListObjectsRequest {
     fn typename() -> &'static str {
         "type.googleapis.com/google.storage.v2.ListObjectsRequest"
+    }
+}
+
+/// Request object for `QueryWriteStatus`.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct QueryWriteStatusRequest {
+    /// Required. The name of the resume token for the object whose write status is
+    /// being requested.
+    #[serde(skip_serializing_if = "std::string::String::is_empty")]
+    pub upload_id: std::string::String,
+
+    /// A set of parameters common to Storage API requests concerning an object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub common_object_request_params: std::option::Option<crate::model::CommonObjectRequestParams>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl QueryWriteStatusRequest {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [upload_id][crate::model::QueryWriteStatusRequest::upload_id].
+    pub fn set_upload_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.upload_id = v.into();
+        self
+    }
+
+    /// Sets the value of [common_object_request_params][crate::model::QueryWriteStatusRequest::common_object_request_params].
+    pub fn set_common_object_request_params<
+        T: std::convert::Into<std::option::Option<crate::model::CommonObjectRequestParams>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.common_object_request_params = v.into();
+        self
+    }
+}
+
+impl wkt::message::Message for QueryWriteStatusRequest {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.storage.v2.QueryWriteStatusRequest"
     }
 }
 
@@ -2123,6 +2535,77 @@ impl MoveObjectRequest {
 impl wkt::message::Message for MoveObjectRequest {
     fn typename() -> &'static str {
         "type.googleapis.com/google.storage.v2.MoveObjectRequest"
+    }
+}
+
+/// Request message StartResumableWrite.
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct StartResumableWriteRequest {
+    /// Required. Contains the information necessary to start a resumable write.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub write_object_spec: std::option::Option<crate::model::WriteObjectSpec>,
+
+    /// A set of parameters common to Storage API requests related to an object.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub common_object_request_params: std::option::Option<crate::model::CommonObjectRequestParams>,
+
+    /// The checksums of the complete object. This is used to validate the
+    /// uploaded object. For each upload, `object_checksums` can be provided when
+    /// initiating a resumable upload with`StartResumableWriteRequest` or when
+    /// completing a write with `WriteObjectRequest` with
+    /// `finish_write` set to `true`.
+    #[serde(skip_serializing_if = "std::option::Option::is_none")]
+    pub object_checksums: std::option::Option<crate::model::ObjectChecksums>,
+
+    #[serde(flatten, skip_serializing_if = "serde_json::Map::is_empty")]
+    _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
+}
+
+impl StartResumableWriteRequest {
+    pub fn new() -> Self {
+        std::default::Default::default()
+    }
+
+    /// Sets the value of [write_object_spec][crate::model::StartResumableWriteRequest::write_object_spec].
+    pub fn set_write_object_spec<
+        T: std::convert::Into<std::option::Option<crate::model::WriteObjectSpec>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.write_object_spec = v.into();
+        self
+    }
+
+    /// Sets the value of [common_object_request_params][crate::model::StartResumableWriteRequest::common_object_request_params].
+    pub fn set_common_object_request_params<
+        T: std::convert::Into<std::option::Option<crate::model::CommonObjectRequestParams>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.common_object_request_params = v.into();
+        self
+    }
+
+    /// Sets the value of [object_checksums][crate::model::StartResumableWriteRequest::object_checksums].
+    pub fn set_object_checksums<
+        T: std::convert::Into<std::option::Option<crate::model::ObjectChecksums>>,
+    >(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.object_checksums = v.into();
+        self
+    }
+}
+
+impl wkt::message::Message for StartResumableWriteRequest {
+    fn typename() -> &'static str {
+        "type.googleapis.com/google.storage.v2.StartResumableWriteRequest"
     }
 }
 


### PR DESCRIPTION
We will use the request structs for media operations. That will automate
more code generation, though we will still need to manually map these
requests to the right fields in the JSON v1 API.

Part of the work for #2040