### PR TITLE
docs: add google-cloud-gax instructions to cloud shell

### DIFF
--- a/guide/src/setting_up_rust_on_cloud_shell.md
+++ b/guide/src/setting_up_rust_on_cloud_shell.md
@@ -59,6 +59,12 @@ Cloud Shell is a great environment to run small examples and tests.
    cargo add google-cloud-secretmanager-v1
    ```
 
+1. Add the [google-cloud-gax] crate to the new project
+
+   ```shell
+   cargo add google-cloud-gax
+   ```
+
 1. Add the [tokio] crate to the new project
 
    ```shell
@@ -82,6 +88,7 @@ Cloud Shell is a great environment to run small examples and tests.
 <!-- markdownlint-enable MD029 -->
 
 [cloud shell]: https://cloud.google.com/shell
+[google-cloud-gax]: https://crates.io/crates/google-cloud-gax
 [rustup]: https://rust-lang.github.io/rustup/
 [secret manager]: https://cloud.google.com/secret-manager/docs/overview
 [tokio]: https://crates.io/crates/tokio

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -76,6 +76,12 @@ Manager API, do the following:
    cargo add google-cloud-secretmanager-v1
    ```
 
+1. Add the [google-cloud-gax] crate to the new project
+
+```shell
+cargo add google-cloud-gax
+```
+
 1. Add the [tokio] crate to the new project
 
    ```shell
@@ -130,6 +136,7 @@ Note: The source of the Cloud Client Libraries for Rust is
 [authn-client-libraries]: https://cloud.google.com/docs/authentication/client-libraries
 [documentation for google cloud products]: https://cloud.google.com/products
 [google cloud cli]: https://cloud.google.com/sdk/
+[google-cloud-gax]: https://crates.io/crates/google-cloud-gax
 [rust]: https://www.rust-lang.org/
 [rust-getting-started]: https://www.rust-lang.org/learn/get-started
 [secret manager]: https://cloud.google.com/secret-manager/docs/overview

--- a/guide/src/setting_up_your_development_environment.md
+++ b/guide/src/setting_up_your_development_environment.md
@@ -78,9 +78,9 @@ Manager API, do the following:
 
 1. Add the [google-cloud-gax] crate to the new project
 
-```shell
-cargo add google-cloud-gax
-```
+   ```shell
+   cargo add google-cloud-gax
+   ```
 
 1. Add the [tokio] crate to the new project
 


### PR DESCRIPTION
Fixes #2111