### PR TITLE
cleanup(auth)!: simplify builder

### DIFF
--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -101,10 +101,7 @@ pub async fn api_key() -> Result<()> {
     let api_key = std::str::from_utf8(&api_key).unwrap();
 
     // Create credentials using the API key.
-    let creds = ApiKeyCredentialsBuilder::new(api_key)
-        .build()
-        .await
-        .map_err(Error::authentication)?;
+    let creds = ApiKeyCredentialsBuilder::new(api_key).build();
 
     // Construct a Natural Language client using the credentials.
     let client = LanguageService::builder()

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -110,7 +110,7 @@ impl Builder {
     }
 
     /// Returns a [Credentials] instance with the configured settings.
-    pub async fn build(self) -> Result<Credentials> {
+    pub fn build(self) -> Credentials {
         let token_provider = ApiKeyTokenProvider {
             api_key: self.api_key,
         };
@@ -119,12 +119,12 @@ impl Builder {
             .ok()
             .or(self.quota_project_id);
 
-        Ok(Credentials {
+        Credentials {
             inner: Arc::new(ApiKeyCredentials {
                 token_provider,
                 quota_project_id,
             }),
-        })
+        }
     }
 }
 
@@ -192,9 +192,7 @@ mod test {
 
         let creds = Builder::new("test-api-key")
             .with_quota_project_id("qp-option")
-            .build()
-            .await
-            .unwrap();
+            .build();
         let headers = creds.headers(Extensions::new()).await.unwrap();
         let api_key = headers.get(API_KEY_HEADER_KEY).unwrap();
         let quota_project = headers.get(QUOTA_PROJECT_KEY).unwrap();
@@ -213,9 +211,7 @@ mod test {
 
         let creds = Builder::new("test-api-key")
             .with_quota_project_id("qp-option")
-            .build()
-            .await
-            .unwrap();
+            .build();
         let headers = creds.headers(Extensions::new()).await.unwrap();
         let api_key = headers.get(API_KEY_HEADER_KEY).unwrap();
         let quota_project = headers.get(QUOTA_PROJECT_KEY).unwrap();

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -187,10 +187,7 @@ mod test {
 
     #[tokio::test]
     async fn create_api_key_credentials_success() {
-        let creds = ApiKeyCredentialsBuilder::new("test-api-key")
-            .build()
-            .await
-            .unwrap();
+        let creds = ApiKeyCredentialsBuilder::new("test-api-key").build();
         let fmt = format!("{:?}", creds);
         assert!(fmt.contains("ApiKeyCredentials"), "{fmt:?}");
         assert!(!fmt.contains("test-api-key"), "{fmt:?}");


### PR DESCRIPTION
This thing doesn't need `async`, and it cannot fail.

I don't think it will ever need `async`, and I don't think it can ever fail, so simplify the build signature.

This makes the examples more accurate too. (They were using `Future<Result<Credentials>>`).