### PR TITLE
cleanup(firestore): use workspace dependencies

### DIFF
--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -27,18 +27,18 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [dependencies]
-async-trait           = { version = "0.1" }
-bytes                 = { version = "1", features = ["serde"] }
-http                  = "1"
-lazy_static           = "1"
+async-trait.workspace = true
+bytes.workspace       = true
+http.workspace        = true
+lazy_static.workspace = true
 prost.workspace       = true
 prost-types.workspace = true
-serde                 = { version = "1", features = ["serde_derive"] }
-serde_json            = { version = "1" }
-serde_with            = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
+serde.workspace       = true
+serde_json.workspace  = true
+serde_with.workspace  = true
 tonic.workspace       = true
-tokio                 = { version = "1", features = ["macros", "rt-multi-thread"] }
-tracing               = "0.1"
+tokio                 = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing.workspace     = true
 # Local crates
 gax.workspace   = true
 gaxi            = { workspace = true, features = ["_internal-common", "_internal-grpc-client"] }
@@ -48,5 +48,5 @@ wkt.workspace   = true
 
 [dev-dependencies]
 anyhow.workspace     = true
-tokio                = { version = "1", features = ["full", "macros"] }
+tokio                = { workspace = true, features = ["full", "macros"] }
 tokio-test.workspace = true


### PR DESCRIPTION
Part of the work for #1646
