### PR TITLE
cleanup(generator): remove default binding

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -240,19 +240,8 @@ func (m *Method) HasRouting() bool {
 
 // Normalized request path information.
 type PathInfo struct {
-	// HTTP Verb.
-	//
-	// This is one of:
-	// - GET
-	// - POST
-	// - PUT
-	// - DELETE
-	// - PATCH
-	Verb string
-	// The path broken by components.
-	PathTemplate []PathSegment
-	// Query parameter fields.
-	QueryParameters map[string]bool
+	// The list of bindings, including the top-level binding.
+	Bindings []*PathBinding
 	// Body is the name of the field that should be used as the body of the
 	// request.
 	//
@@ -261,9 +250,6 @@ type PathInfo struct {
 	//
 	// If this is empty then the body is not used.
 	BodyFieldPath string
-
-	// The list of bindings, including the top-level binding.
-	Bindings []*PathBinding
 	// Language specific annotations
 	Codec any
 }

--- a/generator/internal/dart/annotate.go
+++ b/generator/internal/dart/annotate.go
@@ -524,7 +524,7 @@ func (annotate *annotateModel) annotateMethod(method *api.Method) {
 	annotation := &methodAnnotation{
 		Parent:            method,
 		Name:              strcase.ToLowerCamel(method.Name),
-		RequestMethod:     strings.ToLower(method.PathInfo.Verb),
+		RequestMethod:     strings.ToLower(method.PathInfo.Bindings[0].Verb),
 		RequestType:       annotate.resolveTypeName(state.MessageByID[method.InputTypeID], true),
 		ResponseType:      annotate.resolveTypeName(state.MessageByID[method.OutputTypeID], true),
 		DocLines:          formatDocComments(method.Documentation, state),

--- a/generator/internal/dart/dart.go
+++ b/generator/internal/dart/dart.go
@@ -157,8 +157,7 @@ func enumValueName(e *api.EnumValue) string {
 
 func httpPathFmt(pathInfo *api.PathInfo) string {
 	var builder strings.Builder
-
-	for _, segment := range pathInfo.PathTemplate {
+	for _, segment := range pathInfo.Bindings[0].PathTemplate {
 		switch {
 		case segment.Literal != nil:
 			builder.WriteString("/")
@@ -237,7 +236,13 @@ func shouldGenerateMethod(m *api.Method) bool {
 	// Ignore methods without HTTP annotations; we cannot generate working RPCs
 	// for them.
 	// TODO(#499) Switch to explicitly excluding such functions.
-	return !m.ClientSideStreaming && !m.ServerSideStreaming && m.PathInfo != nil && len(m.PathInfo.PathTemplate) != 0
+	if m.ClientSideStreaming || m.ServerSideStreaming || m.PathInfo == nil {
+		return false
+	}
+	if len(m.PathInfo.Bindings) == 0 {
+		return false
+	}
+	return len(m.PathInfo.Bindings[0].PathTemplate) != 0
 }
 
 func formatDirectory(dir string) error {

--- a/generator/internal/golang/gotemplate.go
+++ b/generator/internal/golang/gotemplate.go
@@ -206,7 +206,7 @@ func annotateMessage(m *api.Message, state *api.APIState, importMap map[string]*
 
 func annotateMethod(m *api.Method, s *api.Service, state *api.APIState) {
 	pathInfoAnnotation := &pathInfoAnnotation{
-		Method:   m.PathInfo.Verb,
+		Method:   m.PathInfo.Bindings[0].Verb,
 		PathFmt:  httpPathFmt(m.PathInfo),
 		PathArgs: httpPathArgs(m.PathInfo),
 		HasBody:  m.PathInfo.BodyFieldPath != "",

--- a/generator/internal/language/codec.go
+++ b/generator/internal/language/codec.go
@@ -43,7 +43,7 @@ func PathParams(m *api.Method, state *api.APIState) []*api.Field {
 		return nil
 	}
 	pathNames := []string{}
-	for _, arg := range m.PathInfo.PathTemplate {
+	for _, arg := range m.PathInfo.Bindings[0].PathTemplate {
 		if arg.FieldPath != nil {
 			components := strings.Split(*arg.FieldPath, ".")
 			pathNames = append(pathNames, components[0])
@@ -73,7 +73,7 @@ func QueryParams(m *api.Method, state *api.APIState) []*api.Field {
 
 	var queryParams []*api.Field
 	for _, field := range msg.Fields {
-		if !m.PathInfo.QueryParameters[field.Name] {
+		if !m.PathInfo.Bindings[0].QueryParameters[field.Name] {
 			continue
 		}
 		queryParams = append(queryParams, field)

--- a/generator/internal/language/codec_test.go
+++ b/generator/internal/language/codec_test.go
@@ -57,10 +57,14 @@ func TestQueryParams(t *testing.T) {
 		InputTypeID:  request.ID,
 		OutputTypeID: ".google.protobuf.Empty",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			QueryParameters: map[string]bool{
-				"options_field": true,
-				"another_field": true,
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					QueryParameters: map[string]bool{
+						"options_field": true,
+						"another_field": true,
+					},
+				},
 			},
 		},
 	}

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -210,9 +210,6 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 			}
 			queryParameters := makeQueryParameters(op.Operation)
 			pathInfo := &api.PathInfo{
-				Verb:            op.Verb,
-				PathTemplate:    pathTemplate,
-				QueryParameters: queryParameters,
 				Bindings: []*api.PathBinding{
 					{
 						Verb:            op.Verb,

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -721,18 +721,6 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		InputTypeID:   "..ListLocationsRequest",
 		OutputTypeID:  "..ListLocationsResponse",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewLiteralPathSegment("projects"),
-				api.NewFieldPathPathSegment("project"),
-				api.NewLiteralPathSegment("locations"),
-			},
-			QueryParameters: map[string]bool{
-				"filter":    true,
-				"pageSize":  true,
-				"pageToken": true,
-			},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
@@ -762,13 +750,12 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 	})
 
 	cs := sample.MethodCreate()
-	cs.PathInfo.PathTemplate = []api.PathSegment{
+	cs.PathInfo.Bindings[0].PathTemplate = []api.PathSegment{
 		api.NewLiteralPathSegment("v1"),
 		api.NewLiteralPathSegment("projects"),
 		api.NewFieldPathPathSegment("project"),
 		api.NewLiteralPathSegment("secrets"),
 	}
-	cs.PathInfo.Bindings[0].PathTemplate = cs.PathInfo.PathTemplate
 	checkMethod(t, service, cs.Name, cs)
 
 	asv := sample.MethodAddSecretVersion()
@@ -920,14 +907,6 @@ func TestOpenAPI_Pagination(t *testing.T) {
 				InputTypeID:  "..ListFoosRequest",
 				OutputTypeID: "..ListFoosResponse",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewLiteralPathSegment("projects"),
-						api.NewFieldPathPathSegment("project"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"pageSize": true, "pageToken": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1141,15 +1120,6 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		InputTypeID:  "..RpcARequest",
 		OutputTypeID: "..Response",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewLiteralPathSegment("projects"),
-				api.NewFieldPathPathSegment("project"),
-				api.NewLiteralPathSegment("rpc"),
-				api.NewLiteralPathSegment("a"),
-			},
-			QueryParameters: map[string]bool{"filter": true},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
@@ -1173,15 +1143,6 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 		InputTypeID:  "..RpcBRequest",
 		OutputTypeID: "..Response",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewLiteralPathSegment("projects"),
-				api.NewFieldPathPathSegment("project"),
-				api.NewLiteralPathSegment("rpc"),
-				api.NewLiteralPathSegment("b"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",

--- a/generator/internal/parser/protobuf_annotations.go
+++ b/generator/internal/parser/protobuf_annotations.go
@@ -66,10 +66,7 @@ func processRule(httpRule *annotations.HttpRule, state *api.APIState, mID string
 		return nil, err
 	}
 	pathInfo := &api.PathInfo{
-		Verb:            binding.Verb,
-		PathTemplate:    binding.PathTemplate,
-		QueryParameters: binding.QueryParameters,
-		BodyFieldPath:   body,
+		BodyFieldPath: body,
 	}
 	// TODO(#2090) - remove the duplicates on the top-level binding
 	pathInfo.Bindings = []*api.PathBinding{binding}

--- a/generator/internal/parser/protobuf_mixin_test.go
+++ b/generator/internal/parser/protobuf_mixin_test.go
@@ -71,12 +71,6 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 		InputTypeID:   ".google.cloud.location.GetLocationRequest",
 		OutputTypeID:  ".google.cloud.location.Location",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewFieldPathPathSegment("name"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
@@ -140,13 +134,6 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 		InputTypeID:   ".google.iam.v1.GetIamPolicyRequest",
 		OutputTypeID:  ".google.iam.v1.Policy",
 		PathInfo: &api.PathInfo{
-			Verb: "POST",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewFieldPathPathSegment("resource"),
-				api.NewVerbPathSegment("getIamPolicy"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "POST",
@@ -218,12 +205,6 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 		InputTypeID:   ".google.longrunning.GetOperationRequest",
 		OutputTypeID:  ".google.longrunning.Operation",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v2"),
-				api.NewFieldPathPathSegment("name"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",
@@ -306,12 +287,6 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 		OutputTypeID:  ".google.protobuf.Empty",
 		ReturnsEmpty:  true,
 		PathInfo: &api.PathInfo{
-			Verb: "DELETE",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v2"),
-				api.NewFieldPathPathSegment("name"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "DELETE",
@@ -391,12 +366,6 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 		InputTypeID:   ".google.longrunning.GetOperationRequest",
 		OutputTypeID:  ".google.longrunning.Operation",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewFieldPathPathSegment("name"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: "GET",

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -443,13 +443,6 @@ func TestProtobuf_Comments(t *testing.T) {
 				InputTypeID:   ".test.Request",
 				OutputTypeID:  ".test.Response",
 				PathInfo: &api.PathInfo{
-					Verb: "POST",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
@@ -834,12 +827,6 @@ func TestProtobuf_Service(t *testing.T) {
 				InputTypeID:   ".test.GetFooRequest",
 				OutputTypeID:  ".test.Foo",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("name"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -860,13 +847,6 @@ func TestProtobuf_Service(t *testing.T) {
 				InputTypeID:   ".test.CreateFooRequest",
 				OutputTypeID:  ".test.Foo",
 				PathInfo: &api.PathInfo{
-					Verb: "POST",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"foo_id": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
@@ -888,12 +868,6 @@ func TestProtobuf_Service(t *testing.T) {
 				InputTypeID:   ".test.DeleteFooRequest",
 				OutputTypeID:  ".google.protobuf.Empty",
 				PathInfo: &api.PathInfo{
-					Verb: "DELETE",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("name"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "DELETE",
@@ -914,9 +888,6 @@ func TestProtobuf_Service(t *testing.T) {
 				InputTypeID:   ".test.CreateFooRequest",
 				OutputTypeID:  ".test.Foo",
 				PathInfo: &api.PathInfo{
-					Verb:            "POST",
-					PathTemplate:    []api.PathSegment{},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb:            "POST",
@@ -935,13 +906,6 @@ func TestProtobuf_Service(t *testing.T) {
 				InputTypeID:   ".test.GetFooRequest",
 				OutputTypeID:  ".test.Foo",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("name"),
-						api.NewVerbPathSegment("Download"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -964,9 +928,6 @@ func TestProtobuf_Service(t *testing.T) {
 				InputTypeID:   ".test.Foo",
 				OutputTypeID:  ".test.Foo",
 				PathInfo: &api.PathInfo{
-					Verb:            "POST",
-					PathTemplate:    []api.PathSegment{},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb:            "POST",
@@ -1003,13 +964,6 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 				InputTypeID:   ".test.CreateFooRequest",
 				OutputTypeID:  ".test.Foo",
 				PathInfo: &api.PathInfo{
-					Verb: "POST",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"foo_id": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
@@ -1031,13 +985,6 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 				InputTypeID:   ".test.AddBarRequest",
 				OutputTypeID:  ".test.Bar",
 				PathInfo: &api.PathInfo{
-					Verb: "POST",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewVerbPathSegment("addFoo"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
@@ -1123,13 +1070,6 @@ func TestProtobuf_Pagination(t *testing.T) {
 				InputTypeID:  ".test.ListFooRequest",
 				OutputTypeID: ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1156,13 +1096,6 @@ func TestProtobuf_Pagination(t *testing.T) {
 				InputTypeID:  ".test.ListFooRequest",
 				OutputTypeID: ".test.ListFooMissingNextPageTokenResponse",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1182,13 +1115,6 @@ func TestProtobuf_Pagination(t *testing.T) {
 				InputTypeID:  ".test.ListFooMissingPageSizeRequest",
 				OutputTypeID: ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"page_token": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1208,13 +1134,6 @@ func TestProtobuf_Pagination(t *testing.T) {
 				InputTypeID:  ".test.ListFooMissingPageTokenRequest",
 				OutputTypeID: ".test.ListFooResponse",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"page_size": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1234,13 +1153,6 @@ func TestProtobuf_Pagination(t *testing.T) {
 				InputTypeID:  ".test.ListFooRequest",
 				OutputTypeID: ".test.ListFooMissingRepeatedItemResponse",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{"page_size": true, "page_token": true},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1360,13 +1272,6 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 				InputTypeID:   ".test.CreateFooRequest",
 				OutputTypeID:  ".google.longrunning.Operation",
 				PathInfo: &api.PathInfo{
-					Verb: "POST",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
@@ -1392,13 +1297,6 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 				InputTypeID:   ".test.CreateFooRequest",
 				OutputTypeID:  ".google.longrunning.Operation",
 				PathInfo: &api.PathInfo{
-					Verb: "POST",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v1"),
-						api.NewFieldPathPathSegment("parent"),
-						api.NewLiteralPathSegment("foos"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "POST",
@@ -1424,12 +1322,6 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 				InputTypeID:   ".google.longrunning.GetOperationRequest",
 				OutputTypeID:  ".google.longrunning.Operation",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("v2"),
-						api.NewFieldPathPathSegment("name"),
-					},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb: "GET",
@@ -1628,9 +1520,6 @@ func TestProtobuf_Deprecated(t *testing.T) {
 				InputTypeID:  ".test.Request",
 				OutputTypeID: ".test.Response",
 				PathInfo: &api.PathInfo{
-					Verb:            "POST",
-					PathTemplate:    []api.PathSegment{},
-					QueryParameters: map[string]bool{},
 					Bindings: []*api.PathBinding{
 						{
 							Verb:            "POST",

--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -524,8 +524,8 @@ func (c *codec) annotateMessage(m *api.Message, state *api.APIState, sourceSpeci
 
 func (c *codec) annotateMethod(m *api.Method, s *api.Service, state *api.APIState, sourceSpecificationPackageName string, packageNamespace string) {
 	pathInfoAnnotation := &pathInfoAnnotation{
-		Method:        m.PathInfo.Verb,
-		MethodToLower: strings.ToLower(m.PathInfo.Verb),
+		Method:        m.PathInfo.Bindings[0].Verb,
+		MethodToLower: strings.ToLower(m.PathInfo.Bindings[0].Verb),
 		PathFmt:       httpPathFmt(m.PathInfo),
 		PathArgs:      httpPathArgs(m.PathInfo, m, state),
 		HasBody:       m.PathInfo.BodyFieldPath != "",

--- a/generator/internal/rust/annotate_test.go
+++ b/generator/internal/rust/annotate_test.go
@@ -70,9 +70,13 @@ func serviceAnnotationsModel() *api.API {
 		InputTypeID:  ".test.v1.Request",
 		OutputTypeID: ".test.v1.Response",
 		PathInfo: &api.PathInfo{
-			Verb: "GET",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("/v1/resource"),
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("/v1/resource"),
+					},
+				},
 			},
 		},
 	}
@@ -82,9 +86,13 @@ func serviceAnnotationsModel() *api.API {
 		InputTypeID:  ".test.v1.Request",
 		OutputTypeID: ".google.protobuf.Empty",
 		PathInfo: &api.PathInfo{
-			Verb: "DELETE",
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("/v1/resource"),
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "DELETE",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("/v1/resource"),
+					},
+				},
 			},
 		},
 		ReturnsEmpty: true,
@@ -1097,9 +1105,13 @@ func TestPathInfoAnnotations(t *testing.T) {
 			InputTypeID:  ".test.v1.Request",
 			OutputTypeID: ".test.v1.Response",
 			PathInfo: &api.PathInfo{
-				Verb: testCase.Verb,
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("/v1/resource"),
+				Bindings: []*api.PathBinding{
+					{
+						Verb: testCase.Verb,
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("/v1/resource"),
+						},
+					},
 				},
 			},
 		}

--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -865,8 +865,9 @@ func bodyAccessor(m *api.Method) string {
 }
 
 func httpPathFmt(m *api.PathInfo) string {
+	binding := m.Bindings[0]
 	fmt := ""
-	for _, segment := range m.PathTemplate {
+	for _, segment := range binding.PathTemplate {
 		if segment.Literal != nil {
 			fmt = fmt + "/" + *segment.Literal
 		} else if segment.FieldPath != nil {
@@ -936,7 +937,7 @@ func httpPathArgs(h *api.PathInfo, method *api.Method, state *api.APIState) []pa
 		return []pathArg{}
 	}
 	var params []pathArg
-	for _, arg := range h.PathTemplate {
+	for _, arg := range h.Bindings[0].PathTemplate {
 		if arg.FieldPath != nil {
 			params = append(params, pathArg{
 				Name:     *arg.FieldPath,
@@ -1642,7 +1643,10 @@ func (c *codec) generateMethod(m *api.Method) bool {
 	if c.includeGrpcOnlyMethods {
 		return true
 	}
-	return m.PathInfo != nil && len(m.PathInfo.PathTemplate) != 0
+	if m.PathInfo == nil || len(m.PathInfo.Bindings) == 0 {
+		return false
+	}
+	return len(m.PathInfo.Bindings[0].PathTemplate) != 0
 }
 
 // The list of Rust keywords and reserved words can be found at:

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -1842,9 +1842,13 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 			{
 				Name: "CreateFoo", ID: ".test.v1.SomeService.CreateFoo",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("/v1/foo"),
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("/v1/foo"),
+							},
+						},
 					},
 				},
 			},
@@ -1860,9 +1864,13 @@ func makeApiForRustFormatDocCommentsCrossLinks() *api.API {
 				Name: "CreateThing",
 				ID:   ".test.v1.YELL.CreateThing",
 				PathInfo: &api.PathInfo{
-					Verb: "GET",
-					PathTemplate: []api.PathSegment{
-						api.NewLiteralPathSegment("/v1/thing"),
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("/v1/thing"),
+							},
+						},
 					},
 				},
 			},
@@ -2095,33 +2103,43 @@ func TestPathFmt(t *testing.T) {
 		{
 			"/v1/fixed",
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewLiteralPathSegment("fixed")},
+				Bindings: []*api.PathBinding{
+					{PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewLiteralPathSegment("fixed")}},
+				},
 			},
 		},
 		{
 			"/v1/{}",
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent")},
+				Bindings: []*api.PathBinding{
+					{PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent")}},
+				},
 			},
 		},
 		{
 			"/v1/{}:action",
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent"), api.NewVerbPathSegment("action")},
+				Bindings: []*api.PathBinding{
+					{PathTemplate: []api.PathSegment{api.NewLiteralPathSegment("v1"), api.NewFieldPathPathSegment("parent"), api.NewVerbPathSegment("action")}},
+				},
 			},
 		},
 		{
 			"/v1/projects/{}/locations/{}/secrets/{}:action",
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewLiteralPathSegment("projects"),
-					api.NewFieldPathPathSegment("project"),
-					api.NewLiteralPathSegment("locations"),
-					api.NewFieldPathPathSegment("location"),
-					api.NewLiteralPathSegment("secrets"),
-					api.NewFieldPathPathSegment("secret"),
-					api.NewVerbPathSegment("action"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewLiteralPathSegment("projects"),
+							api.NewFieldPathPathSegment("project"),
+							api.NewLiteralPathSegment("locations"),
+							api.NewFieldPathPathSegment("location"),
+							api.NewLiteralPathSegment("secrets"),
+							api.NewFieldPathPathSegment("secret"),
+							api.NewVerbPathSegment("action"),
+						},
+					},
 				},
 			},
 		},
@@ -2174,17 +2192,22 @@ func TestPathArgs(t *testing.T) {
 		{
 			nil,
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
+				Bindings: []*api.PathBinding{
+					{},
 				},
 			},
 		},
 		{
 			[]pathArg{{Name: "a", Accessor: ".a"}},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("a")},
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("a"),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -2195,18 +2218,26 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("b"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("b"),
+						},
+					},
 				},
 			},
 		},
 		{
 			[]pathArg{{Name: "c", Accessor: `.c`}},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("c"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("c"),
+						},
+					},
 				},
 			},
 		},
@@ -2218,9 +2249,13 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("d"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("d"),
+						},
+					},
 				},
 			},
 		},
@@ -2232,9 +2267,13 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("e.a"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("e.a"),
+						},
+					},
 				},
 			},
 		},
@@ -2247,9 +2286,13 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("e.b"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("e.b"),
+						},
+					},
 				},
 			},
 		},
@@ -2261,9 +2304,13 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("e.c"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("e.c"),
+						},
+					},
 				},
 			},
 		},
@@ -2276,9 +2323,13 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("e.d"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("e.d"),
+						},
+					},
 				},
 			},
 		},
@@ -2294,10 +2345,14 @@ func TestPathArgs(t *testing.T) {
 				},
 			},
 			&api.PathInfo{
-				PathTemplate: []api.PathSegment{
-					api.NewLiteralPathSegment("v1"),
-					api.NewFieldPathPathSegment("a"),
-					api.NewFieldPathPathSegment("b"),
+				Bindings: []*api.PathBinding{
+					{
+						PathTemplate: []api.PathSegment{
+							api.NewLiteralPathSegment("v1"),
+							api.NewFieldPathPathSegment("a"),
+							api.NewFieldPathPathSegment("b"),
+						},
+					},
 				},
 			},
 		},

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -70,14 +70,6 @@ func MethodCreate() *api.Method {
 		InputTypeID:   CreateRequest().ID,
 		OutputTypeID:  Secret().ID,
 		PathInfo: &api.PathInfo{
-			Verb: http.MethodPost,
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewFieldPathPathSegment("parent"),
-				api.NewLiteralPathSegment("secrets"),
-				api.NewFieldPathPathSegment("secret_id"),
-			},
-			QueryParameters: map[string]bool{"secretId": true},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
@@ -103,14 +95,6 @@ func MethodUpdate() *api.Method {
 		InputTypeID:   UpdateRequest().ID,
 		OutputTypeID:  ".google.protobuf.Empty",
 		PathInfo: &api.PathInfo{
-			Verb: http.MethodPatch,
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewFieldPathPathSegment("secret.name"),
-			},
-			QueryParameters: map[string]bool{
-				"field_mask": true,
-			},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPatch,
@@ -135,16 +119,6 @@ func MethodAddSecretVersion() *api.Method {
 		InputTypeID:   "..AddSecretVersionRequest",
 		OutputTypeID:  "..SecretVersion",
 		PathInfo: &api.PathInfo{
-			Verb: http.MethodPost,
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewLiteralPathSegment("projects"),
-				api.NewFieldPathPathSegment("project"),
-				api.NewLiteralPathSegment("secrets"),
-				api.NewFieldPathPathSegment("secret"),
-				api.NewVerbPathSegment("addVersion"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,
@@ -174,16 +148,6 @@ func MethodListSecretVersions() *api.Method {
 		OutputTypeID:  ListSecretVersionsResponse().ID,
 		OutputType:    ListSecretVersionsResponse(),
 		PathInfo: &api.PathInfo{
-			Verb: http.MethodPost,
-			PathTemplate: []api.PathSegment{
-				api.NewLiteralPathSegment("v1"),
-				api.NewLiteralPathSegment("projects"),
-				api.NewFieldPathPathSegment("parent"),
-				api.NewLiteralPathSegment("secrets"),
-				api.NewFieldPathPathSegment("secret"),
-				api.NewVerbPathSegment("listSecretVersions"),
-			},
-			QueryParameters: map[string]bool{},
 			Bindings: []*api.PathBinding{
 				{
 					Verb: http.MethodPost,


### PR DESCRIPTION
Remove the "default" binding for methods. The codecs now use the first
binding, though in the future they may support *all* bindings for a
method.

Fixes #2090