### PR TITLE
feat(generator): capture all HTTP bindings

### DIFF
--- a/generator/internal/api/model.go
+++ b/generator/internal/api/model.go
@@ -261,8 +261,27 @@ type PathInfo struct {
 	//
 	// If this is empty then the body is not used.
 	BodyFieldPath string
+
+	// The list of bindings, including the top-level binding.
+	Bindings []*PathBinding
 	// Language specific annotations
 	Codec any
+}
+
+type PathBinding struct {
+	// HTTP Verb.
+	//
+	// This is one of:
+	// - GET
+	// - POST
+	// - PUT
+	// - DELETE
+	// - PATCH
+	Verb string
+	// The path broken by components.
+	PathTemplate []PathSegment
+	// Query parameter fields.
+	QueryParameters map[string]bool
 }
 
 // Normalized long running operation info

--- a/generator/internal/parser/openapi.go
+++ b/generator/internal/parser/openapi.go
@@ -208,11 +208,19 @@ func makeMethods(a *api.API, model *libopenapi.DocumentModel[v3.Document], packa
 			if err != nil {
 				return nil, err
 			}
+			queryParameters := makeQueryParameters(op.Operation)
 			pathInfo := &api.PathInfo{
 				Verb:            op.Verb,
 				PathTemplate:    pathTemplate,
-				QueryParameters: makeQueryParameters(op.Operation),
-				BodyFieldPath:   bodyFieldPath,
+				QueryParameters: queryParameters,
+				Bindings: []*api.PathBinding{
+					{
+						Verb:            op.Verb,
+						PathTemplate:    pathTemplate,
+						QueryParameters: queryParameters,
+					},
+				},
+				BodyFieldPath: bodyFieldPath,
 			}
 			mID := fmt.Sprintf("%s.%s", serviceID, op.Operation.OperationId)
 			m := &api.Method{

--- a/generator/internal/parser/openapi_test.go
+++ b/generator/internal/parser/openapi_test.go
@@ -733,6 +733,22 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 				"pageSize":  true,
 				"pageToken": true,
 			},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewLiteralPathSegment("projects"),
+						api.NewFieldPathPathSegment("project"),
+						api.NewLiteralPathSegment("locations"),
+					},
+					QueryParameters: map[string]bool{
+						"filter":    true,
+						"pageSize":  true,
+						"pageToken": true,
+					},
+				},
+			},
 		},
 		Pagination: &api.Field{
 			Name:          "pageToken",
@@ -752,6 +768,7 @@ func TestOpenAPI_MakeAPI(t *testing.T) {
 		api.NewFieldPathPathSegment("project"),
 		api.NewLiteralPathSegment("secrets"),
 	}
+	cs.PathInfo.Bindings[0].PathTemplate = cs.PathInfo.PathTemplate
 	checkMethod(t, service, cs.Name, cs)
 
 	asv := sample.MethodAddSecretVersion()
@@ -911,6 +928,18 @@ func TestOpenAPI_Pagination(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"pageSize": true, "pageToken": true},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewLiteralPathSegment("projects"),
+								api.NewFieldPathPathSegment("project"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"pageSize": true, "pageToken": true},
+						},
+					},
 				},
 				Pagination: &api.Field{
 					Name:          "pageToken",
@@ -1121,6 +1150,19 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 				api.NewLiteralPathSegment("a"),
 			},
 			QueryParameters: map[string]bool{"filter": true},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewLiteralPathSegment("projects"),
+						api.NewFieldPathPathSegment("project"),
+						api.NewLiteralPathSegment("rpc"),
+						api.NewLiteralPathSegment("a"),
+					},
+					QueryParameters: map[string]bool{"filter": true},
+				},
+			},
 		},
 	})
 
@@ -1140,6 +1182,19 @@ func TestOpenAPI_Deprecated(t *testing.T) {
 				api.NewLiteralPathSegment("b"),
 			},
 			QueryParameters: map[string]bool{},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewLiteralPathSegment("projects"),
+						api.NewFieldPathPathSegment("project"),
+						api.NewLiteralPathSegment("rpc"),
+						api.NewLiteralPathSegment("b"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
 		},
 	})
 

--- a/generator/internal/parser/protobuf.go
+++ b/generator/internal/parser/protobuf.go
@@ -438,7 +438,7 @@ func processService(state *api.APIState, s *descriptorpb.ServiceDescriptorProto,
 func processMethod(state *api.APIState, m *descriptorpb.MethodDescriptorProto, mFQN, packagez string) *api.Method {
 	pathInfo, err := parsePathInfo(m, state)
 	if err != nil {
-		slog.Error("unsupported http method", "method", m)
+		slog.Error("unsupported http method", "method", m, "error", err)
 		return nil
 	}
 	routing, err := parseRoutingAnnotations(mFQN, m)

--- a/generator/internal/parser/protobuf_mixin_test.go
+++ b/generator/internal/parser/protobuf_mixin_test.go
@@ -77,6 +77,16 @@ func TestProtobuf_LocationMixin(t *testing.T) {
 				api.NewFieldPathPathSegment("name"),
 			},
 			QueryParameters: map[string]bool{},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("name"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
 		},
 	})
 }
@@ -137,7 +147,18 @@ func TestProtobuf_IAMMixin(t *testing.T) {
 				api.NewVerbPathSegment("getIamPolicy"),
 			},
 			QueryParameters: map[string]bool{},
-			BodyFieldPath:   "*",
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "POST",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("resource"),
+						api.NewVerbPathSegment("getIamPolicy"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
+			BodyFieldPath: "*",
 		},
 	})
 }
@@ -203,7 +224,17 @@ func TestProtobuf_OperationMixin(t *testing.T) {
 				api.NewFieldPathPathSegment("name"),
 			},
 			QueryParameters: map[string]bool{},
-			BodyFieldPath:   "*",
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v2"),
+						api.NewFieldPathPathSegment("name"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
+			BodyFieldPath: "*",
 		},
 	})
 }
@@ -281,7 +312,17 @@ func TestProtobuf_OperationMixinNoEmpty(t *testing.T) {
 				api.NewFieldPathPathSegment("name"),
 			},
 			QueryParameters: map[string]bool{},
-			BodyFieldPath:   "*",
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "DELETE",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v2"),
+						api.NewFieldPathPathSegment("name"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
+			BodyFieldPath: "*",
 		},
 	})
 	got, ok := test.State.MessageByID[".google.protobuf.Empty"]
@@ -356,6 +397,16 @@ func TestProtobuf_DuplicateMixin(t *testing.T) {
 				api.NewFieldPathPathSegment("name"),
 			},
 			QueryParameters: map[string]bool{},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: "GET",
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("name"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
 		},
 	})
 }

--- a/generator/internal/parser/protobuf_test.go
+++ b/generator/internal/parser/protobuf_test.go
@@ -450,7 +450,17 @@ func TestProtobuf_Comments(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "*",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{}},
+					},
+					BodyFieldPath: "*",
 				},
 			},
 		},
@@ -830,7 +840,17 @@ func TestProtobuf_Service(t *testing.T) {
 						api.NewFieldPathPathSegment("name"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("name"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "",
 				},
 			},
 			{
@@ -847,7 +867,18 @@ func TestProtobuf_Service(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"foo_id": true},
-					BodyFieldPath:   "foo",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"foo_id": true},
+						},
+					},
+					BodyFieldPath: "foo",
 				},
 			},
 			{
@@ -863,6 +894,16 @@ func TestProtobuf_Service(t *testing.T) {
 						api.NewFieldPathPathSegment("name"),
 					},
 					QueryParameters: map[string]bool{},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "DELETE",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("name"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
 				},
 				ReturnsEmpty: true,
 			},
@@ -876,7 +917,14 @@ func TestProtobuf_Service(t *testing.T) {
 					Verb:            "POST",
 					PathTemplate:    []api.PathSegment{},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "*",
+					Bindings: []*api.PathBinding{
+						{
+							Verb:            "POST",
+							PathTemplate:    []api.PathSegment{},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "*",
 				},
 				ClientSideStreaming: true,
 			},
@@ -894,7 +942,18 @@ func TestProtobuf_Service(t *testing.T) {
 						api.NewVerbPathSegment("Download"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("name"),
+								api.NewVerbPathSegment("Download"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "",
 				},
 				ServerSideStreaming: true,
 			},
@@ -908,7 +967,14 @@ func TestProtobuf_Service(t *testing.T) {
 					Verb:            "POST",
 					PathTemplate:    []api.PathSegment{},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "*",
+					Bindings: []*api.PathBinding{
+						{
+							Verb:            "POST",
+							PathTemplate:    []api.PathSegment{},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "*",
 				},
 				ClientSideStreaming: true,
 				ServerSideStreaming: true,
@@ -944,7 +1010,18 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"foo_id": true},
-					BodyFieldPath:   "bar",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"foo_id": true},
+						},
+					},
+					BodyFieldPath: "bar",
 				},
 			},
 			{
@@ -961,7 +1038,18 @@ func TestProtobuf_QueryParameters(t *testing.T) {
 						api.NewVerbPathSegment("addFoo"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "*",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewVerbPathSegment("addFoo"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "*",
 				},
 			},
 		},
@@ -1042,6 +1130,17 @@ func TestProtobuf_Pagination(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"page_size": true, "page_token": true},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
+						},
+					},
 				},
 				Pagination: &api.Field{
 					Name:     "page_token",
@@ -1064,6 +1163,17 @@ func TestProtobuf_Pagination(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"page_size": true, "page_token": true},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
+						},
+					},
 				},
 			},
 			{
@@ -1079,6 +1189,17 @@ func TestProtobuf_Pagination(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"page_token": true},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"page_token": true},
+						},
+					},
 				},
 			},
 			{
@@ -1094,6 +1215,17 @@ func TestProtobuf_Pagination(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"page_size": true},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"page_size": true},
+						},
+					},
 				},
 			},
 			{
@@ -1109,6 +1241,17 @@ func TestProtobuf_Pagination(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{"page_size": true, "page_token": true},
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{"page_size": true, "page_token": true},
+						},
+					},
 				},
 			},
 		},
@@ -1224,7 +1367,18 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "foo",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "foo",
 				},
 				OperationInfo: &api.OperationInfo{
 					MetadataTypeID: ".google.protobuf.Empty",
@@ -1245,7 +1399,18 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 						api.NewLiteralPathSegment("foos"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "foo",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "POST",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v1"),
+								api.NewFieldPathPathSegment("parent"),
+								api.NewLiteralPathSegment("foos"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "foo",
 				},
 				OperationInfo: &api.OperationInfo{
 					MetadataTypeID: ".test.CreateMetadata",
@@ -1265,7 +1430,17 @@ func TestProtobuf_OperationInfo(t *testing.T) {
 						api.NewFieldPathPathSegment("name"),
 					},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "*",
+					Bindings: []*api.PathBinding{
+						{
+							Verb: "GET",
+							PathTemplate: []api.PathSegment{
+								api.NewLiteralPathSegment("v2"),
+								api.NewFieldPathPathSegment("name"),
+							},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "*",
 				},
 			},
 		},
@@ -1456,7 +1631,14 @@ func TestProtobuf_Deprecated(t *testing.T) {
 					Verb:            "POST",
 					PathTemplate:    []api.PathSegment{},
 					QueryParameters: map[string]bool{},
-					BodyFieldPath:   "*",
+					Bindings: []*api.PathBinding{
+						{
+							Verb:            "POST",
+							PathTemplate:    []api.PathSegment{},
+							QueryParameters: map[string]bool{},
+						},
+					},
+					BodyFieldPath: "*",
 				},
 			},
 		},

--- a/generator/internal/sample/api.go
+++ b/generator/internal/sample/api.go
@@ -78,7 +78,19 @@ func MethodCreate() *api.Method {
 				api.NewFieldPathPathSegment("secret_id"),
 			},
 			QueryParameters: map[string]bool{"secretId": true},
-			BodyFieldPath:   "requestBody",
+			Bindings: []*api.PathBinding{
+				{
+					Verb: http.MethodPost,
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("parent"),
+						api.NewLiteralPathSegment("secrets"),
+						api.NewFieldPathPathSegment("secret_id"),
+					},
+					QueryParameters: map[string]bool{"secretId": true},
+				},
+			},
+			BodyFieldPath: "requestBody",
 		},
 	}
 }
@@ -99,6 +111,18 @@ func MethodUpdate() *api.Method {
 			QueryParameters: map[string]bool{
 				"field_mask": true,
 			},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: http.MethodPatch,
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewFieldPathPathSegment("secret.name"),
+					},
+					QueryParameters: map[string]bool{
+						"field_mask": true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -111,8 +135,7 @@ func MethodAddSecretVersion() *api.Method {
 		InputTypeID:   "..AddSecretVersionRequest",
 		OutputTypeID:  "..SecretVersion",
 		PathInfo: &api.PathInfo{
-			Verb:          http.MethodPost,
-			BodyFieldPath: "*",
+			Verb: http.MethodPost,
 			PathTemplate: []api.PathSegment{
 				api.NewLiteralPathSegment("v1"),
 				api.NewLiteralPathSegment("projects"),
@@ -122,6 +145,21 @@ func MethodAddSecretVersion() *api.Method {
 				api.NewVerbPathSegment("addVersion"),
 			},
 			QueryParameters: map[string]bool{},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: http.MethodPost,
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewLiteralPathSegment("projects"),
+						api.NewFieldPathPathSegment("project"),
+						api.NewLiteralPathSegment("secrets"),
+						api.NewFieldPathPathSegment("secret"),
+						api.NewVerbPathSegment("addVersion"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
+			BodyFieldPath: "*",
 		},
 	}
 }
@@ -136,8 +174,7 @@ func MethodListSecretVersions() *api.Method {
 		OutputTypeID:  ListSecretVersionsResponse().ID,
 		OutputType:    ListSecretVersionsResponse(),
 		PathInfo: &api.PathInfo{
-			Verb:          http.MethodPost,
-			BodyFieldPath: "*",
+			Verb: http.MethodPost,
 			PathTemplate: []api.PathSegment{
 				api.NewLiteralPathSegment("v1"),
 				api.NewLiteralPathSegment("projects"),
@@ -147,6 +184,21 @@ func MethodListSecretVersions() *api.Method {
 				api.NewVerbPathSegment("listSecretVersions"),
 			},
 			QueryParameters: map[string]bool{},
+			Bindings: []*api.PathBinding{
+				{
+					Verb: http.MethodPost,
+					PathTemplate: []api.PathSegment{
+						api.NewLiteralPathSegment("v1"),
+						api.NewLiteralPathSegment("projects"),
+						api.NewFieldPathPathSegment("parent"),
+						api.NewLiteralPathSegment("secrets"),
+						api.NewFieldPathPathSegment("secret"),
+						api.NewVerbPathSegment("listSecretVersions"),
+					},
+					QueryParameters: map[string]bool{},
+				},
+			},
+			BodyFieldPath: "*",
 		},
 	}
 }


### PR DESCRIPTION
A method may have more than one binding in its HTTP info data structure.
With this change we capture all the bindings. We duplicate some data to
split the change in smaller PRs.

Part of the work for #2090
